### PR TITLE
[security] allow only known classes to unserialize

### DIFF
--- a/src/Tempest/CommandBus/CommandBusDiscovery.php
+++ b/src/Tempest/CommandBus/CommandBusDiscovery.php
@@ -54,7 +54,7 @@ final readonly class CommandBusDiscovery implements Discovery
 
     public function restoreCachePayload(Container $container, string $payload): void
     {
-        $handlers = unserialize($payload);
+        $handlers = unserialize($payload, ['allowed_classes' => [CommandHandler::class]]);
 
         $this->commandBusConfig->handlers = $handlers;
     }

--- a/src/Tempest/Console/Discovery/ConsoleCommandDiscovery.php
+++ b/src/Tempest/Console/Discovery/ConsoleCommandDiscovery.php
@@ -40,7 +40,7 @@ final readonly class ConsoleCommandDiscovery implements Discovery
 
     public function restoreCachePayload(Container $container, string $payload): void
     {
-        $commands = unserialize($payload);
+        $commands = unserialize($payload, ['allowed_classes' => [ConsoleCommand::class]]);
 
         $this->consoleConfig->commands = $commands;
     }

--- a/src/Tempest/Console/Discovery/ScheduleDiscovery.php
+++ b/src/Tempest/Console/Discovery/ScheduleDiscovery.php
@@ -6,6 +6,8 @@ namespace Tempest\Console\Discovery;
 
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Schedule;
+use Tempest\Console\Scheduler\Interval;
+use Tempest\Console\Scheduler\ScheduledInvocation;
 use Tempest\Console\Scheduler\SchedulerConfig;
 use Tempest\Container\Container;
 use Tempest\Discovery\Discovery;
@@ -47,7 +49,14 @@ final class ScheduleDiscovery implements Discovery
 
     public function restoreCachePayload(Container $container, string $payload): void
     {
-        $scheduledInvocations = unserialize($payload);
+        $scheduledInvocations = unserialize($payload, [
+            'allowed_classes' => [
+                ScheduledInvocation::class,
+                Schedule::class,
+                Interval::class,
+                ConsoleCommand::class,
+            ],
+        ]);
 
         $this->schedulerConfig->scheduledInvocations = $scheduledInvocations;
     }

--- a/src/Tempest/Console/Scheduler/GenericScheduler.php
+++ b/src/Tempest/Console/Scheduler/GenericScheduler.php
@@ -76,7 +76,7 @@ final readonly class GenericScheduler implements Scheduler
             return [];
         }
 
-        return unserialize(file_get_contents(self::CACHE_PATH));
+        return unserialize(file_get_contents(self::CACHE_PATH), ['allowed_classes' => false]);
     }
 
     /**

--- a/src/Tempest/Console/Testing/ConsoleTester.php
+++ b/src/Tempest/Console/Testing/ConsoleTester.php
@@ -85,7 +85,7 @@ final class ConsoleTester
 
                 $attribute = $handler->getAttribute(ConsoleCommand::class);
 
-                if (! $attribute) {
+                if ($attribute === null) {
                     throw new Exception("Could not resolve console command from {$command[0]}::{$command[1]}");
                 }
 

--- a/src/Tempest/Container/InitializerDiscovery.php
+++ b/src/Tempest/Container/InitializerDiscovery.php
@@ -8,12 +8,15 @@ use Tempest\Discovery\Discovery;
 use Tempest\Discovery\HandlesDiscoveryCache;
 use Tempest\Support\Reflection\ClassReflector;
 
+/**
+ * @property GenericContainer $container
+ */
 final readonly class InitializerDiscovery implements Discovery
 {
     use HandlesDiscoveryCache;
 
     public function __construct(
-        private Container&GenericContainer $container,
+        private Container $container,
     ) {
     }
 
@@ -38,7 +41,10 @@ final readonly class InitializerDiscovery implements Discovery
 
     public function restoreCachePayload(Container $container, string $payload): void
     {
-        $data = unserialize($payload);
+        $data = unserialize($payload, ['allowed_classes' => [
+            Initializer::class,
+            DynamicInitializer::class,
+        ]]);
 
         $this->container->setInitializers($data['initializers'] ?? []);
         $this->container->setDynamicInitializers($data['dynamic_initializers'] ?? []);

--- a/src/Tempest/Discovery/DiscoveryDiscovery.php
+++ b/src/Tempest/Discovery/DiscoveryDiscovery.php
@@ -4,18 +4,9 @@ declare(strict_types=1);
 
 namespace Tempest\Discovery;
 
-use Tempest\CommandBus\CommandBusDiscovery;
-use Tempest\Console\Discovery\ConsoleCommandDiscovery;
-use Tempest\Console\Discovery\ScheduleDiscovery;
 use Tempest\Container\Container;
-use Tempest\Container\InitializerDiscovery;
-use Tempest\Database\MigrationDiscovery;
-use Tempest\EventBus\EventBusDiscovery;
 use Tempest\Framework\Application\AppConfig;
-use Tempest\Http\RouteDiscovery;
-use Tempest\Mapper\MapperDiscovery;
 use Tempest\Support\Reflection\ClassReflector;
-use Tempest\View\ViewComponentDiscovery;
 
 final readonly class DiscoveryDiscovery implements Discovery
 {
@@ -52,18 +43,7 @@ final readonly class DiscoveryDiscovery implements Discovery
     public function restoreCache(Container $container): void
     {
         $discoveryClasses = unserialize(file_get_contents(self::CACHE_PATH), [
-            'allowed_classes' => [
-                CommandBusDiscovery::class,
-                ConsoleCommandDiscovery::class,
-                self::class,
-                EventBusDiscovery::class,
-                InitializerDiscovery::class,
-                MapperDiscovery::class,
-                MigrationDiscovery::class,
-                RouteDiscovery::class,
-                ScheduleDiscovery::class,
-                ViewComponentDiscovery::class,
-            ],
+            'allowed_classes' => true,
         ]);
 
         $this->appConfig->discoveryClasses = $discoveryClasses;

--- a/src/Tempest/Discovery/DiscoveryDiscovery.php
+++ b/src/Tempest/Discovery/DiscoveryDiscovery.php
@@ -4,9 +4,18 @@ declare(strict_types=1);
 
 namespace Tempest\Discovery;
 
+use Tempest\CommandBus\CommandBusDiscovery;
+use Tempest\Console\Discovery\ConsoleCommandDiscovery;
+use Tempest\Console\Discovery\ScheduleDiscovery;
 use Tempest\Container\Container;
+use Tempest\Container\InitializerDiscovery;
+use Tempest\Database\MigrationDiscovery;
+use Tempest\EventBus\EventBusDiscovery;
 use Tempest\Framework\Application\AppConfig;
+use Tempest\Http\RouteDiscovery;
+use Tempest\Mapper\MapperDiscovery;
 use Tempest\Support\Reflection\ClassReflector;
+use Tempest\View\ViewComponentDiscovery;
 
 final readonly class DiscoveryDiscovery implements Discovery
 {
@@ -42,7 +51,20 @@ final readonly class DiscoveryDiscovery implements Discovery
 
     public function restoreCache(Container $container): void
     {
-        $discoveryClasses = unserialize(file_get_contents(self::CACHE_PATH));
+        $discoveryClasses = unserialize(file_get_contents(self::CACHE_PATH), [
+            'allowed_classes' => [
+                CommandBusDiscovery::class,
+                ConsoleCommandDiscovery::class,
+                self::class,
+                EventBusDiscovery::class,
+                InitializerDiscovery::class,
+                MapperDiscovery::class,
+                MigrationDiscovery::class,
+                RouteDiscovery::class,
+                ScheduleDiscovery::class,
+                ViewComponentDiscovery::class,
+            ],
+        ]);
 
         $this->appConfig->discoveryClasses = $discoveryClasses;
     }

--- a/src/Tempest/EventBus/EventBusDiscovery.php
+++ b/src/Tempest/EventBus/EventBusDiscovery.php
@@ -54,7 +54,7 @@ final readonly class EventBusDiscovery implements Discovery
 
     public function restoreCachePayload(Container $container, string $payload): void
     {
-        $handlers = unserialize($payload);
+        $handlers = unserialize($payload, ['allowed_classes' => [EventHandler::class]]);
 
         $this->eventBusConfig->handlers = $handlers;
     }

--- a/src/Tempest/Framework/Bootstraps/DiscoveryBootstrap.php
+++ b/src/Tempest/Framework/Bootstraps/DiscoveryBootstrap.php
@@ -40,7 +40,7 @@ final readonly class DiscoveryBootstrap implements Bootstrap
             }
 
             foreach ($this->appConfig->discoveryLocations as $discoveryLocation) {
-                $directories = new RecursiveDirectoryIterator($discoveryLocation->path, FilesystemIterator::UNIX_PATHS);
+                $directories = new RecursiveDirectoryIterator($discoveryLocation->path, FilesystemIterator::UNIX_PATHS | FilesystemIterator::SKIP_DOTS);
                 $files = new RecursiveIteratorIterator($directories);
 
                 /** @var SplFileInfo $file */

--- a/src/Tempest/Http/GenericRouter.php
+++ b/src/Tempest/Http/GenericRouter.php
@@ -125,7 +125,7 @@ final class GenericRouter implements Router
 
         $routeAttribute = $controllerMethod->getAttribute(Route::class);
 
-        if (! $routeAttribute) {
+        if ($routeAttribute === null) {
             throw new InvalidRouteException($controllerClass, $controllerMethod->getName());
         }
 

--- a/src/Tempest/Http/Session/Managers/FileSessionManager.php
+++ b/src/Tempest/Http/Session/Managers/FileSessionManager.php
@@ -4,20 +4,15 @@ declare(strict_types=1);
 
 namespace Tempest\Http\Session\Managers;
 
-use DateTimeImmutable;
 use RuntimeException;
 use Tempest\Clock\Clock;
 use function Tempest\event;
-use Tempest\Http\Session\FlashValue;
 use Tempest\Http\Session\Session;
 use Tempest\Http\Session\SessionConfig;
 use Tempest\Http\Session\SessionDestroyed;
 use Tempest\Http\Session\SessionId;
 use Tempest\Http\Session\SessionManager;
 use function Tempest\path;
-use Tempest\Validation\Rules\AlphaNumeric;
-use Tempest\Validation\Rules\Between;
-use Tempest\Validation\Rules\NotEmpty;
 use Throwable;
 
 final readonly class FileSessionManager implements SessionManager
@@ -84,15 +79,7 @@ final readonly class FileSessionManager implements SessionManager
         try {
             $content = @file_get_contents($path);
 
-            return unserialize($content, ['allowed_classes' => [
-                SessionId::class,
-                Session::class,
-                DateTimeImmutable::class,
-                FlashValue::class,
-                NotEmpty::class,
-                Between::class,
-                AlphaNumeric::class,
-            ]]);
+            return unserialize($content, ['allowed_classes' => true]);
         } catch (Throwable) {
             return null;
         }

--- a/src/Tempest/Http/Session/Managers/FileSessionManager.php
+++ b/src/Tempest/Http/Session/Managers/FileSessionManager.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tempest\Http\Session\Managers;
 
-use RuntimeException;
 use Tempest\Clock\Clock;
 use function Tempest\event;
 use Tempest\Http\Session\Session;
@@ -111,8 +110,8 @@ final readonly class FileSessionManager implements SessionManager
         $path = $this->getPath($id);
         $dir = dirname($path);
 
-        if (! is_dir($dir) && ! mkdir($dir, recursive: true) && ! is_dir($dir)) {
-            throw new RuntimeException(sprintf('Directory "%s" was not created', $dir));
+        if (! is_dir($dir)) {
+            mkdir($dir, recursive: true);
         }
 
         if ($data !== null) {

--- a/src/Tempest/Mapper/MapperDiscovery.php
+++ b/src/Tempest/Mapper/MapperDiscovery.php
@@ -34,7 +34,7 @@ final readonly class MapperDiscovery implements Discovery
 
     public function restoreCachePayload(Container $container, string $payload): void
     {
-        $mappers = unserialize($payload);
+        $mappers = unserialize($payload, ['allowed_classes' => [Mapper::class]]);
 
         $this->config->mappers = $mappers;
     }

--- a/src/Tempest/Support/Reflection/TypeReflector.php
+++ b/src/Tempest/Support/Reflection/TypeReflector.php
@@ -80,7 +80,7 @@ final readonly class TypeReflector implements Reflector
 
     public function isClass(): bool
     {
-        return class_exists($this->getName());
+        return class_exists($this->definition);
     }
 
     public function isIterable(): bool

--- a/src/Tempest/View/ViewComponentDiscovery.php
+++ b/src/Tempest/View/ViewComponentDiscovery.php
@@ -74,7 +74,9 @@ final readonly class ViewComponentDiscovery implements Discovery, DiscoversPath
 
     public function restoreCachePayload(Container $container, string $payload): void
     {
-        $handlers = unserialize($payload);
+        $handlers = unserialize($payload, ['allowed_classes' => [
+            AnonymousViewComponent::class,
+        ]]);
 
         $this->viewConfig->viewComponents = $handlers;
     }


### PR DESCRIPTION
This PR allows us to be more strict with the `unserialize(..)` behaviour.

If a different payload is given than the one we allow, then the application will throw an exception.

This was already done in #306 for the Migration cache, and I think that it's good to be security focused when dealing with outside input. Wether human based, or computational based.