### PR TITLE
Added additional architecture tests

### DIFF
--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -73,9 +73,9 @@ class ArchitectureTest
     {
         return PHPat::rule()
             ->classes(Selector::AND(
-				Selector::inNamespace('Tempest'),
-				Selector::NOT(Selector::isInterface()),
-			))
+                Selector::inNamespace('Tempest'),
+                Selector::NOT(Selector::isInterface()),
+            ))
             ->shouldBeFinal();
     }
 
@@ -85,8 +85,8 @@ class ArchitectureTest
             ->classes(Selector::AND(
                 Selector::inNamespace('Tempest'),
                 Selector::implements('/.*/', true),
-				Selector::NOT(Selector::isEnum()),
-				Selector::NOT(Selector::isInterface())
+                Selector::NOT(Selector::isEnum()),
+                Selector::NOT(Selector::isInterface())
             ))
             ->shouldBeReadonly();
     }

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -72,7 +72,10 @@ class ArchitectureTest
     public function test_all_classes_should_be_final(): Rule
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('Tempest'))
+            ->classes(Selector::AND(
+				Selector::inNamespace('Tempest'),
+				Selector::NOT(Selector::isInterface()),
+			))
             ->shouldBeFinal();
     }
 
@@ -81,7 +84,9 @@ class ArchitectureTest
         return PHPat::rule()
             ->classes(Selector::AND(
                 Selector::inNamespace('Tempest'),
-                Selector::implements('/.*/', true)
+                Selector::implements('/.*/', true),
+				Selector::NOT(Selector::isEnum()),
+				Selector::NOT(Selector::isInterface())
             ))
             ->shouldBeReadonly();
     }

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -61,4 +61,28 @@ class ArchitectureTest
                 Selector::inNamespace('Tests\Tempest\Unit'),
             );
     }
+
+    public function test_never_use_abstract_classes(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace('Tempest'))
+            ->shouldNotBeAbstract();
+    }
+
+    public function test_all_classes_should_be_final(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace('Tempest'))
+            ->shouldBeFinal();
+    }
+
+    public function test_classes_that_implement_interfaces_should_be_readonly(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::AND(
+                Selector::inNamespace('Tempest'),
+                Selector::implements('/.*/', true)
+            ))
+            ->shouldBeReadonly();
+    }
 }


### PR DESCRIPTION
As per https://github.com/tempestphp/tempest-framework/issues/116#issuecomment-1970395938

* Added a test to make sure there are no abstract classes.
* From bullet point 2 and 3 we can extract a test to make sure that all classes are final.
* Added a test to make sure that classes that implement anything are readonly.

I've added these tests exactly as they were described in Brent's comment. There are 88 errors currently that would need to be addressed to satisfy those rules. I do believe that there will be exceptions to these rules so I'm not sure how feasible it will be to implement them.