### PR TITLE
feat(support): improve helpers

### DIFF
--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -10,6 +10,7 @@ use Countable;
 use Generator;
 use Iterator;
 use Serializable;
+use Stringable;
 use function Tempest\map;
 
 /**
@@ -32,6 +33,15 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         } else {
             $this->array = [$input];
         }
+    }
+
+    public static function explode(string|Stringable $string, string $separator = ' '): self
+    {
+        if ($separator === '') {
+            return new self([(string) $string]);
+        }
+
+        return new self(explode($separator, (string) $string));
     }
 
     public function equals(array|self $other): bool

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -124,12 +124,13 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self(array_values($this->array));
     }
 
-    /** @param Closure(mixed $value, mixed $key): bool $filter */
-    public function filter(Closure $filter): self
+    /** @param null|Closure(mixed $value, mixed $key): bool $filter */
+    public function filter(?Closure $filter = null): self
     {
         $array = [];
+        $filter ??= static fn (mixed $value, mixed $_) => ! in_array($value, [false, null], strict: true);
 
-        foreach ($this as $key => $value) {
+        foreach ($this->array as $key => $value) {
             if ($filter($value, $key)) {
                 $array[$key] = $value;
             }

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -286,6 +286,11 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self($array);
     }
 
+    public function dd(mixed ...$dd): void
+    {
+        dd($this->array, ...$dd); // @phpstan-ignore-line
+    }
+
     public function toArray(): array
     {
         return $this->array;

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -19,6 +19,11 @@ final readonly class StringHelper implements Stringable
     ) {
     }
 
+    public function toString(): string
+    {
+        return $this->string;
+    }
+
     public function __toString(): string
     {
         return $this->string;

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -368,8 +368,8 @@ final readonly class StringHelper implements Stringable
         return ($this->match($regex)[0] ?? null) !== null;
     }
 
-    public function ld(mixed ...$ld): void
+    public function dd(mixed ...$dd): void
     {
-        ld($this->string, ...$ld);
+        dd($this->string, ...$dd); // @phpstan-ignore-line
     }
 }

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -298,7 +298,7 @@ final readonly class StringHelper implements Stringable
             return $this;
         }
 
-        $position = strpos($this->string, $search);
+        $position = strpos($this->string, (string) $search);
 
         if ($position === false) {
             return $this;
@@ -315,7 +315,7 @@ final readonly class StringHelper implements Stringable
             return $this;
         }
 
-        $position = strrpos($this->string, $search);
+        $position = strrpos($this->string, (string) $search);
 
         if ($position === false) {
             return $this;

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -29,11 +29,9 @@ final readonly class StringHelper implements Stringable
         return $this->string;
     }
 
-    public function equals(string|self $other): bool
+    public function equals(string|Stringable $other): bool
     {
-        $string = is_string($other) ? $other : $other->string;
-
-        return $this->string === $string;
+        return $this->string === (string) $other;
     }
 
     public function title(): self
@@ -133,8 +131,10 @@ final readonly class StringHelper implements Stringable
         return new self(preg_replace('/(?:' . preg_quote($cap, '/') . ')+$/u', replacement: '', subject: $this->string) . $cap);
     }
 
-    public function after(string|array $search): self
+    public function after(Stringable|string|array $search): self
     {
+        $search = $this->normalizeString($search);
+
         if ($search === '' || $search === []) {
             return $this;
         }
@@ -160,8 +160,10 @@ final readonly class StringHelper implements Stringable
         return new self($string);
     }
 
-    public function afterLast(string|array $search): self
+    public function afterLast(Stringable|string|array $search): self
     {
+        $search = $this->normalizeString($search);
+
         if ($search === '' || $search === []) {
             return $this;
         }
@@ -187,8 +189,10 @@ final readonly class StringHelper implements Stringable
         return new self($string);
     }
 
-    public function before(string|array $search): self
+    public function before(Stringable|string|array $search): self
     {
+        $search = $this->normalizeString($search);
+
         if ($search === '' || $search === []) {
             return $this;
         }
@@ -212,8 +216,10 @@ final readonly class StringHelper implements Stringable
         return new self($string);
     }
 
-    public function beforeLast(string|array $search): self
+    public function beforeLast(Stringable|string|array $search): self
     {
+        $search = $this->normalizeString($search);
+
         if ($search === '' || $search === []) {
             return $this;
         }
@@ -237,8 +243,11 @@ final readonly class StringHelper implements Stringable
         return new self($string);
     }
 
-    public function between(int|string $from, int|string $to): self
+    public function between(string|Stringable $from, string|Stringable $to): self
     {
+        $from = $this->normalizeString($from);
+        $to = $this->normalizeString($to);
+
         if ($from === '' || $to === '') {
             return $this;
         }
@@ -271,18 +280,20 @@ final readonly class StringHelper implements Stringable
         return new self(basename(str_replace('\\', '/', $this->string)));
     }
 
-    public function startsWith(string $needle): bool
+    public function startsWith(Stringable|string $needle): bool
     {
-        return str_starts_with($this->string, $needle);
+        return str_starts_with($this->string, (string) $needle);
     }
 
-    public function endsWith(string $needle): bool
+    public function endsWith(Stringable|string $needle): bool
     {
-        return str_ends_with($this->string, $needle);
+        return str_ends_with($this->string, (string) $needle);
     }
 
-    public function replaceFirst(string $search, string $replace): self
+    public function replaceFirst(Stringable|string $search, Stringable|string $replace): self
     {
+        $search = $this->normalizeString($search);
+
         if ($search === '') {
             return $this;
         }
@@ -296,8 +307,10 @@ final readonly class StringHelper implements Stringable
         return new self(substr_replace($this->string, $replace, $position, strlen($search)));
     }
 
-    public function replaceLast(string $search, string $replace): self
+    public function replaceLast(Stringable|string $search, Stringable|string $replace): self
     {
+        $search = $this->normalizeString($search);
+
         if ($search === '') {
             return $this;
         }
@@ -311,8 +324,10 @@ final readonly class StringHelper implements Stringable
         return new self(substr_replace($this->string, $replace, $position, strlen($search)));
     }
 
-    public function replaceEnd(string $search, string $replace): self
+    public function replaceEnd(Stringable|string $search, Stringable|string $replace): self
     {
+        $search = $this->normalizeString($search);
+
         if ($search === '') {
             return $this;
         }
@@ -324,7 +339,7 @@ final readonly class StringHelper implements Stringable
         return $this->replaceLast($search, $replace);
     }
 
-    public function replaceStart(string $search, string $replace): self
+    public function replaceStart(Stringable|string $search, Stringable|string $replace): self
     {
         if ($search === '') {
             return $this;
@@ -337,18 +352,21 @@ final readonly class StringHelper implements Stringable
         return $this->replaceFirst($search, $replace);
     }
 
-    public function append(string ...$append): self
+    public function append(string|Stringable ...$append): self
     {
         return new self($this->string . implode('', $append));
     }
 
-    public function prepend(string ...$prepend): self
+    public function prepend(string|Stringable ...$prepend): self
     {
         return new self(implode('', $prepend) . $this->string);
     }
 
-    public function replace(string|array $search, string|array $replace): self
+    public function replace(Stringable|string|array $search, Stringable|string|array $replace): self
     {
+        $search = $this->normalizeString($search);
+        $replace = $this->normalizeString($replace);
+
         return new self(str_replace($search, $replace, $this->string));
     }
 
@@ -376,5 +394,14 @@ final readonly class StringHelper implements Stringable
     public function dd(mixed ...$dd): void
     {
         dd($this->string, ...$dd); // @phpstan-ignore-line
+    }
+
+    private function normalizeString(mixed $value): mixed
+    {
+        if ($value instanceof Stringable) {
+            return (string) $value;
+        }
+
+        return $value;
     }
 }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -255,4 +255,13 @@ final class ArrayHelperTest extends TestCase
         $this->assertTrue(arr(['a', 'b', 'c'])->contains('b'));
         $this->assertFalse(arr(['a', 'b', 'c'])->contains('d'));
     }
+
+    public function test_explode(): void
+    {
+        $this->assertEquals(['jon', 'doe'], ArrayHelper::explode('jon doe')->toArray());
+        $this->assertEquals(['jon', 'doe'], ArrayHelper::explode(str('jon doe'))->toArray());
+        $this->assertEquals(['jon doe'], ArrayHelper::explode('jon doe', ',')->toArray());
+        $this->assertEquals(['jon', 'doe'], ArrayHelper::explode('jon, doe', ', ')->toArray());
+        $this->assertEquals(['jon, doe'], ArrayHelper::explode('jon, doe', '')->toArray());
+    }
 }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -207,6 +207,14 @@ final class ArrayHelperTest extends TestCase
 
     public function test_filter(): void
     {
+        $this->assertSame(
+            ['a', 'b', '-1', -1, '0', 0],
+            arr(['a', false, 'b', '-1', null, -1, '0', 0])
+                ->filter()
+                ->values()
+                ->toArray(),
+        );
+
         $this->assertTrue(
             arr(['a', 'b', 'c'])
                 ->filter(fn (mixed $value) => $value === 'b')

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use function Tempest\Support\arr;
 use Tempest\Support\ArrayHelper;
 use Tempest\Support\InvalidMapWithKeysUsage;
+use function Tempest\Support\str;
 
 /**
  * @internal

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -114,6 +114,7 @@ final class StringHelperTest extends TestCase
     public function test_str_after(): void
     {
         $this->assertTrue(str('hannah')->after('han')->equals('nah'));
+        $this->assertTrue(str('hannah')->after(str('han'))->equals('nah'));
         $this->assertTrue(str('hannah')->after('n')->equals('nah'));
         $this->assertTrue(str('ééé hannah')->after('han')->equals('nah'));
         $this->assertTrue(str('hannah')->after('xxxx')->equals('hannah'));
@@ -128,6 +129,7 @@ final class StringHelperTest extends TestCase
     public function test_str_after_last(): void
     {
         $this->assertTrue(str('yvette')->afterLast('yve')->equals('tte'));
+        $this->assertTrue(str('yvette')->afterLast(str('yve'))->equals('tte'));
         $this->assertTrue(str('yvette')->afterLast('t')->equals('e'));
         $this->assertTrue(str('ééé yvette')->afterLast('t')->equals('e'));
         $this->assertTrue(str('yvette')->afterLast('tte')->equals(''));
@@ -145,6 +147,7 @@ final class StringHelperTest extends TestCase
         $this->assertTrue(str('abc')->between('a', '')->equals('abc'));
         $this->assertTrue(str('abc')->between('', '')->equals('abc'));
         $this->assertTrue(str('abc')->between('a', 'c')->equals('b'));
+        $this->assertTrue(str('abc')->between(str('a'), str('c'))->equals('b'));
         $this->assertTrue(str('dddabc')->between('a', 'c')->equals('b'));
         $this->assertTrue(str('abcddd')->between('a', 'c')->equals('b'));
         $this->assertTrue(str('dddabcddd')->between('a', 'c')->equals('b'));
@@ -160,6 +163,7 @@ final class StringHelperTest extends TestCase
     public function test_str_before(): void
     {
         $this->assertTrue(str('hannah')->before('nah')->equals('han'));
+        $this->assertTrue(str('hannah')->before(str('nah'))->equals('han'));
         $this->assertTrue(str('hannah')->before('n')->equals('ha'));
         $this->assertTrue(str('ééé hannah')->before('han')->equals('ééé '));
         $this->assertTrue(str('hannah')->before('xxxx')->equals('hannah'));
@@ -179,6 +183,7 @@ final class StringHelperTest extends TestCase
     public function test_str_before_last(): void
     {
         $this->assertTrue(str('yvette')->beforeLast('tte')->equals('yve'));
+        $this->assertTrue(str('yvette')->beforeLast(str('tte'))->equals('yve'));
         $this->assertTrue(str('yvette')->beforeLast('t')->equals('yvet'));
         $this->assertTrue(str('ééé yvette')->beforeLast('yve')->equals('ééé '));
         $this->assertTrue(str('yvette')->beforeLast('yve')->equals(''));
@@ -197,18 +202,22 @@ final class StringHelperTest extends TestCase
     public function test_starts_with(): void
     {
         $this->assertTrue(str('abc')->startsWith('a'));
+        $this->assertTrue(str('abc')->startsWith((str('a'))));
         $this->assertFalse(str('abc')->startsWith('c'));
     }
 
     public function test_ends_with(): void
     {
         $this->assertTrue(str('abc')->endsWith('c'));
+        $this->assertTrue(str('abc')->endsWith(str('c')));
         $this->assertFalse(str('abc')->endsWith('a'));
     }
 
     public function test_replace(): void
     {
         $this->assertTrue(str('foo bar')->replace('bar', 'baz')->equals('foo baz'));
+        $this->assertTrue(str('foo bar')->replace(str('bar'), 'baz')->equals('foo baz'));
+        $this->assertTrue(str('foo bar')->replace('bar', str('baz'))->equals('foo baz'));
         $this->assertTrue(str('jon doe')->replace(['jon', 'jane'], 'luke')->equals('luke doe'));
         $this->assertTrue(str('jon doe')->replace(['jon', 'jane', 'doe'], ['Jon', 'Jane', 'Doe'])->equals('Jon Doe'));
         $this->assertTrue(str('jon doe')->replace(['jon', 'jane', 'doe'], '<censored>')->equals('<censored> <censored>'));
@@ -253,12 +262,14 @@ final class StringHelperTest extends TestCase
     {
         $this->assertTrue(str('foo')->append('bar')->equals('foobar'));
         $this->assertTrue(str('foo')->append('bar', 'baz')->equals('foobarbaz'));
+        $this->assertTrue(str('foo')->append(str('bar'), str('baz'))->equals('foobarbaz'));
     }
 
     public function test_prepend(): void
     {
         $this->assertTrue(str('bar')->prepend('foo')->equals('foobar'));
         $this->assertTrue(str('baz')->prepend('bar', 'foo')->equals('barfoobaz'));
+        $this->assertTrue(str('baz')->prepend(str('bar'), str('foo'))->equals('barfoobaz'));
     }
 
     public function test_match(): void


### PR DESCRIPTION
This pull request adds some improvements to `ArrayHelper` and `StringHelper`:

## ArrayHelper

- Added a `explode` constructor for better chaining (I wanted to use that in #513)
- Added support for no callback on the `filter` method—by default, it filters out `false` and `null` values (strictly)
- Added a `dd` method to help with debugging

## StringHelper

- Added `Stringable` support where it made sense
- Added `toString` for better chaining (`__toString` is ugly, `(string)` feels bad)
- Renamed `ld` to `dd` (I learned that we could ignore a line with phpstan, and `dd` is more intuitive to reach for than `ld`)