### PR TITLE
feat(container): add ability to invoke arbitrary closures

### DIFF
--- a/src/Tempest/Container/src/Container.php
+++ b/src/Tempest/Container/src/Container.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Container;
 
 use Tempest\Reflection\ClassReflector;
+use Tempest\Reflection\FunctionReflector;
 use Tempest\Reflection\MethodReflector;
 
 interface Container
@@ -22,7 +23,7 @@ interface Container
      */
     public function get(string $className, ?string $tag = null, mixed ...$params): object;
 
-    public function invoke(MethodReflector $method, mixed ...$params): mixed;
+    public function invoke(MethodReflector|FunctionReflector|callable|string $method, mixed ...$params): mixed;
 
     /**
      * @template T of \Tempest\Container\Initializer

--- a/src/Tempest/Container/src/Exceptions/InvalidCallableException.php
+++ b/src/Tempest/Container/src/Exceptions/InvalidCallableException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Exceptions;
+
+use Exception;
+use Tempest\Container\Dependency;
+
+final class InvalidCallableException extends Exception
+{
+    public function __construct(Dependency $dependency)
+    {
+        parent::__construct("[{$dependency->getName()}] cannot be invoked through the container.");
+    }
+}

--- a/src/Tempest/Container/src/functions.php
+++ b/src/Tempest/Container/src/functions.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tempest {
 
     use Tempest\Container\GenericContainer;
+    use Tempest\Reflection\FunctionReflector;
+    use Tempest\Reflection\MethodReflector;
 
     /**
      * @template TClassName of object
@@ -16,5 +18,12 @@ namespace Tempest {
         $container = GenericContainer::instance();
 
         return $container->get($className, $tag, ...$params);
+    }
+
+    function invoke(MethodReflector|FunctionReflector|callable|string $callable, mixed ...$params): mixed
+    {
+        $container = GenericContainer::instance();
+
+        return $container->invoke($callable, ...$params);
     }
 }

--- a/src/Tempest/Container/tests/ContainerTest.php
+++ b/src/Tempest/Container/tests/ContainerTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Tempest\Container\Tests;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Tempest\Container\Exceptions\CannotAutowireException;
 use Tempest\Container\Exceptions\CannotResolveTaggedDependency;
 use Tempest\Container\Exceptions\CircularDependencyException;
+use Tempest\Container\Exceptions\InvalidCallableException;
 use Tempest\Container\GenericContainer;
 use Tempest\Container\Tests\Fixtures\BuiltinArrayClass;
 use Tempest\Container\Tests\Fixtures\BuiltinTypesWithDefaultsClass;
@@ -23,6 +26,8 @@ use Tempest\Container\Tests\Fixtures\ContainerObjectE;
 use Tempest\Container\Tests\Fixtures\ContainerObjectEInitializer;
 use Tempest\Container\Tests\Fixtures\DependencyWithTaggedDependency;
 use Tempest\Container\Tests\Fixtures\IntersectionInitializer;
+use Tempest\Container\Tests\Fixtures\InvokableClass;
+use Tempest\Container\Tests\Fixtures\InvokableClassWithParameters;
 use Tempest\Container\Tests\Fixtures\OptionalTypesClass;
 use Tempest\Container\Tests\Fixtures\SingletonClass;
 use Tempest\Container\Tests\Fixtures\SingletonInitializer;
@@ -293,5 +298,66 @@ TXT,
         $b = $container->get(ClassWithSingletonAttribute::class);
 
         $this->assertTrue($b->flag);
+    }
+
+    public function test_invoke_callable(): void
+    {
+        $container = new GenericContainer();
+        $container->singleton(SingletonClass::class, fn () => new SingletonClass());
+
+        $this->assertEquals('foo', $container->invoke(InvokableClass::class));
+        $this->assertEquals('foobar', $container->invoke([new InvokableClass(), 'execute']));
+        $this->assertEquals('bar', $container->invoke(InvokableClassWithParameters::class, param: 'bar'));
+        $this->assertInstanceOf(ReflectionClass::class, $container->invoke(fn (SingletonClass $class) => new ReflectionClass($class)));
+    }
+
+    public function test_call_function_with_parameters(): void
+    {
+        $container = new GenericContainer();
+        $container->singleton(SingletonClass::class, fn () => new SingletonClass());
+
+        $result = $container->invoke(
+            callable: fn (SingletonClass $class, string $prefix) => $prefix.$class::class,
+            prefix: 'My resolved class is ',
+        );
+
+        $this->assertEquals('My resolved class is Tempest\Container\Tests\Fixtures\SingletonClass', $result);
+    }
+
+    public function test_call_function_with_dependencies_and_parameters(): void
+    {
+        $container = new GenericContainer();
+
+        $result = $container->invoke(fn (string $param) => $param, param: 'foo');
+
+        $this->assertEquals('foo', $result);
+    }
+
+    public function test_call_function_with_unresolvable_parameters(): void
+    {
+        $this->expectException(CannotAutowireException::class);
+        $this->expectExceptionMessageMatches('/because string cannot be resolved/');
+
+        $container = new GenericContainer();
+        $container->invoke(fn (string $param) => $param);
+    }
+
+    public function test_call_invalid_closure(): void
+    {
+        $this->expectException(InvalidCallableException::class);
+        $this->expectExceptionMessage('[array_map] cannot be invoked through the container.');
+
+        $container = new GenericContainer();
+        $container->invoke('array_map');
+    }
+
+    public function test_invoke_closure_with_function(): void
+    {
+        GenericContainer::setInstance($container = new GenericContainer());
+        $container->singleton(SingletonClass::class, fn () => new SingletonClass());
+
+        $result = \Tempest\invoke(fn (SingletonClass $class) => $class::class);
+
+        $this->assertEquals(SingletonClass::class, $result);
     }
 }

--- a/src/Tempest/Container/tests/Fixtures/InvokableClass.php
+++ b/src/Tempest/Container/tests/Fixtures/InvokableClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Tests\Fixtures;
+
+final class InvokableClass
+{
+    public function __invoke(): string
+    {
+        return 'foo';
+    }
+
+    public function execute(): string
+    {
+        return 'foobar';
+    }
+}

--- a/src/Tempest/Container/tests/Fixtures/InvokableClassWithParameters.php
+++ b/src/Tempest/Container/tests/Fixtures/InvokableClassWithParameters.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Tests\Fixtures;
+
+final class InvokableClassWithParameters
+{
+    public function __invoke(string $param): string
+    {
+        return $param;
+    }
+}

--- a/src/Tempest/Reflection/src/FunctionReflector.php
+++ b/src/Tempest/Reflection/src/FunctionReflector.php
@@ -20,6 +20,11 @@ final readonly class FunctionReflector implements Reflector
             : $function;
     }
 
+    public function invokeArgs(array $args = []): mixed
+    {
+        return $this->reflectionFunction->invokeArgs($args);
+    }
+
     /** @return Generator|\Tempest\Reflection\ParameterReflector[] */
     public function getParameters(): Generator
     {


### PR DESCRIPTION
This pull request adds the ability to invoke closures from the container. Previously, the container only had the ability to invoke class methods.

```php
$this->container->invoke(function (Kernel $kernel) {});
$this->container->invoke(function (string $foo) {}, foo: 'bar');
$this->container->invoke(InvokableClass::class);
$this->container->invoke([ServiceClass::class, 'handle']);
\Tempest\invoke(function (Service $service) {});
```