### PR TITLE
feat: add autowire/autodiscovery/auto-initialization of interfaces to classes

### DIFF
--- a/src/Tempest/Container/src/AutoDiscovery.php
+++ b/src/Tempest/Container/src/AutoDiscovery.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container;
+
+use Tempest\Core\Discovery;
+use Tempest\Core\HandlesDiscoveryCache;
+use Tempest\Reflection\ClassReflector;
+
+/**
+ * @property GenericContainer $container
+ */
+final class AutoDiscovery implements Discovery
+{
+    use HandlesDiscoveryCache;
+
+    public function __construct(
+        private readonly Container $container,
+    ) {
+    }
+
+    public function discover(ClassReflector $class): void
+    {
+        $autowire = $class->getAttribute(Autowire::class);
+
+        if ($autowire === null) {
+            return;
+        }
+
+        $interfaces = $class->getReflection()->getInterfaceNames();
+
+        foreach ($interfaces as $interface) {
+            $this->container->register($interface, fn (Container $container) => $container->get($class->getName()));
+        }
+    }
+
+    public function createCachePayload(): string
+    {
+        return serialize($this->container->getDefinitions());
+    }
+
+    public function restoreCachePayload(Container $container, string $payload): void
+    {
+        $this->container->setDefinitions(unserialize($payload));
+    }
+}

--- a/src/Tempest/Container/src/Autowire.php
+++ b/src/Tempest/Container/src/Autowire.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Autowire
+{
+}

--- a/src/Tempest/Container/src/GenericContainer.php
+++ b/src/Tempest/Container/src/GenericContainer.php
@@ -36,6 +36,13 @@ final class GenericContainer implements Container
     ) {
     }
 
+    public function setDefinitions(array $definitions): self
+    {
+        $this->definitions = new ArrayIterator($definitions);
+
+        return $this;
+    }
+
     public function setInitializers(array $initializers): self
     {
         $this->initializers = new ArrayIterator($initializers);
@@ -48,6 +55,11 @@ final class GenericContainer implements Container
         $this->dynamicInitializers = new ArrayIterator($dynamicInitializers);
 
         return $this;
+    }
+
+    public function getDefinitions(): array
+    {
+        return $this->definitions->getArrayCopy();
     }
 
     public function getInitializers(): array


### PR DESCRIPTION
## Rationale
First of all, it is exciting to play with this new framework! I like a lot of it already, but I hit one snag when building some services. I usually have an interface for them (for example to make mocking easier). But with Tempest it looks like this would require a initializer class. And I am too lazy to make those for all my services 😜 
A while ago I made an Autowire implementation for Laravel ([link](https://github.com/Jeroen-G/autowire/)) so I thought I would start porting that a little bit to Tempest. So this first PR adds the Autowire attribute which allows autodiscovery of classes (or maybe auto initialization is a name better fitting to Tempest).

Let me know what you think!

## How to use it
GreetingController:
```php
final readonly class GreetingController
{
    public function __construct(public GreetingInterface $service)
    {}

    #[Get('/greetings')]
    public function index(): View
    {
        return view('greeting.view.php')->data(greeting: $this->service->greeting());
    }
}
```
GreetingInterface:
```php
interface GreetingInterface
{
    public function greeting(): string;
}
```
GreetingService:
```php
use Tempest\Container\Autowire;

#[Autowire]
final class GreetingService implements GreetingInterface
{
    public function greeting(): string
    {
        return 'hello world';
    }
}
```