### PR TITLE
feat: add json validation rule

### DIFF
--- a/src/Validation/Rules/JSON.php
+++ b/src/Validation/Rules/JSON.php
@@ -9,9 +9,9 @@ use Tempest\Validation\Rule;
 
 /**
  * We need to polyfill this, because at the moment the minimum required version of php for tempest is ^8.2,
- *  and json_validate was introduced in 8.3
+ * and json_validate was introduced in 8.3
  * @TODO remove this polyfill once the minimum php version is >= than 8.3
- * @link https://php.watch/versions/8.3/json_validate#polyfill
+ * Source @link https://php.watch/versions/8.3/json_validate#polyfill
  */
 if (! function_exists('json_validate')) {
     function json_validate(string $json, int $depth = 512, int $flags = 0): bool

--- a/src/Validation/Rules/JSON.php
+++ b/src/Validation/Rules/JSON.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Validation\Rules;
+
+use Attribute;
+use Tempest\Validation\Rule;
+
+/**
+ * We need to polyfill this, because at the moment the minimum required version of php for tempest is ^8.2,
+ *  and json_validate was introduced in 8.3
+ * @TODO remove this polyfill once the minimum php version is >= than 8.3
+ * @link https://php.watch/versions/8.3/json_validate#polyfill
+ */
+if (! function_exists('json_validate')) {
+    function json_validate(string $json, int $depth = 512, int $flags = 0): bool
+    {
+        if ($flags !== 0 && $flags !== \JSON_INVALID_UTF8_IGNORE) {
+            throw new \ValueError(
+                'json_validate(): Argument #3 ($flags) must be a valid flag (allowed flags: JSON_INVALID_UTF8_IGNORE)'
+            );
+        }
+
+        if ($depth <= 0) {
+            throw new \ValueError('json_validate(): Argument #2 ($depth) must be greater than 0');
+        }
+
+        \json_decode($json, null, $depth, $flags);
+
+        return \json_last_error() === \JSON_ERROR_NONE;
+    }
+}
+
+#[Attribute]
+final readonly class JSON implements Rule
+{
+    public function __construct(
+        private ?int $depth = null,
+        private ?int $flags = null
+    ) {
+    }
+
+    public function isValid(mixed $value): bool
+    {
+        $extraArguments = ['json' => $value];
+        if ($this->depth !== null) {
+            $extraArguments['depth'] = $this->depth;
+        }
+        if ($this->flags !== null) {
+            $extraArguments['flags'] = $this->flags;
+        }
+
+        return json_validate(...$extraArguments);
+    }
+
+    public function message(): string
+    {
+        return 'Value should be a valid JSON string';
+    }
+}

--- a/src/Validation/Rules/JSON.php
+++ b/src/Validation/Rules/JSON.php
@@ -7,31 +7,6 @@ namespace Tempest\Validation\Rules;
 use Attribute;
 use Tempest\Validation\Rule;
 
-/**
- * We need to polyfill this, because at the moment the minimum required version of php for tempest is ^8.2,
- * and json_validate was introduced in 8.3
- * @TODO remove this polyfill once the minimum php version is >= than 8.3
- * Source @link https://php.watch/versions/8.3/json_validate#polyfill
- */
-if (! function_exists('json_validate')) {
-    function json_validate(string $json, int $depth = 512, int $flags = 0): bool
-    {
-        if ($flags !== 0 && $flags !== \JSON_INVALID_UTF8_IGNORE) {
-            throw new \ValueError(
-                'json_validate(): Argument #3 ($flags) must be a valid flag (allowed flags: JSON_INVALID_UTF8_IGNORE)'
-            );
-        }
-
-        if ($depth <= 0) {
-            throw new \ValueError('json_validate(): Argument #2 ($depth) must be greater than 0');
-        }
-
-        \json_decode($json, null, $depth, $flags);
-
-        return \json_last_error() === \JSON_ERROR_NONE;
-    }
-}
-
 #[Attribute]
 final readonly class JSON implements Rule
 {

--- a/src/Validation/Rules/JSON.php
+++ b/src/Validation/Rules/JSON.php
@@ -43,15 +43,16 @@ final readonly class JSON implements Rule
 
     public function isValid(mixed $value): bool
     {
-        $extraArguments = ['json' => $value];
+        $arguments = ['json' => $value];
+
         if ($this->depth !== null) {
-            $extraArguments['depth'] = $this->depth;
+            $arguments['depth'] = $this->depth;
         }
         if ($this->flags !== null) {
-            $extraArguments['flags'] = $this->flags;
+            $arguments['flags'] = $this->flags;
         }
 
-        return json_validate(...$extraArguments);
+        return json_validate(...$arguments);
     }
 
     public function message(): string

--- a/tests/Validation/Rules/JSONTest.php
+++ b/tests/Validation/Rules/JSONTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Validation\Rules;
+
+use Tempest\Validation\Rules\JSON;
+use Tests\Tempest\TestCase;
+use ValueError;
+
+
+
+class JSONTest extends TestCase
+{
+    public function test_it_returns_true_for_valid_json_string(): void
+    {
+        $rule = new JSON();
+        $this->assertTrue($rule->isValid('{"test": "test"}'));
+    }
+
+    public function test_it_returns_false_for_invalid_json_string(): void
+    {
+        $rule = new JSON();
+        $this->assertFalse($rule->isValid('{"test": test}'));
+    }
+
+    public function test_it_allows_to_specify_depth(): void
+    {
+        // Not sure if there is a better way of asserting that a php function was called with a given argument
+        $this->expectException(ValueError::class);
+        $rule = new JSON(depth: 0); // we intentionally send something that is not valid
+        $rule->isValid('{"test": "test"}');
+    }
+
+    public function test_it_allows_to_specify_flags(): void
+    {
+        // Not sure if there is a better way of asserting that a php function was called with a given argument
+        $this->expectException(ValueError::class);
+        $rule = new JSON(flags: 232312312); // we intentionally send something that is not valid
+        $rule->isValid('{"test": "test"}');
+    }
+
+    public function test_it_returns_the_proper_message(): void
+    {
+        $rule = new JSON();
+        $this->assertEquals('Value should be a valid JSON string', $rule->message());
+    }
+}

--- a/tests/Validation/Rules/JSONTest.php
+++ b/tests/Validation/Rules/JSONTest.php
@@ -8,8 +8,6 @@ use Tempest\Validation\Rules\JSON;
 use Tests\Tempest\TestCase;
 use ValueError;
 
-
-
 class JSONTest extends TestCase
 {
     public function test_it_returns_true_for_valid_json_string(): void


### PR DESCRIPTION
I know is not in the list, but I think it might be useful to have it. 

Also it might look ugly, but wanted to use the new function json_validate, maybe instead of adding this polyfill I could just move the body of the function inside the isValid method.