### PR TITLE
Refactor Kernel to extract Bootstraps

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,9 +1,6 @@
 <?php
 
-use Tempest\AppConfig;
-use Tempest\Application\Environment;
 use Tempest\Tempest;
-use function Tempest\env;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 

--- a/src/Application/Kernel.php
+++ b/src/Application/Kernel.php
@@ -9,39 +9,38 @@ use RecursiveIteratorIterator;
 use ReflectionClass;
 use SplFileInfo;
 use Tempest\AppConfig;
-use Tempest\Application\Exceptions\KernelException;
 use Tempest\Container\Container;
 use Tempest\Container\GenericContainer;
 use Tempest\Database\PDOInitializer;
 use Tempest\Discovery\Discovery;
-use Tempest\Discovery\DiscoveryLocation;
 use Tempest\Http\RequestInitializer;
 use Tempest\Http\RouteBindingInitializer;
-use function Tempest\path;
 use Throwable;
 
 final readonly class Kernel
 {
     public function __construct(
-        private string $root,
+        public string $root,
         private AppConfig $appConfig,
+        private array $bootstraps = [],
     ) {
     }
 
     public function init(): Container
     {
-        $container = $this->initContainer();
+        $container = $this->createContainer();
+        $container->config($this->appConfig);
 
-        $this->initDiscoveryLocations();
-
-        $this->initConfig($container);
+        foreach ($this->bootstraps as $bootstrap) {
+            $container->get($bootstrap)->boot();
+        }
 
         $this->initDiscovery($container);
 
         return $container;
     }
 
-    private function initContainer(): Container
+    private function createContainer(): Container
     {
         $container = new GenericContainer();
 
@@ -54,30 +53,12 @@ final readonly class Kernel
             ->addInitializer(new RouteBindingInitializer())
             ->addInitializer(new PDOInitializer());
 
-        return $container;
-    }
-
-    private function initDiscoveryLocations(): void
-    {
-        $this->discoverTempestNamespaces();
-        $this->discoverInstalledPackageLocations();
-    }
-
-    private function initConfig(Container $container): void
-    {
-        // Register AppConfig
-        $container->config($this->appConfig);
-
-        // Scan for package config files
-        foreach ($this->appConfig->discoveryLocations as $package) {
-            $configFiles = glob(path($package->path, 'Config/**.php'));
-
-            foreach ($configFiles as $configFile) {
-                $configFile = require $configFile;
-
-                $container->config($configFile);
-            }
+        /** @var class-string<\Tempest\Bootstraps\Bootstrap> $bootstrap */
+        foreach ($this->bootstraps as $bootstrap) {
+            $container->singleton($bootstrap, fn () => new $bootstrap($container));
         }
+
+        return $container;
     }
 
     private function initDiscovery(Container $container): void
@@ -132,56 +113,5 @@ final readonly class Kernel
 
             $discovery->storeCache();
         }
-    }
-
-    private function discoverInstalledPackageLocations(): void
-    {
-        $composerPath = path($this->root, 'vendor/composer');
-        $installedPath = path($composerPath, 'installed.json');
-
-        $installedJson = $this->loadJsonFile($installedPath);
-        $packages = $installedJson['packages'] ?? [];
-        foreach ($packages as $package) {
-            $packagePath = path($composerPath, $package['install-path']);
-
-            $requiresTempest = isset($package['require']['tempest/framework']);
-            $hasPsr4Namespaces = isset($package['autoload']['psr-4']);
-            if ($requiresTempest && $hasPsr4Namespaces) {
-                foreach ($package['autoload']['psr-4'] as $namespace => $namespacePath) {
-                    $namespacePath = path($packagePath, $namespacePath);
-                    $this->addDiscoveryLocation($namespace, $namespacePath);
-                }
-            }
-        }
-    }
-
-    private function discoverTempestNamespaces(): void
-    {
-        $composer = $this->loadJsonFile(path($this->root, 'composer.json'));
-
-        $namespaceMap = $composer['autoload']['psr-4'] ?? [];
-        foreach ($namespaceMap as $namespace => $path) {
-            $path = path($this->root, $path);
-            $this->addDiscoveryLocation($namespace, $path);
-        }
-    }
-
-    private function addDiscoveryLocation(string $namespace, string $path): void
-    {
-        $this->appConfig->discoveryLocations[] = new DiscoveryLocation(
-            namespace: $namespace,
-            path     : $path,
-        );
-    }
-
-    private function loadJsonFile(string $path): array
-    {
-        if (! is_file($path)) {
-            $relativePath = str_replace($this->root, './', $path);
-
-            throw new KernelException(sprintf('Could not locate %s, try running "composer install"', $relativePath));
-        }
-
-        return json_decode(file_get_contents($path), true);
     }
 }

--- a/src/Application/Kernel.php
+++ b/src/Application/Kernel.php
@@ -10,7 +10,7 @@ use ReflectionClass;
 use SplFileInfo;
 use Tempest\AppConfig;
 use Tempest\Bootstraps\ConfigBootstrap;
-use Tempest\Bootstraps\DiscoveryBootstrap;
+use Tempest\Bootstraps\DiscoveryLocationBootstrap;
 use Tempest\Container\Container;
 use Tempest\Container\GenericContainer;
 use Tempest\Database\PDOInitializer;
@@ -32,7 +32,7 @@ final readonly class Kernel
         $container = $this->createContainer();
 
         $bootstraps = [
-            DiscoveryBootstrap::class,
+            DiscoveryLocationBootstrap::class,
             ConfigBootstrap::class,
         ];
 

--- a/src/Application/Kernel.php
+++ b/src/Application/Kernel.php
@@ -31,6 +31,7 @@ final readonly class Kernel
         $container = $this->createContainer();
         $container->config($this->appConfig);
 
+        /** @var class-string<\Tempest\Bootstraps\Bootstrap> $bootstrap */
         foreach ($this->bootstraps as $bootstrap) {
             $container->get($bootstrap)->boot();
         }
@@ -47,16 +48,11 @@ final readonly class Kernel
         GenericContainer::setInstance($container);
 
         $container
-            ->singleton(Kernel::class, fn () => $this)
+            ->singleton(__CLASS__, fn () => $this)
             ->singleton(Container::class, fn () => $container)
             ->addInitializer(new RequestInitializer())
             ->addInitializer(new RouteBindingInitializer())
             ->addInitializer(new PDOInitializer());
-
-        /** @var class-string<\Tempest\Bootstraps\Bootstrap> $bootstrap */
-        foreach ($this->bootstraps as $bootstrap) {
-            $container->singleton($bootstrap, fn () => new $bootstrap($container));
-        }
 
         return $container;
     }

--- a/src/Bootstraps/Bootstrap.php
+++ b/src/Bootstraps/Bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Bootstraps;
+
+interface Bootstrap
+{
+    public function boot(): void;
+}

--- a/src/Bootstraps/BootstrapException.php
+++ b/src/Bootstraps/BootstrapException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Bootstraps;
+
+use Exception;
+
+class BootstrapException extends Exception
+{
+}

--- a/src/Bootstraps/ConfigBootstrap.php
+++ b/src/Bootstraps/ConfigBootstrap.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Bootstraps;
+
+use Tempest\AppConfig;
+use Tempest\Container\Container;
+use function Tempest\path;
+
+final readonly class ConfigBootstrap implements Bootstrap
+{
+    public function __construct(
+        private Container $container
+    ) {
+    }
+
+    #[\Override]
+    public function boot(): void
+    {
+        // Scan for package config files
+        foreach ($this->container->get(AppConfig::class)->discoveryLocations as $package) {
+            $configFiles = glob(path($package->path, 'Config/**.php'));
+
+            foreach ($configFiles as $configFile) {
+                $configFile = require $configFile;
+
+                $this->container->config($configFile);
+            }
+        }
+    }
+}

--- a/src/Bootstraps/ConfigBootstrap.php
+++ b/src/Bootstraps/ConfigBootstrap.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Bootstraps;
 
+use Override;
 use Tempest\AppConfig;
 use Tempest\Container\Container;
 use function Tempest\path;
@@ -15,7 +16,7 @@ final readonly class ConfigBootstrap implements Bootstrap
     ) {
     }
 
-    #[\Override]
+    #[Override]
     public function boot(): void
     {
         // Scan for package config files

--- a/src/Bootstraps/ConfigBootstrap.php
+++ b/src/Bootstraps/ConfigBootstrap.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tempest\Bootstraps;
 
-use Override;
 use Tempest\AppConfig;
 use Tempest\Container\Container;
 use function Tempest\path;
@@ -12,16 +11,15 @@ use function Tempest\path;
 final readonly class ConfigBootstrap implements Bootstrap
 {
     public function __construct(
-        private Container $container
+        private Container $container,
     ) {
     }
 
-    #[Override]
     public function boot(): void
     {
-        // Scan for package config files
-        foreach ($this->container->get(AppConfig::class)->discoveryLocations as $package) {
-            $configFiles = glob(path($package->path, 'Config/**.php'));
+        // Scan for config files in all discovery locations
+        foreach ($this->container->get(AppConfig::class)->discoveryLocations as $discoveryLocation) {
+            $configFiles = glob(path($discoveryLocation->path, 'Config/**.php'));
 
             foreach ($configFiles as $configFile) {
                 $configFile = require $configFile;

--- a/src/Bootstraps/DiscoveryBootstrap.php
+++ b/src/Bootstraps/DiscoveryBootstrap.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Bootstraps;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use SplFileInfo;
+use Tempest\AppConfig;
+use Tempest\Container\Container;
+use Tempest\Discovery\Discovery;
+use Throwable;
+
+final readonly class DiscoveryBootstrap implements Bootstrap
+{
+    public function __construct(
+        private AppConfig $appConfig,
+        private Container $container,
+    ) {
+    }
+
+    public function boot(): void
+    {
+        reset($this->appConfig->discoveryClasses);
+
+        while ($discoveryClass = current($this->appConfig->discoveryClasses)) {
+            /** @var Discovery $discovery */
+            $discovery = $this->container->get($discoveryClass);
+
+            if ($this->appConfig->discoveryCache && $discovery->hasCache()) {
+                $discovery->restoreCache($this->container);
+                next($this->appConfig->discoveryClasses);
+
+                continue;
+            }
+
+            foreach ($this->appConfig->discoveryLocations as $discoveryLocation) {
+                $directories = new RecursiveDirectoryIterator($discoveryLocation->path);
+                $files = new RecursiveIteratorIterator($directories);
+
+                /** @var SplFileInfo $file */
+                foreach ($files as $file) {
+                    $fileName = $file->getFilename();
+
+                    if (
+                        $fileName === ''
+                        || $fileName === '.'
+                        || $fileName === '..'
+                        || ucfirst($fileName) !== $fileName
+                    ) {
+                        continue;
+                    }
+
+                    $className = str_replace(
+                        [$discoveryLocation->path, '/', '.php', '\\\\'],
+                        [$discoveryLocation->namespace, '\\', '', '\\'],
+                        $file->getPathname(),
+                    );
+
+                    try {
+                        $reflection = new ReflectionClass($className);
+                    } catch (Throwable) {
+                        continue;
+                    }
+
+                    $discovery->discover($reflection);
+                }
+            }
+
+            next($this->appConfig->discoveryClasses);
+
+            $discovery->storeCache();
+        }
+    }
+}

--- a/src/Bootstraps/DiscoveryBootstrap.php
+++ b/src/Bootstraps/DiscoveryBootstrap.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Bootstraps;
 
+use Override;
 use Tempest\AppConfig;
 use Tempest\Application\Kernel;
 use Tempest\Container\Container;
@@ -20,7 +21,7 @@ final readonly class DiscoveryBootstrap implements Bootstrap
         $this->root = $this->container->get(Kernel::class)->root;
     }
 
-    #[\Override]
+    #[Override]
     public function boot(): void
     {
         $discoveredLocations = [

--- a/src/Bootstraps/DiscoveryBootstrap.php
+++ b/src/Bootstraps/DiscoveryBootstrap.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Bootstraps;
+
+use Tempest\AppConfig;
+use Tempest\Application\Kernel;
+use Tempest\Container\Container;
+use Tempest\Discovery\DiscoveryLocation;
+use function Tempest\path;
+
+final readonly class DiscoveryBootstrap implements Bootstrap
+{
+    private string $root;
+
+    public function __construct(
+        private Container $container
+    ) {
+        $this->root = $this->container->get(Kernel::class)->root;
+    }
+
+    #[\Override]
+    public function boot(): void
+    {
+        $discoveredLocations = [
+            ...$this->discoverTempestNamespaces(),
+            ...$this->discoverInstalledPackageLocations(),
+        ];
+
+        $this->addDiscoveryLocations($discoveredLocations);
+    }
+
+    private function discoverInstalledPackageLocations(): array
+    {
+        $composerPath = path($this->root, 'vendor/composer');
+        $installedPath = path($composerPath, 'installed.json');
+
+        $installedJson = $this->loadJsonFile($installedPath);
+        $packages = $installedJson['packages'] ?? [];
+        $discoveredLocations = [];
+        foreach ($packages as $package) {
+            $packagePath = path($composerPath, $package['install-path']);
+
+            $requiresTempest = isset($package['require']['tempest/framework']);
+            $hasPsr4Namespaces = isset($package['autoload']['psr-4']);
+            if ($requiresTempest && $hasPsr4Namespaces) {
+                foreach ($package['autoload']['psr-4'] as $namespace => $namespacePath) {
+                    $namespacePath = path($packagePath, $namespacePath);
+                    $discoveredLocations[] = [
+                        'namespace' => $namespace,
+                        'path' => $namespacePath,
+                    ];
+                }
+            }
+        }
+
+        return $discoveredLocations;
+    }
+
+    private function discoverTempestNamespaces(): array
+    {
+        $composer = $this->loadJsonFile(path($this->root, 'composer.json'));
+
+        $namespaceMap = $composer['autoload']['psr-4'] ?? [];
+        $discoveredLocations = [];
+        foreach ($namespaceMap as $namespace => $path) {
+            $path = path($this->root, $path);
+            $discoveredLocations[] = [
+                'namespace' => $namespace,
+                'path' => $path,
+            ];
+        }
+
+        return $discoveredLocations;
+    }
+
+    private function addDiscoveryLocations(array $discoveredLocations): void
+    {
+        foreach ($discoveredLocations as &$location) {
+            $location = new DiscoveryLocation(...$location);
+        }
+        unset($location);
+
+        $this->container->get(AppConfig::class)->discoveryLocations = $discoveredLocations;
+    }
+
+    private function loadJsonFile(string $path): array
+    {
+        if (! is_file($path)) {
+            $relativePath = str_replace($this->root, '.', $path);
+
+            throw new BootstrapException(sprintf('Could not locate %s, try running "composer install"', $relativePath));
+        }
+
+        return json_decode(file_get_contents($path), true);
+    }
+}

--- a/src/Bootstraps/DiscoveryLocationBootstrap.php
+++ b/src/Bootstraps/DiscoveryLocationBootstrap.php
@@ -10,7 +10,7 @@ use Tempest\Container\Container;
 use Tempest\Discovery\DiscoveryLocation;
 use function Tempest\path;
 
-final readonly class DiscoveryBootstrap implements Bootstrap
+final readonly class DiscoveryLocationBootstrap implements Bootstrap
 {
     private string $root;
 

--- a/src/Tempest.php
+++ b/src/Tempest.php
@@ -22,17 +22,16 @@ final readonly class Tempest
     public static function boot(string $root): self
     {
         $dotenv = Dotenv::createUnsafeImmutable($root);
-        $dotenv->safeLoad();
 
-        $createAppConfig = static fn (): AppConfig => new AppConfig(
-            environment: Environment::from(env('ENVIRONMENT', Environment::LOCAL->value)),
-            discoveryCache: env('DISCOVERY_CACHE', false),
-            enableExceptionHandling: env('EXCEPTION_HANDLING', false),
-        );
+        $dotenv->safeLoad();
 
         $kernel = new Kernel(
             root: $root,
-            appConfig: $createAppConfig(),
+            appConfig: new AppConfig(
+                environment: Environment::from(env('ENVIRONMENT', Environment::LOCAL->value)),
+                discoveryCache: env('DISCOVERY_CACHE', false),
+                enableExceptionHandling: env('EXCEPTION_HANDLING', false),
+            ),
         );
 
         return new self(

--- a/src/Tempest.php
+++ b/src/Tempest.php
@@ -10,8 +10,6 @@ use Tempest\Application\ConsoleApplication;
 use Tempest\Application\Environment;
 use Tempest\Application\HttpApplication;
 use Tempest\Application\Kernel;
-use Tempest\Bootstraps\ConfigBootstrap;
-use Tempest\Bootstraps\DiscoveryBootstrap;
 use Tempest\Exceptions\ExceptionHandler;
 
 final readonly class Tempest
@@ -33,12 +31,8 @@ final readonly class Tempest
         );
 
         $kernel = new Kernel(
-            $root,
-            $createAppConfig(),
-            [
-                DiscoveryBootstrap::class,
-                ConfigBootstrap::class,
-            ],
+            root: $root,
+            appConfig: $createAppConfig(),
         );
 
         return new self(


### PR DESCRIPTION
* Remove `Tempest::__construct()` `$appConfig` parameter - available from Container object
* Add `Kernel::__construct()` `$bootstraps` promoted property
* Rename `Kernel::initContainer()`
* Add Bootstrap classes for Discovery and Config
* Loop `$bootstraps` to register them in the Container as singletons
* Execute Bootstraps `boot()` in `Kernel::init()`
* Set Bootstraps as third Kernel constructor argument
* Fixed some accessors to AppConfig from the `$kernel` object