### PR TITLE
fix: rename console component interfaces

### DIFF
--- a/src/Tempest/Console/src/Components/Interactive/ConfirmComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/ConfirmComponent.php
@@ -8,12 +8,12 @@ use Tempest\Console\Components\Static\StaticConfirmComponent;
 use Tempest\Console\HandlesKey;
 use Tempest\Console\HasCursor;
 use Tempest\Console\HasStaticComponent;
-use Tempest\Console\InteractiveComponent;
+use Tempest\Console\InteractiveConsoleComponent;
 use Tempest\Console\Key;
 use Tempest\Console\Point;
-use Tempest\Console\StaticComponent;
+use Tempest\Console\StaticConsoleComponent;
 
-final class ConfirmComponent implements InteractiveComponent, HasCursor, HasStaticComponent
+final class ConfirmComponent implements InteractiveConsoleComponent, HasCursor, HasStaticComponent
 {
     private bool $answer;
 
@@ -85,7 +85,7 @@ final class ConfirmComponent implements InteractiveComponent, HasCursor, HasStat
         );
     }
 
-    public function getStaticComponent(): StaticComponent
+    public function getStaticComponent(): StaticConsoleComponent
     {
         return new StaticConfirmComponent(
             $this->question,

--- a/src/Tempest/Console/src/Components/Interactive/MultipleChoiceComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/MultipleChoiceComponent.php
@@ -7,11 +7,11 @@ namespace Tempest\Console\Components\Interactive;
 use Tempest\Console\Components\Static\StaticMultipleChoiceComponent;
 use Tempest\Console\HandlesKey;
 use Tempest\Console\HasStaticComponent;
-use Tempest\Console\InteractiveComponent;
+use Tempest\Console\InteractiveConsoleComponent;
 use Tempest\Console\Key;
-use Tempest\Console\StaticComponent;
+use Tempest\Console\StaticConsoleComponent;
 
-final class MultipleChoiceComponent implements InteractiveComponent, HasStaticComponent
+final class MultipleChoiceComponent implements InteractiveConsoleComponent, HasStaticComponent
 {
     public array $selectedOptions = [];
 
@@ -98,7 +98,7 @@ final class MultipleChoiceComponent implements InteractiveComponent, HasStaticCo
         }
     }
 
-    public function getStaticComponent(): StaticComponent
+    public function getStaticComponent(): StaticConsoleComponent
     {
         return new StaticMultipleChoiceComponent(
             $this->question,

--- a/src/Tempest/Console/src/Components/Interactive/PasswordComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/PasswordComponent.php
@@ -6,11 +6,11 @@ namespace Tempest\Console\Components\Interactive;
 
 use Tempest\Console\HandlesKey;
 use Tempest\Console\HasCursor;
-use Tempest\Console\InteractiveComponent;
+use Tempest\Console\InteractiveConsoleComponent;
 use Tempest\Console\Key;
 use Tempest\Console\Point;
 
-final class PasswordComponent implements InteractiveComponent, HasCursor
+final class PasswordComponent implements InteractiveConsoleComponent, HasCursor
 {
     public string $password = '';
 

--- a/src/Tempest/Console/src/Components/Interactive/ProgressBarComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/ProgressBarComponent.php
@@ -8,10 +8,10 @@ use Closure;
 use Generator;
 use Tempest\Console\Components\Static\StaticProgressBarComponent;
 use Tempest\Console\HasStaticComponent;
-use Tempest\Console\InteractiveComponent;
-use Tempest\Console\StaticComponent;
+use Tempest\Console\InteractiveConsoleComponent;
+use Tempest\Console\StaticConsoleComponent;
 
-final readonly class ProgressBarComponent implements InteractiveComponent, HasStaticComponent
+final readonly class ProgressBarComponent implements InteractiveConsoleComponent, HasStaticComponent
 {
     public function __construct(
         private iterable $data,
@@ -70,7 +70,7 @@ final readonly class ProgressBarComponent implements InteractiveComponent, HasSt
         return "Press <em>ctrl+c</em> to cancel";
     }
 
-    public function getStaticComponent(): StaticComponent
+    public function getStaticComponent(): StaticConsoleComponent
     {
         return new StaticProgressBarComponent(
             data: $this->data,

--- a/src/Tempest/Console/src/Components/Interactive/SearchComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/SearchComponent.php
@@ -10,12 +10,12 @@ use Tempest\Console\Components\Static\StaticSearchComponent;
 use Tempest\Console\HandlesKey;
 use Tempest\Console\HasCursor;
 use Tempest\Console\HasStaticComponent;
-use Tempest\Console\InteractiveComponent;
+use Tempest\Console\InteractiveConsoleComponent;
 use Tempest\Console\Key;
 use Tempest\Console\Point;
-use Tempest\Console\StaticComponent;
+use Tempest\Console\StaticConsoleComponent;
 
-final class SearchComponent implements InteractiveComponent, HasCursor, HasStaticComponent
+final class SearchComponent implements InteractiveConsoleComponent, HasCursor, HasStaticComponent
 {
     public Point $cursorPosition;
 
@@ -163,7 +163,7 @@ final class SearchComponent implements InteractiveComponent, HasCursor, HasStati
         return $this->selectedOption === $key;
     }
 
-    public function getStaticComponent(): StaticComponent
+    public function getStaticComponent(): StaticConsoleComponent
     {
         return new StaticSearchComponent(
             label: $this->label,

--- a/src/Tempest/Console/src/Components/Interactive/SingleChoiceComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/SingleChoiceComponent.php
@@ -7,11 +7,11 @@ namespace Tempest\Console\Components\Interactive;
 use Tempest\Console\Components\Static\StaticSingleChoiceComponent;
 use Tempest\Console\HandlesKey;
 use Tempest\Console\HasStaticComponent;
-use Tempest\Console\InteractiveComponent;
+use Tempest\Console\InteractiveConsoleComponent;
 use Tempest\Console\Key;
-use Tempest\Console\StaticComponent;
+use Tempest\Console\StaticConsoleComponent;
 
-final class SingleChoiceComponent implements InteractiveComponent, HasStaticComponent
+final class SingleChoiceComponent implements InteractiveConsoleComponent, HasStaticComponent
 {
     public int $selectedOption;
 
@@ -86,7 +86,7 @@ final class SingleChoiceComponent implements InteractiveComponent, HasStaticComp
         }
     }
 
-    public function getStaticComponent(): StaticComponent
+    public function getStaticComponent(): StaticConsoleComponent
     {
         return new StaticSingleChoiceComponent(
             question: $this->question,

--- a/src/Tempest/Console/src/Components/Interactive/TextBoxComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/TextBoxComponent.php
@@ -8,12 +8,12 @@ use Tempest\Console\Components\Static\StaticTextBoxComponent;
 use Tempest\Console\HandlesKey;
 use Tempest\Console\HasCursor;
 use Tempest\Console\HasStaticComponent;
-use Tempest\Console\InteractiveComponent;
+use Tempest\Console\InteractiveConsoleComponent;
 use Tempest\Console\Key;
 use Tempest\Console\Point;
-use Tempest\Console\StaticComponent;
+use Tempest\Console\StaticConsoleComponent;
 
-final class TextBoxComponent implements InteractiveComponent, HasCursor, HasStaticComponent
+final class TextBoxComponent implements InteractiveConsoleComponent, HasCursor, HasStaticComponent
 {
     public Point $cursorPosition;
 
@@ -111,7 +111,7 @@ final class TextBoxComponent implements InteractiveComponent, HasCursor, HasStat
         );
     }
 
-    public function getStaticComponent(): StaticComponent
+    public function getStaticComponent(): StaticConsoleComponent
     {
         return new StaticTextBoxComponent($this->label);
     }

--- a/src/Tempest/Console/src/Components/InteractiveComponentRenderer.php
+++ b/src/Tempest/Console/src/Components/InteractiveComponentRenderer.php
@@ -8,7 +8,7 @@ use Fiber;
 use Tempest\Console\Console;
 use Tempest\Console\Exceptions\InterruptException;
 use Tempest\Console\HandlesKey;
-use Tempest\Console\InteractiveComponent;
+use Tempest\Console\InteractiveConsoleComponent;
 use Tempest\Console\Key;
 use Tempest\Console\Terminal\Terminal;
 use Tempest\Reflection\ClassReflector;
@@ -23,14 +23,14 @@ final class InteractiveComponentRenderer
 
     private bool $shouldRerender = true;
 
-    public function render(Console $console, InteractiveComponent $component, array $validation = []): mixed
+    public function render(Console $console, InteractiveConsoleComponent $component, array $validation = []): mixed
     {
         $clone = clone $this;
 
         return $clone->renderComponent($console, $component, $validation);
     }
 
-    private function renderComponent(Console $console, InteractiveComponent $component, array $validation = []): mixed
+    private function renderComponent(Console $console, InteractiveConsoleComponent $component, array $validation = []): mixed
     {
         $terminal = $this->createTerminal($console);
 
@@ -78,7 +78,7 @@ final class InteractiveComponentRenderer
         return null;
     }
 
-    private function applyKey(InteractiveComponent $component, Console $console, array $validation): mixed
+    private function applyKey(InteractiveConsoleComponent $component, Console $console, array $validation): mixed
     {
         [$keyBindings, $inputHandlers] = $this->resolveHandlers($component);
 
@@ -140,7 +140,7 @@ final class InteractiveComponentRenderer
         }
     }
 
-    private function renderFrames(InteractiveComponent $component, Terminal $terminal): mixed
+    private function renderFrames(InteractiveConsoleComponent $component, Terminal $terminal): mixed
     {
         while (true) {
             usleep(5000);
@@ -177,7 +177,7 @@ final class InteractiveComponentRenderer
         }
     }
 
-    private function resolveHandlers(InteractiveComponent $component): array
+    private function resolveHandlers(InteractiveConsoleComponent $component): array
     {
         /** @var \Tempest\Reflection\MethodReflector[][] $keyBindings */
         $keyBindings = [];

--- a/src/Tempest/Console/src/Components/Static/StaticConfirmComponent.php
+++ b/src/Tempest/Console/src/Components/Static/StaticConfirmComponent.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tempest\Console\Components\Static;
 
 use Tempest\Console\Console;
-use Tempest\Console\StaticComponent;
+use Tempest\Console\StaticConsoleComponent;
 
-final readonly class StaticConfirmComponent implements StaticComponent
+final readonly class StaticConfirmComponent implements StaticConsoleComponent
 {
     public function __construct(
         private string $question,

--- a/src/Tempest/Console/src/Components/Static/StaticMultipleChoiceComponent.php
+++ b/src/Tempest/Console/src/Components/Static/StaticMultipleChoiceComponent.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tempest\Console\Components\Static;
 
 use Tempest\Console\Console;
-use Tempest\Console\StaticComponent;
+use Tempest\Console\StaticConsoleComponent;
 
-final readonly class StaticMultipleChoiceComponent implements StaticComponent
+final readonly class StaticMultipleChoiceComponent implements StaticConsoleComponent
 {
     public function __construct(
         public string $question,

--- a/src/Tempest/Console/src/Components/Static/StaticProgressBarComponent.php
+++ b/src/Tempest/Console/src/Components/Static/StaticProgressBarComponent.php
@@ -6,9 +6,9 @@ namespace Tempest\Console\Components\Static;
 
 use Closure;
 use Tempest\Console\Console;
-use Tempest\Console\StaticComponent;
+use Tempest\Console\StaticConsoleComponent;
 
-final readonly class StaticProgressBarComponent implements StaticComponent
+final readonly class StaticProgressBarComponent implements StaticConsoleComponent
 {
     public function __construct(
         private iterable $data,

--- a/src/Tempest/Console/src/Components/Static/StaticSearchComponent.php
+++ b/src/Tempest/Console/src/Components/Static/StaticSearchComponent.php
@@ -6,9 +6,9 @@ namespace Tempest\Console\Components\Static;
 
 use Closure;
 use Tempest\Console\Console;
-use Tempest\Console\StaticComponent;
+use Tempest\Console\StaticConsoleComponent;
 
-final readonly class StaticSearchComponent implements StaticComponent
+final readonly class StaticSearchComponent implements StaticConsoleComponent
 {
     public const string SEARCH_AGAIN = 'Search again';
 

--- a/src/Tempest/Console/src/Components/Static/StaticSingleChoiceComponent.php
+++ b/src/Tempest/Console/src/Components/Static/StaticSingleChoiceComponent.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tempest\Console\Components\Static;
 
 use Tempest\Console\Console;
-use Tempest\Console\StaticComponent;
+use Tempest\Console\StaticConsoleComponent;
 
-final readonly class StaticSingleChoiceComponent implements StaticComponent
+final readonly class StaticSingleChoiceComponent implements StaticConsoleComponent
 {
     public function __construct(
         public string $question,

--- a/src/Tempest/Console/src/Components/Static/StaticTextBoxComponent.php
+++ b/src/Tempest/Console/src/Components/Static/StaticTextBoxComponent.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tempest\Console\Components\Static;
 
 use Tempest\Console\Console;
-use Tempest\Console\StaticComponent;
+use Tempest\Console\StaticConsoleComponent;
 
-final readonly class StaticTextBoxComponent implements StaticComponent
+final readonly class StaticTextBoxComponent implements StaticConsoleComponent
 {
     public function __construct(
         public string $label,

--- a/src/Tempest/Console/src/Console.php
+++ b/src/Tempest/Console/src/Console.php
@@ -21,7 +21,7 @@ interface Console
     /**
      * @param \Tempest\Validation\Rule[] $validation
      */
-    public function component(InteractiveComponent $component, array $validation = []): mixed;
+    public function component(InteractiveConsoleComponent $component, array $validation = []): mixed;
 
     /**
      * @param mixed|null $default

--- a/src/Tempest/Console/src/Exceptions/UnsupportedComponent.php
+++ b/src/Tempest/Console/src/Exceptions/UnsupportedComponent.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Tempest\Console\Exceptions;
 
 use Tempest\Console\Console;
-use Tempest\Console\InteractiveComponent;
+use Tempest\Console\InteractiveConsoleComponent;
 
 final class UnsupportedComponent extends ConsoleException
 {
-    public function __construct(InteractiveComponent $component)
+    public function __construct(InteractiveConsoleComponent $component)
     {
         $className = $component::class;
 

--- a/src/Tempest/Console/src/GenericConsole.php
+++ b/src/Tempest/Console/src/GenericConsole.php
@@ -122,7 +122,7 @@ final class GenericConsole implements Console
         return $this;
     }
 
-    public function component(InteractiveComponent $component, array $validation = []): mixed
+    public function component(InteractiveConsoleComponent $component, array $validation = []): mixed
     {
         if ($this->interactiveSupported()) {
             return $this->componentRenderer->render($this, $component, $validation);

--- a/src/Tempest/Console/src/HasStaticComponent.php
+++ b/src/Tempest/Console/src/HasStaticComponent.php
@@ -6,5 +6,5 @@ namespace Tempest\Console;
 
 interface HasStaticComponent
 {
-    public function getStaticComponent(): StaticComponent;
+    public function getStaticComponent(): StaticConsoleComponent;
 }

--- a/src/Tempest/Console/src/InteractiveConsoleComponent.php
+++ b/src/Tempest/Console/src/InteractiveConsoleComponent.php
@@ -6,7 +6,7 @@ namespace Tempest\Console;
 
 use Generator;
 
-interface InteractiveComponent
+interface InteractiveConsoleComponent
 {
     public function render(): Generator|string;
 

--- a/src/Tempest/Console/src/StaticConsoleComponent.php
+++ b/src/Tempest/Console/src/StaticConsoleComponent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Console;
 
-interface StaticComponent
+interface StaticConsoleComponent
 {
     public function render(Console $console): mixed;
 }

--- a/src/Tempest/Console/src/Terminal/Terminal.php
+++ b/src/Tempest/Console/src/Terminal/Terminal.php
@@ -8,7 +8,7 @@ use Generator;
 use Tempest\Console\Console;
 use Tempest\Console\Cursor;
 use Tempest\Console\HasCursor;
-use Tempest\Console\InteractiveComponent;
+use Tempest\Console\InteractiveConsoleComponent;
 use Tempest\Console\Point;
 
 final class Terminal
@@ -64,7 +64,7 @@ final class Terminal
     }
 
     public function render(
-        InteractiveComponent $component,
+        InteractiveConsoleComponent $component,
         array $footerLines = []
     ): Generator {
         $rendered = $component->render();


### PR DESCRIPTION
I noticed during a demo that the naming of these interfaces wasn't all that intuitive. Even though these are longer, I think it makes more sense (especially now that we also have a `ViewComponent` interface, I think it's best to have a clear distinction between them