### PR TITLE
#59 Refactor Kernel to prepare for cache implementation

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,12 +1,9 @@
 <?php
 
-use Tempest\AppConfig;
-use Tempest\Application\Environment;
 use Tempest\Tempest;
-use function Tempest\env;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-Tempest::boot(__DIR__ . '/../')->http()->run();
+Tempest::boot(dirname(__DIR__))->http()->run();
 
 exit;

--- a/src/Bootstraps/Bootstrap.php
+++ b/src/Bootstraps/Bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tempest\Bootstraps;
+
+interface Bootstrap
+{
+    public function boot(): void;
+}

--- a/src/Bootstraps/BootstrapException.php
+++ b/src/Bootstraps/BootstrapException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tempest\Bootstraps;
+
+use Exception;
+
+class BootstrapException extends Exception
+{
+
+}

--- a/src/Bootstraps/ConfigBootstrap.php
+++ b/src/Bootstraps/ConfigBootstrap.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tempest\Bootstraps;
+
+use Tempest\AppConfig;
+use Tempest\Container\Container;
+use function Tempest\path;
+
+final readonly class ConfigBootstrap implements Bootstrap
+{
+    public function __construct(
+        private Container $container
+    ) {}
+
+    #[\Override]
+    public function boot(): void
+    {
+        // Scan for package config files
+        foreach ($this->container->get(AppConfig::class)->discoveryLocations as $package) {
+            $configFiles = glob(path($package->path, 'Config/**.php'));
+
+            foreach ($configFiles as $configFile) {
+                $configFile = require $configFile;
+
+                $this->container->config($configFile);
+            }
+        }
+    }
+}

--- a/src/Bootstraps/DiscoveryBootstrap.php
+++ b/src/Bootstraps/DiscoveryBootstrap.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tempest\Bootstraps;
+
+use Tempest\AppConfig;
+use Tempest\Application\Kernel;
+use Tempest\Container\Container;
+use Tempest\Discovery\DiscoveryLocation;
+use function Tempest\path;
+
+final readonly class DiscoveryBootstrap implements Bootstrap
+{
+    private string $root;
+
+    public function __construct(
+        private Container $container
+    ) {
+        $this->root = $this->container->get(Kernel::class)->root;
+    }
+
+    #[\Override]
+    public function boot(): void
+    {
+        $discoveredLocations = [
+            ...$this->discoverTempestNamespaces(),
+            ...$this->discoverInstalledPackageLocations(),
+        ];
+
+        $this->addDiscoveryLocations($discoveredLocations);
+    }
+
+    private function discoverInstalledPackageLocations(): array
+    {
+        $composerPath = path($this->root, 'vendor/composer');
+        $installedPath = path($composerPath, 'installed.json');
+
+        $installedJson = $this->loadJsonFile($installedPath);
+        $packages = $installedJson['packages'] ?? [];
+        $discoveredLocations = [];
+        foreach ($packages as $package) {
+            $packagePath = path($composerPath, $package['install-path']);
+
+            $requiresTempest = isset($package['require']['tempest/framework']);
+            $hasPsr4Namespaces = isset($package['autoload']['psr-4']);
+            if ($requiresTempest && $hasPsr4Namespaces) {
+                foreach ($package['autoload']['psr-4'] as $namespace => $namespacePath) {
+                    $namespacePath = path($packagePath, $namespacePath);
+                    $discoveredLocations[] = [
+                        'namespace' => $namespace,
+                        'path' => $namespacePath,
+                    ];
+                }
+            }
+        }
+
+        return $discoveredLocations;
+    }
+
+    private function discoverTempestNamespaces(): array
+    {
+        $composer = $this->loadJsonFile(path($this->root, 'composer.json'));
+
+        $namespaceMap = $composer['autoload']['psr-4'] ?? [];
+        $discoveredLocations = [];
+        foreach ($namespaceMap as $namespace => $path) {
+            $path = path($this->root, $path);
+            $discoveredLocations[] = [
+                'namespace' => $namespace,
+                'path' => $path,
+            ];
+        }
+
+        return $discoveredLocations;
+    }
+
+    private function addDiscoveryLocations(array $discoveredLocations): void
+    {
+        foreach ($discoveredLocations as &$location) {
+            $location = new DiscoveryLocation(...$location);
+        }
+        unset($location);
+
+        $this->container->get(AppConfig::class)->discoveryLocations = $discoveredLocations;
+    }
+
+    private function loadJsonFile(string $path): array
+    {
+        if (!is_file($path)) {
+            $relativePath = str_replace($this->root, '.', $path);
+
+            throw new BootstrapException(sprintf('Could not locate %s, try running "composer install"', $relativePath));
+        }
+
+        return json_decode(file_get_contents($path), true);
+    }
+}

--- a/src/Container/GenericContainer.php
+++ b/src/Container/GenericContainer.php
@@ -9,10 +9,10 @@ use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionParameter;
 use ReflectionUnionType;
-use function Tempest\attribute;
 use Tempest\Container\Exceptions\ContainerException;
 use Tempest\Container\Exceptions\InvalidInitializerException;
 use Throwable;
+use function Tempest\attribute;
 
 final class GenericContainer implements Container
 {
@@ -22,7 +22,7 @@ final class GenericContainer implements Container
 
     private array $singletons = [];
 
-    /** @var CanInitialize[] */
+    /** @var Initializer|CanInitialize[] */
     private array $initializers = [];
 
     public function register(string $className, callable $definition): self
@@ -173,7 +173,8 @@ final class GenericContainer implements Container
 
         // If there isn't a constructor, don't waste time
         // trying to build it.
-        if ($reflectionClass->getConstructor() === null) {
+        $constructor = $reflectionClass->getConstructor();
+        if ($constructor === null) {
             return $reflectionClass->newInstanceWithoutConstructor();
         }
 
@@ -181,7 +182,7 @@ final class GenericContainer implements Container
         // and resolving them.
         $dependencies = [];
 
-        foreach ($reflectionClass->getConstructor()->getParameters() as $parameter) {
+        foreach ($constructor->getParameters() as $parameter) {
             $dependencies[] = $this->autowireDependency($parameter, $log);
         }
 


### PR DESCRIPTION
## CLOSING IN FAVOR OF #176


* Remove `Tempest::__construct()` `$appConfig` parameter - available from Container object
* Add `Kernel::__construct()` `$bootstraps` promoted property
* Rename `Kernel::initContainer()`
* Loop `$bootstraps` to register them in the Container as singletons
* Execute Bootstraps `boot()` in `Kernel::init()`
* Add Bootstrap classes for Discovery and Config
* Set Bootstraps as third Kernel constructor argument
* Fixed some accessors to AppConfig from the `$kernel` object