### PR TITLE
feat: add tagged iterators to container resolution

### DIFF
--- a/src/Tempest/Container/src/Tagged.php
+++ b/src/Tempest/Container/src/Tagged.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container;
+
+use Attribute;
+
+#[Attribute]
+final readonly class Tagged
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/src/Tempest/Container/src/TaggedIteratorDiscovery.php
+++ b/src/Tempest/Container/src/TaggedIteratorDiscovery.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container;
+
+use Tempest\Core\Discovery;
+use Tempest\Core\HandlesDiscoveryCache;
+use Tempest\Reflection\ClassReflector;
+
+/**
+ * @property GenericContainer $container
+ */
+final class TaggedIteratorDiscovery implements Discovery
+{
+    use HandlesDiscoveryCache;
+
+    public function __construct(
+        private readonly Container $container,
+    ) {
+    }
+
+    public function discover(ClassReflector $class): void
+    {
+        $tags = $class->getAttributes(Tagged::class);
+        foreach ($tags as $tag) {
+            $this->container->tag($tag->name, $class->getName());
+        }
+    }
+
+    public function createCachePayload(): string
+    {
+        return serialize($this->container->getTaggedDefinitions());
+    }
+
+    public function restoreCachePayload(Container $container, string $payload): void
+    {
+        $this->container->setTaggedDefinitions(unserialize($payload));
+    }
+}

--- a/src/Tempest/Container/tests/ContainerTest.php
+++ b/src/Tempest/Container/tests/ContainerTest.php
@@ -22,6 +22,7 @@ use Tempest\Container\Tests\Fixtures\ContainerObjectDInitializer;
 use Tempest\Container\Tests\Fixtures\ContainerObjectE;
 use Tempest\Container\Tests\Fixtures\ContainerObjectEInitializer;
 use Tempest\Container\Tests\Fixtures\DependencyWithTaggedDependency;
+use Tempest\Container\Tests\Fixtures\DependencyWithTaggedIteratorDependency;
 use Tempest\Container\Tests\Fixtures\IntersectionInitializer;
 use Tempest\Container\Tests\Fixtures\OptionalTypesClass;
 use Tempest\Container\Tests\Fixtures\SingletonClass;
@@ -29,6 +30,8 @@ use Tempest\Container\Tests\Fixtures\SingletonInitializer;
 use Tempest\Container\Tests\Fixtures\TaggedDependency;
 use Tempest\Container\Tests\Fixtures\TaggedDependencyCliInitializer;
 use Tempest\Container\Tests\Fixtures\TaggedDependencyWebInitializer;
+use Tempest\Container\Tests\Fixtures\TaggedIteratorA;
+use Tempest\Container\Tests\Fixtures\TaggedIteratorB;
 use Tempest\Container\Tests\Fixtures\UnionImplementation;
 use Tempest\Container\Tests\Fixtures\UnionInitializer;
 use Tempest\Container\Tests\Fixtures\UnionInterfaceA;
@@ -293,5 +296,20 @@ TXT,
         $b = $container->get(ClassWithSingletonAttribute::class);
 
         $this->assertTrue($b->flag);
+    }
+
+    public function test_tagged_iterators(): void
+    {
+        $container = new GenericContainer();
+        $container->tag('tag', TaggedIteratorA::class);
+        $container->tag('tag', TaggedIteratorB::class);
+
+        /** @var DependencyWithTaggedIteratorDependency $a */
+        $a = $container->get(DependencyWithTaggedIteratorDependency::class);
+
+        $this->assertEquals([
+            $container->get(TaggedIteratorA::class),
+            $container->get(TaggedIteratorB::class),
+        ], $a->param);
     }
 }

--- a/src/Tempest/Container/tests/Fixtures/DependencyWithTaggedIteratorDependency.php
+++ b/src/Tempest/Container/tests/Fixtures/DependencyWithTaggedIteratorDependency.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Tests\Fixtures;
+
+use Tempest\Container\Tagged;
+
+final readonly class DependencyWithTaggedIteratorDependency
+{
+    public function __construct(
+        #[Tagged("tag")] public iterable $param
+    ) {}
+}

--- a/src/Tempest/Container/tests/Fixtures/TaggedIteratorA.php
+++ b/src/Tempest/Container/tests/Fixtures/TaggedIteratorA.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Tests\Fixtures;
+
+use Tempest\Container\Tagged;
+
+#[Tagged("tag")]
+final readonly class TaggedIteratorA
+{
+}

--- a/src/Tempest/Container/tests/Fixtures/TaggedIteratorB.php
+++ b/src/Tempest/Container/tests/Fixtures/TaggedIteratorB.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Tests\Fixtures;
+
+use Tempest\Container\Tagged;
+
+#[Tagged("tag")]
+final readonly class TaggedIteratorB
+{
+}


### PR DESCRIPTION
Hi, I really like what Tempest brings to the table! When digging around I missed something: tagged iterators [1](https://symfony.com/doc/current/service_container/tags.html) , [2](https://laravel.com/docs/11.x/container#tagging). So after some trying I came up with this one: `#[Tagged("tag-name")]` on both the classes to inject and the parameters where to use them. 

The main use case is to easily append dependencies with the same interface. Very useful when implementing the [chain of responsibility](https://refactoring.guru/design-patterns/chain-of-responsibility) design pattern.

What do you think? Happy to receive any feedback. My "main" gripe is the word "tagged" is already used internally for something different, you also already use the `#[Tag("x")]`  for  something different which can be confusing. Any suggestions?

# Usage

```
interface Inspirator {
    public function inspire(): string;
}

#[Tagged("inspirator")]
final class FirstInspire implements Inspirator
{
    public function inspire(): string
    {
        return "One";
    }
}

#[Tagged("inspirator")]
final class TwoInspire implements Inspirator
{
    public function inspire(): string
    {
        return "Two";
    }
}

final class Inspire
{
    public function __construct(
        private Console $console,
        #[Tagged("inspirator")] private iterable $inspirators
    ) {}

    #[ConsoleCommand]
    public function inspire(): void
    {
        $quotes = array_map(static fn (Inspirator $inspirator) => $inspirator->inspire(), (array)$this->inspirators);

        $this->console->writeln(implode("\n", $quotes));
    }
}
```
 