### PR TITLE
feat(support): add `Pluralizer` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `LanguageHelper::pluralize` and `LanguageHelper::singularize`
 - Unit tests for the CommandBus `dispatch` method.
 - Replaced Ignition with Whoops.
 - Properly detect environment from `.env` when present.

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "The PHP framework that gets out of your way.",
     "license": "MIT",
     "require": {
+        "doctrine/inflector": "^2.0",
         "egulias/email-validator": "^4.0.2",
         "ext-dom": "*",
         "ext-fileinfo": "*",

--- a/src/Tempest/Support/composer.json
+++ b/src/Tempest/Support/composer.json
@@ -3,7 +3,9 @@
     "license": "MIT",
     "minimum-stability": "dev",
     "require": {
-        "php": "^8.3"
+        "php": "^8.3",
+        "doctrine/inflector": "^2.0",
+        "tempest/container": "self.version"
     },
     "autoload": {
         "psr-4": {

--- a/src/Tempest/Support/src/LanguageHelper.php
+++ b/src/Tempest/Support/src/LanguageHelper.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Tempest\Support;
 
+use Countable;
+use function Tempest\get;
+use Tempest\Support\Pluralizer\Pluralizer;
+
 final class LanguageHelper
 {
     /**
@@ -18,5 +22,15 @@ final class LanguageHelper
         }
 
         return $last;
+    }
+
+    public static function pluralize(string $value, int|array|Countable $count = 2): string
+    {
+        return get(Pluralizer::class)->pluralize($value, $count);
+    }
+
+    public static function singularize(string $value): string
+    {
+        return get(Pluralizer::class)->singularize($value);
     }
 }

--- a/src/Tempest/Support/src/Pluralizer/InflectorPluralizer.php
+++ b/src/Tempest/Support/src/Pluralizer/InflectorPluralizer.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Pluralizer;
+
+use Countable;
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
+
+final class InflectorPluralizer implements Pluralizer
+{
+    private Inflector $inflector;
+
+    public function __construct(string $language = 'english')
+    {
+        $this->inflector = InflectorFactory::createForLanguage($language)->build();
+    }
+
+    public function pluralize(string $value, int|array|Countable $count = 2): string
+    {
+        if (is_countable($count)) {
+            $count = count($count);
+        }
+
+        if ((int) abs($count) === 1 || preg_match('/^(.*)[A-Za-z0-9\x{0080}-\x{FFFF}]$/u', $value) == 0) {
+            return $value;
+        }
+
+        return $this->matchCase($this->inflector->pluralize($value), $value);
+    }
+
+    public function singularize(string $value): string
+    {
+        return $this->matchCase($this->inflector->singularize($value), $value);
+    }
+
+    private function matchCase(string $value, string $comparison): string
+    {
+        $functions = ['mb_strtolower', 'mb_strtoupper', 'ucfirst', 'ucwords'];
+
+        foreach ($functions as $function) {
+            if ($function($comparison) === $comparison) {
+                return $function($value);
+            }
+        }
+
+        return $value;
+    }
+}

--- a/src/Tempest/Support/src/Pluralizer/Pluralizer.php
+++ b/src/Tempest/Support/src/Pluralizer/Pluralizer.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Pluralizer;
+
+use Countable;
+
+interface Pluralizer
+{
+    public function pluralize(string $value, int|array|Countable $count = 2): string;
+
+    public function singularize(string $value): string;
+}

--- a/src/Tempest/Support/src/Pluralizer/PluralizerInitializer.php
+++ b/src/Tempest/Support/src/Pluralizer/PluralizerInitializer.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Pluralizer;
+
+use Tempest\Container\Container;
+use Tempest\Container\Initializer;
+
+final readonly class PluralizerInitializer implements Initializer
+{
+    public function initialize(Container $container): Pluralizer
+    {
+        return new InflectorPluralizer();
+    }
+}

--- a/src/Tempest/Support/tests/LanguageHelperTest.php
+++ b/src/Tempest/Support/tests/LanguageHelperTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Tests;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\LanguageHelper;
+
+/**
+ * @internal
+ * @small
+ */
+final class LanguageHelperTest extends TestCase
+{
+    #[TestWith([['Jon', 'Jane'], 'Jon and Jane'])]
+    #[TestWith([['Jon', 'Jane', 'Jill'], 'Jon, Jane and Jill'])]
+    public function test_join(array $parts, string $expected): void
+    {
+        $this->assertEquals($expected, LanguageHelper::join($parts));
+    }
+}

--- a/src/Tempest/Support/tests/Pluralizer/InflectorPluralizerTest.php
+++ b/src/Tempest/Support/tests/Pluralizer/InflectorPluralizerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Tests\Pluralizer;
+
+use Countable;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Pluralizer\InflectorPluralizer;
+
+/**
+ * @internal
+ * @small
+ */
+final class InflectorPluralizerTest extends TestCase
+{
+    #[TestWith(['migration', 'migrations', 0])]
+    #[TestWith(['migration', 'migration', 1])]
+    #[TestWith(['Migration', 'Migrations', 2])]
+    #[TestWith(['migration', 'migrations', 2])]
+    #[TestWith(['migration', 'migrations', [1, 2]])]
+    public function test_that_pluralizer_pluralizes(string $value, string $expected, int|array|Countable $count): void
+    {
+        $pluralizer = new InflectorPluralizer();
+
+        $this->assertEquals($expected, $pluralizer->pluralize($value, $count));
+    }
+
+    #[TestWith(['Migrations', 'Migration'])]
+    #[TestWith(['migrations', 'migration'])]
+    public function test_that_pluralizer_singularizes(string $value, string $expected): void
+    {
+        $pluralizer = new InflectorPluralizer();
+
+        $this->assertEquals($expected, $pluralizer->singularize($value));
+    }
+}

--- a/tests/Integration/Support/LanguageHelperTest.php
+++ b/tests/Integration/Support/LanguageHelperTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Support;
+
+use Countable;
+use PHPUnit\Framework\Attributes\TestWith;
+use Tempest\Support\LanguageHelper;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+/**
+ * @internal
+ * @small
+ */
+final class LanguageHelperTest extends FrameworkIntegrationTestCase
+{
+    #[TestWith(['migration', 'migrations', 0])]
+    #[TestWith(['migration', 'migration', 1])]
+    #[TestWith(['Migration', 'Migrations', 2])]
+    #[TestWith(['migration', 'migrations', 2])]
+    #[TestWith(['migration', 'migrations', [1, 2]])]
+    public function test_that_pluralize_pluralizes(string $value, string $expected, int|array|Countable $count): void
+    {
+        $this->assertEquals($expected, LanguageHelper::pluralize($value, $count));
+    }
+
+    #[TestWith(['Migrations', 'Migration'])]
+    #[TestWith(['migrations', 'migration'])]
+    public function test_that_pluralizer_singularizes(string $value, string $expected): void
+    {
+        $this->assertEquals($expected, LanguageHelper::singularize($value));
+    }
+}


### PR DESCRIPTION
This pull request adds support for pluralizing (or singularizing) nouns through `doctrine/inflector`. The implementation is a simplified and cleaner version of Laravel's.

This can be used as a helper in application code through `LanguageHelpers::pluralize()`, but is also intended to be used in the framework itself, such as in database table names, exception and log messages, validation, etc.

Note: I didn't know if I should make a new package or put it in the support one, so I kept things simple and added it to `Support`. I'm assuming `Support` will grow over time and it's not a bad place to have it, but at the same time, `Clock` is a separate package, so I don't know. Happy to update the PR.

Related: https://discord.com/channels/1236153076688359495/1236153079603269766/1268515847073173606