### PR TITLE
feat: add boolean data type (#547)

### DIFF
--- a/src/Tempest/Database/src/QueryStatements/BooleanStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/BooleanStatement.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\QueryStatements;
+
+use Tempest\Database\DatabaseDialect;
+use Tempest\Database\QueryStatement;
+
+final readonly class BooleanStatement implements QueryStatement
+{
+    public function __construct(
+        private string $name,
+        private bool $nullable = false,
+        private ?bool $default = null,
+    ) {
+    }
+
+    public function compile(DatabaseDialect $dialect): string
+    {
+        return sprintf(
+            '`%s` BOOLEAN %s %s',
+            $this->name,
+            $this->default ? "DEFAULT {$this->default}" : '',
+            $this->nullable ? '' : 'NOT NULL',
+        );
+    }
+}

--- a/src/Tempest/Database/src/QueryStatements/CreateTableStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/CreateTableStatement.php
@@ -152,6 +152,20 @@ final class CreateTableStatement implements QueryStatement
         return $this;
     }
 
+    public function boolean(
+        string $name,
+        bool $nullable = false,
+        ?bool $default = null
+    ): self {
+        $this->statements[] = new BooleanStatement(
+            name: $name,
+            nullable: $nullable,
+            default: $default,
+        );
+
+        return $this;
+    }
+
     public function compile(DatabaseDialect $dialect): string
     {
         $compiled = sprintf(

--- a/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
@@ -32,7 +32,8 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
                     ->float('float', default: 0.1)
                     ->integer('integer', default: 1)
                     ->date('date', default: '2024-01-01')
-                    ->datetime('datetime', default: '2024-01-01 00:00:00');
+                    ->datetime('datetime', default: '2024-01-01 00:00:00')
+                    ->boolean('is_active', default: true);
             }
 
             public function down(): QueryStatement|null


### PR DESCRIPTION
In this `PR` the `Boolean` data type is added to the table statements. To create a column with a boolean type:
``` bash
public function up(): QueryStatement|null
{
        return CreateTableStatement::forModel(Book::class)
            ->primary()
            ->text('title')
            ->boolean('is_active', default: true);
}
```