### PR TITLE
feat: add not starts with and not ends with validation rules

### DIFF
--- a/src/Validation/Rules/DoesNotEndWith.php
+++ b/src/Validation/Rules/DoesNotEndWith.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Validation\Rules;
+
+use Attribute;
+use Tempest\Interface\Rule;
+
+#[Attribute]
+class DoesNotEndWith implements Rule
+{
+    public function __construct(
+        private string $needle
+    ) {
+    }
+
+    public function isValid(mixed $value): bool
+    {
+        return ! str_ends_with($value, $this->needle);
+    }
+
+    public function message(): string
+    {
+        return "Value should not end with {$this->needle}";
+    }
+}

--- a/src/Validation/Rules/DoesNotStartWith.php
+++ b/src/Validation/Rules/DoesNotStartWith.php
@@ -10,8 +10,9 @@ use Tempest\Interface\Rule;
 #[Attribute]
 final readonly class DoesNotStartWith implements Rule
 {
-    public function __construct(private string $needle)
-    {
+    public function __construct(
+        private string $needle
+    ) {
     }
 
     public function isValid(mixed $value): bool
@@ -21,6 +22,6 @@ final readonly class DoesNotStartWith implements Rule
 
     public function message(): string
     {
-        return "Value should start with {$this->needle}";
+        return "Value should not start with {$this->needle}";
     }
 }

--- a/src/Validation/Rules/DoesNotStartWith.php
+++ b/src/Validation/Rules/DoesNotStartWith.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Validation\Rules;
+
+use Attribute;
+use Tempest\Interface\Rule;
+
+#[Attribute]
+final readonly class DoesNotStartWith implements Rule
+{
+    public function __construct(private string $needle)
+    {
+    }
+
+    public function isValid(mixed $value): bool
+    {
+        return ! str_starts_with($value, $this->needle);
+    }
+
+    public function message(): string
+    {
+        return "Value should start with {$this->needle}";
+    }
+}

--- a/src/Validation/Rules/Lowercase.php
+++ b/src/Validation/Rules/Lowercase.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tempest\Validation\Rules;
@@ -9,12 +10,11 @@ use Tempest\Interface\Rule;
 #[Attribute]
 class Lowercase implements Rule
 {
-    
     public function isValid(mixed $value): bool
     {
         return $value === mb_strtolower($value);
     }
-    
+
     public function message(): string
     {
         return 'Value should be a lowercase string.';

--- a/src/Validation/Rules/Uppercase.php
+++ b/src/Validation/Rules/Uppercase.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tempest\Validation\Rules;
@@ -9,12 +10,11 @@ use Tempest\Interface\Rule;
 #[Attribute]
 class Uppercase implements Rule
 {
-    
     public function isValid(mixed $value): bool
     {
         return $value === mb_strtoupper($value);
     }
-    
+
     public function message(): string
     {
         return 'Value should be an uppercase string.';

--- a/tests/Validation/Rules/DoesNotEndWithTest.php
+++ b/tests/Validation/Rules/DoesNotEndWithTest.php
@@ -10,13 +10,8 @@ use Tests\Tempest\TestCase;
 class DoesNotEndWithTest extends TestCase
 {
     /**
-     * @param string $needle
-     * @param string $stringToTest
-     * @param bool $expected
      *
      * @dataProvider dataSets
-     *
-     * @return void
      */
     public function test_rule(string $needle, string $stringToTest, bool $expected): void
     {
@@ -25,7 +20,7 @@ class DoesNotEndWithTest extends TestCase
         $this->assertEquals($expected, $rule->isValid($stringToTest));
     }
 
-    public function dataSets(): array
+    public static function dataSets(): array
     {
         return [
             'should return false if it ends with the given string' => ['test', 'this is a test', false],

--- a/tests/Validation/Rules/DoesNotEndWithTest.php
+++ b/tests/Validation/Rules/DoesNotEndWithTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Validation\Rules;
+
+use Tempest\Validation\Rules\DoesNotEndWith;
+use Tests\Tempest\TestCase;
+
+class DoesNotEndWithTest extends TestCase
+{
+    /**
+     * @param string $needle
+     * @param string $stringToTest
+     * @param bool $expected
+     *
+     * @dataProvider dataSets
+     *
+     * @return void
+     */
+    public function test_rule(string $needle, string $stringToTest, bool $expected): void
+    {
+        $rule = new DoesNotEndWith($needle);
+
+        $this->assertEquals($expected, $rule->isValid($stringToTest));
+    }
+
+    public function dataSets(): array
+    {
+        return [
+            'should return false if it ends with the given string' => ['test', 'this is a test', false],
+            'should return true if it does not end with the given string' => ['test', 'test this is a', true],
+            'should return true for an empty string' => ['test', '', true],
+            'should return true for a single non-matching character' => ['test', 'a', true],
+            'should return false for a matching character string' => ['a', 'banana', false],
+            'should return true if it ends with a different string' => [
+                'test',
+                'this is a test best',
+                true,
+            ],
+            'should return true if the string is the reverse of the given string' => ['test', 'tset', true],
+            'should return false if the string and given string are the same' => ['test', 'test', false],
+        ];
+    }
+}

--- a/tests/Validation/Rules/DoesNotStartWithTest.php
+++ b/tests/Validation/Rules/DoesNotStartWithTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Validation\Rules;
+
+use Tempest\Validation\Rules\DoesNotStartWith;
+use Tests\Tempest\TestCase;
+
+class DoesNotStartWithTest extends TestCase
+{
+    /**
+     * @param string $needle
+     * @param string $stringToTest
+     * @param bool $expected
+     *
+     * @dataProvider dataSets
+     *
+     * @return void
+     */
+    public function test_rule(string $needle, string $stringToTest, bool $expected): void
+    {
+        $rule = new DoesNotStartWith($needle);
+
+        $this->assertEquals($expected, $rule->isValid($stringToTest));
+    }
+
+    public function dataSets(): array
+    {
+        return [
+            'should return false if it starts with the given string' => ['test', 'test this is a test', false],
+            'should return true if it does not start with the given string' => ['test', 'this is a test', true],
+            'should return true for an empty string' => ['test', '', true],
+            'should return true for a single non-matching character' => ['test', 'a', true],
+            'should return false for a matching character string' => ['a', 'apple', false],
+            'should return true if it starts with a different string' => ['test', 'best this is a test', true],
+            'should return true if the string is the reverse of the given string' => ['test', 'tset', true],
+            'should return false if the string and given string are the same' => ['test', 'test', false],
+        ];
+    }
+}

--- a/tests/Validation/Rules/DoesNotStartWithTest.php
+++ b/tests/Validation/Rules/DoesNotStartWithTest.php
@@ -10,13 +10,9 @@ use Tests\Tempest\TestCase;
 class DoesNotStartWithTest extends TestCase
 {
     /**
-     * @param string $needle
-     * @param string $stringToTest
-     * @param bool $expected
      *
      * @dataProvider dataSets
      *
-     * @return void
      */
     public function test_rule(string $needle, string $stringToTest, bool $expected): void
     {
@@ -25,7 +21,7 @@ class DoesNotStartWithTest extends TestCase
         $this->assertEquals($expected, $rule->isValid($stringToTest));
     }
 
-    public function dataSets(): array
+    public static function dataSets(): array
     {
         return [
             'should return false if it starts with the given string' => ['test', 'test this is a test', false],

--- a/tests/Validation/Rules/LowercaseTest.php
+++ b/tests/Validation/Rules/LowercaseTest.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Tempest\Validation\Rules;
 
-use Tests\Tempest\TestCase;
 use Tempest\Validation\Rules\Lowercase;
+use Tests\Tempest\TestCase;
 
 class LowercaseTest extends TestCase
 {
     public function test_lowercase()
     {
         $rule = new Lowercase();
-        
+
         $this->assertTrue($rule->isValid('abc'));
         $this->assertTrue($rule->isValid('àbç'));
         $this->assertFalse($rule->isValid('ABC'));

--- a/tests/Validation/Rules/UppercaseTest.php
+++ b/tests/Validation/Rules/UppercaseTest.php
@@ -1,20 +1,22 @@
 <?php
-    
-    namespace Tests\Tempest\Validation\Rules;
-    
-    use Tests\Tempest\TestCase;
-    use Tempest\Validation\Rules\Uppercase;
-    
-    class UppercaseTest extends TestCase
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Validation\Rules;
+
+use Tempest\Validation\Rules\Uppercase;
+use Tests\Tempest\TestCase;
+
+class UppercaseTest extends TestCase
+{
+    public function test_uppercase()
     {
-        public function test_uppercase()
-        {
-            $rule = new Uppercase();
-            
-            $this->assertTrue($rule->isValid('ABC'));
-            $this->assertTrue($rule->isValid('ÀBÇ'));
-            $this->assertFalse($rule->isValid('abc'));
-            $this->assertFalse($rule->isValid('àbç'));
-            $this->assertFalse($rule->isValid('AbC'));
-        }
+        $rule = new Uppercase();
+
+        $this->assertTrue($rule->isValid('ABC'));
+        $this->assertTrue($rule->isValid('ÀBÇ'));
+        $this->assertFalse($rule->isValid('abc'));
+        $this->assertFalse($rule->isValid('àbç'));
+        $this->assertFalse($rule->isValid('AbC'));
     }
+}


### PR DESCRIPTION
Not sure if should have just used the StartsWith and EndsWith rules directly and negate their return.
Something like this: 
```php
$startsWithRule = new StartsWith($needle);

return !$startsWithRule->isValid($value);

```