### PR TITLE
fix(console): support `default` parameter on textbox component

### DIFF
--- a/src/Tempest/Console/src/Components/Interactive/TextBoxComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/TextBoxComponent.php
@@ -21,8 +21,13 @@ final class TextBoxComponent implements InteractiveConsoleComponent, HasCursor, 
 
     public function __construct(
         public string $label,
+        public ?string $default = null,
     ) {
         $this->cursorPosition = new Point(2, 1);
+
+        foreach (str_split($default ?? '') as $character) {
+            $this->input($character);
+        }
     }
 
     public function render(): string

--- a/src/Tempest/Console/src/GenericConsole.php
+++ b/src/Tempest/Console/src/GenericConsole.php
@@ -144,7 +144,7 @@ final class GenericConsole implements Console
         array $validation = [],
     ): string|array {
         if ($options === null || $options === []) {
-            $component = new TextBoxComponent($question);
+            $component = new TextBoxComponent($question, $default);
         } elseif ($multiple) {
             $component = new MultipleChoiceComponent(
                 question: $question,


### PR DESCRIPTION
This pull request adds support for the `default` parameter of `Console#ask`, which wasn't passed down nor taken into account in `TextBoxComponent`.

Note: my approach was the easiest I could think of—reusing the existing methods instead of adding a new cursor manipulation, at the cost of introducing a loop, which I believe is fast enough to not care about it.