### PR TITLE
refactor(database)!: remove `forModel` static constructor

### DIFF
--- a/src/Tempest/Database/src/QueryStatements/AlterTableStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/AlterTableStatement.php
@@ -16,12 +16,6 @@ final class AlterTableStatement implements QueryStatement
     ) {
     }
 
-    /** @param class-string<\Tempest\Database\DatabaseModel> $modelClass */
-    public static function forModel(string $modelClass): self
-    {
-        return new self($modelClass::table()->tableName);
-    }
-
     public function add(QueryStatement $statement): self
     {
         $this->statements[] = new AlterStatement(Alter::ADD, $statement);

--- a/src/Tempest/Database/src/QueryStatements/CreateTableStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/CreateTableStatement.php
@@ -16,12 +16,6 @@ final class CreateTableStatement implements QueryStatement
     ) {
     }
 
-    /** @param class-string<\Tempest\Database\DatabaseModel> $modelClass */
-    public static function forModel(string $modelClass): self
-    {
-        return new self($modelClass::table()->tableName);
-    }
-
     public function primary(string $name = 'id'): self
     {
         $this->statements[] = new PrimaryKeyStatement($name);

--- a/src/Tempest/Database/src/QueryStatements/DropTableStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/DropTableStatement.php
@@ -25,12 +25,6 @@ final class DropTableStatement implements QueryStatement
         return $this;
     }
 
-    /** @param class-string<\Tempest\Database\DatabaseModel> $modelClass */
-    public static function forModel(string $modelClass): self
-    {
-        return new self($modelClass::table()->tableName);
-    }
-
     public function compile(DatabaseDialect $dialect): string
     {
         $statements = [];

--- a/tests/Fixtures/Migrations/CreateAuthorTable.php
+++ b/tests/Fixtures/Migrations/CreateAuthorTable.php
@@ -33,6 +33,6 @@ final readonly class CreateAuthorTable implements Migration
 
     public function down(): QueryStatement|null
     {
-        return DropTableStatement::forModel(Author::class);
+        return new DropTableStatement(Author::table()->tableName);
     }
 }

--- a/tests/Fixtures/Migrations/CreateBookTable.php
+++ b/tests/Fixtures/Migrations/CreateBookTable.php
@@ -19,7 +19,7 @@ final readonly class CreateBookTable implements Migration
 
     public function up(): QueryStatement|null
     {
-        return CreateTableStatement::forModel(Book::class)
+        return (new CreateTableStatement(Book::table()->tableName))
             ->primary()
             ->text('title')
             ->belongsTo('Book.author_id', 'Author.id', nullable: true);
@@ -27,6 +27,6 @@ final readonly class CreateBookTable implements Migration
 
     public function down(): QueryStatement|null
     {
-        return DropTableStatement::forModel(Book::class);
+        return new DropTableStatement(Book::table()->tableName);
     }
 }

--- a/tests/Integration/Database/QueryStatements/AlterTableStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/AlterTableStatementTest.php
@@ -79,7 +79,7 @@ final class AlterTableStatementTest extends FrameworkIntegrationTestCase
 
             public function up(): QueryStatement|null
             {
-                return AlterTableStatement::forModel(User::class)
+                return (new AlterTableStatement(User::table()->tableName))
                     ->add(new VarcharStatement('email'));
             }
 


### PR DESCRIPTION
This pull request follows-up on the note in https://github.com/tempestphp/tempest-framework/pull/453:

> I think we should remove that, because when users will refactor their models at some point, their migrations will stop working properly because the table name inference change. This is like editing an existing migration, it will inevitably break environments when migrations will run from scratch.
