### PR TITLE
Starts to add collections.

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Collection;
+
+use ArrayAccess;
+use Iterator;
+
+/**
+ * @template TKey of int|string
+ * @template TValue
+ *
+ * @extends ArrayAccess<TKey,TValue>
+ * @extends Iterator<TKey,TValue>
+ */
+interface Collection extends ArrayAccess, Iterator
+{
+    /**
+     * Get the item at the referenced key.
+     *
+     * @param TKey $key
+     * @return TValue
+     */
+    public function get(mixed $key): mixed;
+
+    /**
+     * Determined if the specified key exists.
+     *
+     * @param TKey $key
+     * @return bool
+     */
+    public function has(mixed $key): bool;
+
+    /**
+     * Adds a value to an ordered list.
+     *
+     * @param TValue $item
+     * @return self<TKey,TValue>
+     */
+    public function add(mixed $item): self;
+
+    /**
+     * Sets the value at a particular key in an unordered list or updates
+     * the existing value of a key in an ordered list.
+     *
+     * @param TKey $key
+     * @param TValue $value
+     * @return self<TKey,TValue>
+     */
+    public function set(mixed $key, mixed $value): self;
+
+    /**
+     * Removes the specified value from the list.
+     *
+     * @param TValue $item
+     * @return self<TKey,TValue>
+     */
+    public function remove(mixed $item): self;
+
+    /**
+     * Removes the specified key from the list without changing the order.
+     *
+     * @param TKey $key
+     * @return self<TKey,TValue>
+     */
+    public function removeAt(mixed $key): self;
+
+    /**
+     * @param TValue $item
+     * @return TKey
+     */
+    public function indexOf(mixed $item): mixed;
+}

--- a/src/Collection/Generic/GenericCollection.php
+++ b/src/Collection/Generic/GenericCollection.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Collection\Generic;
+
+use Exception;
+use Tempest\Collection\Collection;
+
+final class GenericCollection implements Collection
+{
+    private string|int $index = 0;
+
+    private array $items = [];
+
+    public function __construct(array $items = [])
+    {
+        $this->items = $items;
+    }
+
+    public function get(mixed $key): mixed
+    {
+        return $this->items[$key];
+    }
+
+    public function has(mixed $key): bool
+    {
+        return isset($this->items[$key]);
+    }
+
+    public function add(mixed $item): Collection
+    {
+        $this->items[] = $item;
+
+        return $this;
+    }
+
+    public function set(mixed $key, mixed $value): Collection
+    {
+        $this->items[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function remove(mixed $item): Collection
+    {
+        return $this->removeAt(
+            $this->indexOf($item)
+        );
+    }
+
+    public function removeAt(mixed $key): Collection
+    {
+        unset($this->items[$key]);
+
+        return $this;
+    }
+
+    public function indexOf(mixed $item): string|int
+    {
+        $item = array_search($item, $this->items, true);
+
+        // TODO: Update
+        if ($item === false) {
+            throw new Exception();
+        }
+
+        return $item;
+    }
+
+    public function current(): mixed
+    {
+        return current($this->items);
+    }
+
+    public function next(): void
+    {
+        next($this->items);
+    }
+
+    public function key(): mixed
+    {
+        return key($this->items);
+    }
+
+    public function valid(): bool
+    {
+        return isset(
+            $this->items[$this->key()]
+        );
+    }
+
+    public function rewind(): void
+    {
+        reset($this->items);
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return $this->has($offset);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->get($offset);
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->set($offset, $value);
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        $this->removeAt($offset);
+    }
+}

--- a/src/Collection/Generic/GenericQueue.php
+++ b/src/Collection/Generic/GenericQueue.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Collection\Generic;
+
+use Exception;
+use Tempest\Collection\Queue;
+
+final class GenericQueue implements Queue
+{
+    private array $items = [];
+
+    public function __construct(array $items = [])
+    {
+        foreach ($items as $item) {
+            $this->enqueue($item);
+        }
+    }
+
+    public function enqueue(mixed $item): Queue
+    {
+        $this->items[] = $item;
+
+        return $this;
+    }
+
+    public function dequeue(): mixed
+    {
+        $item = array_shift($this->items);
+
+        if ($item === null) {
+            throw new Exception();
+        }
+
+        return $item;
+    }
+
+    public function peek(): mixed
+    {
+        return $this->items[0] ?? throw new Exception();
+    }
+
+    public function contains(mixed $item): bool
+    {
+        return in_array($item, $this->items, true);
+    }
+
+    public function clone(): Queue
+    {
+        return new GenericQueue($this->items);
+    }
+
+    public function toArray(): array
+    {
+        return $this->items;
+    }
+}

--- a/src/Collection/Generic/GenericStack.php
+++ b/src/Collection/Generic/GenericStack.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Collection\Generic;
+
+use Exception;
+use Tempest\Collection\Stack;
+
+final class GenericStack implements Stack
+{
+    private array $items = [];
+
+    public function __construct(array $items = [])
+    {
+        foreach ($items as $item) {
+            $this->push($item);
+        }
+    }
+
+    public function push(mixed $item): Stack
+    {
+        array_push($this->items, $item);
+
+        return $this;
+    }
+
+    public function pop(): mixed
+    {
+        $item = array_pop($this->items);
+
+        if ($item === null) {
+            // TODO: Update exception.
+            throw new Exception();
+        }
+
+        return $item;
+    }
+
+    public function peek(): mixed
+    {
+        $item = $this->items[array_key_last($this->items)] ?? null;
+
+        if ($item === null) {
+            // TODO: Update exception.
+            throw new Exception();
+        }
+
+        return $item;
+    }
+
+    public function contains(mixed $item): bool
+    {
+        return in_array($item, $this->items, true);
+    }
+
+    public function clone(): Stack
+    {
+        return new GenericStack($this->items);
+    }
+
+    public function toArray(): array
+    {
+        return $this->items;
+    }
+}

--- a/src/Collection/Queue.php
+++ b/src/Collection/Queue.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Collection;
+
+/**
+ * @template TValue
+ */
+interface Queue
+{
+    /**
+     * @param TValue $item
+     * @return self<TValue>
+     */
+    public function enqueue(mixed $item): self;
+
+    /**
+     * @return TValue
+     */
+    public function dequeue(): mixed;
+
+    /**
+     * @return TValue
+     */
+    public function peek(): mixed;
+
+    /**
+     * @param TValue $item
+     * @return bool
+     */
+    public function contains(mixed $item): bool;
+
+    /**
+     * Clones the items in the existing queue to a new queue object.
+     *
+     * @return self<TValue>
+     */
+    public function clone(): self;
+
+    /**
+     * Returns an array of enqueued items.
+     *
+     * @return array<int,TValue>
+     */
+    public function toArray(): array;
+}

--- a/src/Collection/Stack.php
+++ b/src/Collection/Stack.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Collection;
+
+/**
+ * @template TValue
+ */
+interface Stack
+{
+    /**
+     * @param TValue $item
+     * @return self<TValue>
+     */
+    public function push(mixed $item): self;
+
+    /**
+     * @return TValue
+     */
+    public function pop(): mixed;
+
+    /**
+     * @return TValue
+     */
+    public function peek(): mixed;
+
+    /**
+     * @param TValue $item
+     * @return bool
+     */
+    public function contains(mixed $item): bool;
+
+    /**
+     * Clones the items in the existing queue to a new queue object.
+     *
+     * @return self<TValue>
+     */
+    public function clone(): self;
+
+    /**
+     * Returns an array of enqueued items.
+     *
+     * @return array<int,TValue>
+     */
+    public function toArray(): array;
+}

--- a/tests/Unit/Collection/Generic/GenericCollectionTest.php
+++ b/tests/Unit/Collection/Generic/GenericCollectionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Unit\Collection\Generic;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Collection\Generic\GenericCollection;
+
+/**
+ * @internal
+ * @small
+ */
+class GenericCollectionTest extends TestCase
+{
+    public function test_getting_items_from_a_collection(): void
+    {
+        $collection = new GenericCollection([
+            'key1' => 'value1',
+            'key2' => 'value2',
+        ]);
+
+        $this->assertSame('value1', $collection->get('key1'));
+        $this->assertSame('value2', $collection->get('key2'));
+    }
+
+    public function test_determining_if_collection_has_key(): void
+    {
+        $collection = new GenericCollection([
+            'key1' => 'value1',
+        ]);
+
+        $this->assertTrue($collection->has('key1'));
+        $this->assertFalse($collection->has('key2'));
+    }
+
+    public function test_adding_items_to_a_collection(): void
+    {
+        $collection = new GenericCollection();
+
+        $collection->add('testing');
+
+        $this->assertContainsEquals('testing', $collection);
+    }
+
+    public function test_setting_keys_in_a_collection(): void
+    {
+        $collection = new GenericCollection(['key2' => 'value3']);
+
+        $collection->set('key1', 'value1');
+        $collection->set('key2', 'value2');
+
+        $this->assertEqualsCanonicalizing([
+            'key1' => 'value1',
+            'key2' => 'value2',
+        ], iterator_to_array($collection));
+    }
+
+    public function test_removing_item_from_collection_by_key(): void
+    {
+        $collection = new GenericCollection([
+            'key1' => 'value1',
+            'key2' => 'value2',
+        ]);
+
+        $collection->removeAt('key2');
+
+        $this->assertFalse(
+            $collection->has('key2')
+        );
+    }
+
+    public function test_removing_item_from_collection_by_value(): void
+    {
+        $collection = new GenericCollection([
+            'key1' => 'value1',
+            'key2' => 'value2',
+        ]);
+
+        $collection->remove('value1');
+
+        $this->assertFalse(
+            $collection->has('key1')
+        );
+    }
+
+    public function test_determining_index_of_item_in_collection(): void
+    {
+        $collection = new GenericCollection([
+            'key1' => 'value1',
+        ]);
+
+        $this->assertSame(
+            'key1',
+            $collection->indexOf('value1')
+        );
+    }
+
+    public function test_array_access(): void
+    {
+        $collection = new GenericCollection();
+
+        $collection['key1'] = 'value1';
+
+        $this->assertSame('value1', $collection['key1']);
+        $this->assertTrue(isset($collection['key1']));
+
+        unset($collection['key1']);
+
+        $this->assertFalse(isset($collection['key1']));
+    }
+}

--- a/tests/Unit/Collection/Generic/GenericQueueTest.php
+++ b/tests/Unit/Collection/Generic/GenericQueueTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Unit\Collection\Generic;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Collection\Generic\GenericQueue;
+
+/**
+ * @internal
+ * @small
+ */
+class GenericQueueTest extends TestCase
+{
+    public function test_enqueuing_an_item(): void
+    {
+        $queue = new GenericQueue();
+
+        $queue->enqueue('value1');
+
+        $this->assertEqualsCanonicalizing([
+            'value1',
+        ], $queue->toArray());
+    }
+
+    public function test_dequeuing_an_item(): void
+    {
+        $queue = new GenericQueue([
+            'value1',
+            'value2',
+        ]);
+
+        $this->assertSame('value1', $queue->dequeue());
+        $this->assertSame('value2', $queue->dequeue());
+    }
+
+    public function test_peeking_at_the_next_item(): void
+    {
+        $queue = new GenericQueue([
+            'value1',
+            'value2',
+        ]);
+
+        $this->assertSame('value1', $queue->peek());
+        $this->assertSame('value1', $queue->dequeue());
+    }
+
+    public function test_checking_if_queue_contains_item(): void
+    {
+        $queue = new GenericQueue([
+            'value1',
+        ]);
+
+        $this->assertTrue($queue->contains('value1'));
+        $this->assertFalse($queue->contains('value2'));
+    }
+
+    public function test_cloning_a_queue(): void
+    {
+        $queue1 = new GenericQueue(['value1']);
+        $queue2 = $queue1->clone();
+
+        $this->assertNotSame($queue1, $queue2);
+        $this->assertEquals($queue1, $queue2);
+    }
+}

--- a/tests/Unit/Collection/Generic/GenericStackTest.php
+++ b/tests/Unit/Collection/Generic/GenericStackTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Unit\Collection\Generic;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Collection\Generic\GenericStack;
+
+/**
+ * @internal
+ * @small
+ */
+class GenericStackTest extends TestCase
+{
+    public function test_pushing_an_item(): void
+    {
+        $stack = new GenericStack();
+
+        $stack->push('value1');
+
+        $this->assertEqualsCanonicalizing(['value1'], $stack->toArray());
+    }
+
+    public function test_popping_an_item(): void
+    {
+        $stack = new GenericStack([
+            'value1',
+            'value2',
+        ]);
+
+        $this->assertSame('value2', $stack->pop());
+        $this->assertSame('value1', $stack->pop());
+    }
+
+    public function test_peeking_at_the_next_item(): void
+    {
+        $stack = new GenericStack([
+            'value1',
+            'value2',
+        ]);
+
+        $this->assertSame('value2', $stack->peek());
+        $this->assertSame('value2', $stack->pop());
+    }
+
+    public function test_checking_if_stack_contains_item(): void
+    {
+        $stack = new GenericStack([
+            'value1',
+        ]);
+
+        $this->assertTrue($stack->contains('value1'));
+        $this->assertFalse($stack->contains('value2'));
+    }
+
+    public function test_cloning_a_stack(): void
+    {
+        $stack1 = new GenericStack(['value1']);
+        $stack2 = $stack1->clone();
+
+        $this->assertNotSame($stack1, $stack2);
+        $this->assertEquals($stack1, $stack2);
+    }
+}


### PR DESCRIPTION
This pull requests begins to add collections to Tempest along with a couple of helper classes. I was debating whether to separate out collections into `ArrayList` (an ordered list) and `Dictionary` (a keyed dictionary). There is value to that, in my opinion, since it can enforce a collection to be ordered or keyed respectively. Speaking with @brendt, we will hold off on that for now.

I have included `Queue` (first in, first out) and `Stack` (last in, first out) and may add a few other helpers as well.