### PR TITLE
ci: lint pull request title

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "subject-case": [
+      2,
+      "always",
+      ["lower-case"]
+    ]
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@ phpunit.xml.dist          export-ignore
 README.md                 export-ignore
 rector.php                export-ignore
 cliff.toml                export-ignore
+.commitlintrc.json        export-ignore
 
 # Configure diff output for .php and .phar files.
 *.php diff=php

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,27 @@
+name: Lint pull request title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: |
+          bun install @commitlint/config-conventional @commitlint/cli
+
+      - name: Lint title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "$PR_TITLE" | bunx commitlint


### PR DESCRIPTION
This pull request adds a GitHub Action that lints pull request titles, so we don't forget to rename them before merging.

This is done through the [commitlint](https://commitlint.js.org/) project, which is quite [configurable](https://commitlint.js.org/reference/rules.html), so we may update rules as you see fit