### PR TITLE
Response objects

### DIFF
--- a/src/Http/Responses/CreatedResponse.php
+++ b/src/Http/Responses/CreatedResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Responses;
+
+use Tempest\Http\IsResponse;
+use Tempest\Http\Response;
+use Tempest\Http\Status;
+
+final class CreatedResponse implements Response
+{
+    use IsResponse;
+
+    public function __construct(
+        private string $body = '',
+        private array $headers = [],
+    )
+    {
+        $this->status = Status::CREATED;
+    }
+}

--- a/src/Tempest.php
+++ b/src/Tempest.php
@@ -25,7 +25,7 @@ final readonly class Tempest
             $dotenv = Dotenv::createUnsafeImmutable($root);
             $dotenv->load();
         } catch (InvalidPathException) {
-            // Do nothing, only avoid the exception making the app crash
+            die("Missing .env file in {$root}" . PHP_EOL);
         }
 
         $appConfig = $createAppConfig();

--- a/src/Tempest.php
+++ b/src/Tempest.php
@@ -25,7 +25,7 @@ final readonly class Tempest
             $dotenv = Dotenv::createUnsafeImmutable($root);
             $dotenv->load();
         } catch (InvalidPathException) {
-            die("Missing .env file in {$root}" . PHP_EOL);
+            // Do nothing, only avoid the exception making the app crash
         }
 
         $appConfig = $createAppConfig();

--- a/tests/Http/Responses/CreatedResponseTest.php
+++ b/tests/Http/Responses/CreatedResponseTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Http\Responses;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Http\Responses\CreatedResponse;
+use Tempest\Http\Status;
+
+class CreatedResponseTest extends TestCase
+{
+    public function test_created_response()
+    {
+        $response = new CreatedResponse(json_encode(['foo' => 'bar']));
+
+        $this->assertSame(Status::CREATED, $response->getStatus());
+        $this->assertSame([], $response->getHeaders());
+        $this->assertSame('{"foo":"bar"}', $response->getBody());
+        $this->assertNotSame(Status::OK, $response->getStatus());
+    }
+}


### PR DESCRIPTION
Hi!

Regarding [Issue #39](https://github.com/tempestphp/tempest-framework/issues/39) this PR adds:

- Adds preconfigured CreatedResponse and it's test.

Let  me know if something must to be changed.

Thanks!