### PR TITLE
feat: add initializer for builtin types

### DIFF
--- a/src/Tempest/Container/src/Container.php
+++ b/src/Tempest/Container/src/Container.php
@@ -11,7 +11,7 @@ interface Container
 {
     public function register(string $className, callable $definition): self;
 
-    public function singleton(string $className, object|callable $definition, ?string $tag = null): self;
+    public function singleton(string $className, mixed $definition, ?string $tag = null): self;
 
     public function config(object $config): self;
 

--- a/src/Tempest/Container/src/Exceptions/InvalidInitializerException.php
+++ b/src/Tempest/Container/src/Exceptions/InvalidInitializerException.php
@@ -8,8 +8,15 @@ use Exception;
 
 final class InvalidInitializerException extends Exception
 {
-    public function __construct(string $initializerClassName)
+    public static function dynamicInitializerNotAllowed(string $initializerClassName): self
     {
-        parent::__construct("Initializers must be implement Initializer, {$initializerClassName} does not.");
+        return new self(
+            "Dynamic initializers are not allowed for native values, {$initializerClassName} is a dynamic initializer."
+        );
+    }
+
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
     }
 }

--- a/src/Tempest/Container/src/GenericContainer.php
+++ b/src/Tempest/Container/src/GenericContainer.php
@@ -79,7 +79,7 @@ final class GenericContainer implements Container
         return $this;
     }
 
-    public function singleton(string $className, object|callable $definition, ?string $tag = null): self
+    public function singleton(string $className, mixed $definition, ?string $tag = null): self
     {
         $className = $this->resolveTaggedName($className, $tag);
 
@@ -179,7 +179,7 @@ final class GenericContainer implements Container
         }
 
         // Next we check if any of our default initializers can initialize this class.
-        if (($initializer = $this->initializerFor($class, $tag)) !== null) {
+        if (($initializer = $this->initializerForClass($class, $tag)) !== null) {
             $initializerClass = new ClassReflector($initializer);
 
             $this->resolveChain()->add($initializerClass);
@@ -208,15 +208,24 @@ final class GenericContainer implements Container
         return $this->autowire($className, ...$params);
     }
 
-    private function initializerFor(ClassReflector $class, ?string $tag = null): null|Initializer|DynamicInitializer
+    private function initializerForBuiltin(TypeReflector $target, string $tag): null|Initializer
+    {
+        if ($initializerClass = $this->initializers[$this->resolveTaggedName($target->getName(), $tag)] ?? null) {
+            return $this->resolve($initializerClass);
+        }
+
+        return null;
+    }
+
+    private function initializerForClass(ClassReflector $target, ?string $tag = null): null|Initializer|DynamicInitializer
     {
         // Initializers themselves can't be initialized,
         // otherwise you'd end up with infinite loops
-        if ($class->getType()->matches(Initializer::class) || $class->getType()->matches(DynamicInitializer::class)) {
+        if ($target->getType()->matches(Initializer::class) || $target->getType()->matches(DynamicInitializer::class)) {
             return null;
         }
 
-        if ($initializerClass = $this->initializers[$this->resolveTaggedName($class, $tag)] ?? null) {
+        if ($initializerClass = $this->initializers[$this->resolveTaggedName($target->getName(), $tag)] ?? null) {
             return $this->resolve($initializerClass);
         }
 
@@ -226,7 +235,7 @@ final class GenericContainer implements Container
             /** @var DynamicInitializer $initializer */
             $initializer = $this->resolve($initializerClass);
 
-            if (! $initializer->canInitialize($class)) {
+            if (! $initializer->canInitialize($target)) {
                 continue;
             }
 
@@ -294,14 +303,15 @@ final class GenericContainer implements Container
     {
         $parameterType = $parameter->getType();
 
-        // If the parameter is a built-in type, immediately skip reflection
-        // stuff and attempt to give it a default or null value.
+        // If the parameter is a built-in type, skip reflection and attempt to provide the value by
+        // tagged initializer, a default value or null value.
         if ($parameterType->isBuiltin()) {
             return $this->autowireBuiltinDependency($parameter, $providedValue);
         }
 
         // Loop through each type until we hit a match.
         foreach ($parameter->getType()->split() as $type) {
+
             try {
                 return $this->autowireObjectDependency(
                     type: $type,
@@ -342,6 +352,24 @@ final class GenericContainer implements Container
 
     private function autowireBuiltinDependency(ParameterReflector $parameter, mixed $providedValue): mixed
     {
+        $typeName = $parameter->getType()->getName();
+        $tag = $parameter->getAttribute(Tag::class);
+
+        if ($tag !== null && $initializer = $this->initializerForBuiltin($parameter->getType(), $tag->name)) {
+            $initializerClass = new ClassReflector($initializer);
+
+            $object = $initializer->initialize($this->clone());
+
+            $singleton = $initializerClass->getAttribute(Singleton::class)
+                ?? $initializerClass->getMethod('initialize')->getAttribute(Singleton::class);
+
+            if ($singleton !== null) {
+                $this->singleton($typeName, $object, $tag->name);
+            }
+
+            return $object;
+        }
+
         // Due to type coercion, the provided value may (or may not) work.
         // Here we give up trying to do type work for people. If they
         // didn't provide the right type, that's on them.
@@ -398,10 +426,8 @@ final class GenericContainer implements Container
         $this->chain = $this->chain?->clone();
     }
 
-    private function resolveTaggedName(string|ClassReflector $class, ?string $tag): string
+    private function resolveTaggedName(string $className, ?string $tag): string
     {
-        $className = is_string($class) ? $class : $class->getName();
-
         return $tag
             ? "{$className}#{$tag}"
             : $className;

--- a/src/Tempest/Container/src/Initializer.php
+++ b/src/Tempest/Container/src/Initializer.php
@@ -6,5 +6,5 @@ namespace Tempest\Container;
 
 interface Initializer
 {
-    public function initialize(Container $container): object;
+    public function initialize(Container $container): mixed;
 }

--- a/src/Tempest/Container/tests/ContainerTest.php
+++ b/src/Tempest/Container/tests/ContainerTest.php
@@ -9,6 +9,9 @@ use Tempest\Container\Exceptions\CannotResolveTaggedDependency;
 use Tempest\Container\Exceptions\CircularDependencyException;
 use Tempest\Container\GenericContainer;
 use Tempest\Container\Tests\Fixtures\BuiltinArrayClass;
+use Tempest\Container\Tests\Fixtures\BuiltinDependencyArrayInitializer;
+use Tempest\Container\Tests\Fixtures\BuiltinDependencyBoolInitializer;
+use Tempest\Container\Tests\Fixtures\BuiltinDependencyStringInitializer;
 use Tempest\Container\Tests\Fixtures\BuiltinTypesWithDefaultsClass;
 use Tempest\Container\Tests\Fixtures\CallContainerObjectE;
 use Tempest\Container\Tests\Fixtures\CircularWithInitializerA;
@@ -21,6 +24,7 @@ use Tempest\Container\Tests\Fixtures\ContainerObjectD;
 use Tempest\Container\Tests\Fixtures\ContainerObjectDInitializer;
 use Tempest\Container\Tests\Fixtures\ContainerObjectE;
 use Tempest\Container\Tests\Fixtures\ContainerObjectEInitializer;
+use Tempest\Container\Tests\Fixtures\DependencyWithBuiltinDependencies;
 use Tempest\Container\Tests\Fixtures\DependencyWithTaggedDependency;
 use Tempest\Container\Tests\Fixtures\IntersectionInitializer;
 use Tempest\Container\Tests\Fixtures\OptionalTypesClass;
@@ -293,5 +297,20 @@ TXT,
         $b = $container->get(ClassWithSingletonAttribute::class);
 
         $this->assertTrue($b->flag);
+    }
+
+    public function test_builtin_dependency_initializer(): void
+    {
+        $container = new GenericContainer();
+        $container->addInitializer(BuiltinDependencyArrayInitializer::class);
+        $container->addInitializer(BuiltinDependencyBoolInitializer::class);
+        $container->addInitializer(BuiltinDependencyStringInitializer::class);
+
+        /** @var DependencyWithBuiltinDependencies $a */
+        $a = $container->get(DependencyWithBuiltinDependencies::class);
+
+        $this->assertSame("Hallo dependency!", $a->stringValue);
+        $this->assertSame(["hallo", "array", 42], $a->arrayValue);
+        $this->assertTrue($a->boolValue);
     }
 }

--- a/src/Tempest/Container/tests/Fixtures/BuiltinDependencyArrayInitializer.php
+++ b/src/Tempest/Container/tests/Fixtures/BuiltinDependencyArrayInitializer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Tests\Fixtures;
+
+use Tempest\Container\Container;
+use Tempest\Container\Initializer;
+use Tempest\Container\Singleton;
+
+final class BuiltinDependencyArrayInitializer implements Initializer
+{
+    #[Singleton(tag:"builtin-dependency-array")]
+    public function initialize(Container $container): array
+    {
+        return ["hallo", "array", 42];
+    }
+}

--- a/src/Tempest/Container/tests/Fixtures/BuiltinDependencyBoolInitializer.php
+++ b/src/Tempest/Container/tests/Fixtures/BuiltinDependencyBoolInitializer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Tests\Fixtures;
+
+use Tempest\Container\Container;
+use Tempest\Container\Initializer;
+use Tempest\Container\Singleton;
+
+final class BuiltinDependencyBoolInitializer implements Initializer
+{
+    #[Singleton(tag:"builtin-dependency-bool")]
+    public function initialize(Container $container): bool
+    {
+        return true;
+    }
+}

--- a/src/Tempest/Container/tests/Fixtures/BuiltinDependencyStringInitializer.php
+++ b/src/Tempest/Container/tests/Fixtures/BuiltinDependencyStringInitializer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Tests\Fixtures;
+
+use Tempest\Container\Container;
+use Tempest\Container\Initializer;
+use Tempest\Container\Singleton;
+
+final class BuiltinDependencyStringInitializer implements Initializer
+{
+    #[Singleton(tag:"builtin-dependency-string")]
+    public function initialize(Container $container): string
+    {
+        return "Hallo dependency!";
+    }
+}

--- a/src/Tempest/Container/tests/Fixtures/DependencyWithBuiltinDependencies.php
+++ b/src/Tempest/Container/tests/Fixtures/DependencyWithBuiltinDependencies.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Tests\Fixtures;
+
+use Tempest\Container\Tag;
+
+final class DependencyWithBuiltinDependencies
+{
+    public function __construct(
+        #[Tag("builtin-dependency-array")]
+        public readonly array $arrayValue,
+        #[Tag("builtin-dependency-string")]
+        public readonly string $stringValue,
+        #[Tag("builtin-dependency-bool")]
+        public readonly bool $boolValue,
+    ) {
+
+    }
+}


### PR DESCRIPTION
Hi again,

In #522  we briefly discussed how it wasn't yet possible to initialize native types (like arrays). With these changes you should be able to do so. With it you can inject arrays like any other class without the help of your ArrayHelper. In my opinion, not having to use the ArrayHelper is more in line with the project goals of "getting out of the way" where you can use builtin types without the wrappers (and with if you prefer of course). 

I hope you guys like it as much as I do.

## Usage

With this you can inject an array , string, bool and more. The "most common" usage would be to inject groups of dependencies more easily. But you could even inject config values with it. 

```php
final class InspiratorCombinatorInitializer implements Initializer
{
    #[Singleton(tag: 'inspirators')]
    public function initialize(Container $container): array
    {
        return [
            $container->get(FirstInspire::class),
            $container->get(SecondInspire::class),
        ];
    }
}
...
final class InspiratorCombinator implements Inspirator
{
    public function __construct(#[Tag('inspirators')] private readonly array $inspirators)
    {
    }

    public function inspire(): string
    {
        return implode(
            '\n',
            array_map(static fn (Inspirator $inspirator) => $inspirator->inspire(), $this->inspirators)
        );
    }
}
```