### PR TITLE
Make the punctuation style of rule messages consistent

### DIFF
--- a/src/Validation/Rules/Email.php
+++ b/src/Validation/Rules/Email.php
@@ -27,6 +27,6 @@ final readonly class Email implements Rule
 
     public function message(): string
     {
-        return "Value should be a valid email address.";
+        return "Value should be a valid email address";
     }
 }

--- a/src/Validation/Rules/PhoneNumber.php
+++ b/src/Validation/Rules/PhoneNumber.php
@@ -31,11 +31,11 @@ final readonly class PhoneNumber implements Rule
     public function message(): string
     {
         if (! $this->defaultRegion) {
-            return 'Value should be a valid phone number.';
+            return 'Value should be a valid phone number';
         }
 
         return sprintf(
-            'Value should be a valid %s phone number.',
+            'Value should be a valid %s phone number',
             strtoupper($this->defaultRegion)
         );
     }

--- a/tests/Validation/Rules/EmailTest.php
+++ b/tests/Validation/Rules/EmailTest.php
@@ -13,6 +13,7 @@ class EmailTest extends TestCase
     {
         $rule = new Email();
 
+        $this->assertSame('Value should be a valid email address', $rule->message());
         $this->assertFalse($rule->isValid('this is not an email'));
         $this->assertTrue($rule->isValid('jim.halpert@dundermifflinpaper.biz'));
     }

--- a/tests/Validation/Rules/PhoneNumberTest.php
+++ b/tests/Validation/Rules/PhoneNumberTest.php
@@ -13,7 +13,7 @@ class PhoneNumberTest extends TestCase
     {
         $rule = new PhoneNumber();
 
-        $this->assertSame('Value should be a valid phone number.', $rule->message());
+        $this->assertSame('Value should be a valid phone number', $rule->message());
 
         $this->assertFalse($rule->isValid('this is not a phone number'));
         $this->assertFalse($rule->isValid('john.doe@example.com'));
@@ -22,12 +22,12 @@ class PhoneNumberTest extends TestCase
 
         $rule = new PhoneNumber('US');
 
-        $this->assertSame('Value should be a valid US phone number.', $rule->message());
+        $this->assertSame('Value should be a valid US phone number', $rule->message());
         $this->assertTrue($rule->isValid('(805) 380-4329'));
 
         $rule = new PhoneNumber('BE');
 
-        $this->assertSame('Value should be a valid BE phone number.', $rule->message());
+        $this->assertSame('Value should be a valid BE phone number', $rule->message());
         $this->assertTrue($rule->isValid('0497 88 93 11'));
     }
 }


### PR DESCRIPTION
This pull request removes punctuation from the `Email` and `PhoneNumber` rules to be consistent with the rest of the rules.