### PR TITLE
Finalize NullShellExecutor

### DIFF
--- a/src/Tempest/Console/Scheduler/NullShellExecutor.php
+++ b/src/Tempest/Console/Scheduler/NullShellExecutor.php
@@ -6,7 +6,7 @@ namespace Tempest\Console\Scheduler;
 
 use Tempest\Console\ShellExecutor;
 
-class NullShellExecutor implements ShellExecutor
+final class NullShellExecutor implements ShellExecutor
 {
     public function execute(string $compiledCommand): void
     {

--- a/src/Tempest/Testing/BypassMock/Bypass.php
+++ b/src/Tempest/Testing/BypassMock/Bypass.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tempest\Testing\BypassMock;
+
+final class Bypass
+{
+    /** holds php tokens, e.g. final | readonly */
+    private static array $tokens = [];
+
+    public static function enable(bool $readonly = true, bool $final = true): void
+    {
+        self::addToTokens($readonly, $final);
+
+        stream_filter_register(Filter::NAME, Filter::class);
+
+        stream_wrapper_unregister(Wrapper::Protocol);
+        stream_wrapper_register(Wrapper::Protocol, Wrapper::class);
+    }
+
+    public static function getTokens(): array
+    {
+        return self::$tokens;
+    }
+
+    private static function addToTokens(bool $readonly, bool $final): void
+    {
+        if ($readonly && PHP_VERSION_ID >= 80100) {
+            self::$tokens[T_READONLY] = 'readonly';
+        }
+
+        if ($final) {
+            self::$tokens[T_FINAL] = 'final';
+        }
+    }
+}

--- a/src/Tempest/Testing/BypassMock/Bypass.php
+++ b/src/Tempest/Testing/BypassMock/Bypass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tempest\Testing\BypassMock;
 
 final class Bypass

--- a/src/Tempest/Testing/BypassMock/Filter.php
+++ b/src/Tempest/Testing/BypassMock/Filter.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Testing\BypassMock;
+
+use php_user_filter;
+
+final class Filter extends php_user_filter
+{
+    public const NAME = 'bypass.mock';
+
+    private mixed $bucket;
+    private string $data;
+    private array $tokens;
+
+    public function onCreate(): bool
+    {
+        $this->data = '';
+        $this->tokens = Bypass::getTokens();
+        return true;
+    }
+
+    public function filter($in, $out, &$consumed, $closing): int
+    {
+        $consumed = 0;
+
+        // read data from $in and set data properties
+        while($bucket = stream_bucket_make_writeable($in)) {
+            $this->data .= $bucket->data;
+            $this->bucket = $bucket;
+        }
+
+        if (!$closing) {
+            return PSFS_FEED_ME;
+        }
+
+        $consumed += strlen($this->data);
+
+        // filter out tokens
+        $filter = $this->modifyCode($this->data);
+
+        $this->bucket->data = $filter;
+        $this->bucket->datalen = strlen($this->data);
+
+        if(!empty($this->bucket->data)) {
+            stream_bucket_append($out, $this->bucket);
+        }
+
+        return PSFS_PASS_ON;
+    }
+
+	private function modifyCode(string $code): string
+	{
+		foreach ($this->tokens as $text) {
+			if (stripos($code, $text) !== false) {
+                return $this->removeTokens($code);
+			}
+		}
+
+		return $code;
+	}
+
+	private function removeTokens(string $code): string
+	{
+		try {
+			$tokens = token_get_all($code, TOKEN_PARSE);
+		} catch (\ParseError $e) {
+			return $code;
+		}
+
+		$code = '';
+		foreach ($tokens as $token) {
+			$code .= is_array($token)
+				? (isset($this->tokens[$token[0]]) ? '' : $token[1])
+				: $token;
+		}
+
+		return $code;
+	}
+}

--- a/src/Tempest/Testing/BypassMock/Filter.php
+++ b/src/Tempest/Testing/BypassMock/Filter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Testing\BypassMock;
 
+use ParseError;
 use php_user_filter;
 
 final class Filter extends php_user_filter
@@ -18,6 +19,7 @@ final class Filter extends php_user_filter
     {
         $this->data = '';
         $this->tokens = Bypass::getTokens();
+
         return true;
     }
 
@@ -31,7 +33,7 @@ final class Filter extends php_user_filter
             $this->bucket = $bucket;
         }
 
-        if (!$closing) {
+        if (! $closing) {
             return PSFS_FEED_ME;
         }
 
@@ -43,39 +45,39 @@ final class Filter extends php_user_filter
         $this->bucket->data = $filter;
         $this->bucket->datalen = strlen($this->data);
 
-        if(!empty($this->bucket->data)) {
+        if(! empty($this->bucket->data)) {
             stream_bucket_append($out, $this->bucket);
         }
 
         return PSFS_PASS_ON;
     }
 
-	private function modifyCode(string $code): string
-	{
-		foreach ($this->tokens as $text) {
-			if (stripos($code, $text) !== false) {
+    private function modifyCode(string $code): string
+    {
+        foreach ($this->tokens as $text) {
+            if (stripos($code, $text) !== false) {
                 return $this->removeTokens($code);
-			}
-		}
+            }
+        }
 
-		return $code;
-	}
+        return $code;
+    }
 
-	private function removeTokens(string $code): string
-	{
-		try {
-			$tokens = token_get_all($code, TOKEN_PARSE);
-		} catch (\ParseError $e) {
-			return $code;
-		}
+    private function removeTokens(string $code): string
+    {
+        try {
+            $tokens = token_get_all($code, TOKEN_PARSE);
+        } catch (ParseError $e) {
+            return $code;
+        }
 
-		$code = '';
-		foreach ($tokens as $token) {
-			$code .= is_array($token)
-				? (isset($this->tokens[$token[0]]) ? '' : $token[1])
-				: $token;
-		}
+        $code = '';
+        foreach ($tokens as $token) {
+            $code .= is_array($token)
+                ? (isset($this->tokens[$token[0]]) ? '' : $token[1])
+                : $token;
+        }
 
-		return $code;
-	}
+        return $code;
+    }
 }

--- a/src/Tempest/Testing/BypassMock/Wrapper.php
+++ b/src/Tempest/Testing/BypassMock/Wrapper.php
@@ -8,224 +8,230 @@ use RuntimeException;
 
 final class Wrapper
 {
-	public const Protocol = 'file';
+    public const Protocol = 'file';
 
-	/** @var resource|null */
-	public $context;
+    /** @var resource|null */
+    public $context;
 
-	/** @var resource|null */
-	public $handle;
+    /** @var resource|null */
+    public $handle;
 
-	public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
-	{
-		if (is_dir($path)) {
-			return false;
-		}
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+    {
+        if (is_dir($path)) {
+            return false;
+        }
 
-		if (!$this->open_the_stream($path, $mode, $options, $openedPath)) {
-			return false;
-		}
+        if (! $this->open_the_stream($path, $mode, $options, $openedPath)) {
+            return false;
+        }
 
-		if ($mode === 'rb' && pathinfo($path, PATHINFO_EXTENSION) === 'php') {
-			$content = '';
+        if ($mode === 'rb' && pathinfo($path, PATHINFO_EXTENSION) === 'php') {
+            $content = '';
 
-			while (!$this->stream_eof()) {
-				$content .= $this->stream_read(8192);
-			}
+            while (! $this->stream_eof()) {
+                $content .= $this->stream_read(8192);
+            }
 
             $this->stream_filter(Filter::NAME);
             $this->stream_seek(0);
-		}
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	private function open_the_stream(string $path, string $mode, int $options = 0, ?string &$openedPath = null): bool
-	{
-		$usePath = (bool) ($options & STREAM_USE_PATH);
+    private function open_the_stream(string $path, string $mode, int $options = 0, ?string &$openedPath = null): bool
+    {
+        $usePath = (bool) ($options & STREAM_USE_PATH);
 
-		$this->handle = $this->context
-			? $this->native('fopen', $path, $mode, $usePath, $this->context)
-			: $this->native('fopen', $path, $mode, $usePath);
+        $this->handle = $this->context
+            ? $this->native('fopen', $path, $mode, $usePath, $this->context)
+            : $this->native('fopen', $path, $mode, $usePath);
 
-		return (bool) $this->handle;
-	}
+        return (bool) $this->handle;
+    }
 
-	public function dir_closedir(): void
-	{
-		closedir($this->handle);
-	}
+    public function dir_closedir(): void
+    {
+        closedir($this->handle);
+    }
 
-	public function dir_opendir(string $path, int $options): bool
-	{
-		$this->handle = $this->context
-			? $this->native('opendir', $path, $this->context)
-			: $this->native('opendir', $path);
-		return (bool) $this->handle;
-	}
+    public function dir_opendir(string $path, int $options): bool
+    {
+        $this->handle = $this->context
+            ? $this->native('opendir', $path, $this->context)
+            : $this->native('opendir', $path);
 
-	public function dir_readdir()
-	{
-		return readdir($this->handle);
-	}
+        return (bool) $this->handle;
+    }
 
-	public function dir_rewinddir(): bool
-	{
-		rewinddir($this->handle);
-		return true;
-	}
+    public function dir_readdir()
+    {
+        return readdir($this->handle);
+    }
 
-	public function mkdir(string $path, int $mode, int $options): bool
-	{
-		$recursive = (bool) ($options & STREAM_MKDIR_RECURSIVE);
-		return $this->context
-			? $this->native('mkdir', $path, $mode, $recursive, $this->context)
-			: $this->native('mkdir', $path, $mode, $recursive);
-	}
+    public function dir_rewinddir(): bool
+    {
+        rewinddir($this->handle);
 
-	public function rename(string $pathFrom, string $pathTo): bool
-	{
-		return $this->context
-			? $this->native('rename', $pathFrom, $pathTo, $this->context)
-			: $this->native('rename', $pathFrom, $pathTo);
-	}
+        return true;
+    }
 
-	public function rmdir(string $path, int $options): bool
-	{
-		return $this->context
-			? $this->native('rmdir', $path, $this->context)
-			: $this->native('rmdir', $path);
-	}
+    public function mkdir(string $path, int $mode, int $options): bool
+    {
+        $recursive = (bool) ($options & STREAM_MKDIR_RECURSIVE);
 
-	public function stream_cast(int $castAs): mixed
-	{
-		return $this->handle;
-	}
+        return $this->context
+            ? $this->native('mkdir', $path, $mode, $recursive, $this->context)
+            : $this->native('mkdir', $path, $mode, $recursive);
+    }
 
-	public function stream_close(): void
-	{
-		fclose($this->handle);
-	}
+    public function rename(string $pathFrom, string $pathTo): bool
+    {
+        return $this->context
+            ? $this->native('rename', $pathFrom, $pathTo, $this->context)
+            : $this->native('rename', $pathFrom, $pathTo);
+    }
 
-	public function stream_eof(): bool
-	{
-		return feof($this->handle);
-	}
+    public function rmdir(string $path, int $options): bool
+    {
+        return $this->context
+            ? $this->native('rmdir', $path, $this->context)
+            : $this->native('rmdir', $path);
+    }
 
-	public function stream_flush(): bool
-	{
-		return fflush($this->handle);
-	}
+    public function stream_cast(int $castAs): mixed
+    {
+        return $this->handle;
+    }
 
-	public function stream_lock(int $operation): bool
-	{
-		return $operation
-			? flock($this->handle, $operation)
-			: true;
-	}
+    public function stream_close(): void
+    {
+        fclose($this->handle);
+    }
 
-	public function stream_metadata(string $path, int $option, mixed $value): bool
-	{
-		switch ($option) {
-			case STREAM_META_TOUCH:
-				return $this->native('touch', $path, $value[0] ?? time(), $value[1] ?? time());
-			case STREAM_META_OWNER_NAME:
-			case STREAM_META_OWNER:
-				return $this->native('chown', $path, $value);
-			case STREAM_META_GROUP_NAME:
-			case STREAM_META_GROUP:
-				return $this->native('chgrp', $path, $value);
-			case STREAM_META_ACCESS:
-				return $this->native('chmod', $path, $value);
-			default:
-				return false;
-		}
-	}
+    public function stream_eof(): bool
+    {
+        return feof($this->handle);
+    }
 
-	public function stream_read(int $count): string|false
-	{
-		return fread($this->handle, $count);
-	}
+    public function stream_flush(): bool
+    {
+        return fflush($this->handle);
+    }
 
-	public function stream_seek(int $offset, int $whence = SEEK_SET): bool
-	{
-		return fseek($this->handle, $offset, $whence) === 0;
-	}
+    public function stream_lock(int $operation): bool
+    {
+        return $operation
+            ? flock($this->handle, $operation)
+            : true;
+    }
 
-	public function stream_set_option(int $option, int $arg1, ?int $arg2)
-	{
-		switch ($option) {
-			case STREAM_OPTION_BLOCKING:
-				return stream_set_blocking($this->handle, (bool) $arg1);
-			case STREAM_OPTION_READ_BUFFER:
-				return stream_set_read_buffer($this->handle, $arg2);
-			case STREAM_OPTION_WRITE_BUFFER:
-				return stream_set_write_buffer($this->handle, $arg2);
-			case STREAM_OPTION_READ_TIMEOUT:
-				return stream_set_timeout($this->handle, $arg1, $arg2);
-			default:
-				return false;
-		}
-	}
+    public function stream_metadata(string $path, int $option, mixed $value): bool
+    {
+        switch ($option) {
+            case STREAM_META_TOUCH:
+                return $this->native('touch', $path, $value[0] ?? time(), $value[1] ?? time());
+            case STREAM_META_OWNER_NAME:
+            case STREAM_META_OWNER:
+                return $this->native('chown', $path, $value);
+            case STREAM_META_GROUP_NAME:
+            case STREAM_META_GROUP:
+                return $this->native('chgrp', $path, $value);
+            case STREAM_META_ACCESS:
+                return $this->native('chmod', $path, $value);
+            default:
+                return false;
+        }
+    }
 
-	public function stream_stat(): array|false
-	{
-		return fstat($this->handle);
-	}
+    public function stream_read(int $count): string|false
+    {
+        return fread($this->handle, $count);
+    }
 
-	public function stream_tell(): int
-	{
-		return ftell($this->handle);
-	}
+    public function stream_seek(int $offset, int $whence = SEEK_SET): bool
+    {
+        return fseek($this->handle, $offset, $whence) === 0;
+    }
 
-	public function stream_truncate(int $newSize): bool
-	{
-		return ftruncate($this->handle, $newSize);
-	}
+    public function stream_set_option(int $option, int $arg1, ?int $arg2)
+    {
+        switch ($option) {
+            case STREAM_OPTION_BLOCKING:
+                return stream_set_blocking($this->handle, (bool) $arg1);
+            case STREAM_OPTION_READ_BUFFER:
+                return stream_set_read_buffer($this->handle, $arg2);
+            case STREAM_OPTION_WRITE_BUFFER:
+                return stream_set_write_buffer($this->handle, $arg2);
+            case STREAM_OPTION_READ_TIMEOUT:
+                return stream_set_timeout($this->handle, $arg1, $arg2);
+            default:
+                return false;
+        }
+    }
 
-	public function stream_write(string $data): int
-	{
-		return fwrite($this->handle, $data);
-	}
+    public function stream_stat(): array|false
+    {
+        return fstat($this->handle);
+    }
+
+    public function stream_tell(): int
+    {
+        return ftell($this->handle);
+    }
+
+    public function stream_truncate(int $newSize): bool
+    {
+        return ftruncate($this->handle, $newSize);
+    }
+
+    public function stream_write(string $data): int
+    {
+        return fwrite($this->handle, $data);
+    }
 
     public function stream_filter(string $filter): bool
     {
         return (bool) $this->native('stream_filter_append', $this->handle, $filter);
     }
 
-	public function unlink(string $path): bool
-	{
-		return $this->native('unlink', $path);
-	}
+    public function unlink(string $path): bool
+    {
+        return $this->native('unlink', $path);
+    }
 
-	public function url_stat(string $path, int $flags): array|false
-	{
-		if ($flags & STREAM_URL_STAT_QUIET) {
-			set_error_handler(function () {
-				return true;
-			});
-		}
-		try {
-			$func = $flags & STREAM_URL_STAT_LINK ? 'lstat' : 'stat';
-			return $this->native($func, $path);
-		} catch (RuntimeException $e) {
-			// SplFileInfo::isFile throws exception
-			return false;
-		} finally {
-			if ($flags & STREAM_URL_STAT_QUIET) {
-				restore_error_handler();
-			}
-		}
-	}
+    public function url_stat(string $path, int $flags): array|false
+    {
+        if ($flags & STREAM_URL_STAT_QUIET) {
+            set_error_handler(function () {
+                return true;
+            });
+        }
 
-	private function native(string $func): mixed
-	{
-		stream_wrapper_restore(self::Protocol);
-		try {
-			return $func(...array_slice(func_get_args(), 1));
-		} finally {
-			stream_wrapper_unregister(self::Protocol);
-			stream_wrapper_register(self::Protocol, self::class);
-		}
-	}
+        try {
+            $func = $flags & STREAM_URL_STAT_LINK ? 'lstat' : 'stat';
+
+            return $this->native($func, $path);
+        } catch (RuntimeException $e) {
+            // SplFileInfo::isFile throws exception
+            return false;
+        } finally {
+            if ($flags & STREAM_URL_STAT_QUIET) {
+                restore_error_handler();
+            }
+        }
+    }
+
+    private function native(string $func): mixed
+    {
+        stream_wrapper_restore(self::Protocol);
+
+        try {
+            return $func(...array_slice(func_get_args(), 1));
+        } finally {
+            stream_wrapper_unregister(self::Protocol);
+            stream_wrapper_register(self::Protocol, self::class);
+        }
+    }
 }

--- a/src/Tempest/Testing/BypassMock/Wrapper.php
+++ b/src/Tempest/Testing/BypassMock/Wrapper.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Testing\BypassMock;
+
+use RuntimeException;
+
+final class Wrapper
+{
+	public const Protocol = 'file';
+
+	/** @var resource|null */
+	public $context;
+
+	/** @var resource|null */
+	public $handle;
+
+	public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+	{
+		if (is_dir($path)) {
+			return false;
+		}
+
+		if (!$this->open_the_stream($path, $mode, $options, $openedPath)) {
+			return false;
+		}
+
+		if ($mode === 'rb' && pathinfo($path, PATHINFO_EXTENSION) === 'php') {
+			$content = '';
+
+			while (!$this->stream_eof()) {
+				$content .= $this->stream_read(8192);
+			}
+
+            $this->stream_filter(Filter::NAME);
+            $this->stream_seek(0);
+		}
+
+		return true;
+	}
+
+	private function open_the_stream(string $path, string $mode, int $options = 0, ?string &$openedPath = null): bool
+	{
+		$usePath = (bool) ($options & STREAM_USE_PATH);
+
+		$this->handle = $this->context
+			? $this->native('fopen', $path, $mode, $usePath, $this->context)
+			: $this->native('fopen', $path, $mode, $usePath);
+
+		return (bool) $this->handle;
+	}
+
+	public function dir_closedir(): void
+	{
+		closedir($this->handle);
+	}
+
+	public function dir_opendir(string $path, int $options): bool
+	{
+		$this->handle = $this->context
+			? $this->native('opendir', $path, $this->context)
+			: $this->native('opendir', $path);
+		return (bool) $this->handle;
+	}
+
+	public function dir_readdir()
+	{
+		return readdir($this->handle);
+	}
+
+	public function dir_rewinddir(): bool
+	{
+		rewinddir($this->handle);
+		return true;
+	}
+
+	public function mkdir(string $path, int $mode, int $options): bool
+	{
+		$recursive = (bool) ($options & STREAM_MKDIR_RECURSIVE);
+		return $this->context
+			? $this->native('mkdir', $path, $mode, $recursive, $this->context)
+			: $this->native('mkdir', $path, $mode, $recursive);
+	}
+
+	public function rename(string $pathFrom, string $pathTo): bool
+	{
+		return $this->context
+			? $this->native('rename', $pathFrom, $pathTo, $this->context)
+			: $this->native('rename', $pathFrom, $pathTo);
+	}
+
+	public function rmdir(string $path, int $options): bool
+	{
+		return $this->context
+			? $this->native('rmdir', $path, $this->context)
+			: $this->native('rmdir', $path);
+	}
+
+	public function stream_cast(int $castAs): mixed
+	{
+		return $this->handle;
+	}
+
+	public function stream_close(): void
+	{
+		fclose($this->handle);
+	}
+
+	public function stream_eof(): bool
+	{
+		return feof($this->handle);
+	}
+
+	public function stream_flush(): bool
+	{
+		return fflush($this->handle);
+	}
+
+	public function stream_lock(int $operation): bool
+	{
+		return $operation
+			? flock($this->handle, $operation)
+			: true;
+	}
+
+	public function stream_metadata(string $path, int $option, mixed $value): bool
+	{
+		switch ($option) {
+			case STREAM_META_TOUCH:
+				return $this->native('touch', $path, $value[0] ?? time(), $value[1] ?? time());
+			case STREAM_META_OWNER_NAME:
+			case STREAM_META_OWNER:
+				return $this->native('chown', $path, $value);
+			case STREAM_META_GROUP_NAME:
+			case STREAM_META_GROUP:
+				return $this->native('chgrp', $path, $value);
+			case STREAM_META_ACCESS:
+				return $this->native('chmod', $path, $value);
+			default:
+				return false;
+		}
+	}
+
+	public function stream_read(int $count): string|false
+	{
+		return fread($this->handle, $count);
+	}
+
+	public function stream_seek(int $offset, int $whence = SEEK_SET): bool
+	{
+		return fseek($this->handle, $offset, $whence) === 0;
+	}
+
+	public function stream_set_option(int $option, int $arg1, ?int $arg2)
+	{
+		switch ($option) {
+			case STREAM_OPTION_BLOCKING:
+				return stream_set_blocking($this->handle, (bool) $arg1);
+			case STREAM_OPTION_READ_BUFFER:
+				return stream_set_read_buffer($this->handle, $arg2);
+			case STREAM_OPTION_WRITE_BUFFER:
+				return stream_set_write_buffer($this->handle, $arg2);
+			case STREAM_OPTION_READ_TIMEOUT:
+				return stream_set_timeout($this->handle, $arg1, $arg2);
+			default:
+				return false;
+		}
+	}
+
+	public function stream_stat(): array|false
+	{
+		return fstat($this->handle);
+	}
+
+	public function stream_tell(): int
+	{
+		return ftell($this->handle);
+	}
+
+	public function stream_truncate(int $newSize): bool
+	{
+		return ftruncate($this->handle, $newSize);
+	}
+
+	public function stream_write(string $data): int
+	{
+		return fwrite($this->handle, $data);
+	}
+
+    public function stream_filter(string $filter): bool
+    {
+        return (bool) $this->native('stream_filter_append', $this->handle, $filter);
+    }
+
+	public function unlink(string $path): bool
+	{
+		return $this->native('unlink', $path);
+	}
+
+	public function url_stat(string $path, int $flags): array|false
+	{
+		if ($flags & STREAM_URL_STAT_QUIET) {
+			set_error_handler(function () {
+				return true;
+			});
+		}
+		try {
+			$func = $flags & STREAM_URL_STAT_LINK ? 'lstat' : 'stat';
+			return $this->native($func, $path);
+		} catch (RuntimeException $e) {
+			// SplFileInfo::isFile throws exception
+			return false;
+		} finally {
+			if ($flags & STREAM_URL_STAT_QUIET) {
+				restore_error_handler();
+			}
+		}
+	}
+
+	private function native(string $func): mixed
+	{
+		stream_wrapper_restore(self::Protocol);
+		try {
+			return $func(...array_slice(func_get_args(), 1));
+		} finally {
+			stream_wrapper_unregister(self::Protocol);
+			stream_wrapper_register(self::Protocol, self::class);
+		}
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,3 +5,4 @@ declare(strict_types=1);
 require_once  __DIR__ . '/../vendor/autoload.php';
 
 passthru('./tempest discovery:clear');
+Tempest\Testing\BypassMock\Bypass::enable();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,8 +1,9 @@
 <?php
 
 declare(strict_types=1);
+use Tempest\Testing\BypassMock\Bypass;
 
 require_once  __DIR__ . '/../vendor/autoload.php';
 
 passthru('./tempest discovery:clear');
-Tempest\Testing\BypassMock\Bypass::enable();
+Bypass::enable();


### PR DESCRIPTION
**Issue:** https://github.com/tempestphp/tempest-framework/issues/259

We can not create a mock of final classes in phpunit.

**Solution:**

Tempest/Testing/BypassMock was created to filter out `final` token in each php file. It overrides php file stream wrapper and turns all final classes into normal classes that can be mocked.