### PR TITLE
feat(core): add `Composer` util

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,6 +19,9 @@ parameters:
 			message: '#.*#'
 			path:  tests/Integration/View/blade/cache/**.php
 		-
+			message: '#.*[Rr]eadonly.*#'
+			path: src/Tempest/Core/src/Composer.php
+		-
 			message: '#.*#'
 			path: src/Tempest/Http/Exceptions/HttpExceptionHandler.php
 		-

--- a/src/Tempest/Core/src/Composer.php
+++ b/src/Tempest/Core/src/Composer.php
@@ -9,13 +9,15 @@ use Tempest\Support\PathHelper;
 final readonly class Composer
 {
     public array $namespaces;
+
     public string $mainNamespace;
+
     public string $mainNamespacePath;
 
     public function __construct(
-        private Kernel $kernel
+        string $root,
     ) {
-        $composerFilePath = PathHelper::make($kernel->root, 'composer.json');
+        $composerFilePath = PathHelper::make($root, 'composer.json');
         $composer = $this->loadComposerFile($composerFilePath);
 
         $this->namespaces = $composer['autoload']['psr-4'] ?? [];

--- a/src/Tempest/Core/src/Composer.php
+++ b/src/Tempest/Core/src/Composer.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Core;
+
+use Tempest\Support\PathHelper;
+
+final readonly class Composer
+{
+    public array $namespaces;
+    public string $mainNamespace;
+    public string $mainNamespacePath;
+
+    public function __construct(
+        private Kernel $kernel
+    ) {
+        $composerFilePath = PathHelper::make($kernel->root, 'composer.json');
+        $composer = $this->loadComposerFile($composerFilePath);
+
+        $this->namespaces = $composer['autoload']['psr-4'] ?? [];
+
+        foreach ($this->namespaces as $namespace => $path) {
+            if (str_starts_with($path, 'app/') || str_starts_with($path, 'src/')) {
+                $this->mainNamespace = $namespace;
+                $this->mainNamespacePath = $path;
+
+                break;
+            }
+        }
+
+        if (! $this->mainNamespace) {
+            $this->mainNamespace = array_key_first($this->namespaces);
+            $this->mainNamespacePath = $this->namespaces[$this->mainNamespace];
+        }
+
+        if (! $this->mainNamespace) {
+            throw new KernelException("Tempest requires at least one PSR-4 namespace to be defined in composer.json.");
+        }
+    }
+
+    private function loadComposerFile(string $path): array
+    {
+        if (! file_exists($path)) {
+            throw new KernelException("Could not locate composer.json.");
+        }
+
+        return json_decode(file_get_contents($path), true);
+    }
+}

--- a/src/Tempest/Core/src/ComposerNamespace.php
+++ b/src/Tempest/Core/src/ComposerNamespace.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Core;
+
+final readonly class ComposerNamespace
+{
+    public function __construct(
+        public string $namespace,
+        public string $path,
+    ) {
+    }
+}

--- a/src/Tempest/Core/src/Kernel.php
+++ b/src/Tempest/Core/src/Kernel.php
@@ -65,7 +65,7 @@ final class Kernel
 
     private function loadComposer(): self
     {
-        $this->container->singleton(Composer::class, new Composer($this));
+        $this->container->singleton(Composer::class, new Composer($this->root));
 
         return $this;
     }

--- a/src/Tempest/Core/src/Kernel.php
+++ b/src/Tempest/Core/src/Kernel.php
@@ -36,6 +36,7 @@ final class Kernel
             ->setDiscoveryCache($discoveryCache)
             ->registerShutdownFunction()
             ->registerKernel()
+            ->loadComposer()
             ->loadDiscoveryLocations()
             ->loadConfig()
             ->loadExceptionHandler()
@@ -60,6 +61,13 @@ final class Kernel
         $container->singleton(Container::class, fn () => $container);
 
         return $container;
+    }
+
+    private function loadComposer(): self
+    {
+        $this->container->singleton(Composer::class, new Composer($this));
+
+        return $this;
     }
 
     private function loadEnv(): self

--- a/src/Tempest/Core/src/Kernel/LoadDiscoveryLocations.php
+++ b/src/Tempest/Core/src/Kernel/LoadDiscoveryLocations.php
@@ -68,10 +68,10 @@ final readonly class LoadDiscoveryLocations
     {
         $discoveredLocations = [];
 
-        foreach ($this->composer->namespaces as $namespace => $path) {
-            $path = PathHelper::make($this->kernel->root, $path);
+        foreach ($this->composer->namespaces as $namespace) {
+            $path = PathHelper::make($this->kernel->root, $namespace->path);
 
-            $discoveredLocations[] = new DiscoveryLocation($namespace, $path);
+            $discoveredLocations[] = new DiscoveryLocation($namespace->namespace, $path);
         }
 
         return $discoveredLocations;

--- a/src/Tempest/Core/src/Kernel/LoadDiscoveryLocations.php
+++ b/src/Tempest/Core/src/Kernel/LoadDiscoveryLocations.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Core\Kernel;
 
+use Tempest\Core\Composer;
 use Tempest\Core\DiscoveryException;
 use Tempest\Core\DiscoveryLocation;
 use Tempest\Core\Kernel;
@@ -14,6 +15,7 @@ final readonly class LoadDiscoveryLocations
 {
     public function __construct(
         private Kernel $kernel,
+        private Composer $composer,
     ) {
     }
 
@@ -64,12 +66,9 @@ final readonly class LoadDiscoveryLocations
      */
     private function discoverAppNamespaces(): array
     {
-        $composer = $this->loadJsonFile(PathHelper::make($this->kernel->root, 'composer.json'));
-        $namespaceMap = $composer['autoload']['psr-4'] ?? [];
-
         $discoveredLocations = [];
 
-        foreach ($namespaceMap as $namespace => $path) {
+        foreach ($this->composer->namespaces as $namespace => $path) {
             $path = PathHelper::make($this->kernel->root, $path);
 
             $discoveredLocations[] = new DiscoveryLocation($namespace, $path);

--- a/tests/Fixtures/Core/Composer/.gitignore
+++ b/tests/Fixtures/Core/Composer/.gitignore
@@ -1,0 +1,1 @@
+composer.json

--- a/tests/Integration/Core/ComposerTest.php
+++ b/tests/Integration/Core/ComposerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Tempest\Integration\Core;
 
 use PHPUnit\Framework\Attributes\Test;
 use Tempest\Core\Composer;
+use Tempest\Core\KernelException;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 /**
@@ -89,5 +90,20 @@ final class ComposerTest extends FrameworkIntegrationTestCase
 
         $this->assertSame('App\\', $composer->mainNamespace->namespace);
         $this->assertSame('src/', $composer->mainNamespace->path);
+    }
+
+    #[Test]
+    public function errors_without_namespace(): void
+    {
+        $this->expectException(KernelException::class);
+        $this->initializeComposer([]);
+    }
+
+    #[Test]
+    public function errors_without_composer_file(): void
+    {
+        $this->expectException(KernelException::class);
+
+        new Composer(root: __DIR__);
     }
 }

--- a/tests/Integration/Core/ComposerTest.php
+++ b/tests/Integration/Core/ComposerTest.php
@@ -33,9 +33,9 @@ final class ComposerTest extends FrameworkIntegrationTestCase
             ],
         ]);
 
-        $this->assertSame('App\\', $composer->mainNamespace);
-        $this->assertSame('app/', $composer->mainNamespacePath);
-        $this->assertSame(["App\\" => 'app/'], $composer->namespaces);
+        $this->assertSame('App\\', $composer->mainNamespace->namespace);
+        $this->assertSame('app/', $composer->mainNamespace->path);
+        $this->assertCount(1, $composer->namespaces);
     }
 
     #[Test]
@@ -51,13 +51,12 @@ final class ComposerTest extends FrameworkIntegrationTestCase
             ],
         ]);
 
-        $this->assertSame('Module\\', $composer->mainNamespace);
-        $this->assertSame('src/Module/', $composer->mainNamespacePath);
-        $this->assertSame([
-            'Module\\' => 'src/Module/',
-            'Module\\Foo\\' => 'src/Module/Foo/',
-            'Module\\Bar\\' => 'src/Module/Bar/',
-        ], $composer->namespaces);
+        $this->assertSame('Module\\', $composer->mainNamespace->namespace);
+        $this->assertSame('src/Module/', $composer->mainNamespace->path);
+        $this->assertCount(3, $composer->namespaces);
+        $this->assertSame('Module\\', $composer->namespaces[0]->namespace);
+        $this->assertSame('Module\\Foo\\', $composer->namespaces[1]->namespace);
+        $this->assertSame('Module\\Bar\\', $composer->namespaces[2]->namespace);
     }
 
     #[Test]
@@ -72,8 +71,8 @@ final class ComposerTest extends FrameworkIntegrationTestCase
             ],
         ]);
 
-        $this->assertSame('App\\', $composer->mainNamespace);
-        $this->assertSame('app/', $composer->mainNamespacePath);
+        $this->assertSame('App\\', $composer->mainNamespace->namespace);
+        $this->assertSame('app/', $composer->mainNamespace->path);
     }
 
     #[Test]
@@ -88,7 +87,7 @@ final class ComposerTest extends FrameworkIntegrationTestCase
             ],
         ]);
 
-        $this->assertSame('App\\', $composer->mainNamespace);
-        $this->assertSame('src/', $composer->mainNamespacePath);
+        $this->assertSame('App\\', $composer->mainNamespace->namespace);
+        $this->assertSame('src/', $composer->mainNamespace->path);
     }
 }

--- a/tests/Integration/Core/ComposerTest.php
+++ b/tests/Integration/Core/ComposerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Core;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Core\Composer;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+/**
+ * @internal
+ */
+final class ComposerTest extends FrameworkIntegrationTestCase
+{
+    private function initializeComposer(array $composer): Composer
+    {
+        file_put_contents(__DIR__ . '/../../Fixtures/Core/Composer/composer.json', json_encode($composer, JSON_PRETTY_PRINT));
+
+        return new Composer(
+            root: realpath(__DIR__ . '/../../Fixtures/Core/Composer')
+        );
+    }
+
+    #[Test]
+    public function takes_first_namespace_as_main(): void
+    {
+        $composer = $this->initializeComposer([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'app/',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('App\\', $composer->mainNamespace);
+        $this->assertSame('app/', $composer->mainNamespacePath);
+        $this->assertSame(["App\\" => 'app/'], $composer->namespaces);
+    }
+
+    #[Test]
+    public function loads_composer_class_with_multiple_namespaces(): void
+    {
+        $composer = $this->initializeComposer([
+            'autoload' => [
+                'psr-4' => [
+                    'Module\\' => 'src/Module/',
+                    'Module\\Foo\\' => 'src/Module/Foo/',
+                    'Module\\Bar\\' => 'src/Module/Bar/',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('Module\\', $composer->mainNamespace);
+        $this->assertSame('src/Module/', $composer->mainNamespacePath);
+        $this->assertSame([
+            'Module\\' => 'src/Module/',
+            'Module\\Foo\\' => 'src/Module/Foo/',
+            'Module\\Bar\\' => 'src/Module/Bar/',
+        ], $composer->namespaces);
+    }
+
+    #[Test]
+    public function takes_app_namespace_in_priority(): void
+    {
+        $composer = $this->initializeComposer([
+            'autoload' => [
+                'psr-4' => [
+                    'Config\\' => 'config/',
+                    'App\\' => 'app/',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('App\\', $composer->mainNamespace);
+        $this->assertSame('app/', $composer->mainNamespacePath);
+    }
+
+    #[Test]
+    public function takes_src_namespace_in_priority(): void
+    {
+        $composer = $this->initializeComposer([
+            'autoload' => [
+                'psr-4' => [
+                    'Config\\' => 'config/',
+                    'App\\' => 'src/',
+                ],
+            ],
+        ]);
+
+        $this->assertSame('App\\', $composer->mainNamespace);
+        $this->assertSame('src/', $composer->mainNamespacePath);
+    }
+}


### PR DESCRIPTION
This pull request introduces a `Composer` util class in `tempest/core`, that's useful for reusing composer-related code in other parts of the framework.

I have refactored a little part of `LoadDiscoveryLocations` with it, and will be using it as well in #513.

Later on, we can move more composer-related code into this class, but I preferred not to move to many things around in this specific pull request, for simplicity.