### PR TITLE
Adds time rule

### DIFF
--- a/src/Validation/Rules/Time.php
+++ b/src/Validation/Rules/Time.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tempest\Validation\Rules;
+
+use Attribute;
+use Tempest\Interface\Rule;
+
+#[Attribute]
+final readonly class Time implements Rule
+{
+    public function __construct(
+        private bool $twentyFourHour = false
+    ) {}
+
+    public function isValid(mixed $value): bool
+    {
+        if ($this->twentyFourHour) {
+            return preg_match('/^([0-1][0-9]|2[0-3]):?[0-5][0-9]$|^(([0-1]?[0-9]|2[0-3]):[0-5][0-9])$/', $value) === 1;
+        }
+
+        return preg_match('/^([0-1]?[0-9]):[0-5][0-9]\s([aApP].[mM].|[aApP][mM])$/', $value) === 1;
+    }
+
+    public function message(): string
+    {
+        if ($this->twentyFourHour) {
+            return 'Value should be a valid time in the 24-hour format of hh:mm';
+        }
+
+        return 'Value should be a valid time in the format of hh:mm xm';
+    }
+}

--- a/tests/Validation/Rules/TimeTest.php
+++ b/tests/Validation/Rules/TimeTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Tempest\Validation\Rules;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Validation\Rules\Time;
+
+class TimeTest extends TestCase
+{
+    public function test_time()
+    {
+        $rule = new Time();
+
+        $this->assertSame('Value should be a valid time in the format of hh:mm xm', $rule->message());
+
+        $this->assertFalse($rule->isValid('0001'));
+        $this->assertFalse($rule->isValid('01:00'));
+        $this->assertFalse($rule->isValid('200'));
+        $this->assertFalse($rule->isValid('01:60 a.m.'));
+        $this->assertFalse($rule->isValid('23:00'));
+        $this->assertFalse($rule->isValid('2300'));
+
+
+        $this->assertTrue($rule->isValid('01:00 am'));
+        $this->assertTrue($rule->isValid('01:00 a.m.'));
+        $this->assertTrue($rule->isValid('01:00 A.M.'));
+        $this->assertTrue($rule->isValid('01:00 AM'));
+        $this->assertTrue($rule->isValid('01:00 pm'));
+        $this->assertTrue($rule->isValid('01:00 p.m.'));
+        $this->assertTrue($rule->isValid('01:00 P.M.'));
+        $this->assertTrue($rule->isValid('01:00 PM'));
+        $this->assertTrue($rule->isValid('01:59 a.m.'));
+    }
+
+    public function test_military_time()
+    {
+        $rule = new Time(twentyFourHour: true);
+
+        $this->assertSame('Value should be a valid time in the 24-hour format of hh:mm', $rule->message());
+
+        $this->assertFalse($rule->isValid('2400'));
+        $this->assertFalse($rule->isValid('01:00 am'));
+        $this->assertFalse($rule->isValid('01:00 a.m.'));
+        $this->assertFalse($rule->isValid('01:00 A.M.'));
+        $this->assertFalse($rule->isValid('01:00 AM'));
+        $this->assertFalse($rule->isValid('01:00 pm'));
+        $this->assertFalse($rule->isValid('01:00 p.m.'));
+        $this->assertFalse($rule->isValid('01:00 P.M.'));
+        $this->assertFalse($rule->isValid('01:00 PM'));
+        $this->assertFalse($rule->isValid('01:59 a.m.'));
+        $this->assertFalse($rule->isValid('24:00'));
+
+        $this->assertTrue($rule->isValid('23:00'));
+        $this->assertTrue($rule->isValid('2300'));
+        $this->assertTrue($rule->isValid('0100'));
+        $this->assertTrue($rule->isValid('0200'));
+        $this->assertTrue($rule->isValid('0300'));
+        $this->assertTrue($rule->isValid('0400'));
+        $this->assertTrue($rule->isValid('0500'));
+        $this->assertTrue($rule->isValid('0600'));
+        $this->assertTrue($rule->isValid('0700'));
+        $this->assertTrue($rule->isValid('0800'));
+        $this->assertTrue($rule->isValid('0900'));
+        $this->assertTrue($rule->isValid('1000'));
+        $this->assertTrue($rule->isValid('1100'));
+        $this->assertTrue($rule->isValid('1200'));
+        $this->assertTrue($rule->isValid('1300'));
+        $this->assertTrue($rule->isValid('1400'));
+        $this->assertTrue($rule->isValid('1500'));
+        $this->assertTrue($rule->isValid('1600'));
+        $this->assertTrue($rule->isValid('1700'));
+        $this->assertTrue($rule->isValid('1800'));
+        $this->assertTrue($rule->isValid('1900'));
+        $this->assertTrue($rule->isValid('2000'));
+        $this->assertTrue($rule->isValid('2100'));
+        $this->assertTrue($rule->isValid('2200'));
+        $this->assertTrue($rule->isValid('2300'));
+        $this->assertTrue($rule->isValid('2340'));
+    }
+}


### PR DESCRIPTION
This rule uses regex to validate time in standard format (hh:mm xm) or military (24-hour) format (hh:mm). It covers the rule mentioned in #3.