### PR TITLE
refactor: improve matchAll string helper

### DIFF
--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -371,7 +371,7 @@ final readonly class StringHelper implements Stringable
 
     public function matchAll(string $regex, int $flags = 0, int $offset = 0): array
     {
-        $result = preg_match_all($regex, $this->string, $matches);
+        $result = preg_match_all($regex, $this->string, $matches, $flags, $offset);
 
         if ($result === 0) {
             return [];

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -55,7 +55,11 @@ final readonly class StringHelper implements Stringable
         }
 
         $string = preg_replace('/(.)(?=[A-Z])/u', '$1' . $delimiter, $string);
-        $string = preg_replace('![^' . preg_quote($delimiter) . '\pL\pN\s]+!u', $delimiter, mb_strtolower($string, 'UTF-8'));
+        $string = preg_replace(
+            '![^' . preg_quote($delimiter) . '\pL\pN\s]+!u',
+            $delimiter,
+            mb_strtolower($string, 'UTF-8')
+        );
         $string = preg_replace('/\s+/u', $delimiter, $string);
         $string = trim($string, $delimiter);
 
@@ -79,7 +83,7 @@ final readonly class StringHelper implements Stringable
 
     public function camel(): self
     {
-        return new self(lcfirst((string) $this->pascal()));
+        return new self(lcfirst((string)$this->pascal()));
     }
 
     public function deduplicate(string|array $characters = ' '): self
@@ -115,7 +119,7 @@ final readonly class StringHelper implements Stringable
 
         while (($len = strlen($string)) < $length) {
             $size = $length - $len;
-            $bytesSize = (int) ceil($size / 3) * 3;
+            $bytesSize = (int)ceil($size / 3) * 3;
             $bytes = random_bytes($bytesSize);
             $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), offset: 0, length: $size);
         }
@@ -125,7 +129,9 @@ final readonly class StringHelper implements Stringable
 
     public function finish(string $cap): self
     {
-        return new self(preg_replace('/(?:' . preg_quote($cap, '/') . ')+$/u', replacement: '', subject: $this->string) . $cap);
+        return new self(
+            preg_replace('/(?:' . preg_quote($cap, '/') . ')+$/u', replacement: '', subject: $this->string) . $cap
+        );
     }
 
     public function after(string|array $search): self
@@ -363,9 +369,13 @@ final readonly class StringHelper implements Stringable
         return $matches;
     }
 
-    public function matchAll(string $regex): array
+    public function matchAll(string $regex, int $flags = 0, int $offset = 0): array
     {
-        preg_match_all($regex, $this->string, $matches);
+        $result = preg_match_all($regex, $this->string, $matches);
+
+        if ($result === 0) {
+            return [];
+        }
 
         return $matches;
     }

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -324,7 +324,7 @@ final class StringHelperTest extends TestCase
         // Test for No Matches
         $regex = '/cat/';
         $matches = str('The quick brown fox, then the lazy dog')->matchAll($regex);
-        $expected = [[]];
+        $expected = [];
         $this->assertSame($expected, $matches);
 
         // Test for Mixed Captures

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -361,5 +361,35 @@ final class StringHelperTest extends TestCase
             ],
         ];
         $this->assertSame($expected, $matches);
+
+        // Test flags
+        $regex = '/(foo)(bar)/';
+        $matches = str('foobarbaz')->matchAll($regex, PREG_OFFSET_CAPTURE);
+        $expected = [
+            [
+                [
+                    'foobar',
+                    0,
+                ],
+            ],
+            [
+                [
+                    'foo',
+                    0,
+                ],
+            ],
+            [
+                [
+                    'bar',
+                    3,
+                ],
+            ],
+        ];
+        $this->assertSame($expected, $matches);
+
+        $regex = '/^def/';
+        $matches = str('abcdef')->matchAll(regex: $regex, offset: 3);
+        $expected = [];
+        $this->assertSame($expected, $matches);
     }
 }


### PR DESCRIPTION
I think I did a bad job on the first PR about this helper, this aims to improve the method a bit, and I simplify the no match result.