### PR TITLE
Validate password

### DIFF
--- a/src/Validation/Rules/Password.php
+++ b/src/Validation/Rules/Password.php
@@ -53,6 +53,31 @@ final readonly class Password implements Rule
 
     public function message(): string
     {
-        return "Value should be a valid password";
+        $messages = ["at least {$this->min} characters"];
+
+        if ($this->mixedCase) {
+            $messages[] = 'at least one uppercase and one lowercase letter';
+        }
+        if ($this->numbers) {
+            $messages[] = 'at least one number';
+        }
+        if ($this->letters) {
+            $messages[] = 'at least one letter';
+        }
+        if ($this->symbols) {
+            $messages[] = 'at least one symbol';
+        }
+
+        return 'Value should contain ' . $this->natural_language_join($messages);
+    }
+
+    private function natural_language_join(array $list)
+    {
+        $last = array_pop($list);
+        if ($list) {
+            return implode(', ', $list) . ' ' . 'and' . ' ' . $last;
+        }
+
+        return $last;
     }
 }

--- a/src/Validation/Rules/Password.php
+++ b/src/Validation/Rules/Password.php
@@ -11,18 +11,15 @@ use Tempest\Validation\Rule;
 final readonly class Password implements Rule
 {
     private int $min;
-    private ?int $max;
 
     public function __construct(
         int $min = 12,
-        ?int $max = null,
         private bool $mixedCase = false,
         private bool $numbers = false,
         private bool $letters = false,
         private bool $symbols = false,
     ) {
         $this->min = max(1, $min);
-        $this->max = $max ? max($this->min, $max) : null;
     }
 
     public function isValid(mixed $value): bool
@@ -32,10 +29,6 @@ final readonly class Password implements Rule
         }
 
         if (strlen($value) < $this->min) {
-            return false;
-        }
-
-        if ($this->max !== null && strlen($value) > $this->max) {
             return false;
         }
 

--- a/src/Validation/Rules/Password.php
+++ b/src/Validation/Rules/Password.php
@@ -5,33 +5,30 @@ declare(strict_types=1);
 namespace Tempest\Validation\Rules;
 
 use Attribute;
-use http\Exception\InvalidArgumentException;
 use Tempest\Validation\Rule;
 
 #[Attribute]
 final readonly class Password implements Rule
 {
+    private int $min;
+    private ?int $max;
+
     public function __construct(
-        private int $min = 8,
-        private ?int $max = null,
+        int $min = 8,
+        ?int $max = null,
         private bool $mixedCase = false,
         private bool $numbers = false,
         private bool $letters = false,
         private bool $symbols = false,
     ) {
-        if ($this->min < 1) {
-            throw new \InvalidArgumentException("Minimum length must be at least 1");
-        }
-
-        if ($this->max !== null && $this->max < $this->min) {
-            throw new \InvalidArgumentException("Maximum length must be greater than or equal to the minimum length");
-        }
+        $this->min = max(1, $min);
+        $this->max = $max ? max($this->min, $max) : null;
     }
 
     public function isValid(mixed $value): bool
     {
         if (! is_string($value)) {
-            throw new InvalidArgumentException("Value must be a string");
+            return false;
         }
 
         if (strlen($value) < $this->min) {

--- a/src/Validation/Rules/Password.php
+++ b/src/Validation/Rules/Password.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Validation\Rules;
+
+use Attribute;
+use http\Exception\InvalidArgumentException;
+use Tempest\Validation\Rule;
+
+#[Attribute]
+final readonly class Password implements Rule
+{
+    public function __construct(
+        private int $min = 8,
+        private ?int $max = null,
+        private bool $mixedCase = false,
+        private bool $numbers = false,
+        private bool $letters = false,
+        private bool $symbols = false,
+    ) {
+        if ($this->min < 1) {
+            throw new \InvalidArgumentException("Minimum length must be at least 1");
+        }
+
+        if ($this->max !== null && $this->max < $this->min) {
+            throw new \InvalidArgumentException("Maximum length must be greater than or equal to the minimum length");
+        }
+    }
+
+    public function isValid(mixed $value): bool
+    {
+        if (! is_string($value)) {
+            throw new InvalidArgumentException("Value must be a string");
+        }
+
+        if (strlen($value) < $this->min) {
+            return false;
+        }
+
+        if ($this->max !== null && strlen($value) > $this->max) {
+            return false;
+        }
+
+        if ($this->mixedCase && ! preg_match('/(\p{Ll}+.*\p{Lu})|(\p{Lu}+.*\p{Ll})/u', $value)) {
+            return false;
+        }
+
+        if ($this->numbers && ! preg_match('/\p{N}/u', $value)) {
+            return false;
+        }
+
+        if ($this->letters && ! preg_match('/\p{L}/u', $value)) {
+            return false;
+        }
+
+        if ($this->symbols && ! preg_match('/\p{Z}|\p{S}|\p{P}/u', $value)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function message(): string
+    {
+        return "Value should be a valid password";
+    }
+}

--- a/src/Validation/Rules/Password.php
+++ b/src/Validation/Rules/Password.php
@@ -14,7 +14,7 @@ final readonly class Password implements Rule
     private ?int $max;
 
     public function __construct(
-        int $min = 8,
+        int $min = 12,
         ?int $max = null,
         private bool $mixedCase = false,
         private bool $numbers = false,

--- a/tests/Validation/Rules/PasswordTest.php
+++ b/tests/Validation/Rules/PasswordTest.php
@@ -17,6 +17,13 @@ class PasswordTest extends TestCase
         $this->assertTrue($rule->isValid('aaaaaaaa'));
     }
 
+    public function test_invalid_input()
+    {
+        $rule = new Password();
+        $this->assertFalse($rule->isValid(12345678));
+        $this->assertFalse($rule->isValid([12345678]));
+    }
+
     public function test_minimum()
     {
         $rule = new Password(min: 4);
@@ -31,6 +38,12 @@ class PasswordTest extends TestCase
         $this->assertTrue($rule->isValid('12345678'));
         $this->assertTrue($rule->isValid('1234567890'));
         $this->assertFalse($rule->isValid('12345678901'));
+    }
+
+    public function test_maximum_less_than_minimum()
+    {
+        $rule = new Password(min: 4, max: 2);
+        $this->assertTrue($rule->isValid('1234'));
     }
 
     public function test_mixed_case()

--- a/tests/Validation/Rules/PasswordTest.php
+++ b/tests/Validation/Rules/PasswordTest.php
@@ -13,15 +13,15 @@ class PasswordTest extends TestCase
     {
         $rule = new Password();
 
-        $this->assertTrue($rule->isValid('12345678'));
-        $this->assertTrue($rule->isValid('aaaaaaaa'));
+        $this->assertTrue($rule->isValid('123456789012'));
+        $this->assertTrue($rule->isValid('aaaaaaaaaaaa'));
     }
 
     public function test_invalid_input()
     {
         $rule = new Password();
-        $this->assertFalse($rule->isValid(12345678));
-        $this->assertFalse($rule->isValid([12345678]));
+        $this->assertFalse($rule->isValid(123456789012));
+        $this->assertFalse($rule->isValid([123456789012]));
     }
 
     public function test_minimum()
@@ -34,9 +34,9 @@ class PasswordTest extends TestCase
 
     public function test_maximum()
     {
-        $rule = new Password(max: 10);
-        $this->assertTrue($rule->isValid('12345678'));
-        $this->assertTrue($rule->isValid('1234567890'));
+        $rule = new Password(max: 14);
+        $this->assertTrue($rule->isValid('1234567890123'));
+        $this->assertTrue($rule->isValid('12345678901234'));
         $this->assertFalse($rule->isValid('12345678901'));
     }
 
@@ -49,31 +49,31 @@ class PasswordTest extends TestCase
     public function test_mixed_case()
     {
         $rule = new Password(mixedCase: true);
-        $this->assertTrue($rule->isValid('abcdEFGH'));
-        $this->assertFalse($rule->isValid('abcdefgh'));
-        $this->assertFalse($rule->isValid('ABCDEFGH'));
+        $this->assertTrue($rule->isValid('abcdEFGHIJKL'));
+        $this->assertFalse($rule->isValid('abcdefghijkl'));
+        $this->assertFalse($rule->isValid('ABCDEFGHIJKL'));
     }
 
     public function test_letters()
     {
         $rule = new Password(letters: true);
-        $this->assertTrue($rule->isValid('1234567a'));
-        $this->assertFalse($rule->isValid('12345678'));
+        $this->assertTrue($rule->isValid('12345678901a'));
+        $this->assertFalse($rule->isValid('123456789012'));
     }
 
     public function test_numbers()
     {
         $rule = new Password(numbers: true);
-        $this->assertTrue($rule->isValid('12345678'));
-        $this->assertTrue($rule->isValid('1aaaaaaaa'));
-        $this->assertFalse($rule->isValid('abcdefgh'));
+        $this->assertTrue($rule->isValid('123456789012'));
+        $this->assertTrue($rule->isValid('1aaaaaaaaaaa'));
+        $this->assertFalse($rule->isValid('abcdefghijkl'));
     }
 
     public function test_symbols()
     {
         $rule = new Password(symbols: true);
-        $this->assertTrue($rule->isValid('1234567@'));
-        $this->assertFalse($rule->isValid('12345678'));
+        $this->assertTrue($rule->isValid('123456789012@'));
+        $this->assertFalse($rule->isValid('123456789012'));
     }
 
     public function test_message()

--- a/tests/Validation/Rules/PasswordTest.php
+++ b/tests/Validation/Rules/PasswordTest.php
@@ -65,6 +65,24 @@ class PasswordTest extends TestCase
     public function test_message()
     {
         $rule = new Password();
-        $this->assertSame('Value should be a valid password', $rule->message());
+        $this->assertSame('Value should contain at least 12 characters', $rule->message());
+
+        $rule = new Password(min: 4);
+        $this->assertSame('Value should contain at least 4 characters', $rule->message());
+
+        $rule = new Password(mixedCase: true);
+        $this->assertSame('Value should contain at least 12 characters and at least one uppercase and one lowercase letter', $rule->message());
+
+        $rule = new Password(letters: true);
+        $this->assertSame('Value should contain at least 12 characters and at least one letter', $rule->message());
+
+        $rule = new Password(numbers: true);
+        $this->assertSame('Value should contain at least 12 characters and at least one number', $rule->message());
+
+        $rule = new Password(symbols: true);
+        $this->assertSame('Value should contain at least 12 characters and at least one symbol', $rule->message());
+
+        $rule = new Password(min: 4, mixedCase: true, letters: true, numbers: true, symbols: true);
+        $this->assertSame('Value should contain at least 4 characters, at least one uppercase and one lowercase letter, at least one number, at least one letter and at least one symbol', $rule->message());
     }
 }

--- a/tests/Validation/Rules/PasswordTest.php
+++ b/tests/Validation/Rules/PasswordTest.php
@@ -32,20 +32,6 @@ class PasswordTest extends TestCase
         $this->assertFalse($rule->isValid('123'));
     }
 
-    public function test_maximum()
-    {
-        $rule = new Password(max: 14);
-        $this->assertTrue($rule->isValid('1234567890123'));
-        $this->assertTrue($rule->isValid('12345678901234'));
-        $this->assertFalse($rule->isValid('12345678901'));
-    }
-
-    public function test_maximum_less_than_minimum()
-    {
-        $rule = new Password(min: 4, max: 2);
-        $this->assertTrue($rule->isValid('1234'));
-    }
-
     public function test_mixed_case()
     {
         $rule = new Password(mixedCase: true);

--- a/tests/Validation/Rules/PasswordTest.php
+++ b/tests/Validation/Rules/PasswordTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Validation\Rules;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Validation\Rules\Password;
+
+class PasswordTest extends TestCase
+{
+    public function test_defaults()
+    {
+        $rule = new Password();
+
+        $this->assertTrue($rule->isValid('12345678'));
+        $this->assertTrue($rule->isValid('aaaaaaaa'));
+    }
+
+    public function test_minimum()
+    {
+        $rule = new Password(min: 4);
+        $this->assertTrue($rule->isValid('12345'));
+        $this->assertTrue($rule->isValid('1234'));
+        $this->assertFalse($rule->isValid('123'));
+    }
+
+    public function test_maximum()
+    {
+        $rule = new Password(max: 10);
+        $this->assertTrue($rule->isValid('12345678'));
+        $this->assertTrue($rule->isValid('1234567890'));
+        $this->assertFalse($rule->isValid('12345678901'));
+    }
+
+    public function test_mixed_case()
+    {
+        $rule = new Password(mixedCase: true);
+        $this->assertTrue($rule->isValid('abcdEFGH'));
+        $this->assertFalse($rule->isValid('abcdefgh'));
+        $this->assertFalse($rule->isValid('ABCDEFGH'));
+    }
+
+    public function test_letters()
+    {
+        $rule = new Password(letters: true);
+        $this->assertTrue($rule->isValid('1234567a'));
+        $this->assertFalse($rule->isValid('12345678'));
+    }
+
+    public function test_numbers()
+    {
+        $rule = new Password(numbers: true);
+        $this->assertTrue($rule->isValid('12345678'));
+        $this->assertTrue($rule->isValid('1aaaaaaaa'));
+        $this->assertFalse($rule->isValid('abcdefgh'));
+    }
+
+    public function test_symbols()
+    {
+        $rule = new Password(symbols: true);
+        $this->assertTrue($rule->isValid('1234567@'));
+        $this->assertFalse($rule->isValid('12345678'));
+    }
+
+    public function test_message()
+    {
+        $rule = new Password();
+        $this->assertSame('Value should be a valid password', $rule->message());
+    }
+}


### PR DESCRIPTION
Added some basic password validation (addresses #3)

Have selected most rules to be disabled by default. NIST guidelines don't recommend any sort of password enforcement. Instead they recommend using a list of compromised passwords to compare against (which we are handling separately).

I'm not sure if we want to have different messages for different issues - but then we may want message() to allow returning an array of errors. Seems like it's something a little out of scope for this one though.

Source: https://pages.nist.gov/800-63-FAQ/#q-b06