### PR TITLE
feat: allow object to define how they are mapped to array

### DIFF
--- a/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
+++ b/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Mapper\Mappers;
 
+use JsonSerializable;
 use Tempest\Mapper\Mapper;
 use Tempest\Mapper\MapTo;
 
@@ -16,6 +17,10 @@ final readonly class ObjectToArrayMapper implements Mapper
 
     public function map(mixed $from, mixed $to): array
     {
+        if ($from instanceof JsonSerializable) {
+            return $from->jsonSerialize();
+        }
+
         return (array) $from;
     }
 }

--- a/tests/Integration/Mapper/Fixtures/ObjectWithJsonSerialize.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithJsonSerialize.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+use JsonSerializable;
+use Tempest\Mapper\Strict;
+
+#[Strict]
+final class ObjectWithJsonSerialize implements JsonSerializable
+{
+    public function __construct(
+        public string $a,
+        public string $b,
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'c' => $this->a,
+            'd' => $this->b,
+        ];
+    }
+}

--- a/tests/Integration/Mapper/Mappers/ObjectToArrayMapperTestCase.php
+++ b/tests/Integration/Mapper/Mappers/ObjectToArrayMapperTestCase.php
@@ -8,6 +8,7 @@ use function Tempest\map;
 use Tempest\Mapper\MapTo;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectA;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithJsonSerialize;
 
 /**
  * @internal
@@ -19,5 +20,12 @@ final class ObjectToArrayMapperTestCase extends FrameworkIntegrationTestCase
         $array = map(new ObjectA('a', 'b'))->to(MapTo::ARRAY);
 
         $this->assertSame(['a' => 'a', 'b' => 'b'], $array);
+    }
+
+    public function test_custom_to_array(): void
+    {
+        $array = map(new ObjectWithJsonSerialize('a', 'b'))->to(MapTo::ARRAY);
+
+        $this->assertSame(['c' => 'a', 'd' => 'b'], $array);
     }
 }


### PR DESCRIPTION
I wrote an object that I wanted to be mapped to array differently then just property -> value. PHP supports this with the JsonSerialize interface. So I wrote a simple check (with test) for that!

For the example, I think the test speaks for itself.