### PR TITLE
[bug] fix MySQL driver DSN format

### DIFF
--- a/src/Tempest/Database/Drivers/MySqlDriver.php
+++ b/src/Tempest/Database/Drivers/MySqlDriver.php
@@ -25,7 +25,7 @@ final readonly class MySqlDriver implements DatabaseDriver
 
     public function getDsn(): string
     {
-        return "mysql:host={$this->host};port={$this->port};dbname={$this->database}";
+        return "mysql:host={$this->host}:{$this->port};dbname={$this->database}";
     }
 
     public function getUsername(): ?string

--- a/tests/Unit/Database/DatabaseDriverTest.php
+++ b/tests/Unit/Database/DatabaseDriverTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Tempest\Unit\Database;
+
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Database\DatabaseDriver;
+use Tempest\Database\Drivers\MySqlDriver;
+use Tempest\Database\Drivers\SQLiteDriver;
+
+final class DatabaseDriverTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('provide_database_drivers')]
+    public function driver_has_the_correct_dsn(DatabaseDriver $driver, string $dsn): void
+    {
+        self::assertSame($dsn, $driver->getDsn());
+    }
+
+    public static function provide_database_drivers(): Generator
+    {
+        yield 'sqlite' => [
+            new SQLiteDriver(path: 'localhost'),
+            'sqlite:localhost',
+        ];
+
+        yield 'mysql' => [
+            new MySqlDriver(
+                host: 'localhost',
+                port: '3307',
+                username: 'user',
+                password: 'secret',
+                database: 'tempest'
+            ),
+            'mysql:host=localhost:3307;dbname=tempest',
+        ];
+    }
+}


### PR DESCRIPTION
fixes #292

As outlined in the issue the format of the DSN that the MySQL creates did not have the right format.

This PR fixes the format and adds a very simple test to check the DSN both for MySQL and Sqlite. With the possibility to add PostgreSQL.