### PR TITLE
#117 Use installed.json for package discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
+# See \Tempest\Application\Environment for supported values
 ENVIRONMENT=production
+
 DISCOVERY_CACHE=false

--- a/src/Application/Exceptions/KernelException.php
+++ b/src/Application/Exceptions/KernelException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tempest\Application\Exceptions;
+
+use Exception;
+
+class KernelException extends Exception
+{
+
+}


### PR DESCRIPTION
Replace namespace source with root `composer.json` `"autoload"` data and `vendor/composer/installed.json` `"packages"` data

Root `composer.json` includes `"autoload-dev"` conditionally on `ENVIRONMENT` value