### PR TITLE
refactor: fix tests on windows

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         php: [8.3]
         stability: [prefer-stable]
 

--- a/.github/workflows/quality-control.yml
+++ b/.github/workflows/quality-control.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         php: [8.3]
         stability: [prefer-stable]
 

--- a/src/Tempest/Console/Testing/ConsoleTester.php
+++ b/src/Tempest/Console/Testing/ConsoleTester.php
@@ -177,9 +177,10 @@ final class ConsoleTester
         return $this->assertDoesNotContain($text);
     }
 
-    public function assertContains(string $text): self
+    public function assertContains(string $text, bool $ignoreLineEndings = false): self
     {
-        Assert::assertStringContainsString(
+        $method = $ignoreLineEndings ? 'assertStringContainsStringIgnoringLineEndings' : 'assertStringContainsString';
+        Assert::$method(
             $text,
             $this->output->asUnformattedString(),
             sprintf(

--- a/src/Tempest/Support/PathHelper.php
+++ b/src/Tempest/Support/PathHelper.php
@@ -11,8 +11,8 @@ final readonly class PathHelper
         $path = implode('/', $parts);
 
         return str_replace(
-            ['//', '\\', '\\\\'],
-            ['/', '/', '/'],
+            ['//', '\\'],
+            DIRECTORY_SEPARATOR,
             $path,
         );
     }

--- a/tests/Integration/Console/Components/MultipleChoiceComponentTest.php
+++ b/tests/Integration/Console/Components/MultipleChoiceComponentTest.php
@@ -17,7 +17,7 @@ class MultipleChoiceComponentTest extends TestCase
     {
         $component = new MultipleChoiceComponent('Label', ['a', 'b', 'c']);
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'TXT'
             <question>Label</question>
             > [ ]<em> a</em>

--- a/tests/Integration/Console/Components/Static/StaticProgressBarComponentTest.php
+++ b/tests/Integration/Console/Components/Static/StaticProgressBarComponentTest.php
@@ -31,6 +31,7 @@ class StaticProgressBarComponentTest extends FrameworkIntegrationTestCase
 [===============================] (3/3)
 ["aa","bb","cc"]
 TXT,
+                true
             );
     }
 }

--- a/tests/Integration/Console/Components/Static/StaticSearchComponentTest.php
+++ b/tests/Integration/Console/Components/Static/StaticSearchComponentTest.php
@@ -32,6 +32,7 @@ class StaticSearchComponentTest extends FrameworkIntegrationTestCase
 - [2] Aidan
 - [3] Roman
 TXT,
+                true
             )
             ->submit(0)
             ->submit('b')
@@ -40,6 +41,7 @@ TXT,
 - [0] Search again
 - [1] Brent
 TXT,
+                true
             )
             ->submit(1)
             ->assertContains("Hello Brent");

--- a/tests/Integration/View/TempestViewRendererTest.php
+++ b/tests/Integration/View/TempestViewRendererTest.php
@@ -102,7 +102,7 @@ class TempestViewRendererTest extends FrameworkIntegrationTestCase
 
     public function test_foreach_attribute(): void
     {
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'HTML'
             <div :foreach="$this->items as $foo">a</div>
             <div :foreach="$this->items as $foo">b</div>
@@ -172,7 +172,7 @@ class TempestViewRendererTest extends FrameworkIntegrationTestCase
 
     public function test_multiple_slots(): void
     {
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'HTML'
             injected scripts
                 

--- a/tests/Integration/View/TempestViewRendererTest.php
+++ b/tests/Integration/View/TempestViewRendererTest.php
@@ -130,7 +130,7 @@ class TempestViewRendererTest extends FrameworkIntegrationTestCase
 
     public function test_default_slot(): void
     {
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'HTML'
             <div class="base">
                 
@@ -152,7 +152,7 @@ class TempestViewRendererTest extends FrameworkIntegrationTestCase
 
     public function test_implicit_default_slot(): void
     {
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'HTML'
             <div class="base">
                 
@@ -215,7 +215,7 @@ class TempestViewRendererTest extends FrameworkIntegrationTestCase
 
     public function test_pre(): void
     {
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<'HTML'
             <pre>
             a

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -182,7 +182,7 @@ class ViewComponentTest extends FrameworkIntegrationTestCase
             )
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<HTML
         <div>
                 test    </div>

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -21,7 +21,7 @@ class ViewComponentTest extends FrameworkIntegrationTestCase
     #[DataProvider('view_components')]
     public function test_view_components(string $component, string $rendered): void
     {
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             expected: $rendered,
             actual: $this->render(view($component)),
         );
@@ -49,7 +49,7 @@ class ViewComponentTest extends FrameworkIntegrationTestCase
 
     public function test_nested_components(): void
     {
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             expected: <<<'HTML'
             <form action="#" method="post"><div><div><label for="a">a</label>
             <input type="number" name="a" id="a" value></input></div></div>
@@ -118,7 +118,7 @@ class ViewComponentTest extends FrameworkIntegrationTestCase
 
     public function test_component_with_foreach(): void
     {
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             expected: '<div>a</div>
 <div>b</div>',
             actual: $this->render(view('<x-my :foreach="$this->items as $foo">{{ $foo }}</x-my>')->data(items: ['a', 'b'])),
@@ -203,7 +203,7 @@ class ViewComponentTest extends FrameworkIntegrationTestCase
             ),
         );
 
-        $this->assertSame(
+        $this->assertStringEqualsStringIgnoringLineEndings(
             <<<HTML
         <div>
                 a    </div>

--- a/tests/Integration/View/ViewTest.php
+++ b/tests/Integration/View/ViewTest.php
@@ -30,7 +30,7 @@ class ViewTest extends FrameworkIntegrationTestCase
             </body></html>
             HTML;
 
-        $this->assertEquals($expected, $html);
+        $this->assertStringContainsStringIgnoringLineEndings($expected, $html);
     }
 
     public function test_render_with_view_model(): void
@@ -57,7 +57,7 @@ HTML;
         <h1>hi</h1>
         HTML;
 
-        $this->assertSame(trim($expected), trim($html));
+        $this->assertStringEqualsStringIgnoringLineEndings(trim($expected), trim($html));
     }
 
     public function test_custom_view_with_response_data(): void

--- a/tests/Unit/Container/ContainerTest.php
+++ b/tests/Unit/Container/ContainerTest.php
@@ -273,7 +273,7 @@ class ContainerTest extends TestCase
         try {
             $container->get(DependencyWithTaggedDependency::class);
         } catch (CannotResolveTaggedDependency $cannotResolveTaggedDependency) {
-            $this->assertStringContainsString(
+            $this->assertStringContainsStringIgnoringLineEndings(
                 <<<'TXT'
 	┌── DependencyWithTaggedDependency::__construct(TaggedDependency $dependency)
 	└── Tests\Tempest\Unit\Container\Fixtures\TaggedDependency

--- a/tests/Unit/Container/Exceptions/CannotAutowireExceptionTest.php
+++ b/tests/Unit/Container/Exceptions/CannotAutowireExceptionTest.php
@@ -33,7 +33,7 @@ class CannotAutowireExceptionTest extends TestCase
 	                                                    ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 TXT;
 
-            $this->assertStringContainsString($expected, $cannotAutowireException->getMessage());
+            $this->assertStringContainsStringIgnoringLineEndings($expected, $cannotAutowireException->getMessage());
             $this->assertStringContainsString("CannotAutowireExceptionTest.php:25", $cannotAutowireException->getMessage());
 
             throw $cannotAutowireException;

--- a/tests/Unit/Container/Exceptions/CircularDependencyExceptionTest.php
+++ b/tests/Unit/Container/Exceptions/CircularDependencyExceptionTest.php
@@ -34,7 +34,7 @@ class CircularDependencyExceptionTest extends TestCase
 	└───────────────────────────────────────────────────▒▒▒▒▒▒▒▒▒▒▒▒
 TXT;
 
-            $this->assertStringContainsString($expected, $circularDependencyException->getMessage());
+            $this->assertStringContainsStringIgnoringLineEndings($expected, $circularDependencyException->getMessage());
 
             $this->assertStringContainsString("CircularDependencyExceptionTest.php:", $circularDependencyException->getMessage());
 
@@ -61,7 +61,7 @@ TXT;
 	└───────────────────────────────────────────────────▒▒▒▒▒▒▒▒▒▒▒▒
 TXT;
 
-            $this->assertStringContainsString($expected, $circularDependencyException->getMessage());
+            $this->assertStringContainsStringIgnoringLineEndings($expected, $circularDependencyException->getMessage());
 
             throw $circularDependencyException;
         }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,4 +4,16 @@ declare(strict_types=1);
 
 require_once  __DIR__ . '/../vendor/autoload.php';
 
-passthru('./tempest discovery:clear');
+
+$script = 'tempest discovery:clear';
+
+// Adjust the command for the OS
+if (PHP_OS_FAMILY === 'Windows') {
+    // On Windows, use "php" executable and provide the relative path
+    $command = "php {$script}";
+} else {
+    // On Unix-based systems, execute the script directly
+    $command = "./{$script}";
+}
+
+passthru($command);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,16 +4,4 @@ declare(strict_types=1);
 
 require_once  __DIR__ . '/../vendor/autoload.php';
 
-
-$script = 'tempest discovery:clear';
-
-// Adjust the command for the OS
-if (PHP_OS_FAMILY === 'Windows') {
-    // On Windows, use "php" executable and provide the relative path
-    $command = "php {$script}";
-} else {
-    // On Unix-based systems, execute the script directly
-    $command = "./{$script}";
-}
-
-passthru($command);
+passthru("php tempest discovery:clear");

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,4 +4,4 @@ declare(strict_types=1);
 
 require_once  __DIR__ . '/../vendor/autoload.php';
 
-passthru("php tempest discovery:clear");
+passthru('php tempest discovery:clear');


### PR DESCRIPTION
I mainly use wsl2 to work on projects, but, I saw that there is PR to add a windows runner. The only tests that failed for me on windows  where related to different line endings between the expected string and the result (lf vs clrf), and most of the console related tests, but those where related to how the tests/bootstrap.php file was trying to run the `tempest discovery:clear` command, for windows it needs to be run with php explicitly.

If this changes make no sense at all please feel free to close the pr, thanks.
