### PR TITLE
Isolate extract method

### DIFF
--- a/src/Tempest/View/Renderers/TempestViewRenderer.php
+++ b/src/Tempest/View/Renderers/TempestViewRenderer.php
@@ -161,17 +161,7 @@ final class TempestViewRenderer implements ViewRenderer
             throw new Exception("View {$path} not found");
         }
 
-        return $this->y($path, $view->getData());
-    }
-
-    private function resolveContentIsolated(string $_path, array $_data): string {
-        ob_start();
-
-        extract($_data, flags: EXTR_SKIP);
-
-        include $_path;
-
-        return ob_get_clean();
+        return $this->resolveContentIsolated($path, $view->getData());
     }
 
     private function resolveViewComponent(GenericElement $element): ?ViewComponent
@@ -314,5 +304,15 @@ final class TempestViewRenderer implements ViewRenderer
         }
 
         return "<{$element->getTag()}{$attributes}>{$content}</{$element->getTag()}>";
+    }
+
+    private function resolveContentIsolated(string $_path, array $_data): string {
+        ob_start();
+
+        extract($_data, flags: EXTR_SKIP);
+
+        include $_path;
+
+        return ob_get_clean();
     }
 }

--- a/src/Tempest/View/Renderers/TempestViewRenderer.php
+++ b/src/Tempest/View/Renderers/TempestViewRenderer.php
@@ -161,13 +161,15 @@ final class TempestViewRenderer implements ViewRenderer
             throw new Exception("View {$path} not found");
         }
 
-        ob_start();
+        return $this->y($path, $view->getData());
+    }
 
-        $_data = $view->getData();
+    private function resolveContentIsolated(string $_path, array $_data): string {
+        ob_start();
 
         extract($_data, flags: EXTR_SKIP);
 
-        include $path;
+        include $_path;
 
         return ob_get_clean();
     }


### PR DESCRIPTION
When the extract part is in an isolated method, variables from the `resolveContent` method can be reused in the view file.

Conflicts with variables like `$view` or `$path` e.g. are prevented. Only `$_path` and `$_data` are reserved as a minimum.