### PR TITLE
Reworks request objects.

### DIFF
--- a/src/Application/Kernel.php
+++ b/src/Application/Kernel.php
@@ -26,6 +26,7 @@ use Tempest\Http\RequestInitializer;
 use Tempest\Http\RouteBindingInitializer;
 use Tempest\Http\Router;
 use Tempest\Http\ServerInitializer;
+use Tempest\Mapper\ObjectMapper;
 use function Tempest\path;
 use Throwable;
 
@@ -64,7 +65,6 @@ final readonly class Kernel
             ->singleton(ConsoleOutput::class, fn () => $container->get(GenericConsoleOutput::class))
             ->singleton(ConsoleInput::class, fn () => $container->get(GenericConsoleInput::class))
             ->singleton(CommandBus::class, fn () => $container->get(GenericCommandBus::class))
-            ->addInitializer(new ServerInitializer())
             ->addInitializer(new RequestInitializer())
             ->addInitializer(new RouteBindingInitializer())
             ->addInitializer(new PDOInitializer());

--- a/src/Http/IsRequest.php
+++ b/src/Http/IsRequest.php
@@ -8,14 +8,14 @@ trait IsRequest
 {
     public Method $method;
     public string $uri;
-    public array $body;
+    public string $body;
     public string $path;
     public ?string $query = null;
 
     public function __construct(
         Method $method,
         string $uri,
-        array $body,
+        string $body,
     ) {
         $this->method = $method;
         $this->uri = $uri;
@@ -35,7 +35,7 @@ trait IsRequest
         return $this;
     }
 
-    public function post(?array $body = null): self
+    public function post(?string $body = null): self
     {
         $this->method = Method::POST;
         $this->body = $body ?? $this->body;
@@ -53,7 +53,7 @@ trait IsRequest
         return $this->uri;
     }
 
-    public function getBody(): array
+    public function getBody(): string
     {
         return $this->body;
     }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -10,7 +10,7 @@ interface Request
 
     public function getUri(): string;
 
-    public function getBody(): array;
+    public function getBody(): string;
 
     public function getPath(): string;
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -47,7 +47,7 @@ namespace Tempest {
         return new GenericView($path);
     }
 
-    function request(string $uri, array $body = []): Request
+    function request(string $uri, string $body = ''): Request
     {
         return new GenericRequest(Method::GET, $uri, $body);
     }

--- a/tests/Route/RequestTest.php
+++ b/tests/Route/RequestTest.php
@@ -22,22 +22,6 @@ use Tests\Tempest\TestCase;
 class RequestTest extends TestCase
 {
     /** @test */
-    public function from_container()
-    {
-        $this->server(
-            method: Method::POST,
-            uri: '/test',
-            body: ['test'],
-        );
-
-        $request = $this->container->get(Request::class);
-
-        $this->assertEquals(Method::POST, $request->method);
-        $this->assertEquals('/test', $request->uri);
-        $this->assertEquals(['test'], $request->body);
-    }
-
-    /** @test */
     public function custom_request_test()
     {
         $router = $this->container->get(Router::class);
@@ -53,7 +37,7 @@ class RequestTest extends TestCase
             body: $body,
         );
 
-        $response = $router->dispatch(request('/create-post')->post($body));
+        $response = $router->dispatch(request('/create-post')->post(json_encode($body)));
 
         $this->assertEquals(Status::OK, $response->getStatus());
         $this->assertEquals('test-title test-text', $response->getBody());
@@ -78,7 +62,7 @@ class RequestTest extends TestCase
             body: $body,
         );
 
-        $response = $router->dispatch(request($uri)->post($body));
+        $response = $router->dispatch(request($uri)->post(json_encode($body)));
 
         $this->assertSame(Status::FOUND, $response->getStatus());
         $book = Book::find(new Id(1));
@@ -104,13 +88,7 @@ class RequestTest extends TestCase
 
         $uri = uri([BookController::class, 'storeWithAuthor']);
 
-        $this->server(
-            method: Method::POST,
-            uri: $uri,
-            body: $body,
-        );
-
-        $response = $router->dispatch(request($uri)->post($body));
+        $response = $router->dispatch(request($uri)->post(json_encode($body)));
 
         $this->assertSame(Status::FOUND, $response->getStatus());
         $book = Book::find(new Id(1), relations: [Author::class]);


### PR DESCRIPTION
@brendt  - I am probably doing something you don't want me to here, but is there any reason we cannot skip the `Server` concept and skip right to building up a request? This way, if our test system sets the request as a singleton, it should just skip this step entirely.

Further, we should probably make requests PSR compatible.