### PR TITLE
feat(discovery): allow exceptions on `DoNotDiscover` classes

### DIFF
--- a/src/Tempest/Core/src/DoNotDiscover.php
+++ b/src/Tempest/Core/src/DoNotDiscover.php
@@ -9,4 +9,12 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class DoNotDiscover
 {
+    public function __construct(
+        /**
+         * Allows the specified `Discovery` classes to still discover this class.
+         * @var array<class-string<\Tempest\Core\Discovery>>
+         */
+        public readonly array $except = [],
+    ) {
+    }
 }

--- a/src/Tempest/Core/src/Kernel/LoadDiscoveryClasses.php
+++ b/src/Tempest/Core/src/Kernel/LoadDiscoveryClasses.php
@@ -95,12 +95,10 @@ final readonly class LoadDiscoveryClasses
                         }
                     }
 
-                    if ($input instanceof ClassReflector && $input->hasAttribute(DoNotDiscover::class)) {
-                        continue;
-                    }
-
                     if ($input instanceof ClassReflector) {
-                        $discovery->discover($input);
+                        if ($this->shouldDiscover($discovery, $input)) {
+                            $discovery->discover($input);
+                        }
                     } elseif ($discovery instanceof DiscoversPath) {
                         $discovery->discoverPath($input);
                     }
@@ -113,5 +111,14 @@ final readonly class LoadDiscoveryClasses
                 $discovery->storeCache();
             }
         }
+    }
+
+    private function shouldDiscover(Discovery $discovery, ClassReflector $input): bool
+    {
+        if (is_null($attribute = $input->getAttribute(DoNotDiscover::class))) {
+            return true;
+        }
+
+        return in_array($discovery::class, $attribute->except, strict: true);
     }
 }

--- a/tests/Fixtures/Discovery/HiddenMigratableMigration.php
+++ b/tests/Fixtures/Discovery/HiddenMigratableMigration.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Discovery;
+
+use Tempest\Core\DoNotDiscover;
+use Tempest\Database\Migration;
+use Tempest\Database\MigrationDiscovery;
+use Tempest\Database\QueryStatement;
+
+#[DoNotDiscover(except: [MigrationDiscovery::class])]
+final class HiddenMigratableMigration implements Migration
+{
+    public function getName(): string
+    {
+        return 'hidden-migratable-migration';
+    }
+
+    public function up(): ?QueryStatement
+    {
+        return null;
+    }
+
+    public function down(): ?QueryStatement
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
This pull request is a follow-up of #512—it adds the ability for classes that should not be discovered by Discovery to still be seen by the specified Discovery classes.

For instance, publishable classes that generally should not be discovered may allow the `tempest publish` command to show them as publishable classes.

Related to #513