### PR TITLE
feat(discovery): add ability to hide classes from discovery

### DIFF
--- a/src/Tempest/Core/src/DoNotDiscover.php
+++ b/src/Tempest/Core/src/DoNotDiscover.php
@@ -7,6 +7,6 @@ namespace Tempest\Core;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_CLASS)]
-final class HideFromDiscovery
+final class DoNotDiscover
 {
 }

--- a/src/Tempest/Core/src/HideFromDiscovery.php
+++ b/src/Tempest/Core/src/HideFromDiscovery.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Core;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class HideFromDiscovery
+{
+}

--- a/src/Tempest/Core/src/Kernel/LoadDiscoveryClasses.php
+++ b/src/Tempest/Core/src/Kernel/LoadDiscoveryClasses.php
@@ -12,6 +12,7 @@ use SplFileInfo;
 use Tempest\Container\Container;
 use Tempest\Core\DiscoversPath;
 use Tempest\Core\Discovery;
+use Tempest\Core\HideFromDiscovery;
 use Tempest\Core\Kernel;
 use Tempest\Reflection\ClassReflector;
 use Throwable;
@@ -92,6 +93,10 @@ final readonly class LoadDiscoveryClasses
                         } catch (Throwable) {
                             // Nothing should happen
                         }
+                    }
+
+                    if ($input instanceof ClassReflector && $input->hasAttribute(HideFromDiscovery::class)) {
+                        continue;
                     }
 
                     if ($input instanceof ClassReflector) {

--- a/src/Tempest/Core/src/Kernel/LoadDiscoveryClasses.php
+++ b/src/Tempest/Core/src/Kernel/LoadDiscoveryClasses.php
@@ -12,7 +12,7 @@ use SplFileInfo;
 use Tempest\Container\Container;
 use Tempest\Core\DiscoversPath;
 use Tempest\Core\Discovery;
-use Tempest\Core\HideFromDiscovery;
+use Tempest\Core\DoNotDiscover;
 use Tempest\Core\Kernel;
 use Tempest\Reflection\ClassReflector;
 use Throwable;
@@ -95,7 +95,7 @@ final readonly class LoadDiscoveryClasses
                         }
                     }
 
-                    if ($input instanceof ClassReflector && $input->hasAttribute(HideFromDiscovery::class)) {
+                    if ($input instanceof ClassReflector && $input->hasAttribute(DoNotDiscover::class)) {
                         continue;
                     }
 

--- a/tests/Fixtures/Discovery/HiddenMigration.php
+++ b/tests/Fixtures/Discovery/HiddenMigration.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Discovery;
+
+use Tempest\Core\HideFromDiscovery;
+use Tempest\Database\Migration;
+use Tempest\Database\QueryStatement;
+
+#[HideFromDiscovery]
+final class HiddenMigration implements Migration
+{
+    public function getName(): string
+    {
+        return 'hidden-migration';
+    }
+
+    public function up(): ?QueryStatement
+    {
+        return null;
+    }
+
+    public function down(): ?QueryStatement
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/Discovery/HiddenMigration.php
+++ b/tests/Fixtures/Discovery/HiddenMigration.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Fixtures\Discovery;
 
-use Tempest\Core\HideFromDiscovery;
+use Tempest\Core\DoNotDiscover;
 use Tempest\Database\Migration;
 use Tempest\Database\QueryStatement;
 
-#[HideFromDiscovery]
+#[DoNotDiscover]
 final class HiddenMigration implements Migration
 {
     public function getName(): string

--- a/tests/Integration/Core/LoadDiscoveryClassesTest.php
+++ b/tests/Integration/Core/LoadDiscoveryClassesTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Core;
+
+use function PHPUnit\Framework\assertNotContains;
+use Tempest\Core\Kernel\LoadDiscoveryClasses;
+use Tempest\Database\DatabaseConfig;
+use Tempest\Database\MigrationDiscovery;
+use function Tempest\get;
+use Tests\Tempest\Fixtures\Discovery\HiddenMigration;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+/**
+ * @internal
+ */
+final class LoadDiscoveryClassesTest extends FrameworkIntegrationTestCase
+{
+    public function test_hidden_from_discovery()
+    {
+        $this->kernel->discoveryClasses = [
+            MigrationDiscovery::class,
+        ];
+
+        $this->kernel->discoveryLocations = [
+            realpath(__DIR__.'../../Fixtures/Discovery'),
+        ];
+
+        (new LoadDiscoveryClasses($this->kernel, $this->container));
+
+        $migrations = get(DatabaseConfig::class)->getMigrations();
+
+        assertNotContains(HiddenMigration::class, $migrations);
+    }
+}

--- a/tests/Integration/Core/LoadDiscoveryClassesTest.php
+++ b/tests/Integration/Core/LoadDiscoveryClassesTest.php
@@ -17,7 +17,7 @@ use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
  */
 final class LoadDiscoveryClassesTest extends FrameworkIntegrationTestCase
 {
-    public function test_hidden_from_discovery()
+    public function test_hidden_from_discovery(): void
     {
         $this->kernel->discoveryClasses = [
             MigrationDiscovery::class,


### PR DESCRIPTION
This pull request adds the ability to hide classes from all discovery implementations by adding a `HideFromDiscovery` attribute (**edit**: updated to `DoNotDiscover`).

Happy to change the attribute name to anything else:
- `SkipDiscovery`
- `IgnoreFromDiscovery`
- `WithoutDiscovery`
- `\Tempest\Core\Discovery\Ignore`
- `\Tempest\Core\Discovery\Skip`

Closes #338
Related to #509