### PR TITLE
Added pest architecture test

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run PHPStan
         run: vendor/bin/phpstan --error-format=github
 
-  phpunit:
+  pest:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -86,7 +86,7 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/phpunit --coverage-clover build/reports/clover.xml
+        run: vendor/bin/pest --coverage-clover build/reports/clover.xml --compact
 
       - name: Upload coverage results to Coveralls
         env:

--- a/.github/workflows/quality-control.yml
+++ b/.github/workflows/quality-control.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run PHPStan
         run: vendor/bin/phpstan --error-format=github
 
-  phpunit:
+  pest:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -96,7 +96,7 @@ jobs:
           php ./tempest discovery:status
 
       - name: Execute tests
-        run: vendor/bin/phpunit --coverage-clover build/reports/clover.xml
+        run: vendor/bin/pest --coverage-clover build/reports/clover.xml --compact
 
       - name: Upload coverage results to Coveralls
         env:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "phpunit/phpunit": "^10.2",
         "larapack/dd": "^1.1",
         "phpstan/phpstan": "^1.10.0",
-        "friendsofphp/php-cs-fixer": "^3.21"
+        "friendsofphp/php-cs-fixer": "^3.21",
+        "pestphp/pest": "^2.34"
     },
     "bin": [
         "tempest"
@@ -34,15 +35,20 @@
         }
     },
     "scripts": {
-        "phpunit": "vendor/bin/phpunit --display-warnings --display-skipped --display-deprecations --display-errors --display-notices",
-        "coverage": "vendor/bin/phpunit --coverage-html build/reports/html --coverage-clover build/reports/clover.xml",
+        "pest": "vendor/bin/pest --display-warnings --display-skipped --display-deprecations --display-errors --display-notices --compact",
+        "coverage": "vendor/bin/pest --coverage-html build/reports/html --coverage-clover build/reports/clover.xml --compact",
         "csfixer": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
         "phpstan": "vendor/bin/phpstan analyse src tests app",
         "qa": [
             "composer csfixer",
             "composer phpstan",
-            "composer phpunit"
+            "composer pest"
         ]
     },
-    "license": "MIT"
+    "license": "MIT",
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    }
 }

--- a/tests/ArchitectureTest.php
+++ b/tests/ArchitectureTest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+arch('src')
+    ->expect('Tempest\Validation\Rules')
+    ->toHaveAttribute(Attribute::class)
+    ->toImplement(Tempest\Validation\Rule::class)
+    ->toBeFinal()
+    ->toBeReadonly();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+// uses(Tests\TestCase::class)->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+//expect()->extend('toBeOne', function () {
+//    return $this->toBe(1);
+//});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+//function something()
+//{
+//    // ..
+//}


### PR DESCRIPTION
As discussed in https://github.com/tempestphp/tempest-framework/issues/116, I've added an example of how architecture tests could be implemented with Pest.

I've purposely left it failing to showcase that it's working. `Lowercase`, `Uppercase` and `DoesNotEndWith` rules are not `final` and `readonly` like others are.