### PR TITLE
Add test helpers

### DIFF
--- a/src/Testing/Http/TestResponse.php
+++ b/src/Testing/Http/TestResponse.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Testing\Http;
+
+use PHPUnit\Framework\Assert;
+use Tempest\Http\Response;
+use Tempest\Http\Status;
+
+final readonly class TestResponse implements Response
+{
+    public function __construct(private Response $response)
+    {
+    }
+
+    public function getStatus(): Status
+    {
+        return $this->response->getStatus();
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->response->getHeaders();
+    }
+
+    public function getBody(): string
+    {
+        return $this->response->getBody();
+    }
+
+    public function body(string $body): self
+    {
+        $this->response->body($body);
+
+        return $this;
+    }
+
+    public function header(string $key, string $value): self
+    {
+        $this->header($key, $value);
+
+        return $this;
+    }
+
+    public function ok(): self
+    {
+        $this->response->ok();
+
+        return $this;
+    }
+
+    public function notFound(): self
+    {
+        $this->response->notFound();
+
+        return $this;
+    }
+
+    public function redirect(string $to): self
+    {
+        $this->response->redirect($to);
+
+        return $this;
+    }
+
+    public function status(Status $status): self
+    {
+        $this->response->status($status);
+
+        return $this;
+    }
+
+    public function assertOk(): self
+    {
+        return $this->assertStatus(Status::OK);
+    }
+
+    public function assertNotFound(): self
+    {
+        return $this->assertStatus(Status::NOT_FOUND);
+    }
+
+    public function assertStatus(Status $expected): self
+    {
+        Assert::assertSame(
+            expected: $expected,
+            actual: $this->response->getStatus(),
+            message: sprintf(
+                'Failed asserting status [%s] matched expected status of [%s].',
+                $expected->value,
+                $this->response->getStatus()->value,
+            )
+        );
+
+        return $this;
+    }
+}

--- a/src/Testing/Http/TestResponseSender.php
+++ b/src/Testing/Http/TestResponseSender.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Testing\Http;
+
+use Tempest\Container\InitializedBy;
+use Tempest\Http\Response;
+use Tempest\Http\ResponseSender;
+
+#[InitializedBy(TestResponseSenderInitializer::class)]
+final class TestResponseSender implements ResponseSender
+{
+    public function send(Response $response): Response
+    {
+        return new TestResponse($response);
+    }
+}

--- a/src/Testing/Http/TestResponseSenderInitializer.php
+++ b/src/Testing/Http/TestResponseSenderInitializer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Testing\Http;
+
+use Tempest\Container\CanInitialize;
+use Tempest\Container\Container;
+use Tempest\Http\Response;
+use Tempest\Http\ResponseSender;
+
+final class TestResponseSenderInitializer implements CanInitialize
+{
+    public function canInitialize(string $className): bool
+    {
+        return in_array($className, [Response::class, TestResponse::class]);
+    }
+
+    public function initialize(string $className, Container $container): object
+    {
+        $responseSender = new TestResponseSender();
+
+        $container->singleton(ResponseSender::class, fn () => $responseSender);
+
+        return $responseSender;
+    }
+}

--- a/src/Testing/Http/TestsHttpRequests.php
+++ b/src/Testing/Http/TestsHttpRequests.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Testing\Http;
+
+use Tempest\Http\GenericRequest;
+use Tempest\Http\Method;
+use Tempest\Http\Request;
+use Tempest\Http\ResponseSender;
+use Tempest\Http\Router;
+
+trait TestsHttpRequests
+{
+    protected function get(string $path): TestResponse
+    {
+        return $this->performRequest(
+            new GenericRequest(
+                method: Method::GET,
+                uri: $path,
+                body: []
+            )
+        );
+    }
+
+    protected function post(string $path): TestResponse
+    {
+        return $this->performRequest(
+            new GenericRequest(
+                method: Method::POST,
+                uri: $path,
+                body: []
+            )
+        );
+    }
+
+    private function performRequest(Request $request): TestResponse
+    {
+        // Register our test request in the container.
+        $this->container->singleton(Request::class, fn () => $request);
+        $this->container->singleton(ResponseSender::class, fn () => new TestResponseSender());
+
+        $router = $this->container->get(Router::class);
+        $responseSender = $this->container->get(ResponseSender::class);
+
+        return $responseSender->send(
+            $router->dispatch($request)
+        );
+    }
+}

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Testing;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+use Tempest\AppConfig;
+use Tempest\Application\Kernel;
+use Tempest\Container\Container;
+use Tempest\Testing\Http\TestsHttpRequests;
+
+abstract class TestCase extends BaseTestCase
+{
+    use TestsHttpRequests;
+
+    private Kernel $kernel;
+
+    private Container $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->kernel = new Kernel(__DIR__ . '/../../', new AppConfig(
+            discoveryCache: true,
+        ));
+
+        $this->container = $this->kernel->init();
+    }
+}

--- a/tests/TestingTest.php
+++ b/tests/TestingTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest;
+
+class TestingTest extends \Tempest\Testing\TestCase
+{
+    public function test_testing()
+    {
+        $this
+            ->get('books')
+            ->assertNotFound();
+
+        $this
+            ->get('/')
+            ->assertOk();
+    }
+}


### PR DESCRIPTION
@brendt Not sure if you have any input here. I am somewhat following Laravel's syntax for testing for now (there may be some things we change along the way).

A few things that I am running into:

1. We do not currently have a way to set priority for an initializer, right? What's the best way to override a default implementation?
2. Due to the application self-processing the request, we basically cut it out entirely in the test helper. Not sure if we are just fine with that or if you have other thoughts here.