### PR TITLE
UPPERCASE/lowercase rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
         "ext-pdo": "*",
         "vlucas/phpdotenv": "^5.6",
         "ext-dom": "*",
+        "ext-mbstring": "*",
         "giggsey/libphonenumber-for-php": "^8.13",
         "egulias/email-validator": "^4.0"
     },

--- a/src/Validation/Rules/EndsWith.php
+++ b/src/Validation/Rules/EndsWith.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Validation\Rules;
+
+use Attribute;
+use Tempest\Interface\Rule;
+
+#[Attribute]
+final readonly class EndsWith implements Rule
+{
+    public function __construct(
+        private string $needle,
+    ) {
+    }
+
+    public function isValid(mixed $value): bool
+    {
+        return str_ends_with($value, $this->needle);
+    }
+
+    public function message(): string
+    {
+        return "Value should end with {$this->needle}";
+    }
+}

--- a/src/Validation/Rules/Lowercase.php
+++ b/src/Validation/Rules/Lowercase.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Tempest\Validation\Rules;
+
+use Attribute;
+use Tempest\Interface\Rule;
+
+#[Attribute]
+class Lowercase implements Rule
+{
+    
+    public function isValid(mixed $value): bool
+    {
+        return $value === mb_strtolower($value);
+    }
+    
+    public function message(): string
+    {
+        return 'Value should be a lowercase string.';
+    }
+}

--- a/src/Validation/Rules/Uppercase.php
+++ b/src/Validation/Rules/Uppercase.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Tempest\Validation\Rules;
+
+use Attribute;
+use Tempest\Interface\Rule;
+
+#[Attribute]
+class Uppercase implements Rule
+{
+    
+    public function isValid(mixed $value): bool
+    {
+        return $value === mb_strtoupper($value);
+    }
+    
+    public function message(): string
+    {
+        return 'Value should be an uppercase string.';
+    }
+}

--- a/tests/Validation/Rules/EndsWithTest.php
+++ b/tests/Validation/Rules/EndsWithTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Validation\Rules;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Validation\Rules\EndsWith;
+
+class EndsWithTest extends TestCase
+{
+    /** @test */
+    public function test_ends_with()
+    {
+        $rule = new EndsWith(needle: 'ab');
+
+        $this->assertTrue($rule->isValid('ab'));
+        $this->assertTrue($rule->isValid('cab'));
+        $this->assertFalse($rule->isValid('b'));
+        $this->assertFalse($rule->isValid('3434'));
+    }
+}

--- a/tests/Validation/Rules/LowercaseTest.php
+++ b/tests/Validation/Rules/LowercaseTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Tempest\Validation\Rules;
+
+use Tests\Tempest\TestCase;
+use Tempest\Validation\Rules\Lowercase;
+
+class LowercaseTest extends TestCase
+{
+    public function test_lowercase()
+    {
+        $rule = new Lowercase();
+        
+        $this->assertTrue($rule->isValid('abc'));
+        $this->assertTrue($rule->isValid('àbç'));
+        $this->assertFalse($rule->isValid('ABC'));
+        $this->assertFalse($rule->isValid('ÀBÇ'));
+        $this->assertFalse($rule->isValid('AbC'));
+    }
+}

--- a/tests/Validation/Rules/UppercaseTest.php
+++ b/tests/Validation/Rules/UppercaseTest.php
@@ -1,0 +1,20 @@
+<?php
+    
+    namespace Tests\Tempest\Validation\Rules;
+    
+    use Tests\Tempest\TestCase;
+    use Tempest\Validation\Rules\Uppercase;
+    
+    class UppercaseTest extends TestCase
+    {
+        public function test_uppercase()
+        {
+            $rule = new Uppercase();
+            
+            $this->assertTrue($rule->isValid('ABC'));
+            $this->assertTrue($rule->isValid('ÀBÇ'));
+            $this->assertFalse($rule->isValid('abc'));
+            $this->assertFalse($rule->isValid('àbç'));
+            $this->assertFalse($rule->isValid('AbC'));
+        }
+    }


### PR DESCRIPTION
As stated in #3, these rules are still missing.

I added them in this PR.

As discussed in #81, they use `mbstring` variants of `strtoupper()/strtolower()` to match against special characters too.