### PR TITLE
fix(#275): implement weekly log rotation

### DIFF
--- a/src/Tempest/Log/src/Channels/WeeklyLogChannel.php
+++ b/src/Tempest/Log/src/Channels/WeeklyLogChannel.php
@@ -9,11 +9,11 @@ use Monolog\Processor\PsrLogMessageProcessor;
 use Tempest\Log\FileHandlers\RotatingFileHandler;
 use Tempest\Log\LogChannel;
 
-final readonly class DailyLogChannel implements LogChannel
+final readonly class WeeklyLogChannel implements LogChannel
 {
     public function __construct(
         private string $path,
-        private int $maxFiles = 31,
+        private int $maxFiles = 5,
         private bool $bubble = true,
         private ?int $filePermission = null,
         private bool $useLocking = false,
@@ -30,7 +30,7 @@ final readonly class DailyLogChannel implements LogChannel
                 bubble: $this->bubble,
                 filePermission: $this->filePermission,
                 useLocking: $this->useLocking,
-                dateFormat: RotatingFileHandler::FILE_PER_DAY,
+                dateFormat: RotatingFileHandler::FILE_PER_WEEK,
             ),
         ];
     }

--- a/src/Tempest/Log/src/FileHandlers/RotatingFileHandler.php
+++ b/src/Tempest/Log/src/FileHandlers/RotatingFileHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Log\FileHandlers;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+use Monolog\Handler\RotatingFileHandler as MonoRotatingFileHandler;
+
+final class RotatingFileHandler extends MonoRotatingFileHandler
+{
+    public const string FILE_PER_WEEK = 'Y-W';
+
+    protected function setDateFormat(string $dateFormat): void
+    {
+        if (0 === preg_match('{^[Yy](([/_.-]?m([/_.-]?d)?)|([/_.-]?W))?$}', $dateFormat)) {
+            throw new InvalidArgumentException(
+                'Invalid date format - format must be one of '.
+                'RotatingFileHandler::FILE_PER_DAY ("Y-m-d"), RotatingFileHandler::FILE_PER_WEEK ("Y-W"), '.
+                'RotatingFileHandler::FILE_PER_MONTH ("Y-m") or RotatingFileHandler::FILE_PER_YEAR ("Y"), '.
+                'or you can set one of the date formats using slashes, underscores and/or dots instead of dashes.'
+            );
+        }
+
+        $this->dateFormat = $dateFormat;
+    }
+
+    protected function getNextRotation(): DateTimeImmutable
+    {
+        return match (str_replace(['/','_','.'], '-', $this->dateFormat)) {
+            self::FILE_PER_WEEK => (new DateTimeImmutable('first day of next week'))->setTime(0, 0, 0),
+            self::FILE_PER_MONTH => (new DateTimeImmutable('first day of next month'))->setTime(0, 0, 0),
+            self::FILE_PER_YEAR => (new DateTimeImmutable('first day of January next year'))->setTime(0, 0, 0),
+            default => (new DateTimeImmutable('tomorrow'))->setTime(0, 0, 0),
+        };
+    }
+}

--- a/src/Tempest/Log/tests/GenericLoggerTest.php
+++ b/src/Tempest/Log/tests/GenericLoggerTest.php
@@ -7,6 +7,7 @@ namespace Tempest\Log\Tests;
 use PHPUnit\Framework\TestCase;
 use Tempest\Log\Channels\AppendLogChannel;
 use Tempest\Log\Channels\DailyLogChannel;
+use Tempest\Log\Channels\WeeklyLogChannel;
 use Tempest\Log\GenericLogger;
 use Tempest\Log\LogConfig;
 
@@ -41,6 +42,25 @@ final class GenericLoggerTest extends TestCase
         $config = new LogConfig(
             channels: [
                 new DailyLogChannel(__DIR__ . '/logs/tempest.log'),
+            ],
+        );
+
+        $logger = new GenericLogger($config);
+
+        $logger->info('test');
+
+        $this->assertFileExists($filePath);
+
+        $this->assertStringContainsString('test', file_get_contents($filePath));
+    }
+
+    public function test_weekly_log_channel_works(): void
+    {
+        $filePath = __DIR__ . '/logs/tempest-' . date('Y-W') . '.log';
+
+        $config = new LogConfig(
+            channels: [
+                new WeeklyLogChannel(__DIR__ . '/logs/tempest.log'),
             ],
         );
 


### PR DESCRIPTION
Added weekly log rotation.

This fix creates a `RotatingFileHandler` that extends the `Mono/RotatingFileHandler` and overwrites only the methods required to make this work. Might be considered hacky by some.
