### PR TITLE
fix(phpstan): fix phpstan issues

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,76 +6,12 @@ parameters:
 			path: src/Tempest/Console/src/Exceptions/ConsoleException.php
 
 		-
-			message: "#^Calling exec\\(\\) is forbidden\\.$#"
-			count: 3
-			path: src/Tempest/Console/src/Terminal/Terminal.php
-
-		-
 			message: "#^Tempest\\\\Database\\\\Exceptions\\\\DatabaseException should be final$#"
 			count: 1
 			path: src/Tempest/Database/src/Exceptions/DatabaseException.php
 
 		-
-			message: "#^Method Tempest\\\\Http\\\\Exceptions\\\\HttpExceptionHandler\\:\\:getCodeSample\\(\\) is unused\\.$#"
+			message: "#^Tempest\\\\Generation\\\\Tests\\\\TestCase should be final$#"
 			count: 1
-			path: src/Tempest/Http/src/Exceptions/HttpExceptionHandler.php
+			path: src/Tempest/Generation/tests/TestCase.php
 
-		-
-			message: "#^Parameter \\$string of function str_pad expects string, float\\|int given\\.$#"
-			count: 1
-			path: src/Tempest/Http/src/Exceptions/HttpExceptionHandler.php
-
-		-
-			message: "#^PHPDoc tag @var contains unresolvable type\\.$#"
-			count: 1
-			path: src/Tempest/Http/src/Exceptions/exception.php
-
-		-
-			message: "#^PHPDoc tag @var does not specify variable name\\.$#"
-			count: 1
-			path: src/Tempest/Http/src/Exceptions/exception.php
-
-		-
-			message: "#^Variable \\$this might not be defined\\.$#"
-			count: 9
-			path: src/Tempest/Http/src/Exceptions/exception.php
-
-		-
-			message: "#^Parameter \\$middleware of method Tempest\\\\Http\\\\Route\\:\\:__construct\\(\\) has invalid type Tempest\\\\Http\\\\MiddlewareClass\\.$#"
-			count: 1
-			path: src/Tempest/Http/src/Route.php
-
-		-
-			message: "#^Property Tempest\\\\Http\\\\Route\\:\\:\\$middleware has unknown class Tempest\\\\Http\\\\MiddlewareClass as its type\\.$#"
-			count: 1
-			path: src/Tempest/Http/src/Route.php
-
-		-
-			message: "#^Comparison operation \"\\<\" between 500\\|501\\|502\\|503\\|504\\|505\\|506\\|507\\|508\\|510\\|511 and 600 is always true\\.$#"
-			count: 1
-			path: src/Tempest/Http/src/Status.php
-
-		-
-			message: "#^Comparison operation \"\\>\\=\" between 100\\|101\\|102\\|103\\|200\\|201\\|202\\|203\\|204\\|205\\|206\\|207\\|208\\|226\\|300\\|301\\|302\\|303\\|304\\|305\\|306\\|307\\|308\\|400\\|401\\|402\\|403\\|404\\|405\\|406\\|407\\|408\\|409\\|410\\|411\\|412\\|413\\|414\\|415\\|416\\|417\\|418\\|421\\|422\\|423\\|424\\|425\\|426\\|428\\|429\\|431\\|451\\|500\\|501\\|502\\|503\\|504\\|505\\|506\\|507\\|508\\|510\\|511 and 100 is always true\\.$#"
-			count: 1
-			path: src/Tempest/Http/src/Status.php
-
-		-
-			message: "#^Match expression does not handle remaining values\\: 306\\|418$#"
-			count: 1
-			path: src/Tempest/Http/src/Status.php
-
-		-
-			message: "#^Parameter \\#1 \\$request of method Tempest\\\\HttpClient\\\\Driver\\\\Psr18Driver\\:\\:sendRequest\\(\\) expects Psr\\\\Http\\\\Message\\\\RequestInterface, Tempest\\\\Http\\\\Request given\\.$#"
-			count: 1
-			path: src/Tempest/HttpClient/src/Driver/Psr18Driver.php
-
-		-
-			message: "#^Calling eval\\(\\) is forbidden\\.$#"
-			count: 1
-			path: src/Tempest/Reflection/src/TypeReflector.php
-
-		-
-			message: "#^Access to an undefined property Tempest\\\\View\\\\GenericView\\:\\:\\$property\\.$#"
-			count: 1
-			path: tests/Fixtures/Views/rawAndEscaping.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,22 +9,18 @@ services:
 			- phpat.test
 parameters:
 	level: 5
-	reportUnmatchedIgnoredErrors: false
 	tmpDir: .cache/phpstan
+	excludePaths:
+	    - tests/Integration/View/blade/cache/**.php
 	paths:
 		- src
 		- tests
 	ignoreErrors:
-		-
-			message: '#.*#'
-			path:  tests/Integration/View/blade/cache/**.php
+
 		-
 			message: '#.*[Rr]eadonly.*#'
 			path: src/Tempest/Core/src/Composer.php
 
-		-
-			message: '#.*#'
-			path: src/Tempest/Http/Exceptions/HttpExceptionHandler.php
 		-
 			message: '#.*#'
 			path: src/Tempest/Http/src/Exceptions/exception.php
@@ -34,9 +30,7 @@ parameters:
 		-
 			message: '#.*might not be defined.*#'
 			path: tests/**/**.view.php
-		-
-			message: '#.*eval*#'
-			path:  src/Tempest/Support/Reflection/TypeReflector.php
+
 		-
 			message: '#.*exec*#'
 			path:  src/Tempest/Console/src/Commands/InstallCommand.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,13 +25,6 @@ parameters:
 			message: '#.*#'
 			path: src/Tempest/Http/src/Exceptions/exception.php
 		-
-			message: '#Access to an undefined property.*#'
-			path: tests/**/**.view.php
-		-
-			message: '#.*might not be defined.*#'
-			path: tests/**/**.view.php
-
-		-
 			message: '#.*exec*#'
 			path:  src/Tempest/Console/src/Commands/InstallCommand.php
 		-

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,15 +21,13 @@ parameters:
 		-
 			message: '#.*[Rr]eadonly.*#'
 			path: src/Tempest/Core/src/Composer.php
-		-
-			message: '#.*final#'
-			path:  src/Tempest/Generation/tests/TestCase.php
+
 		-
 			message: '#.*#'
 			path: src/Tempest/Http/Exceptions/HttpExceptionHandler.php
 		-
 			message: '#.*#'
-			path: src/Tempest/Http/Exceptions/exception.php
+			path: src/Tempest/Http/src/Exceptions/exception.php
 		-
 			message: '#Access to an undefined property.*#'
 			path: tests/**/**.view.php
@@ -42,6 +40,10 @@ parameters:
 		-
 			message: '#.*exec*#'
 			path:  src/Tempest/Console/src/Commands/InstallCommand.php
+		-
+		    message: '#.*exec*#'
+		    path: src/Tempest/Console/src/Terminal/Terminal.php
+
 	disallowedFunctionCalls:
 		-
 			function: 'exec()'

--- a/src/Tempest/Console/src/Scheduler/NullShellExecutor.php
+++ b/src/Tempest/Console/src/Scheduler/NullShellExecutor.php
@@ -6,7 +6,6 @@ namespace Tempest\Console\Scheduler;
 
 use Tempest\Console\ShellExecutor;
 
-/** @phpstan-ignore-next-line  */
 final class NullShellExecutor implements ShellExecutor
 {
     public ?string $executedCommand = null;

--- a/src/Tempest/Container/tests/Fixtures/CircularWithInitializerA.php
+++ b/src/Tempest/Container/tests/Fixtures/CircularWithInitializerA.php
@@ -6,7 +6,6 @@ namespace Tempest\Container\Tests\Fixtures;
 
 final readonly class CircularWithInitializerA
 {
-    /** @phpstan-ignore-next-line */
     public function __construct()
     {
     }

--- a/src/Tempest/Container/tests/Fixtures/CircularWithInitializerB.php
+++ b/src/Tempest/Container/tests/Fixtures/CircularWithInitializerB.php
@@ -6,7 +6,6 @@ namespace Tempest\Container\Tests\Fixtures;
 
 final readonly class CircularWithInitializerB
 {
-    /** @phpstan-ignore-next-line */
     public function __construct()
     {
     }

--- a/src/Tempest/Container/tests/Fixtures/CircularWithInitializerC.php
+++ b/src/Tempest/Container/tests/Fixtures/CircularWithInitializerC.php
@@ -6,7 +6,6 @@ namespace Tempest\Container\Tests\Fixtures;
 
 final readonly class CircularWithInitializerC
 {
-    /** @phpstan-ignore-next-line */
     public function __construct()
     {
     }

--- a/src/Tempest/Database/src/Builder/ModelDefinition.php
+++ b/src/Tempest/Database/src/Builder/ModelDefinition.php
@@ -12,7 +12,6 @@ use Tempest\Database\HasOne;
 use function Tempest\reflect;
 use Tempest\Reflection\ClassReflector;
 
-/** @phpstan-ignore-next-line */
 final readonly class ModelDefinition
 {
     public function __construct(

--- a/src/Tempest/Http/src/Exceptions/HttpExceptionHandler.php
+++ b/src/Tempest/Http/src/Exceptions/HttpExceptionHandler.php
@@ -25,6 +25,8 @@ final class HttpExceptionHandler implements ExceptionHandler
 
         ob_start();
 
+        ([$this, "getCodeSample"]); // unused
+
         include __DIR__ . '/exception.php';
 
         $contents = ob_get_clean();
@@ -55,7 +57,7 @@ final class HttpExceptionHandler implements ExceptionHandler
             }
 
             $lines[$i] = '<span class="' . $class . '">' . str_pad(
-                string: '' . $i + 1,
+                string: (string) ($i + 1),
                 length: 3,
                 pad_type: STR_PAD_LEFT,
             ) . '</span>' . $line;

--- a/src/Tempest/Http/src/Exceptions/exception.php
+++ b/src/Tempest/Http/src/Exceptions/exception.php
@@ -1,5 +1,8 @@
 <?php
-/** @var \Tempest\Http\Exceptions\HttpExceptionHandler $this */
+
+use Tempest\Http\Exceptions\HttpExceptionHandler;
+
+/** @var HttpExceptionHandler $this */
 ?>
 
 <html>

--- a/src/Tempest/Http/src/Exceptions/exception.php
+++ b/src/Tempest/Http/src/Exceptions/exception.php
@@ -1,5 +1,5 @@
 <?php
-/** @var $this \Tempest\Http\Exceptions\HttpExceptionHandler */
+/** @var \Tempest\Http\Exceptions\HttpExceptionHandler $this */
 ?>
 
 <html>

--- a/src/Tempest/Http/src/Route.php
+++ b/src/Tempest/Http/src/Route.php
@@ -31,8 +31,7 @@ class Route
         public Method $method,
 
         /**
-         * @template MiddlewareClass of \Tempest\Http\HttpMiddleware
-         * @var class-string<MiddlewareClass>[] $middleware
+         * @var class-string<\Tempest\Http\HttpMiddleware>[] $middleware
          */
         public array $middleware = [],
     ) {

--- a/src/Tempest/Http/src/Status.php
+++ b/src/Tempest/Http/src/Status.php
@@ -109,6 +109,7 @@ enum Status: int
             303 => 'See Other',
             304 => 'Not Modified',
             305 => 'Use Proxy',
+            306 => 'Unused',
             307 => 'Temporary Redirect',
             308 => 'Permanent Redirect',
 
@@ -130,6 +131,7 @@ enum Status: int
             415 => 'Unsupported Media Type',
             416 => 'Range Not Satisfiable',
             417 => 'Expectation Failed',
+            418 => 'I Am A Teapot',
             421 => 'Misdirected Request',
             422 => 'Unprocessable Content',
             423 => 'Locked',
@@ -157,7 +159,7 @@ enum Status: int
 
     public function isInformational(): bool
     {
-        return $this->value >= 100 && $this->value < 200;
+        return $this->value < 200;
     }
 
     public function isSuccessful(): bool
@@ -177,6 +179,6 @@ enum Status: int
 
     public function isServerError(): bool
     {
-        return $this->value >= 500 && $this->value < 600;
+        return $this->value >= 500;
     }
 }

--- a/src/Tempest/HttpClient/src/Driver/Psr18Driver.php
+++ b/src/Tempest/HttpClient/src/Driver/Psr18Driver.php
@@ -28,17 +28,15 @@ final class Psr18Driver implements ClientInterface, HttpClientDriver
 
     public function send(Request $request): Response
     {
+        $psrRequest = $this->convertTempestRequestToPsrRequest($request);
+
         return $this->convertPsrResponseToTempestResponse(
-            $this->sendRequest($request)
+            $this->sendRequest($psrRequest)
         );
     }
 
-    public function sendRequest(Request|RequestInterface $request): ResponseInterface
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
-        if ($request instanceof Request) {
-            $request = $this->convertTempestRequestToPsrRequest($request);
-        }
-
         return $this->client->sendRequest($request);
     }
 

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -563,14 +563,14 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
 
     public function dump(mixed ...$dumps): self
     {
-        lw($this->array, ...$dumps); // @phpstan-ignore-line
+        lw($this->array, ...$dumps);
 
         return $this;
     }
 
     public function dd(mixed ...$dd): void
     {
-        ld($this->array, ...$dd); // @phpstan-ignore-line
+        ld($this->array, ...$dd);
     }
 
     /**

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -430,12 +430,12 @@ final readonly class StringHelper implements Stringable
 
     public function dd(mixed ...$dd): void
     {
-        ld($this->string, ...$dd); // @phpstan-ignore-line
+        ld($this->string, ...$dd);
     }
 
     public function dump(mixed ...$dumps): self
     {
-        lw($this->string, ...$dumps); // @phpstan-ignore-line
+        lw($this->string, ...$dumps);
 
         return $this;
     }


### PR DESCRIPTION

## What 

Related to #379


I resolved some issues related to phpstan. I moved some ignore patterns around, removed unused ignore patterns, fixed some issues.

Here is the full breakdown:

Some are ignored in the "normal" phpstan config file like others. 
- forbidden `exec` in `src/Tempest/Console/src/Terminal/Terminal.php` . Which seems as expected and other exec calls are also ignored this way
- `src/Tempest/Http/src/Exceptions/exception.php` seems to have been moved, so I changed the path for the ignore rule

Others where ignore patterns which were no longer required:
- `NullShellExecutor.php`
- `CircularWithInitializer[ABC].php`
- `ModelDefinition.php`
- I excluded the whole `tests/Integration/View/blade/cache/**.php` path instead of ignoring errors from it.

Lastly I fixed some actual  issues:
- issues in `Status.php`:
  -  Some cases were missing in description, this would cause issues, so jeeej for phpstan spotting it.
  - In some condition a "sanity" check was done on the status value, like `status >= 100` and  `status < 600` . But phpstan doesn't like sanity, it likes strict typing ;) 
- `Route.php`: Fixed some logic you cannot apply a template in the middle of any class. In this case I didn't think it was needed anyway.
- `HttpExceptionHandler.php` :  added a "hack" to ensure `getCodeSample` get's referenced. If you don't like it I can always re-add it to the ignore list
- `HttpExceptionHandler.php`: str_pad got used incorrectly, this actually seemed like a bug? so jeeej for phpstan spotting it.

## Pending issues
- `HttpExceptionHandler.php` :  added a "hack" to ensure `getCodeSample` get's referenced. If you don't like it I can always re-add it to the ignore list
- The whole `A should be final` thing seems weird. I get that you would want to enforce final, but something that is explicitly marked as abstract should be the exception right. From my knowledge phpstan should not report this on abstract classes.