### PR TITLE
add a driver for PostgreSql

### DIFF
--- a/src/Tempest/Database/Drivers/PostgreSqlDriver.php
+++ b/src/Tempest/Database/Drivers/PostgreSqlDriver.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Drivers;
+
+use SensitiveParameter;
+use Tempest\Database\DatabaseDriver;
+
+final class PostgreSqlDriver implements DatabaseDriver
+{
+    public function __construct(
+        #[SensitiveParameter]
+        public string $host = 'localhost',
+        #[SensitiveParameter]
+        public string $port = '5432',
+        #[SensitiveParameter]
+        public string $username = 'postgres',
+        #[SensitiveParameter]
+        public string $password = '',
+        #[SensitiveParameter]
+        public string $database = 'app',
+    ) {
+    }
+
+    public function getDsn(): string
+    {
+        return "postgresql:{$this->host}:{$this->port}/{$this->database}";
+    }
+
+    public function getUsername(): ?string
+    {
+        return $this->username;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->password;
+    }
+}

--- a/tests/Unit/Database/DatabaseDriverTest.php
+++ b/tests/Unit/Database/DatabaseDriverTest.php
@@ -21,9 +21,11 @@ final class DatabaseDriverTest extends TestCase
 {
     #[Test]
     #[DataProvider('provide_database_drivers')]
-    public function driver_has_the_correct_dsn(DatabaseDriver $driver, string $dsn): void
+    public function driver_has_the_correct_dsn(DatabaseDriver $driver, string $dsn, string $username, string $password): void
     {
         $this->assertSame($dsn, $driver->getDsn());
+        $this->assertSame($username, $driver->getUsername());
+        $this->assertSame($password, $driver->getPassword());
     }
 
     public static function provide_database_drivers(): Generator
@@ -42,6 +44,8 @@ final class DatabaseDriverTest extends TestCase
                 database: 'tempest'
             ),
             'mysql:host=localhost:3307;dbname=tempest',
+            'user',
+            'secret',
         ];
 
         yield 'postgresql' => [
@@ -49,10 +53,12 @@ final class DatabaseDriverTest extends TestCase
                 host: 'localhost',
                 port: '5432',
                 username: 'postgres',
-                password: '',
+                password: 'secret',
                 database: 'tempest'
             ),
             'postgresql:localhost:5432/tempest',
+            'postgres',
+            'secret',
         ];
     }
 }

--- a/tests/Unit/Database/DatabaseDriverTest.php
+++ b/tests/Unit/Database/DatabaseDriverTest.php
@@ -21,7 +21,7 @@ final class DatabaseDriverTest extends TestCase
 {
     #[Test]
     #[DataProvider('provide_database_drivers')]
-    public function driver_has_the_correct_dsn(DatabaseDriver $driver, string $dsn, string $username, string $password): void
+    public function driver_has_the_correct_dsn(DatabaseDriver $driver, string $dsn, ?string $username, ?string $password): void
     {
         $this->assertSame($dsn, $driver->getDsn());
         $this->assertSame($username, $driver->getUsername());
@@ -33,6 +33,8 @@ final class DatabaseDriverTest extends TestCase
         yield 'sqlite' => [
             new SQLiteDriver(path: '/usr/local/db.sqlite'),
             'sqlite:/usr/local/db.sqlite',
+            null,
+            null,
         ];
 
         yield 'mysql' => [

--- a/tests/Unit/Database/DatabaseDriverTest.php
+++ b/tests/Unit/Database/DatabaseDriverTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Tempest\Database\DatabaseDriver;
 use Tempest\Database\Drivers\MySqlDriver;
+use Tempest\Database\Drivers\PostgreSqlDriver;
 use Tempest\Database\Drivers\SQLiteDriver;
 
 /**
@@ -28,8 +29,8 @@ final class DatabaseDriverTest extends TestCase
     public static function provide_database_drivers(): Generator
     {
         yield 'sqlite' => [
-            new SQLiteDriver(path: 'localhost'),
-            'sqlite:localhost',
+            new SQLiteDriver(path: '/usr/local/db.sqlite'),
+            'sqlite:/usr/local/db.sqlite',
         ];
 
         yield 'mysql' => [
@@ -41,6 +42,17 @@ final class DatabaseDriverTest extends TestCase
                 database: 'tempest'
             ),
             'mysql:host=localhost:3307;dbname=tempest',
+        ];
+
+        yield 'postgresql' => [
+            new PostgreSqlDriver(
+                host: 'localhost',
+                port: '5432',
+                username: 'postgres',
+                password: '',
+                database: 'tempest'
+            ),
+            'postgresql:localhost:5432/tempest',
         ];
     }
 }


### PR DESCRIPTION
resolves #295

This PR adds a driver for using the PostgreSQL database. Pretty straightforward, mirrored after the MySQL driver.

I don't have PostgreSql locally, so I've not been able to test this.