### PR TITLE
move cache files to a single directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cache/
 .idea/
 build/
 sessions/
@@ -6,10 +7,6 @@ src/Tempest/database.sqlite
 tests/Fixtures/database.sqlite
 tests/Unit/Console/test-console.log
 .env
-.php-cs-fixer.cache
-.phpunit.result.cache
 composer.lock
 debug.log
 tempest.log
-*.cache.php
-tests/Integration/View/blade/cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
 $finder = Symfony\Component\Finder\Finder::create()
     ->in([
         __DIR__ . '/src',
@@ -12,6 +14,7 @@ $finder = Symfony\Component\Finder\Finder::create()
 
 return (new PhpCsFixer\Config())
     ->setCacheFile('.cache/fixer/cs-fixer.cache')
+    ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRules([
         '@PSR12' => true,
         'array_syntax' => ['syntax' => 'short'],

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,6 +11,7 @@ $finder = Symfony\Component\Finder\Finder::create()
     ->ignoreVCS(true);
 
 return (new PhpCsFixer\Config())
+    ->setCacheFile('.cache/fixer/cs-fixer.cache')
     ->setRules([
         '@PSR12' => true,
         'array_syntax' => ['syntax' => 'short'],

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,7 @@ services:
 parameters:
 	level: 5
 	reportUnmatchedIgnoredErrors: false
+	tmpDir: .cache/phpstan
 	paths:
 		- src
 		- tests

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,7 @@
         displayDetailsOnTestsThatTriggerNotices="true"
         displayDetailsOnTestsThatTriggerWarnings="true"
         bootstrap="./tests/bootstrap.php"
+        cacheDirectory=".cache/phpunit"
 >
   <testsuites>
     <testsuite name="Integration">

--- a/src/Tempest/CommandBus/CommandBusDiscovery.php
+++ b/src/Tempest/CommandBus/CommandBusDiscovery.php
@@ -13,7 +13,7 @@ use Tempest\Discovery\Discovery;
 
 final readonly class CommandBusDiscovery implements Discovery
 {
-    private const CACHE_PATH = __DIR__ . '/command-bus-discovery.cache.php';
+    private const string CACHE_PATH = __DIR__ . '/../../../.cache/tempest/command-bus-discovery.cache.php';
 
     public function __construct(
         private CommandBusConfig $commandBusConfig,

--- a/src/Tempest/Console/Discovery/ConsoleCommandDiscovery.php
+++ b/src/Tempest/Console/Discovery/ConsoleCommandDiscovery.php
@@ -14,7 +14,7 @@ use Tempest\Support\Reflection\Attributes;
 
 final readonly class ConsoleCommandDiscovery implements Discovery
 {
-    private const CACHE_PATH = __DIR__ . '/../../../../.cache/tempest/console-command-discovery.cache.php';
+    private const string CACHE_PATH = __DIR__ . '/../../../../.cache/tempest/console-command-discovery.cache.php';
 
     public function __construct(private ConsoleConfig $consoleConfig)
     {

--- a/src/Tempest/Console/Discovery/ConsoleCommandDiscovery.php
+++ b/src/Tempest/Console/Discovery/ConsoleCommandDiscovery.php
@@ -14,7 +14,7 @@ use Tempest\Support\Reflection\Attributes;
 
 final readonly class ConsoleCommandDiscovery implements Discovery
 {
-    private const CACHE_PATH = __DIR__ . '/console-command-discovery.cache.php';
+    private const CACHE_PATH = __DIR__ . '/../../../../.cache/tempest/console-command-discovery.cache.php';
 
     public function __construct(private ConsoleConfig $consoleConfig)
     {

--- a/src/Tempest/Console/Discovery/ScheduleDiscovery.php
+++ b/src/Tempest/Console/Discovery/ScheduleDiscovery.php
@@ -13,7 +13,7 @@ use Tempest\Container\Container;
 use Tempest\Discovery\Discovery;
 use Tempest\Support\Reflection\Attributes;
 
-final class ScheduleDisovery implements Discovery
+final class ScheduleDiscovery implements Discovery
 {
     private const string CACHE_PATH = __DIR__ . '/../../../../.cache/tempest/schedule-discovery.cache.php';
 

--- a/src/Tempest/Console/Discovery/ScheduleDisovery.php
+++ b/src/Tempest/Console/Discovery/ScheduleDisovery.php
@@ -15,7 +15,7 @@ use Tempest\Support\Reflection\Attributes;
 
 final class ScheduleDisovery implements Discovery
 {
-    private const CACHE_PATH = __DIR__ . '/../../../../.cache/tempest/schedule-discovery.cache.php';
+    private const string CACHE_PATH = __DIR__ . '/../../../../.cache/tempest/schedule-discovery.cache.php';
 
     public function __construct(private SchedulerConfig $schedulerConfig)
     {

--- a/src/Tempest/Console/Discovery/ScheduleDisovery.php
+++ b/src/Tempest/Console/Discovery/ScheduleDisovery.php
@@ -15,7 +15,7 @@ use Tempest\Support\Reflection\Attributes;
 
 final class ScheduleDisovery implements Discovery
 {
-    private const CACHE_PATH = __DIR__ . '/schedule-discovery.cache.php';
+    private const CACHE_PATH = __DIR__ . '/../../../../.cache/tempest/schedule-discovery.cache.php';
 
     public function __construct(private SchedulerConfig $schedulerConfig)
     {

--- a/src/Tempest/Console/Scheduler/GenericScheduler.php
+++ b/src/Tempest/Console/Scheduler/GenericScheduler.php
@@ -10,7 +10,7 @@ use Tempest\Console\ShellExecutor;
 
 final readonly class GenericScheduler implements Scheduler
 {
-    public const string CACHE_PATH = __DIR__ . '/last-schedule-run.cache.php';
+    public const string CACHE_PATH = __DIR__ . '/../../../../.cache/tempest/last-schedule-run.cache.php';
 
     public function __construct(
         private SchedulerConfig $config,

--- a/src/Tempest/Container/InitializerDiscovery.php
+++ b/src/Tempest/Container/InitializerDiscovery.php
@@ -9,7 +9,7 @@ use Tempest\Discovery\Discovery;
 
 final readonly class InitializerDiscovery implements Discovery
 {
-    private const string CACHE_PATH = __DIR__ . '/initializer-discovery.cache.php';
+    private const string CACHE_PATH = __DIR__ . '/../../../.cache/tempest/initializer-discovery.cache.php';
 
     public function __construct(
         private Container&GenericContainer $container,

--- a/src/Tempest/Database/MigrationDiscovery.php
+++ b/src/Tempest/Database/MigrationDiscovery.php
@@ -10,7 +10,7 @@ use Tempest\Discovery\Discovery;
 
 final class MigrationDiscovery implements Discovery
 {
-    private const CACHE_PATH = __DIR__ . '/../../../.cache/tempest/migration-discovery.cache.php';
+    private const string CACHE_PATH = __DIR__ . '/../../../.cache/tempest/migration-discovery.cache.php';
 
     public function __construct(private DatabaseConfig $databaseConfig)
     {

--- a/src/Tempest/Database/MigrationDiscovery.php
+++ b/src/Tempest/Database/MigrationDiscovery.php
@@ -10,7 +10,7 @@ use Tempest\Discovery\Discovery;
 
 final class MigrationDiscovery implements Discovery
 {
-    private const CACHE_PATH = __DIR__ . '/migration-discovery.cache.php';
+    private const CACHE_PATH = __DIR__ . '/../../../.cache/tempest/migration-discovery.cache.php';
 
     public function __construct(private DatabaseConfig $databaseConfig)
     {

--- a/src/Tempest/Discovery/DiscoveryDiscovery.php
+++ b/src/Tempest/Discovery/DiscoveryDiscovery.php
@@ -10,7 +10,7 @@ use Tempest\Framework\Application\AppConfig;
 
 final readonly class DiscoveryDiscovery implements Discovery
 {
-    public const CACHE_PATH = __DIR__ . '/discovery-discovery.cache.php';
+    public const CACHE_PATH = __DIR__ . '/../../../.cache/tempest/discovery-discovery.cache.php';
 
     public function __construct(
         private AppConfig $appConfig,

--- a/src/Tempest/Discovery/DiscoveryDiscovery.php
+++ b/src/Tempest/Discovery/DiscoveryDiscovery.php
@@ -10,7 +10,7 @@ use Tempest\Framework\Application\AppConfig;
 
 final readonly class DiscoveryDiscovery implements Discovery
 {
-    public const CACHE_PATH = __DIR__ . '/../../../.cache/tempest/discovery-discovery.cache.php';
+    public const string CACHE_PATH = __DIR__ . '/../../../.cache/tempest/discovery-discovery.cache.php';
 
     public function __construct(
         private AppConfig $appConfig,

--- a/src/Tempest/EventBus/EventBusDiscovery.php
+++ b/src/Tempest/EventBus/EventBusDiscovery.php
@@ -13,7 +13,7 @@ use Tempest\Support\Reflection\Attributes;
 
 final readonly class EventBusDiscovery implements Discovery
 {
-    private const string CACHE_PATH = __DIR__ . '/event-bus-discovery.cache.php';
+    private const string CACHE_PATH = __DIR__ . '/../../../.cache/tempest/event-bus-discovery.cache.php';
 
     public function __construct(
         private EventBusConfig $eventBusConfig,

--- a/src/Tempest/Http/RouteDiscovery.php
+++ b/src/Tempest/Http/RouteDiscovery.php
@@ -13,7 +13,7 @@ use Tempest\Support\VarExport\VarExportPhpFile;
 
 final readonly class RouteDiscovery implements Discovery
 {
-    private const CACHE_PATH = __DIR__ . '/route-discovery.cache.php';
+    private const CACHE_PATH = __DIR__ . '/../../../.cache/tempest/route-discovery.cache.php';
 
     /** @var VarExportPhpFile<RouteConfig> */
     private VarExportPhpFile $routeCacheFile;

--- a/src/Tempest/Http/RouteDiscovery.php
+++ b/src/Tempest/Http/RouteDiscovery.php
@@ -13,7 +13,7 @@ use Tempest\Support\VarExport\VarExportPhpFile;
 
 final readonly class RouteDiscovery implements Discovery
 {
-    private const CACHE_PATH = __DIR__ . '/../../../.cache/tempest/route-discovery.cache.php';
+    private const string CACHE_PATH = __DIR__ . '/../../../.cache/tempest/route-discovery.cache.php';
 
     /** @var VarExportPhpFile<RouteConfig> */
     private VarExportPhpFile $routeCacheFile;

--- a/src/Tempest/Mapper/MapperDiscovery.php
+++ b/src/Tempest/Mapper/MapperDiscovery.php
@@ -10,7 +10,7 @@ use Tempest\Discovery\Discovery;
 
 final readonly class MapperDiscovery implements Discovery
 {
-    private const string CACHE_PATH = __DIR__ . '/mapper-discovery.cache.php';
+    private const string CACHE_PATH = __DIR__ . '/../../../.cache/tempest/mapper-discovery.cache.php';
 
     public function __construct(
         private MapperConfig $config,

--- a/src/Tempest/View/ViewComponentDiscovery.php
+++ b/src/Tempest/View/ViewComponentDiscovery.php
@@ -11,7 +11,7 @@ use Tempest\View\Components\AnonymousViewComponent;
 
 final readonly class ViewComponentDiscovery implements Discovery
 {
-    private const string CACHE_PATH = __DIR__ . '/view-component-discovery.cache.php';
+    private const string CACHE_PATH = __DIR__ . '/../../../.cache/tempest/view-component-discovery.cache.php';
 
     public function __construct(
         private ViewConfig $viewConfig,

--- a/tests/Integration/View/BladeViewRendererTest.php
+++ b/tests/Integration/View/BladeViewRendererTest.php
@@ -25,7 +25,7 @@ class BladeViewRendererTest extends FrameworkIntegrationTestCase
 
         $this->container->config(new BladeConfig(
             viewPaths: [__DIR__ . '/blade'],
-            cachePath: __DIR__ . '/blade/cache',
+            cachePath: __DIR__ . '/../../../../.cache/tempest/blade/cache',
         ));
 
         $renderer = $this->container->get(ViewRenderer::class);

--- a/tests/Integration/View/BladeViewRendererTest.php
+++ b/tests/Integration/View/BladeViewRendererTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Integration\View;
+namespace Tests\Tempest\Integration\View;
 
 use function Tempest\view;
 use Tempest\View\Renderers\BladeConfig;

--- a/tests/Unit/KernelTest.php
+++ b/tests/Unit/KernelTest.php
@@ -50,9 +50,9 @@ class KernelTest extends TestCase
         //        $this->assertSame(InitializerDiscovery::class, $appConfig->discoveryClasses[5]);
         //        $this->assertSame(RouteDiscovery::class, $appConfig->discoveryClasses[6]);
         //        $this->assertSame(ViewComponentDiscovery::class, $appConfig->discoveryClasses[7]);
-        //        $this->assertSame(ScheduleDisovery::class, $appConfig->discoveryClasses[8]);
+        //        $this->assertSame(ScheduleDiscovery::class, $appConfig->discoveryClasses[8]);
         //        $this->assertSame(EventBusDiscovery::class, $appConfig->discoveryClasses[9]);
-        //        $this->assertSame(ScheduleDisovery::class, $appConfig->discoveryClasses[10]);
+        //        $this->assertSame(ScheduleDiscovery::class, $appConfig->discoveryClasses[10]);
         //        $this->assertSame(ConsoleCommandDiscovery::class, $appConfig->discoveryClasses[11]);
 
         //        $this->assertCount(2, $appConfig->discoveryLocations);


### PR DESCRIPTION
This might just be a personal preference, but this PR moves all the cache files to a single directory.
Instead of having them scattered throughout 

**Additional**
- enabled the cache for PHPStan
- enable parallel fixing for CS fixer

**Note**
Enabling cache on Github Actions is also possible :)