### PR TITLE
ci(lint-pr-title): fix subject case rule

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -3,8 +3,8 @@
   "rules": {
     "subject-case": [
       2,
-      "always",
-      ["lower-case"]
+      "never",
+			["sentence-case", "start-case", "pascal-case", "upper-case"]
     ]
   }
 }


### PR DESCRIPTION
This pull request decreases the strictness of the linting or pull request titles. The following commit name is now allowed:

```
feat(core): add `Composer` util 
```

It was previously not allowed due to the uppercase `C`, which should not be forbidden.