### PR TITLE
fix(view/tempest-renderer): join generic elements with an empty string

### DIFF
--- a/src/Tempest/View/src/Renderers/TempestViewRenderer.php
+++ b/src/Tempest/View/src/Renderers/TempestViewRenderer.php
@@ -285,7 +285,7 @@ final class TempestViewRenderer implements ViewRenderer
             $content[] = $this->renderElement($view, $child);
         }
 
-        $content = implode(PHP_EOL, $content);
+        $content = implode('', $content);
 
         $attributes = [];
 

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -52,10 +52,7 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
     {
         $this->assertStringEqualsStringIgnoringLineEndings(
             expected: <<<'HTML'
-            <form action="#" method="post"><div><div><label for="a">a</label>
-            <input type="number" name="a" id="a" value></input></div></div>
-            <div><label for="b">b</label>
-            <input type="text" name="b" id="b" value></input></div></form>
+            <form action="#" method="post"><div><div><label for="a">a</label><input type="number" name="a" id="a" value></input></div></div><div><label for="b">b</label><input type="text" name="b" id="b" value></input></div></form>
             HTML,
             actual: $this->render(view(
                 <<<'HTML'
@@ -140,8 +137,7 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
 
         yield [
             '<x-my><p>a</p><p>b</p></x-my>',
-            '<div><p>a</p>
-<p>b</p></div>',
+            '<div><p>a</p><p>b</p></div>',
         ];
 
         yield [

--- a/tests/Integration/View/ViewTest.php
+++ b/tests/Integration/View/ViewTest.php
@@ -23,8 +23,7 @@ final class ViewTest extends FrameworkIntegrationTestCase
         $html = $this->render($view);
 
         $expected = <<<HTML
-            <html lang="en"><head><title></title></head>
-            <body>
+            <html lang="en"><head><title></title></head><body>
                 Hello Brent!
             </body></html>
             HTML;


### PR DESCRIPTION
On the live docs, I noticed there's a space between inline elements and text: 

![CleanShot 2024-09-20 at 20 36 59@2x](https://github.com/user-attachments/assets/8a508e49-6330-45eb-9888-08269e1df4e4)

This happens because the Tempest view renderer separates elements with `PHP_EOL`, so the generated HTML has a new line. In this case, the generated HTML is the following:

```html
<p><strong>Tempest is a PHP framework that gets out of your way</strong>

. Its design philosophy is that developers should write as little framework-related code as possible, so that they can 

<strong>focus on application code</strong>

 instead.</p>
```

This pull request changes this behavior by separating generic elements with an empty string, resulting in the following HTML:

```html
<p><strong>Tempest is a PHP framework that gets out of your way</strong>. Its design philosophy is that developers should write as little framework-related code as possible, so that they can <strong>focus on application code</strong> instead.</p>
```

I didn't touch the other parts where elements are separated by `PHP_EOL` as I didn't notice other bugs, but for consistency we might want to do that.