### PR TITLE
fix: add optional port argument to serve command(#537)

### DIFF
--- a/src/Tempest/Http/src/Commands/ServeCommand.php
+++ b/src/Tempest/Http/src/Commands/ServeCommand.php
@@ -12,8 +12,8 @@ final readonly class ServeCommand
         name: 'serve',
         description: 'Start a PHP development server'
     )]
-    public function __invoke(string $host = 'localhost:8000', string $publicDir = 'public/'): void
+    public function __invoke(string $host = 'localhost', int $port = 8000, string $publicDir = 'public/'): void
     {
-        passthru("php -S {$host} -t {$publicDir}");
+        passthru("php -S {$host}:{$port} -t {$publicDir}");
     }
 }


### PR DESCRIPTION
Tempest serves without specifying a port:
```bash
./tempest serve --host=localhost 
```

With a specific port:

```bash
 ./tempest serve --host=localhost --port=8082 
 ```