### PR TITLE
feat(support): add `StringHelper`

### DIFF
--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support;
+
+use Countable;
+
+final readonly class StringHelper
+{
+    public static function title(string $value): string
+    {
+        return mb_convert_case($value, MB_CASE_TITLE, 'UTF-8');
+    }
+
+    public static function lower(string $value): string
+    {
+        return mb_strtolower($value, 'UTF-8');
+    }
+
+    public static function upper(string $value): string
+    {
+        return mb_strtoupper($value, 'UTF-8');
+    }
+
+    public static function snake(string $value, string $delimiter = '_'): string
+    {
+        if (ctype_lower($value)) {
+            return $value;
+        }
+
+        $value = preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value);
+        $value = preg_replace('![^'.preg_quote($delimiter).'\pL\pN\s]+!u', $delimiter, static::lower($value));
+        $value = preg_replace('/\s+/u', $delimiter, $value);
+        $value = trim($value, $delimiter);
+
+        return static::deduplicate($value, $delimiter);
+    }
+
+    public static function kebab(string $value): string
+    {
+        return static::snake($value, '-');
+    }
+
+    public static function pascal(string $value): string
+    {
+        $words = explode(' ', str_replace(['-', '_'], ' ', $value));
+        $studlyWords = array_map(static fn (string $word) => mb_ucfirst($word), $words);
+
+        return implode($studlyWords);
+    }
+
+    public static function deduplicate(string $string, string|array $characters = ' '): string
+    {
+        foreach (ArrayHelper::wrap($characters) as $character) {
+            $string = preg_replace('/'.preg_quote($character, '/').'+/u', $character, $string);
+        }
+
+        return $string;
+    }
+
+    public static function pluralize(string $value, int|array|Countable $count = 2): string
+    {
+        return LanguageHelper::pluralize($value, $count);
+    }
+
+    public static function pluralizeLast(string $value, int|array|Countable $count = 2): string
+    {
+        $parts = preg_split('/(.)(?=[A-Z])/u', $value, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $lastWord = array_pop($parts);
+
+        return implode('', $parts) . self::pluralize($lastWord, $count);
+    }
+
+    public static function random(int $length = 16): string
+    {
+        $string = '';
+
+        while (($len = strlen($string)) < $length) {
+            $size = $length - $len;
+            $bytesSize = (int) ceil($size / 3) * 3;
+            $bytes = random_bytes($bytesSize);
+            $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), offset: 0, length: $size);
+        }
+
+        return $string;
+    }
+
+    public static function finish(string $value, string $cap): string
+    {
+        return preg_replace('/(?:' . preg_quote($cap, '/') . ')+$/u', replacement: '', subject: $value) . $cap;
+    }
+
+    public static function after(string $subject, string|int $search): string
+    {
+        if ($search === '') {
+            return $subject;
+        }
+
+        return head(array_reverse(explode((string) $search, $subject, limit: 2)));
+    }
+
+    public static function afterLast(string $subject, string|int $search): string
+    {
+        if ($search === '') {
+            return $subject;
+        }
+
+        $position = strrpos($subject, (string) $search);
+
+        if ($position === false) {
+            return $subject;
+        }
+
+        return substr($subject, $position + strlen((string) $search));
+    }
+
+    public static function before(string $subject, string|int $search): string
+    {
+        if ($search === '') {
+            return $subject;
+        }
+
+        $result = strstr($subject, (string) $search, before_needle: true);
+
+        if ($result === false) {
+            return $subject;
+        }
+
+        return $result;
+    }
+
+    public static function beforeLast(string $subject, string|int $search): string
+    {
+        if ($search === '') {
+            return $subject;
+        }
+
+        $pos = mb_strrpos($subject, (string) $search);
+
+        if ($pos === false) {
+            return $subject;
+        }
+
+        return mb_substr($subject, start: 0, length: $pos);
+    }
+
+    public static function between(string $subject, int|string $from, int|string $to): string
+    {
+        if ($from === '' || $to === '') {
+            return $subject;
+        }
+
+        return static::beforeLast(static::after($subject, $from), $to);
+    }
+}

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -47,7 +47,7 @@ final readonly class StringHelper
         $words = explode(' ', str_replace(['-', '_'], ' ', $value));
         $studlyWords = array_map(static fn (string $word) => mb_ucfirst($word), $words);
 
-        return implode($studlyWords);
+        return implode('', $studlyWords);
     }
 
     public static function deduplicate(string $string, string|array $characters = ' '): string

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -14,7 +14,7 @@ use Tempest\Support\StringHelper;
  */
 final class StringHelperTest extends TestCase
 {
-    public function test_title()
+    public function test_title(): void
     {
         $this->assertSame('Jefferson Costella', StringHelper::title('jefferson costella'));
         $this->assertSame('Jefferson Costella', StringHelper::title('jefFErson coSTella'));
@@ -31,7 +31,7 @@ final class StringHelperTest extends TestCase
         $this->assertSame($expectedResult, StringHelper::title($longString));
     }
 
-    public function test_deduplicate()
+    public function test_deduplicate(): void
     {
         $this->assertSame('/some/odd/path/', StringHelper::deduplicate('/some//odd//path/', '/'));
         $this->assertSame(' tempest php framework ', StringHelper::deduplicate(' tempest   php  framework '));
@@ -97,12 +97,12 @@ final class StringHelperTest extends TestCase
     #[TestWith([0])]
     #[TestWith([16])]
     #[TestWith([100])]
-    public function test_random(int $length)
+    public function test_random(int $length): void
     {
         $this->assertEquals($length, strlen(StringHelper::random($length)));
     }
 
-    public function test_finish()
+    public function test_finish(): void
     {
         $this->assertSame('foo/', StringHelper::finish('foo', '/'));
         $this->assertSame('foo/', StringHelper::finish('foo/', '/'));
@@ -110,7 +110,7 @@ final class StringHelperTest extends TestCase
         $this->assertSame('abcbbc', StringHelper::finish('abcbbcbc', 'bc'));
     }
 
-    public function test_str_after()
+    public function test_str_after(): void
     {
         $this->assertSame('nah', StringHelper::after('hannah', 'han'));
         $this->assertSame('nah', StringHelper::after('hannah', 'n'));
@@ -122,7 +122,7 @@ final class StringHelperTest extends TestCase
         $this->assertSame('nah', StringHelper::after('han2nah', 2));
     }
 
-    public function test_str_after_last()
+    public function test_str_after_last(): void
     {
         $this->assertSame('tte', StringHelper::afterLast('yvette', 'yve'));
         $this->assertSame('e', StringHelper::afterLast('yvette', 't'));

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Tests;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\StringHelper;
+
+/**
+ * @internal
+ * @small
+ */
+final class StringHelperTest extends TestCase
+{
+    public function test_title()
+    {
+        $this->assertSame('Jefferson Costella', StringHelper::title('jefferson costella'));
+        $this->assertSame('Jefferson Costella', StringHelper::title('jefFErson coSTella'));
+
+        $this->assertSame('', StringHelper::title(''));
+        $this->assertSame('123 Tempest', StringHelper::title('123 tempest'));
+        $this->assertSame('❤Tempest', StringHelper::title('❤tempest'));
+        $this->assertSame('Tempest ❤', StringHelper::title('tempest ❤'));
+        $this->assertSame('Tempest123', StringHelper::title('tempest123'));
+        $this->assertSame('Tempest123', StringHelper::title('Tempest123'));
+
+        $longString = 'lorem ipsum '.str_repeat('dolor sit amet ', 1000);
+        $expectedResult = 'Lorem Ipsum Dolor Sit Amet '.str_repeat('Dolor Sit Amet ', 999);
+        $this->assertSame($expectedResult, StringHelper::title($longString));
+    }
+
+    public function test_deduplicate()
+    {
+        $this->assertSame('/some/odd/path/', StringHelper::deduplicate('/some//odd//path/', '/'));
+        $this->assertSame(' tempest php framework ', StringHelper::deduplicate(' tempest   php  framework '));
+        $this->assertSame('what', StringHelper::deduplicate('whaaat', 'a'));
+        $this->assertSame('ムだム', StringHelper::deduplicate('ムだだム', 'だ'));
+    }
+
+    public function test_pascal(): void
+    {
+        $this->assertSame('', StringHelper::pascal(''));
+        $this->assertSame('FooBar', StringHelper::pascal('foo bar'));
+        $this->assertSame('FooBar', StringHelper::pascal('foo - bar'));
+        $this->assertSame('FooBar', StringHelper::pascal('foo__bar'));
+        $this->assertSame('FooBar', StringHelper::pascal('_foo__bar'));
+        $this->assertSame('FooBar', StringHelper::pascal('-foo__bar'));
+        $this->assertSame('FooBar', StringHelper::pascal('fooBar'));
+        $this->assertSame('FooBar', StringHelper::pascal('foo_bar'));
+        $this->assertSame('FooBar1', StringHelper::pascal('foo_bar1'));
+        $this->assertSame('1fooBar', StringHelper::pascal('1foo_bar'));
+        $this->assertSame('1fooBar11', StringHelper::pascal('1foo_bar11'));
+        $this->assertSame('1foo1bar1', StringHelper::pascal('1foo_1bar1'));
+        $this->assertSame('FooBarBaz', StringHelper::pascal('foo-barBaz'));
+        $this->assertSame('FooBarBaz', StringHelper::pascal('foo-bar_baz'));
+        $this->assertSame('ÖffentlicheÜberraschungen', StringHelper::pascal('öffentliche-überraschungen'));
+    }
+
+    public function test_kebab(): void
+    {
+        $this->assertSame('', StringHelper::kebab(''));
+        $this->assertSame('foo-bar', StringHelper::kebab('foo bar'));
+        $this->assertSame('foo-bar', StringHelper::kebab('foo - bar'));
+        $this->assertSame('foo-bar', StringHelper::kebab('foo__bar'));
+        $this->assertSame('foo-bar', StringHelper::kebab('_foo__bar'));
+        $this->assertSame('foo-bar', StringHelper::kebab('-foo__bar'));
+        $this->assertSame('foo-bar', StringHelper::kebab('fooBar'));
+        $this->assertSame('foo-bar', StringHelper::kebab('foo_bar'));
+        $this->assertSame('foo-bar1', StringHelper::kebab('foo_bar1'));
+        $this->assertSame('1foo-bar', StringHelper::kebab('1foo_bar'));
+        $this->assertSame('1foo-bar11', StringHelper::kebab('1foo_bar11'));
+        $this->assertSame('1foo-1bar1', StringHelper::kebab('1foo_1bar1'));
+        $this->assertSame('foo-bar-baz', StringHelper::kebab('foo-barBaz'));
+        $this->assertSame('foo-bar-baz', StringHelper::kebab('foo-bar_baz'));
+    }
+
+    public function test_snake(): void
+    {
+        $this->assertSame('', StringHelper::snake(''));
+        $this->assertSame('foo_bar', StringHelper::snake('foo bar'));
+        $this->assertSame('foo_bar', StringHelper::snake('foo - bar'));
+        $this->assertSame('foo_bar', StringHelper::snake('foo__bar'));
+        $this->assertSame('foo_bar', StringHelper::snake('_foo__bar'));
+        $this->assertSame('foo_bar', StringHelper::snake('-foo__bar'));
+        $this->assertSame('foo_bar', StringHelper::snake('fooBar'));
+        $this->assertSame('foo_bar', StringHelper::snake('foo_bar'));
+        $this->assertSame('foo_bar1', StringHelper::snake('foo_bar1'));
+        $this->assertSame('1foo_bar', StringHelper::snake('1foo_bar'));
+        $this->assertSame('1foo_bar11', StringHelper::snake('1foo_bar11'));
+        $this->assertSame('1foo_1bar1', StringHelper::snake('1foo_1bar1'));
+        $this->assertSame('foo_bar_baz', StringHelper::snake('foo-barBaz'));
+        $this->assertSame('foo_bar_baz', StringHelper::snake('foo-bar_baz'));
+    }
+
+    #[TestWith([0])]
+    #[TestWith([16])]
+    #[TestWith([100])]
+    public function test_random(int $length)
+    {
+        $this->assertEquals($length, strlen(StringHelper::random($length)));
+    }
+
+    public function test_finish()
+    {
+        $this->assertSame('foo/', StringHelper::finish('foo', '/'));
+        $this->assertSame('foo/', StringHelper::finish('foo/', '/'));
+        $this->assertSame('abbc', StringHelper::finish('abbcbc', 'bc'));
+        $this->assertSame('abcbbc', StringHelper::finish('abcbbcbc', 'bc'));
+    }
+
+    public function test_str_after()
+    {
+        $this->assertSame('nah', StringHelper::after('hannah', 'han'));
+        $this->assertSame('nah', StringHelper::after('hannah', 'n'));
+        $this->assertSame('nah', StringHelper::after('ééé hannah', 'han'));
+        $this->assertSame('hannah', StringHelper::after('hannah', 'xxxx'));
+        $this->assertSame('hannah', StringHelper::after('hannah', ''));
+        $this->assertSame('nah', StringHelper::after('han0nah', '0'));
+        $this->assertSame('nah', StringHelper::after('han0nah', 0));
+        $this->assertSame('nah', StringHelper::after('han2nah', 2));
+    }
+
+    public function test_str_after_last()
+    {
+        $this->assertSame('tte', StringHelper::afterLast('yvette', 'yve'));
+        $this->assertSame('e', StringHelper::afterLast('yvette', 't'));
+        $this->assertSame('e', StringHelper::afterLast('ééé yvette', 't'));
+        $this->assertSame('', StringHelper::afterLast('yvette', 'tte'));
+        $this->assertSame('yvette', StringHelper::afterLast('yvette', 'xxxx'));
+        $this->assertSame('yvette', StringHelper::afterLast('yvette', ''));
+        $this->assertSame('te', StringHelper::afterLast('yv0et0te', '0'));
+        $this->assertSame('te', StringHelper::afterLast('yv0et0te', 0));
+        $this->assertSame('te', StringHelper::afterLast('yv2et2te', 2));
+        $this->assertSame('foo', StringHelper::afterLast('----foo', '---'));
+    }
+
+    public function test_str_between(): void
+    {
+        $this->assertSame('abc', StringHelper::between('abc', '', 'c'));
+        $this->assertSame('abc', StringHelper::between('abc', 'a', ''));
+        $this->assertSame('abc', StringHelper::between('abc', '', ''));
+        $this->assertSame('b', StringHelper::between('abc', 'a', 'c'));
+        $this->assertSame('b', StringHelper::between('dddabc', 'a', 'c'));
+        $this->assertSame('b', StringHelper::between('abcddd', 'a', 'c'));
+        $this->assertSame('b', StringHelper::between('dddabcddd', 'a', 'c'));
+        $this->assertSame('nn', StringHelper::between('hannah', 'ha', 'ah'));
+        $this->assertSame('a]ab[b', StringHelper::between('[a]ab[b]', '[', ']'));
+        $this->assertSame('foo', StringHelper::between('foofoobar', 'foo', 'bar'));
+        $this->assertSame('bar', StringHelper::between('foobarbar', 'foo', 'bar'));
+        $this->assertSame('234', StringHelper::between('12345', 1, 5));
+        $this->assertSame('45', StringHelper::between('123456789', '123', '6789'));
+        $this->assertSame('nothing', StringHelper::between('nothing', 'foo', 'bar'));
+    }
+
+    public function test_str_before(): void
+    {
+        $this->assertSame('han', StringHelper::before('hannah', 'nah'));
+        $this->assertSame('ha', StringHelper::before('hannah', 'n'));
+        $this->assertSame('ééé ', StringHelper::before('ééé hannah', 'han'));
+        $this->assertSame('hannah', StringHelper::before('hannah', 'xxxx'));
+        $this->assertSame('hannah', StringHelper::before('hannah', ''));
+        $this->assertSame('han', StringHelper::before('han0nah', '0'));
+        $this->assertSame('han', StringHelper::before('han0nah', 0));
+        $this->assertSame('han', StringHelper::before('han2nah', 2));
+        $this->assertSame('', StringHelper::before('', ''));
+        $this->assertSame('', StringHelper::before('', 'a'));
+        $this->assertSame('', StringHelper::before('a', 'a'));
+        $this->assertSame('foo', StringHelper::before('foo@bar.com', '@'));
+        $this->assertSame('foo', StringHelper::before('foo@@bar.com', '@'));
+        $this->assertSame('', StringHelper::before('@foo@bar.com', '@'));
+    }
+
+    public function test_str_before_last(): void
+    {
+        $this->assertSame('yve', StringHelper::beforeLast('yvette', 'tte'));
+        $this->assertSame('yvet', StringHelper::beforeLast('yvette', 't'));
+        $this->assertSame('ééé ', StringHelper::beforeLast('ééé yvette', 'yve'));
+        $this->assertSame('', StringHelper::beforeLast('yvette', 'yve'));
+        $this->assertSame('yvette', StringHelper::beforeLast('yvette', 'xxxx'));
+        $this->assertSame('yvette', StringHelper::beforeLast('yvette', ''));
+        $this->assertSame('yv0et', StringHelper::beforeLast('yv0et0te', '0'));
+        $this->assertSame('yv0et', StringHelper::beforeLast('yv0et0te', 0));
+        $this->assertSame('yv2et', StringHelper::beforeLast('yv2et2te', 2));
+        $this->assertSame('', StringHelper::beforeLast('', 'test'));
+        $this->assertSame('', StringHelper::beforeLast('yvette', 'yvette'));
+        $this->assertSame('tempest', StringHelper::beforeLast('tempest framework', ' '));
+        $this->assertSame('yvette', StringHelper::beforeLast("yvette\tyv0et0te", "\t"));
+    }
+}

--- a/tests/Integration/Support/StringHelperTest.php
+++ b/tests/Integration/Support/StringHelperTest.php
@@ -13,7 +13,7 @@ use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
  */
 final class StringHelperTest extends FrameworkIntegrationTestCase
 {
-    public function test_plural_studly()
+    public function test_plural_studly(): void
     {
         $this->assertSame('RealHumans', StringHelper::pluralizeLast('RealHuman'));
         $this->assertSame('Models', StringHelper::pluralizeLast('Model'));

--- a/tests/Integration/Support/StringHelperTest.php
+++ b/tests/Integration/Support/StringHelperTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Support;
+
+use Tempest\Support\StringHelper;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+/**
+ * @internal
+ * @small
+ */
+final class StringHelperTest extends FrameworkIntegrationTestCase
+{
+    public function test_plural_studly()
+    {
+        $this->assertSame('RealHumans', StringHelper::pluralizeLast('RealHuman'));
+        $this->assertSame('Models', StringHelper::pluralizeLast('Model'));
+        $this->assertSame('VortexFields', StringHelper::pluralizeLast('VortexField'));
+        $this->assertSame('MultipleWordsInOneStrings', StringHelper::pluralizeLast('MultipleWordsInOneString'));
+    }
+}


### PR DESCRIPTION
Related to https://github.com/tempestphp/tempest-framework/issues/288

This pull request adds a new `StringHelper` class with a few of the most used string helpers from Laravel ("most used" is totally arbitrary there, but I think these are the ones most likely to be used withing Tempest itself).

Most of the code is the same, except for `snake`—the Laravel version doesn't take some edge cases into account, which I've fixed here (like trimming or deduplicating `$delimiter`).