### PR TITLE
feat(support): improve array helper with additional methods

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -7,8 +7,10 @@ use Tempest\Http\HttpApplication;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-HttpApplication::boot(__DIR__ . '/../',     discoveryLocations: [
-    new DiscoveryLocation('Tests\\Tempest\\Fixtures\\', __DIR__ . '/../tests/Fixtures')
+HttpApplication::boot(
+    __DIR__ . '/../',
+    discoveryLocations: [
+    new DiscoveryLocation('Tests\\Tempest\\Fixtures\\', __DIR__ . '/../tests/Fixtures'),
 ],
 )->run();
 

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -259,6 +259,14 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self($array);
     }
 
+    /**
+     * @alias self::set()
+     */
+    public function put(string $key, mixed $value): self
+    {
+        return $this->set($key, $value);
+    }
+
     public function unwrap(): self
     {
         $unwrapValue = function (string|int $key, mixed $value) {

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -8,6 +8,7 @@ use ArrayAccess;
 use Closure;
 use Countable;
 use Generator;
+use InvalidArgumentException;
 use Iterator;
 use Random\Randomizer;
 use Serializable;
@@ -17,7 +18,7 @@ use function Tempest\map;
 /**
  * @template TKey of array-key
  * @template TValue
- * 
+ *
  * @implements ArrayAccess<TKey, TValue>
  * @implements Iterator<TKey, TValue>
  */
@@ -50,37 +51,38 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     /**
      * Get one or a specified number of random values from the array.
      *
-     * @param integer $number The number of random values to get.
-     * @param boolean $preserveKey Whether to preserve the keys of the original array. ( won't work if $number is 1 as it will return a single value )
+     * @param int $number The number of random values to get.
+     * @param bool $preserveKey Whether to preserve the keys of the original array. ( won't work if $number is 1 as it will return a single value )
      *
      * @return self<TKey, TValue>|mixed The random values or single value if $number is 1.
      */
-    public function random( int $number = 1, bool $preserveKey = false ): mixed {
-        $count = count( $this->array );
+    public function random(int $number = 1, bool $preserveKey = false): mixed
+    {
+        $count = count($this->array);
 
-        if ( $number > $count ) {
-            throw new \InvalidArgumentException( "Cannot retrive {$number} items from an array of {$count} items." );
+        if ($number > $count) {
+            throw new InvalidArgumentException("Cannot retrive {$number} items from an array of {$count} items.");
         }
 
-        if ( $number < 1 ) {
-            throw new \InvalidArgumentException( "Random value only accepts positive integers, {$number} requested." );
+        if ($number < 1) {
+            throw new InvalidArgumentException("Random value only accepts positive integers, {$number} requested.");
         }
 
-        $keys = (new Randomizer)->pickArrayKeys( $this->array, $number );
+        $keys = (new Randomizer())->pickArrayKeys($this->array, $number);
 
         $randomValues = [];
-        foreach ( $keys as $key ) {
+        foreach ($keys as $key) {
             $preserveKey
                 ? $randomValues[$key] = $this->array[$key]
                 : $randomValues[] = $this->array[$key];
         }
 
-        if ( $preserveKey === false ) {
-            shuffle( $randomValues );
+        if ($preserveKey === false) {
+            shuffle($randomValues);
         }
 
-        return count( $randomValues ) > 1
-            ? new self( $randomValues )
+        return count($randomValues) > 1
+            ? new self($randomValues)
             : $randomValues[0];
     }
 
@@ -93,31 +95,32 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      *
      * @return self<TKey, TValue>
      */
-    public function pluck( string $value, ?string $key = null ): self {
+    public function pluck(string $value, ?string $key = null): self
+    {
         $results = [];
 
-        foreach ( $this->array as $item ) {
-            if ( ! is_array( $item ) ) {
+        foreach ($this->array as $item) {
+            if (! is_array($item)) {
                 continue;
             }
-            
-            $itemValue = arr($item)->get( $value );
+
+            $itemValue = arr($item)->get($value);
 
             /**
              * Perform basic pluck if no key is given.
              * Otherwise, also pluck the key as well.
              */
-            if ( is_null( $key ) ) {
+            if (is_null($key)) {
                 $results[] = $itemValue;
             } else {
-                $itemKey           = arr($item)->get( $key );
+                $itemKey = arr($item)->get($key);
                 $results[$itemKey] = $itemValue;
             }
         }
 
-        return new self( $results );
+        return new self($results);
     }
-    
+
     /**
      * @alias of add.
      */
@@ -133,7 +136,8 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      *
      * @return self<TKey, TValue>
      */
-    public function add( mixed $value ): self {
+    public function add(mixed $value): self
+    {
         $this->array[] = $value;
 
         return $this;
@@ -142,12 +146,13 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     /**
      * Pad the array to the specified size with a value.
      *
-     * @param integer $size
+     * @param int $size
      * @param mixed $value
      *
      * @return self<TKey, TValue>
      */
-    public function pad(int $size, mixed $value): self {
+    public function pad(int $size, mixed $value): self
+    {
         return new self(array_pad($this->array, $size, $value));
     }
 
@@ -156,7 +161,8 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      *
      * @return self<TValue&array-key, TKey>
      */
-    public function flip(): self {
+    public function flip(): self
+    {
         return new self(array_flip($this->array));
     }
 

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -324,6 +324,10 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self($array);
     }
 
+    public function dump(mixed ...$dumps): void {
+        dump($this->array, ...$dumps); // @phpstan-ignore-line
+    }
+    
     public function dd(mixed ...$dd): void
     {
         dd($this->array, ...$dd); // @phpstan-ignore-line

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -66,6 +66,32 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
+     * Keep only the items that are present in all of the given arrays.
+     *
+     * @param array<TKey, TValue>|self<TKey, TValue> ...$arrays
+     *
+     * @return self<TKey, TValue>
+     */
+    public function intersect( array|self ...$arrays ): self {
+        $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
+
+        return new self( array_intersect( $this->toArray(), ...$arrays ) );
+    }
+
+    /**
+     * Keep only the items whose keys are present in all of the given arrays.
+     *
+     * @param array<TKey, TValue>|self<TKey, TValue> ...$arrays
+     *
+     * @return self<TKey, TValue>
+     */
+    public function intersectKeys( array|self ...$arrays ): self {
+        $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
+
+        return new self( array_intersect_key( $this->toArray(), ...$arrays ) );
+    }
+
+    /**
      * Merge the array with the given arrays.
      *
      * @param array<TKey, TValue>|self<TKey, TValue> ...$arrays The arrays to merge.

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -62,7 +62,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
             }
 
             $filterValue = is_array( $item )
-                ? $item[$key] ?? null
+                ? arr($item)->get($key)
                 : $item;
 
             if ( is_null( $filterValue ) ) {

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -90,7 +90,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     public function diff( array|self ...$arrays ): self {
         $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
 
-        return new self( array_diff( $this->toArray(), ...$arrays ) );
+        return new self( array_diff( $this->array, ...$arrays ) );
     }
     
     /**
@@ -103,7 +103,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     public function diffKeys( array|self ...$arrays ): self {
         $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
 
-        return new self( array_diff_key( $this->toArray(), ...$arrays ) );
+        return new self( array_diff_key( $this->array, ...$arrays ) );
     }
 
     /**
@@ -116,7 +116,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     public function intersect( array|self ...$arrays ): self {
         $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
 
-        return new self( array_intersect( $this->toArray(), ...$arrays ) );
+        return new self( array_intersect( $this->array, ...$arrays ) );
     }
 
     /**
@@ -129,7 +129,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     public function intersectKeys( array|self ...$arrays ): self {
         $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
 
-        return new self( array_intersect_key( $this->toArray(), ...$arrays ) );
+        return new self( array_intersect_key( $this->array, ...$arrays ) );
     }
 
     /**
@@ -142,7 +142,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     public function merge( array|self ...$arrays ): self {
         $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
 
-        return new self( array_merge( $this->toArray(), ...$arrays ) );
+        return new self( array_merge( $this->array, ...$arrays ) );
     }
 
     /**
@@ -158,7 +158,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         $values = $values instanceof self
             ? $values->toArray()
             : $values;
-        return new self( array_combine( $this->toArray(), $values ) );
+        return new self( array_combine( $this->array, $values ) );
     }
 
     public static function explode(string|Stringable $string, string $separator = ' '): self

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -14,8 +14,10 @@ use Stringable;
 use function Tempest\map;
 
 /**
- * @template TValueType
- * @implements ArrayAccess<array-key, TValueType>
+ * @template TKey of array-key
+ * @template TValue
+ * @implements ArrayAccess<TKey, TValue>
+ * @implements Iterator<TKey, TValue>
  */
 final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countable
 {
@@ -23,6 +25,9 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
 
     private array $array;
 
+    /**
+     * @param array<TKey, TValue>|self<TKey, TValue>|TValue $input
+     */
     public function __construct(
         mixed $input = [],
     ) {
@@ -33,6 +38,22 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         } else {
             $this->array = [$input];
         }
+    }
+
+    /**
+     * Create a new array with this current array values as keys and the given values as values.
+     *
+     * @template TCombineValue
+     * 
+     * @param array<array-key, TCombineValue>|self<array-key, TCombineValue> $values
+     *
+     * @return self<array-key, TCombineValue>
+     */
+    public function combine( array|self $values ): self {
+        $values = $values instanceof self
+            ? $values->toArray()
+            : $values;
+        return new self( array_combine( $this->toArray(), $values ) );
     }
 
     public static function explode(string|Stringable $string, string $separator = ' '): self
@@ -299,6 +320,9 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         dd($this->array, ...$dd); // @phpstan-ignore-line
     }
 
+    /**
+     * @return array<TKey, TValue>
+     */
     public function toArray(): array
     {
         return $this->array;

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -566,14 +566,14 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
 
     public function dump(mixed ...$dumps): self
     {
-        dump($this->array, ...$dumps); // @phpstan-ignore-line
+        lw($this->array, ...$dumps); // @phpstan-ignore-line
 
         return $this;
     }
 
     public function dd(mixed ...$dd): void
     {
-        dd($this->array, ...$dd); // @phpstan-ignore-line
+        ld($this->array, ...$dd); // @phpstan-ignore-line
     }
 
     /**

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -47,7 +47,41 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * @alias of add
+     * Retrieve values from a given key in each sub-array of the current array.
+     * Optionally, you can pass a second parameter to also get the keys following the same pattern.
+     *
+     * @param array-key $value The key to assign the values from, support dot notation.
+     * @param string|null $key The key to assign the keys from, support dot notation.
+     *
+     * @return self<TKey, TValue>
+     */
+    public function pluck( string $value, ?string $key = null ): self {
+        $results = [];
+
+        foreach ( $this->array as $item ) {
+            if ( ! is_array( $item ) ) {
+                continue;
+            }
+            
+            $itemValue = arr($item)->get( $value );
+
+            /**
+             * Perform basic pluck if no key is given.
+             * Otherwise, also pluck the key as well.
+             */
+            if ( is_null( $key ) ) {
+                $results[] = $itemValue;
+            } else {
+                $itemKey           = arr($item)->get( $key );
+                $results[$itemKey] = $itemValue;
+            }
+        }
+
+        return new self( $results );
+    }
+    
+    /**
+     * @alias of add.
      */
     public function push(mixed $value): self
     {

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -41,6 +41,46 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
+     * Keep only the unique items in the array.
+     * 
+     * @param string|null $key The key to use as the uniqueness criteria in nested arrays.
+     * @param bool $should_be_strict Whether the comparison should be strict, only used when giving a key parameter.
+     *
+     * @return self<TKey, TValue>
+     */
+    public function unique( ?string $key = null, bool $should_be_strict = false ): self {
+        if ( is_null( $key ) && $should_be_strict === false ) {
+            return new self( array_unique( $this->array, flags: SORT_REGULAR ) );
+        }
+        
+        $uniqueItems          = [];
+        $uniqueFilteredValues = [];
+        foreach ( $this->array as $item ) {
+            // Ensure we don't check raw values with key filter
+            if ( ! is_null( $key ) && ! is_array( $item ) ) {
+                continue;
+            }
+
+            $filterValue = is_array( $item )
+                ? $item[$key] ?? null
+                : $item;
+
+            if ( is_null( $filterValue ) ) {
+                continue;
+            }
+
+            if ( in_array( $filterValue, $uniqueFilteredValues, strict: $should_be_strict ) ) {
+                continue;
+            }
+
+            $uniqueItems[]          = $item;
+            $uniqueFilteredValues[] = $filterValue;
+        }
+
+        return new self( $uniqueItems );
+    }
+
+    /**
      * Keep only the items that are not present in any of the given arrays.
      *
      * @param array<TKey, TValue>|self<TKey, TValue> ...$arrays
@@ -52,6 +92,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
 
         return new self( array_diff( $this->toArray(), ...$arrays ) );
     }
+    
     /**
      * Keep only the items whose keys are not present in any of the given arrays.
      *

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -42,42 +42,43 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
 
     /**
      * Keep only the unique items in the array.
-     * 
+     *
      * @param string|null $key The key to use as the uniqueness criteria in nested arrays.
      * @param bool $should_be_strict Whether the comparison should be strict, only used when giving a key parameter.
      *
      * @return self<TKey, TValue>
      */
-    public function unique( ?string $key = null, bool $should_be_strict = false ): self {
-        if ( is_null( $key ) && $should_be_strict === false ) {
-            return new self( array_unique( $this->array, flags: SORT_REGULAR ) );
+    public function unique(?string $key = null, bool $should_be_strict = false): self
+    {
+        if (is_null($key) && $should_be_strict === false) {
+            return new self(array_unique($this->array, flags: SORT_REGULAR));
         }
-        
-        $uniqueItems          = [];
+
+        $uniqueItems = [];
         $uniqueFilteredValues = [];
-        foreach ( $this->array as $item ) {
+        foreach ($this->array as $item) {
             // Ensure we don't check raw values with key filter
-            if ( ! is_null( $key ) && ! is_array( $item ) ) {
+            if (! is_null($key) && ! is_array($item)) {
                 continue;
             }
 
-            $filterValue = is_array( $item )
+            $filterValue = is_array($item)
                 ? arr($item)->get($key)
                 : $item;
 
-            if ( is_null( $filterValue ) ) {
+            if (is_null($filterValue)) {
                 continue;
             }
 
-            if ( in_array( $filterValue, $uniqueFilteredValues, strict: $should_be_strict ) ) {
+            if (in_array($filterValue, $uniqueFilteredValues, strict: $should_be_strict)) {
                 continue;
             }
 
-            $uniqueItems[]          = $item;
+            $uniqueItems[] = $item;
             $uniqueFilteredValues[] = $filterValue;
         }
 
-        return new self( $uniqueItems );
+        return new self($uniqueItems);
     }
 
     /**
@@ -87,12 +88,13 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      *
      * @return self<TKey, TValue>
      */
-    public function diff( array|self ...$arrays ): self {
-        $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
+    public function diff(array|self ...$arrays): self
+    {
+        $arrays = array_map(fn (array|self $array) => $array instanceof self ? $array->toArray() : $array, $arrays);
 
-        return new self( array_diff( $this->array, ...$arrays ) );
+        return new self(array_diff($this->array, ...$arrays));
     }
-    
+
     /**
      * Keep only the items whose keys are not present in any of the given arrays.
      *
@@ -100,10 +102,11 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      *
      * @return self<TKey, TValue>
      */
-    public function diffKeys( array|self ...$arrays ): self {
-        $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
+    public function diffKeys(array|self ...$arrays): self
+    {
+        $arrays = array_map(fn (array|self $array) => $array instanceof self ? $array->toArray() : $array, $arrays);
 
-        return new self( array_diff_key( $this->array, ...$arrays ) );
+        return new self(array_diff_key($this->array, ...$arrays));
     }
 
     /**
@@ -113,10 +116,11 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      *
      * @return self<TKey, TValue>
      */
-    public function intersect( array|self ...$arrays ): self {
-        $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
+    public function intersect(array|self ...$arrays): self
+    {
+        $arrays = array_map(fn (array|self $array) => $array instanceof self ? $array->toArray() : $array, $arrays);
 
-        return new self( array_intersect( $this->array, ...$arrays ) );
+        return new self(array_intersect($this->array, ...$arrays));
     }
 
     /**
@@ -126,10 +130,11 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      *
      * @return self<TKey, TValue>
      */
-    public function intersectKeys( array|self ...$arrays ): self {
-        $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
+    public function intersectKeys(array|self ...$arrays): self
+    {
+        $arrays = array_map(fn (array|self $array) => $array instanceof self ? $array->toArray() : $array, $arrays);
 
-        return new self( array_intersect_key( $this->array, ...$arrays ) );
+        return new self(array_intersect_key($this->array, ...$arrays));
     }
 
     /**
@@ -139,26 +144,29 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      *
      * @return self<TKey, TValue>
      */
-    public function merge( array|self ...$arrays ): self {
-        $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
+    public function merge(array|self ...$arrays): self
+    {
+        $arrays = array_map(fn (array|self $array) => $array instanceof self ? $array->toArray() : $array, $arrays);
 
-        return new self( array_merge( $this->array, ...$arrays ) );
+        return new self(array_merge($this->array, ...$arrays));
     }
 
     /**
      * Create a new array with this current array values as keys and the given values as values.
      *
      * @template TCombineValue
-     * 
+     *
      * @param array<array-key, TCombineValue>|self<array-key, TCombineValue> $values
      *
      * @return self<array-key, TCombineValue>
      */
-    public function combine( array|self $values ): self {
+    public function combine(array|self $values): self
+    {
         $values = $values instanceof self
             ? $values->toArray()
             : $values;
-        return new self( array_combine( $this->array, $values ) );
+
+        return new self(array_combine($this->array, $values));
     }
 
     public static function explode(string|Stringable $string, string $separator = ' '): self
@@ -247,11 +255,12 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
 
     /**
      * Create a new array with the keys of this array as values.
-     * 
+     *
      * @return self<array-key, TKey>
      */
-    public function keys(): self {
-        return new self( array_keys( $this->array ) );
+    public function keys(): self
+    {
+        return new self(array_keys($this->array));
     }
 
     public function values(): self
@@ -429,12 +438,13 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self($array);
     }
 
-    public function dump(mixed ...$dumps): self {
+    public function dump(mixed ...$dumps): self
+    {
         dump($this->array, ...$dumps); // @phpstan-ignore-line
 
         return $this;
     }
-    
+
     public function dd(mixed ...$dd): void
     {
         dd($this->array, ...$dd); // @phpstan-ignore-line

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -47,6 +47,18 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
+     * Pad the array to the specified size with a value.
+     *
+     * @param integer $size
+     * @param mixed $value
+     *
+     * @return self<TKey, TValue>
+     */
+    public function pad(int $size, mixed $value): self {
+        return new self(array_pad($this->array, $size, $value));
+    }
+
+    /**
      * Reverse the keys and values of the array.
      *
      * @return self<TValue&array-key, TKey>

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -140,6 +140,15 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return implode($glue, $this->array);
     }
 
+    /**
+     * Create a new array with the keys of this array as values.
+     * 
+     * @return self<array-key, TKey>
+     */
+    public function keys(): self {
+        return new self( array_keys( $this->array ) );
+    }
+
     public function values(): self
     {
         return new self(array_values($this->array));

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -132,7 +132,6 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     /**
      * Add an item at the end of the array.
      *
-     * @param mixed $value
      *
      * @return self<TKey, TValue>
      */
@@ -146,8 +145,6 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     /**
      * Pad the array to the specified size with a value.
      *
-     * @param int $size
-     * @param mixed $value
      *
      * @return self<TKey, TValue>
      */

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -47,6 +47,14 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
+     * @alias of add
+     */
+    public function push(mixed $value): self
+    {
+        return $this->add($value);
+    }
+
+    /**
      * Add an item at the end of the array.
      *
      * @param mixed $value

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -16,6 +16,7 @@ use function Tempest\map;
 /**
  * @template TKey of array-key
  * @template TValue
+ * 
  * @implements ArrayAccess<TKey, TValue>
  * @implements Iterator<TKey, TValue>
  */
@@ -23,6 +24,11 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
 {
     use IsIterable;
 
+    /**
+     * The underlying array.
+     *
+     * @var array<TKey, TValue>
+     */
     private array $array;
 
     /**
@@ -38,6 +44,15 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         } else {
             $this->array = [$input];
         }
+    }
+
+    /**
+     * Reverse the keys and values of the array.
+     *
+     * @return self<TValue&array-key, TKey>
+     */
+    public function flip(): self {
+        return new self(array_flip($this->array));
     }
 
     /**

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -41,6 +41,44 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
+     * Keep only the items that are not present in any of the given arrays.
+     *
+     * @param array<TKey, TValue>|self<TKey, TValue> ...$arrays
+     *
+     * @return self<TKey, TValue>
+     */
+    public function diff( array|self ...$arrays ): self {
+        $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
+
+        return new self( array_diff( $this->toArray(), ...$arrays ) );
+    }
+    /**
+     * Keep only the items whose keys are not present in any of the given arrays.
+     *
+     * @param array<TKey, TValue>|self<TKey, TValue> ...$arrays
+     *
+     * @return self<TKey, TValue>
+     */
+    public function diffKeys( array|self ...$arrays ): self {
+        $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
+
+        return new self( array_diff_key( $this->toArray(), ...$arrays ) );
+    }
+
+    /**
+     * Merge the array with the given arrays.
+     *
+     * @param array<TKey, TValue>|self<TKey, TValue> ...$arrays The arrays to merge.
+     *
+     * @return self<TKey, TValue>
+     */
+    public function merge( array|self ...$arrays ): self {
+        $arrays = array_map( fn( array|self $array ) => $array instanceof self ? $array->toArray() : $array, $arrays );
+
+        return new self( array_merge( $this->toArray(), ...$arrays ) );
+    }
+
+    /**
      * Create a new array with this current array values as keys and the given values as values.
      *
      * @template TCombineValue

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -47,6 +47,19 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
+     * Add an item at the end of the array.
+     *
+     * @param mixed $value
+     *
+     * @return self<TKey, TValue>
+     */
+    public function add( mixed $value ): self {
+        $this->array[] = $value;
+
+        return $this;
+    }
+
+    /**
      * Pad the array to the specified size with a value.
      *
      * @param integer $size

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -388,8 +388,10 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self($array);
     }
 
-    public function dump(mixed ...$dumps): void {
+    public function dump(mixed ...$dumps): self {
         dump($this->array, ...$dumps); // @phpstan-ignore-line
+
+        return $this;
     }
     
     public function dd(mixed ...$dd): void

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -375,4 +375,80 @@ final class ArrayHelperTest extends TestCase
 
         $this->assertSame($expected, $current);
     }
+
+    public function test_merge_array(): void {
+        $collection = arr([
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe'
+        ]);
+        $current = $collection
+            ->merge([
+                'framework' => 'Tempest'
+            ])
+            ->toArray();
+        $expected = [
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe',
+            'framework'  => 'Tempest'
+        ];
+
+        $this->assertSame($expected, $current);
+    }
+
+    public function test_merge_collection(): void {
+        $collection = arr([
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe'
+        ]);
+        $current = $collection
+            ->merge(arr([
+                'framework' => 'Tempest'
+            ]))
+            ->toArray();
+        $expected = [
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe',
+            'framework'  => 'Tempest'
+        ];
+
+        $this->assertSame($expected, $current);
+    }
+
+    public function test_diff_values(): void {
+        $collection = arr([
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe',
+            'age'        => 42
+        ]);
+        $current = $collection
+            ->diff([
+                'Jon',
+                'Doe'
+            ])
+            ->toArray();
+        $expected = [
+            'age' => 42
+        ];
+
+        $this->assertSame($expected, $current);
+    }
+
+    public function test_diff_keys(): void {
+        $collection = arr([
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe',
+            'age'        => 42
+        ]);
+        $current = $collection
+            ->diffKeys([
+                'age' => 10
+            ])
+            ->toArray();
+        $expected = [
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe'
+        ];
+
+        $this->assertSame($expected, $current);
+    }
 }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -105,6 +105,21 @@ final class ArrayHelperTest extends TestCase
         $this->assertTrue(arr($array)->set('a', 'c')->equals(['a' => 'c']));
     }
 
+    public function test_arr_put_is_alias_of_set(): void {
+        $array = [
+            'a' => [
+                'b' => [
+                    'c' => 'c',
+                ],
+            ],
+        ];
+
+        $this->assertTrue(arr()->set('a.b.c', 'c')->equals($array));
+        $this->assertTrue(arr()->put('a.b.c', 'c')->equals($array));
+        $this->assertTrue(arr($array)->set('a', 'c')->equals(['a' => 'c']));
+        $this->assertTrue(arr($array)->put('a', 'c')->equals(['a' => 'c']));
+    }
+
     public function test_unwrap(): void
     {
         $expected = [

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -1030,6 +1030,7 @@ final class ArrayHelperTest extends TestCase
             $this->assertIsInt($value);
             $this->assertContains($value, $collection->toArray());
         }
+
         $this->assertCount(3, $randoms);
     }
 

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -763,4 +763,19 @@ final class ArrayHelperTest extends TestCase
             ],
         );
     }
+
+    public function test_flip(): void {
+        $this->assertSame(
+            actual: arr([
+                'first_name' => 'John',
+                'last_name'  => 'Doe',
+            ])
+                ->flip()
+                ->toArray(),
+            expected: [
+                'John' => 'first_name',
+                'Doe'  => 'last_name',
+            ],
+        );
+    }
 }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -778,4 +778,34 @@ final class ArrayHelperTest extends TestCase
             ],
         );
     }
+
+    public function test_pad(): void {
+        $this->assertSame(
+            actual: arr([1, 2, 3])
+                ->pad(4, 0)
+                ->toArray(),
+            expected: [1, 2, 3, 0],
+        );
+
+        $this->assertSame(
+            actual: arr([1, 2, 3, 4, 5])
+                ->pad(4, 0)
+                ->toArray(),
+            expected: [1, 2, 3, 4, 5],
+        );
+
+        $this->assertSame(
+            actual: arr([1, 2, 3])
+                ->pad(-4, 0)
+                ->toArray(),
+            expected: [0, 1, 2, 3],
+        );
+
+        $this->assertSame(
+            actual: arr([1, 2, 3, 4, 5])
+                ->pad(-4, 0)
+                ->toArray(),
+            expected: [1, 2, 3, 4, 5],
+        );
+    }
 }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -519,13 +519,13 @@ final class ArrayHelperTest extends TestCase
             'first_name' => 'John',
             'last_name'  => 'Doe',
             'age'        => 42,
-            'first_name' => 'Jane'
+            'steal_name' => 'John'
         ]);
         $current = $collection
             ->unique()
             ->toArray();
         $expected = [
-            'first_name' => 'Jane',
+            'first_name' => 'John',
             'last_name'  => 'Doe',
             'age'        => 42
         ];

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -862,7 +862,7 @@ final class ArrayHelperTest extends TestCase
     }
 
     public function test_push_is_alias_of_add(): void {
-        $first_collection  = arr()
+        $first_collection = arr()
             ->add(42)
             ->add('Hello')
             ->add([])
@@ -876,5 +876,138 @@ final class ArrayHelperTest extends TestCase
             ->push(null);
 
         $this->assertTrue( $first_collection->equals($second_collection) );
+    }
+
+    public function test_pluck_without_arrays(): void {
+        $this->assertSame(
+            actual: arr([
+                'name' => 'John',
+                'age'  => 42,
+            ])
+                ->pluck('name')
+                ->toArray(),
+            expected: [],
+        );
+    }
+
+    public function test_pluck_basics(): void {
+        $collection = arr([
+            ['name' => 'John', 'age' => 42],
+            ['name' => 'Jane', 'age' => 35],
+            ['name' => 'Alice', 'age' => 28],
+        ]);
+
+        $this->assertSame(
+            actual: $collection
+                ->pluck('name')
+                ->toArray(),
+            expected: ['John', 'Jane', 'Alice'],
+        );
+
+        $this->assertSame(
+            actual: $collection
+                ->pluck('age')
+                ->toArray(),
+            expected: [42, 35, 28],
+        );
+
+        $this->assertSame(
+            actual: $collection
+                ->pluck('name', 'age')
+                ->toArray(),
+            expected: [
+                42 => 'John',
+                35 => 'Jane',
+                28 => 'Alice',
+            ],
+        );
+
+        $this->assertSame(
+            actual: $collection
+                ->pluck('age', 'name')
+                ->toArray(),
+            expected: [
+                'John' => 42,
+                'Jane' => 35,
+                'Alice' => 28,
+            ],
+        );
+    }
+
+    public function test_pluck_dot_notation(): void {
+        $collection = arr([
+            [
+                'id' => 1,
+                'title' => 'First Post',
+                'author' => ['id' => 1, 'name' => 'John Doe'],
+            ],
+            [
+                'id' => 2,
+                'title' => 'Second Post',
+                'author' => ['id' => 2, 'name' => 'Jane Smith'],
+            ],
+            [
+                'id' => 3,
+                'title' => 'Third Post',
+                'author' => ['id' => 1, 'name' => 'John Doe'],
+            ],
+            [
+                'id' => 4,
+                'title' => 'Fourth Post',
+                'author' => ['id' => 3, 'name' => 'Alice Johnson'],
+            ],
+            [
+                'id' => 5,
+                'title' => 'Fifth Post',
+                'author' => ['id' => 2, 'name' => 'Jane Smith'],
+            ],
+            [
+                'id' => 6,
+                'title' => 'Sixth Post',
+                'author' => ['id' => 4, 'name' => 'Bob Brown'],
+            ],
+        ]);
+
+        $this->assertSame(
+            actual: $collection
+                ->pluck('author.name')
+                ->toArray(),
+            expected: [
+                'John Doe',
+                'Jane Smith',
+                'John Doe',
+                'Alice Johnson',
+                'Jane Smith',
+                'Bob Brown',
+            ],
+        );
+
+        $this->assertSame(
+            actual: $collection
+                ->pluck('author.name', 'id')
+                ->toArray(),
+            expected: [
+                1 => 'John Doe',
+                2 => 'Jane Smith',
+                3 => 'John Doe',
+                4 => 'Alice Johnson',
+                5 => 'Jane Smith',
+                6 => 'Bob Brown',
+            ],
+        );
+
+        $this->assertSame(
+            actual: $collection
+                ->pluck('author.name', 'author.id')
+                ->toArray(),
+            expected: [
+                1 => 'John Doe',
+                2 => 'Jane Smith',
+                1 => 'John Doe',
+                3 => 'Alice Johnson',
+                2 => 'Jane Smith',
+                4 => 'Bob Brown',
+            ],
+        );
     }
 }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -288,4 +288,73 @@ final class ArrayHelperTest extends TestCase
         $this->assertEquals(['jon', 'doe'], ArrayHelper::explode('jon, doe', ', ')->toArray());
         $this->assertEquals(['jon, doe'], ArrayHelper::explode('jon, doe', '')->toArray());
     }
+
+    public function test_combine_with_integers(): void {
+        $collection = arr([1, 2, 3]);
+        $current    = $collection
+            ->combine([4, 5, 6])
+            ->toArray();
+        $expected = [
+            1 => 4,
+            2 => 5,
+            3 => 6,
+        ];
+
+        $this->assertSame($expected, $current);
+    }
+
+    public function test_combine_with_strings(): void {
+        $collection = arr([
+            'first_name',
+            'last_name'
+        ]);
+        $current = $collection
+            ->combine([
+                'Jon',
+                'Doe'
+            ])
+            ->toArray();
+        $expected = [
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe'
+        ];
+
+        $this->assertSame($expected, $current);
+    }
+
+    public function test_combine_with_associative_arrays(): void {
+        $collection = arr([
+            5      => 'first_name',
+            'test' => 'last_name',
+            42     => 'age'
+        ]);
+        $current = $collection
+            ->combine([
+                4 => 'Jon',
+                5 => 'Doe',
+                6 => 50
+            ])
+            ->toArray();
+        $expected = [
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe',
+            'age'        => 50
+        ];
+
+        $this->assertSame($expected, $current);
+    }
+
+    public function test_combine_with_collection(): void {
+        $collection        = arr(['first_name', 'last_name']);
+        $another_collection = arr(['Jon', 'Doe']);
+        $current           = $collection
+            ->combine($another_collection)
+            ->toArray();
+        $expected          = [
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe'
+        ];
+
+        $this->assertSame($expected, $current);
+    }
 }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -678,4 +678,68 @@ final class ArrayHelperTest extends TestCase
             ],
         );
     }
+
+    public function test_unique_key_dot_notation(): void {
+        $collection = arr([
+            [
+                'id'     => 1,
+                'title'  => 'First Post',
+                'author' => ['id' => 1, 'name' => 'John Doe']
+            ],
+            [
+                'id'     => 2,
+                'title'  => 'Second Post',
+                'author' => ['id' => 2, 'name' => 'Jane Smith']
+            ],
+            [
+                'id'     => 3,
+                'title'  => 'Third Post',
+                'author' => ['id' => 1, 'name' => 'John Doe']  // Duplicate author
+            ],
+            [
+                'id'     => 4,
+                'title'  => 'Fourth Post',
+                'author' => ['id' => 3, 'name' => 'Alice Johnson']
+            ],
+            [
+                'id'     => 5,
+                'title'  => 'Fifth Post',
+                'author' => ['id' => 2, 'name' => 'Jane Smith']  // Duplicate author
+            ],
+            [
+                'id'     => 6,
+                'title'  => 'Sixth Post',
+                'author' => ['id' => 4, 'name' => 'Bob Brown']
+            ]
+        ]);
+
+        $this->assertSame(
+            actual: $collection
+                ->unique('author.id')
+                ->values()
+                ->toArray(),
+            expected: [
+                [
+                    'id'     => 1,
+                    'title'  => 'First Post',
+                    'author' => ['id' => 1, 'name' => 'John Doe']
+                ],
+                [
+                    'id'     => 2,
+                    'title'  => 'Second Post',
+                    'author' => ['id' => 2, 'name' => 'Jane Smith']
+                ],
+                [
+                    'id'     => 4,
+                    'title'  => 'Fourth Post',
+                    'author' => ['id' => 3, 'name' => 'Alice Johnson']
+                ],
+                [
+                    'id'     => 6,
+                    'title'  => 'Sixth Post',
+                    'author' => ['id' => 4, 'name' => 'Bob Brown']
+                ]
+            ],
+        );
+    }
 }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -860,4 +860,21 @@ final class ArrayHelperTest extends TestCase
             expected: [1, 2, '', null, false, [], 'name'],
         );
     }
+
+    public function test_push_is_alias_of_add(): void {
+        $first_collection  = arr()
+            ->add(42)
+            ->add('Hello')
+            ->add([])
+            ->add(false)
+            ->add(null);
+        $second_collection = arr()
+            ->push(42)
+            ->push('Hello')
+            ->push([])
+            ->push(false)
+            ->push(null);
+
+        $this->assertTrue( $first_collection->equals($second_collection) );
+    }
 }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Support\Tests;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use function Tempest\Support\arr;
 use Tempest\Support\ArrayHelper;
@@ -764,22 +765,24 @@ final class ArrayHelperTest extends TestCase
         );
     }
 
-    public function test_flip(): void {
+    public function test_flip(): void
+    {
         $this->assertSame(
             actual: arr([
                 'first_name' => 'John',
-                'last_name'  => 'Doe',
+                'last_name' => 'Doe',
             ])
                 ->flip()
                 ->toArray(),
             expected: [
                 'John' => 'first_name',
-                'Doe'  => 'last_name',
+                'Doe' => 'last_name',
             ],
         );
     }
 
-    public function test_pad(): void {
+    public function test_pad(): void
+    {
         $this->assertSame(
             actual: arr([1, 2, 3])
                 ->pad(4, 0)
@@ -809,7 +812,8 @@ final class ArrayHelperTest extends TestCase
         );
     }
 
-    public function test_add(): void {
+    public function test_add(): void
+    {
         $collection = arr();
         $this->assertSame(
             actual: $collection
@@ -861,7 +865,8 @@ final class ArrayHelperTest extends TestCase
         );
     }
 
-    public function test_push_is_alias_of_add(): void {
+    public function test_push_is_alias_of_add(): void
+    {
         $first_collection = arr()
             ->add(42)
             ->add('Hello')
@@ -875,14 +880,15 @@ final class ArrayHelperTest extends TestCase
             ->push(false)
             ->push(null);
 
-        $this->assertTrue( $first_collection->equals($second_collection) );
+        $this->assertTrue($first_collection->equals($second_collection));
     }
 
-    public function test_pluck_without_arrays(): void {
+    public function test_pluck_without_arrays(): void
+    {
         $this->assertSame(
             actual: arr([
                 'name' => 'John',
-                'age'  => 42,
+                'age' => 42,
             ])
                 ->pluck('name')
                 ->toArray(),
@@ -890,7 +896,8 @@ final class ArrayHelperTest extends TestCase
         );
     }
 
-    public function test_pluck_basics(): void {
+    public function test_pluck_basics(): void
+    {
         $collection = arr([
             ['name' => 'John', 'age' => 42],
             ['name' => 'Jane', 'age' => 35],
@@ -934,7 +941,8 @@ final class ArrayHelperTest extends TestCase
         );
     }
 
-    public function test_pluck_dot_notation(): void {
+    public function test_pluck_dot_notation(): void
+    {
         $collection = arr([
             [
                 'id' => 1,
@@ -1009,13 +1017,14 @@ final class ArrayHelperTest extends TestCase
         );
     }
 
-    public function test_random(): void {
+    public function test_random(): void
+    {
         $collection = arr([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        
+
         $random = $collection->random();
         $this->assertIsInt($random);
         $this->assertContains($random, $collection->toArray());
-        
+
         $randoms = $collection->random(3);
         foreach ($randoms as $value) {
             $this->assertIsInt($value);
@@ -1024,10 +1033,11 @@ final class ArrayHelperTest extends TestCase
         $this->assertCount(3, $randoms);
     }
 
-    public function test_random_with_preserve_keys(): void {
+    public function test_random_with_preserve_keys(): void
+    {
         $collection = arr([
-            'id'     => 1,
-            'title'  => 'First Post',
+            'id' => 1,
+            'title' => 'First Post',
             'author' => ['id' => 1, 'name' => 'John Doe'],
         ]);
 
@@ -1040,30 +1050,33 @@ final class ArrayHelperTest extends TestCase
 
         $randoms = $collection->random(2, preserveKey: true);
 
-        $this->assertCount(2, array_intersect_key($collection->toArray(), $randoms->toArray()) );
+        $this->assertCount(2, array_intersect_key($collection->toArray(), $randoms->toArray()));
     }
 
-    public function test_random_on_empty_array(): void {
+    public function test_random_on_empty_array(): void
+    {
         $collection = arr();
-        
-        $this->expectException(\InvalidArgumentException::class);
+
+        $this->expectException(InvalidArgumentException::class);
 
         $collection->random();
     }
 
-    public function test_random_with_count_superior_than_array_count(): void {
+    public function test_random_with_count_superior_than_array_count(): void
+    {
         $collection = arr([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        
-        $this->expectException(\InvalidArgumentException::class);
+
+        $this->expectException(InvalidArgumentException::class);
 
         $collection->random(15);
     }
 
-    public function test_random_throw_exception_when_giving_negative_integer(): void {
+    public function test_random_throw_exception_when_giving_negative_integer(): void
+    {
         $collection = arr([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        
-        $this->expectException(\InvalidArgumentException::class);
-        
+
+        $this->expectException(InvalidArgumentException::class);
+
         $collection->random(-1);
     }
 }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -451,4 +451,44 @@ final class ArrayHelperTest extends TestCase
 
         $this->assertSame($expected, $current);
     }
+
+    public function test_intersect(): void {
+        $collection = arr([
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe',
+            'age'        => 42
+        ]);
+        $current = $collection
+            ->intersect([
+                'Jon',
+                'Doe'
+            ])
+            ->toArray();
+        $expected = [
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe'
+        ];
+
+        $this->assertSame($expected, $current);
+    }
+
+    public function test_intersect_keys(): void {
+        $collection = arr([
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe',
+            'age'        => 42
+        ]);
+        $current = $collection
+            ->intersectKeys([
+                'first_name' => true,
+                'last_name'  => true
+            ])
+            ->toArray();
+        $expected = [
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe'
+        ];
+
+        $this->assertSame($expected, $current);
+    }
 }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -808,4 +808,56 @@ final class ArrayHelperTest extends TestCase
             expected: [1, 2, 3, 4, 5],
         );
     }
+
+    public function test_add(): void {
+        $collection = arr();
+        $this->assertSame(
+            actual: $collection
+                ->add(1)
+                ->toArray(),
+            expected: [1],
+        );
+
+        $this->assertSame(
+            actual: $collection
+                ->add(2)
+                ->toArray(),
+            expected: [1, 2],
+        );
+
+        $this->assertSame(
+            actual: $collection
+                ->add('')
+                ->toArray(),
+            expected: [1, 2, ''],
+        );
+
+        $this->assertSame(
+            actual: $collection
+                ->add(null)
+                ->toArray(),
+            expected: [1, 2, '', null],
+        );
+
+        $this->assertSame(
+            actual: $collection
+                ->add(false)
+                ->toArray(),
+            expected: [1, 2, '', null, false],
+        );
+
+        $this->assertSame(
+            actual: $collection
+                ->add([])
+                ->toArray(),
+            expected: [1, 2, '', null, false, []],
+        );
+
+        $this->assertSame(
+            actual: $collection
+                ->add('name')
+                ->toArray(),
+            expected: [1, 2, '', null, false, [], 'name'],
+        );
+    }
 }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -345,14 +345,32 @@ final class ArrayHelperTest extends TestCase
     }
 
     public function test_combine_with_collection(): void {
-        $collection        = arr(['first_name', 'last_name']);
+        $collection         = arr(['first_name', 'last_name']);
         $another_collection = arr(['Jon', 'Doe']);
-        $current           = $collection
+        $current            = $collection
             ->combine($another_collection)
             ->toArray();
-        $expected          = [
+        $expected = [
             'first_name' => 'Jon',
             'last_name'  => 'Doe'
+        ];
+
+        $this->assertSame($expected, $current);
+    }
+
+    public function test_keys(): void {
+        $collection = arr([
+            'first_name' => 'Jon',
+            'last_name'  => 'Doe',
+            'framework'  => 'Tempest'
+        ]);
+        $current = $collection
+            ->keys()
+            ->toArray();
+        $expected = [
+            'first_name',
+            'last_name',
+            'framework'
         ];
 
         $this->assertSame($expected, $current);

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -1003,11 +1003,67 @@ final class ArrayHelperTest extends TestCase
             expected: [
                 1 => 'John Doe',
                 2 => 'Jane Smith',
-                1 => 'John Doe',
                 3 => 'Alice Johnson',
-                2 => 'Jane Smith',
                 4 => 'Bob Brown',
             ],
         );
+    }
+
+    public function test_random(): void {
+        $collection = arr([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        
+        $random = $collection->random();
+        $this->assertIsInt($random);
+        $this->assertContains($random, $collection->toArray());
+        
+        $randoms = $collection->random(3);
+        foreach ($randoms as $value) {
+            $this->assertIsInt($value);
+            $this->assertContains($value, $collection->toArray());
+        }
+        $this->assertCount(3, $randoms);
+    }
+
+    public function test_random_with_preserve_keys(): void {
+        $collection = arr([
+            'id'     => 1,
+            'title'  => 'First Post',
+            'author' => ['id' => 1, 'name' => 'John Doe'],
+        ]);
+
+        $randoms = $collection->random(3, preserveKey: true);
+
+        $this->assertCount(3, $randoms);
+        $this->assertArrayHasKey('id', $randoms);
+        $this->assertArrayHasKey('title', $randoms);
+        $this->assertArrayHasKey('author', $randoms);
+
+        $randoms = $collection->random(2, preserveKey: true);
+
+        $this->assertCount(2, array_intersect_key($collection->toArray(), $randoms->toArray()) );
+    }
+
+    public function test_random_on_empty_array(): void {
+        $collection = arr();
+        
+        $this->expectException(\InvalidArgumentException::class);
+
+        $collection->random();
+    }
+
+    public function test_random_with_count_superior_than_array_count(): void {
+        $collection = arr([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        
+        $this->expectException(\InvalidArgumentException::class);
+
+        $collection->random(15);
+    }
+
+    public function test_random_throw_exception_when_giving_negative_integer(): void {
+        $collection = arr([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        
+        $this->expectException(\InvalidArgumentException::class);
+        
+        $collection->random(-1);
     }
 }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -105,7 +105,8 @@ final class ArrayHelperTest extends TestCase
         $this->assertTrue(arr($array)->set('a', 'c')->equals(['a' => 'c']));
     }
 
-    public function test_arr_put_is_alias_of_set(): void {
+    public function test_arr_put_is_alias_of_set(): void
+    {
         $array = [
             'a' => [
                 'b' => [
@@ -289,9 +290,10 @@ final class ArrayHelperTest extends TestCase
         $this->assertEquals(['john, doe'], ArrayHelper::explode('john, doe', '')->toArray());
     }
 
-    public function test_combine_with_integers(): void {
+    public function test_combine_with_integers(): void
+    {
         $collection = arr([1, 2, 3]);
-        $current    = $collection
+        $current = $collection
             ->combine([4, 5, 6])
             ->toArray();
         $expected = [
@@ -303,66 +305,70 @@ final class ArrayHelperTest extends TestCase
         $this->assertSame($expected, $current);
     }
 
-    public function test_combine_with_strings(): void {
+    public function test_combine_with_strings(): void
+    {
         $collection = arr([
             'first_name',
-            'last_name'
+            'last_name',
         ]);
         $current = $collection
             ->combine([
                 'John',
-                'Doe'
+                'Doe',
             ])
             ->toArray();
         $expected = [
             'first_name' => 'John',
-            'last_name'  => 'Doe'
+            'last_name' => 'Doe',
         ];
 
         $this->assertSame($expected, $current);
     }
 
-    public function test_combine_with_associative_arrays(): void {
+    public function test_combine_with_associative_arrays(): void
+    {
         $collection = arr([
-            5      => 'first_name',
+            5 => 'first_name',
             'test' => 'last_name',
-            42     => 'age'
+            42 => 'age',
         ]);
         $current = $collection
             ->combine([
                 4 => 'John',
                 5 => 'Doe',
-                6 => 50
+                6 => 50,
             ])
             ->toArray();
         $expected = [
             'first_name' => 'John',
-            'last_name'  => 'Doe',
-            'age'        => 50
+            'last_name' => 'Doe',
+            'age' => 50,
         ];
 
         $this->assertSame($expected, $current);
     }
 
-    public function test_combine_with_collection(): void {
-        $collection         = arr(['first_name', 'last_name']);
+    public function test_combine_with_collection(): void
+    {
+        $collection = arr(['first_name', 'last_name']);
         $another_collection = arr(['John', 'Doe']);
-        $current            = $collection
+        $current = $collection
             ->combine($another_collection)
             ->toArray();
         $expected = [
             'first_name' => 'John',
-            'last_name'  => 'Doe'
+            'last_name' => 'Doe',
         ];
 
         $this->assertSame($expected, $current);
     }
 
-    public function test_keys(): void {
+    public function test_keys(): void
+    {
         $collection = arr([
             'first_name' => 'John',
-            'last_name'  => 'Doe',
-            'framework'  => 'Tempest'
+            'last_name' => 'Doe',
+            'framework' => 'Tempest',
         ]);
         $current = $collection
             ->keys()
@@ -370,136 +376,143 @@ final class ArrayHelperTest extends TestCase
         $expected = [
             'first_name',
             'last_name',
-            'framework'
+            'framework',
         ];
 
         $this->assertSame($expected, $current);
     }
 
-    public function test_merge_array(): void {
+    public function test_merge_array(): void
+    {
         $collection = arr([
             'first_name' => 'John',
-            'last_name'  => 'Doe'
+            'last_name' => 'Doe',
         ]);
         $current = $collection
             ->merge([
-                'framework' => 'Tempest'
+                'framework' => 'Tempest',
             ])
             ->toArray();
         $expected = [
             'first_name' => 'John',
-            'last_name'  => 'Doe',
-            'framework'  => 'Tempest'
+            'last_name' => 'Doe',
+            'framework' => 'Tempest',
         ];
 
         $this->assertSame($expected, $current);
     }
 
-    public function test_merge_collection(): void {
+    public function test_merge_collection(): void
+    {
         $collection = arr([
             'first_name' => 'John',
-            'last_name'  => 'Doe'
+            'last_name' => 'Doe',
         ]);
         $current = $collection
             ->merge(arr([
-                'framework' => 'Tempest'
+                'framework' => 'Tempest',
             ]))
             ->toArray();
         $expected = [
             'first_name' => 'John',
-            'last_name'  => 'Doe',
-            'framework'  => 'Tempest'
+            'last_name' => 'Doe',
+            'framework' => 'Tempest',
         ];
 
         $this->assertSame($expected, $current);
     }
 
-    public function test_diff_values(): void {
+    public function test_diff_values(): void
+    {
         $collection = arr([
             'first_name' => 'John',
-            'last_name'  => 'Doe',
-            'age'        => 42
+            'last_name' => 'Doe',
+            'age' => 42,
         ]);
         $current = $collection
             ->diff([
                 'John',
-                'Doe'
+                'Doe',
             ])
             ->toArray();
         $expected = [
-            'age' => 42
+            'age' => 42,
         ];
 
         $this->assertSame($expected, $current);
     }
 
-    public function test_diff_keys(): void {
+    public function test_diff_keys(): void
+    {
         $collection = arr([
             'first_name' => 'John',
-            'last_name'  => 'Doe',
-            'age'        => 42
+            'last_name' => 'Doe',
+            'age' => 42,
         ]);
         $current = $collection
             ->diffKeys([
-                'age' => 10
+                'age' => 10,
             ])
             ->toArray();
         $expected = [
             'first_name' => 'John',
-            'last_name'  => 'Doe'
+            'last_name' => 'Doe',
         ];
 
         $this->assertSame($expected, $current);
     }
 
-    public function test_intersect(): void {
+    public function test_intersect(): void
+    {
         $collection = arr([
             'first_name' => 'John',
-            'last_name'  => 'Doe',
-            'age'        => 42
+            'last_name' => 'Doe',
+            'age' => 42,
         ]);
         $current = $collection
             ->intersect([
                 'John',
-                'Doe'
+                'Doe',
             ])
             ->toArray();
         $expected = [
             'first_name' => 'John',
-            'last_name'  => 'Doe'
+            'last_name' => 'Doe',
         ];
 
         $this->assertSame($expected, $current);
     }
 
-    public function test_intersect_keys(): void {
+    public function test_intersect_keys(): void
+    {
         $collection = arr([
             'first_name' => 'John',
-            'last_name'  => 'Doe',
-            'age'        => 42
+            'last_name' => 'Doe',
+            'age' => 42,
         ]);
         $current = $collection
             ->intersectKeys([
                 'first_name' => true,
-                'last_name'  => true
+                'last_name' => true,
             ])
             ->toArray();
         $expected = [
             'first_name' => 'John',
-            'last_name'  => 'Doe'
+            'last_name' => 'Doe',
         ];
 
         $this->assertSame($expected, $current);
     }
 
-    public function test_unique_with_basic_item(): void {
+    public function test_unique_with_basic_item(): void
+    {
         $collection = arr([
             'John',
             'Doe',
             'John',
             'Doe',
             'Jane',
-            'Doe'
+            'Doe',
         ]);
         $current = $collection
             ->unique()
@@ -508,38 +521,40 @@ final class ArrayHelperTest extends TestCase
         $expected = [
             'John',
             'Doe',
-            'Jane'
+            'Jane',
         ];
 
         $this->assertSame($expected, $current);
     }
 
-    public function test_unique_with_associative_array(): void {
+    public function test_unique_with_associative_array(): void
+    {
         $collection = arr([
             'first_name' => 'John',
-            'last_name'  => 'Doe',
-            'age'        => 42,
-            'steal_name' => 'John'
+            'last_name' => 'Doe',
+            'age' => 42,
+            'steal_name' => 'John',
         ]);
         $current = $collection
             ->unique()
             ->toArray();
         $expected = [
             'first_name' => 'John',
-            'last_name'  => 'Doe',
-            'age'        => 42
+            'last_name' => 'Doe',
+            'age' => 42,
         ];
 
         $this->assertSame($expected, $current);
     }
 
-    public function test_unique_with_arrays(): void {
+    public function test_unique_with_arrays(): void
+    {
         $collection = arr([
             ['John', 'Doe'],
             ['John', 'Doe'],
             [1, 2],
             [1, 2],
-            [3, 4]
+            [3, 4],
         ]);
         $current = $collection
             ->unique()
@@ -548,18 +563,19 @@ final class ArrayHelperTest extends TestCase
         $expected = [
             ['John', 'Doe'],
             [1, 2],
-            [3, 4]
+            [3, 4],
         ];
 
         $this->assertSame($expected, $current);
     }
 
-    public function test_unique_with_key(): void {
+    public function test_unique_with_key(): void
+    {
         $collection = arr([
             ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
             ['id' => 2, 'first_name' => 'John', 'last_name' => 'Doe'],
             ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe'],
-            ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Duplicate']
+            ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Duplicate'],
         ]);
 
         $this->assertSame(
@@ -569,7 +585,7 @@ final class ArrayHelperTest extends TestCase
                 ->toArray(),
             expected: [
                 ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
-                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe']
+                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe'],
             ],
         );
 
@@ -580,7 +596,7 @@ final class ArrayHelperTest extends TestCase
                 ->toArray(),
             expected: [
                 ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
-                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Duplicate']
+                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Duplicate'],
             ],
         );
 
@@ -592,19 +608,20 @@ final class ArrayHelperTest extends TestCase
             expected: [
                 ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
                 ['id' => 2, 'first_name' => 'John', 'last_name' => 'Doe'],
-                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe']
+                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe'],
             ],
         );
     }
 
-    public function test_unique_ensure_unnested_value_is_rejected_when_key_is_set(): void {
+    public function test_unique_ensure_unnested_value_is_rejected_when_key_is_set(): void
+    {
         $collection = arr([
             42,
             'Hello World',
             ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
             ['id' => 2, 'first_name' => 'John', 'last_name' => 'Doe'],
             ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe'],
-            ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Duplicate']
+            ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Duplicate'],
         ]);
 
         $this->assertSame(
@@ -615,12 +632,13 @@ final class ArrayHelperTest extends TestCase
             expected: [
                 ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
                 ['id' => 2, 'first_name' => 'John', 'last_name' => 'Doe'],
-                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe']
+                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe'],
             ],
         );
     }
 
-    public function test_unique_unstrict_check(): void {
+    public function test_unique_unstrict_check(): void
+    {
         $this->assertSame(
             actual: arr([
                 42,
@@ -638,7 +656,8 @@ final class ArrayHelperTest extends TestCase
         );
     }
 
-    public function test_unique_strict_check(): void {
+    public function test_unique_strict_check(): void
+    {
         $this->assertSame(
             actual: arr([
                 42,
@@ -658,14 +677,15 @@ final class ArrayHelperTest extends TestCase
         );
     }
 
-    public function test_unique_with_key_and_strict_check(): void {
+    public function test_unique_with_key_and_strict_check(): void
+    {
         $this->assertSame(
             actual: arr([
                 ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
                 ['id' => '1', 'first_name' => 'John', 'last_name' => 'Doe'],
                 ['id' => 2, 'first_name' => 'John', 'last_name' => 'Doe'],
                 ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe'],
-                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Duplicate']
+                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Duplicate'],
             ])
                 ->unique('id', should_be_strict: true)
                 ->values()
@@ -674,43 +694,44 @@ final class ArrayHelperTest extends TestCase
                 ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
                 ['id' => '1', 'first_name' => 'John', 'last_name' => 'Doe'],
                 ['id' => 2, 'first_name' => 'John', 'last_name' => 'Doe'],
-                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe']
+                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe'],
             ],
         );
     }
 
-    public function test_unique_key_dot_notation(): void {
+    public function test_unique_key_dot_notation(): void
+    {
         $collection = arr([
             [
-                'id'     => 1,
-                'title'  => 'First Post',
-                'author' => ['id' => 1, 'name' => 'John Doe']
+                'id' => 1,
+                'title' => 'First Post',
+                'author' => ['id' => 1, 'name' => 'John Doe'],
             ],
             [
-                'id'     => 2,
-                'title'  => 'Second Post',
-                'author' => ['id' => 2, 'name' => 'Jane Smith']
+                'id' => 2,
+                'title' => 'Second Post',
+                'author' => ['id' => 2, 'name' => 'Jane Smith'],
             ],
             [
-                'id'     => 3,
-                'title'  => 'Third Post',
-                'author' => ['id' => 1, 'name' => 'John Doe']  // Duplicate author
+                'id' => 3,
+                'title' => 'Third Post',
+                'author' => ['id' => 1, 'name' => 'John Doe'],  // Duplicate author
             ],
             [
-                'id'     => 4,
-                'title'  => 'Fourth Post',
-                'author' => ['id' => 3, 'name' => 'Alice Johnson']
+                'id' => 4,
+                'title' => 'Fourth Post',
+                'author' => ['id' => 3, 'name' => 'Alice Johnson'],
             ],
             [
-                'id'     => 5,
-                'title'  => 'Fifth Post',
-                'author' => ['id' => 2, 'name' => 'Jane Smith']  // Duplicate author
+                'id' => 5,
+                'title' => 'Fifth Post',
+                'author' => ['id' => 2, 'name' => 'Jane Smith'],  // Duplicate author
             ],
             [
-                'id'     => 6,
-                'title'  => 'Sixth Post',
-                'author' => ['id' => 4, 'name' => 'Bob Brown']
-            ]
+                'id' => 6,
+                'title' => 'Sixth Post',
+                'author' => ['id' => 4, 'name' => 'Bob Brown'],
+            ],
         ]);
 
         $this->assertSame(
@@ -720,25 +741,25 @@ final class ArrayHelperTest extends TestCase
                 ->toArray(),
             expected: [
                 [
-                    'id'     => 1,
-                    'title'  => 'First Post',
-                    'author' => ['id' => 1, 'name' => 'John Doe']
+                    'id' => 1,
+                    'title' => 'First Post',
+                    'author' => ['id' => 1, 'name' => 'John Doe'],
                 ],
                 [
-                    'id'     => 2,
-                    'title'  => 'Second Post',
-                    'author' => ['id' => 2, 'name' => 'Jane Smith']
+                    'id' => 2,
+                    'title' => 'Second Post',
+                    'author' => ['id' => 2, 'name' => 'Jane Smith'],
                 ],
                 [
-                    'id'     => 4,
-                    'title'  => 'Fourth Post',
-                    'author' => ['id' => 3, 'name' => 'Alice Johnson']
+                    'id' => 4,
+                    'title' => 'Fourth Post',
+                    'author' => ['id' => 3, 'name' => 'Alice Johnson'],
                 ],
                 [
-                    'id'     => 6,
-                    'title'  => 'Sixth Post',
-                    'author' => ['id' => 4, 'name' => 'Bob Brown']
-                ]
+                    'id' => 6,
+                    'title' => 'Sixth Post',
+                    'author' => ['id' => 4, 'name' => 'Bob Brown'],
+                ],
             ],
         );
     }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -282,11 +282,11 @@ final class ArrayHelperTest extends TestCase
 
     public function test_explode(): void
     {
-        $this->assertEquals(['jon', 'doe'], ArrayHelper::explode('jon doe')->toArray());
-        $this->assertEquals(['jon', 'doe'], ArrayHelper::explode(str('jon doe'))->toArray());
-        $this->assertEquals(['jon doe'], ArrayHelper::explode('jon doe', ',')->toArray());
-        $this->assertEquals(['jon', 'doe'], ArrayHelper::explode('jon, doe', ', ')->toArray());
-        $this->assertEquals(['jon, doe'], ArrayHelper::explode('jon, doe', '')->toArray());
+        $this->assertEquals(['john', 'doe'], ArrayHelper::explode('john doe')->toArray());
+        $this->assertEquals(['john', 'doe'], ArrayHelper::explode(str('john doe'))->toArray());
+        $this->assertEquals(['john doe'], ArrayHelper::explode('john doe', ',')->toArray());
+        $this->assertEquals(['john', 'doe'], ArrayHelper::explode('john, doe', ', ')->toArray());
+        $this->assertEquals(['john, doe'], ArrayHelper::explode('john, doe', '')->toArray());
     }
 
     public function test_combine_with_integers(): void {
@@ -310,12 +310,12 @@ final class ArrayHelperTest extends TestCase
         ]);
         $current = $collection
             ->combine([
-                'Jon',
+                'John',
                 'Doe'
             ])
             ->toArray();
         $expected = [
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe'
         ];
 
@@ -330,13 +330,13 @@ final class ArrayHelperTest extends TestCase
         ]);
         $current = $collection
             ->combine([
-                4 => 'Jon',
+                4 => 'John',
                 5 => 'Doe',
                 6 => 50
             ])
             ->toArray();
         $expected = [
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe',
             'age'        => 50
         ];
@@ -346,12 +346,12 @@ final class ArrayHelperTest extends TestCase
 
     public function test_combine_with_collection(): void {
         $collection         = arr(['first_name', 'last_name']);
-        $another_collection = arr(['Jon', 'Doe']);
+        $another_collection = arr(['John', 'Doe']);
         $current            = $collection
             ->combine($another_collection)
             ->toArray();
         $expected = [
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe'
         ];
 
@@ -360,7 +360,7 @@ final class ArrayHelperTest extends TestCase
 
     public function test_keys(): void {
         $collection = arr([
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe',
             'framework'  => 'Tempest'
         ]);
@@ -378,7 +378,7 @@ final class ArrayHelperTest extends TestCase
 
     public function test_merge_array(): void {
         $collection = arr([
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe'
         ]);
         $current = $collection
@@ -387,7 +387,7 @@ final class ArrayHelperTest extends TestCase
             ])
             ->toArray();
         $expected = [
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe',
             'framework'  => 'Tempest'
         ];
@@ -397,7 +397,7 @@ final class ArrayHelperTest extends TestCase
 
     public function test_merge_collection(): void {
         $collection = arr([
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe'
         ]);
         $current = $collection
@@ -406,7 +406,7 @@ final class ArrayHelperTest extends TestCase
             ]))
             ->toArray();
         $expected = [
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe',
             'framework'  => 'Tempest'
         ];
@@ -416,13 +416,13 @@ final class ArrayHelperTest extends TestCase
 
     public function test_diff_values(): void {
         $collection = arr([
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe',
             'age'        => 42
         ]);
         $current = $collection
             ->diff([
-                'Jon',
+                'John',
                 'Doe'
             ])
             ->toArray();
@@ -435,7 +435,7 @@ final class ArrayHelperTest extends TestCase
 
     public function test_diff_keys(): void {
         $collection = arr([
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe',
             'age'        => 42
         ]);
@@ -445,7 +445,7 @@ final class ArrayHelperTest extends TestCase
             ])
             ->toArray();
         $expected = [
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe'
         ];
 
@@ -454,18 +454,18 @@ final class ArrayHelperTest extends TestCase
 
     public function test_intersect(): void {
         $collection = arr([
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe',
             'age'        => 42
         ]);
         $current = $collection
             ->intersect([
-                'Jon',
+                'John',
                 'Doe'
             ])
             ->toArray();
         $expected = [
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe'
         ];
 
@@ -474,7 +474,7 @@ final class ArrayHelperTest extends TestCase
 
     public function test_intersect_keys(): void {
         $collection = arr([
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe',
             'age'        => 42
         ]);
@@ -485,10 +485,197 @@ final class ArrayHelperTest extends TestCase
             ])
             ->toArray();
         $expected = [
-            'first_name' => 'Jon',
+            'first_name' => 'John',
             'last_name'  => 'Doe'
         ];
 
         $this->assertSame($expected, $current);
+    }
+
+    public function test_unique_with_basic_item(): void {
+        $collection = arr([
+            'John',
+            'Doe',
+            'John',
+            'Doe',
+            'Jane',
+            'Doe'
+        ]);
+        $current = $collection
+            ->unique()
+            ->values()
+            ->toArray();
+        $expected = [
+            'John',
+            'Doe',
+            'Jane'
+        ];
+
+        $this->assertSame($expected, $current);
+    }
+
+    public function test_unique_with_associative_array(): void {
+        $collection = arr([
+            'first_name' => 'John',
+            'last_name'  => 'Doe',
+            'age'        => 42,
+            'first_name' => 'Jane'
+        ]);
+        $current = $collection
+            ->unique()
+            ->toArray();
+        $expected = [
+            'first_name' => 'Jane',
+            'last_name'  => 'Doe',
+            'age'        => 42
+        ];
+
+        $this->assertSame($expected, $current);
+    }
+
+    public function test_unique_with_arrays(): void {
+        $collection = arr([
+            ['John', 'Doe'],
+            ['John', 'Doe'],
+            [1, 2],
+            [1, 2],
+            [3, 4]
+        ]);
+        $current = $collection
+            ->unique()
+            ->values()
+            ->toArray();
+        $expected = [
+            ['John', 'Doe'],
+            [1, 2],
+            [3, 4]
+        ];
+
+        $this->assertSame($expected, $current);
+    }
+
+    public function test_unique_with_key(): void {
+        $collection = arr([
+            ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
+            ['id' => 2, 'first_name' => 'John', 'last_name' => 'Doe'],
+            ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe'],
+            ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Duplicate']
+        ]);
+
+        $this->assertSame(
+            actual: $collection
+                ->unique('first_name')
+                ->values()
+                ->toArray(),
+            expected: [
+                ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
+                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe']
+            ],
+        );
+
+        $this->assertSame(
+            actual: $collection
+                ->unique('last_name')
+                ->values()
+                ->toArray(),
+            expected: [
+                ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
+                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Duplicate']
+            ],
+        );
+
+        $this->assertSame(
+            actual: $collection
+                ->unique('id')
+                ->values()
+                ->toArray(),
+            expected: [
+                ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
+                ['id' => 2, 'first_name' => 'John', 'last_name' => 'Doe'],
+                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe']
+            ],
+        );
+    }
+
+    public function test_unique_ensure_unnested_value_is_rejected_when_key_is_set(): void {
+        $collection = arr([
+            42,
+            'Hello World',
+            ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
+            ['id' => 2, 'first_name' => 'John', 'last_name' => 'Doe'],
+            ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe'],
+            ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Duplicate']
+        ]);
+
+        $this->assertSame(
+            actual: $collection
+                ->unique('id')
+                ->values()
+                ->toArray(),
+            expected: [
+                ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
+                ['id' => 2, 'first_name' => 'John', 'last_name' => 'Doe'],
+                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe']
+            ],
+        );
+    }
+
+    public function test_unique_unstrict_check(): void {
+        $this->assertSame(
+            actual: arr([
+                42,
+                '42',
+                true,
+                'true',
+            ])
+                ->unique(should_be_strict: false)
+                ->values()
+                ->toArray(),
+            expected: [
+                42,
+                'true',
+            ],
+        );
+    }
+
+    public function test_unique_strict_check(): void {
+        $this->assertSame(
+            actual: arr([
+                42,
+                '42',
+                true,
+                'true',
+            ])
+                ->unique(should_be_strict: true)
+                ->values()
+                ->toArray(),
+            expected: [
+                42,
+                '42',
+                true,
+                'true',
+            ],
+        );
+    }
+
+    public function test_unique_with_key_and_strict_check(): void {
+        $this->assertSame(
+            actual: arr([
+                ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
+                ['id' => '1', 'first_name' => 'John', 'last_name' => 'Doe'],
+                ['id' => 2, 'first_name' => 'John', 'last_name' => 'Doe'],
+                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe'],
+                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Duplicate']
+            ])
+                ->unique('id', should_be_strict: true)
+                ->values()
+                ->toArray(),
+            expected: [
+                ['id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
+                ['id' => '1', 'first_name' => 'John', 'last_name' => 'Doe'],
+                ['id' => 2, 'first_name' => 'John', 'last_name' => 'Doe'],
+                ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe']
+            ],
+        );
     }
 }


### PR DESCRIPTION
As discussed in #543 This pull request add some additional methods to the array helper.

As seen in other PR/Issues the goal for this helper isn't to be a clone of laravel collections but a much simpler wrapper around native php's array functions and some other useful methods such as mapWithKeys, pluck etc..

Here's my current work progression :
- [x] put()
- [x] combine()
- [x] keys()
- [x] dump()
- [x] diff()
- [x] diffKeys()
- [x] merge()
- [x] intersect()
- [x] intersectKeys()
- [x] unique()
- [x] flip()
- [x] pad()
- [x] add()
- [x] push()
- [ ] reduce()
- [x] pluck()
- [ ] chunk() ?
- [x] random()
- [ ] pull() ?
- [ ] search() ?
- [ ] slice()
- [ ] sort() => and probably its variations
- [ ] flatten() => I must check if unwrap isn't doing the same before
- [ ] wrap() ?
- [ ] remove()
- [ ] forget() => alias of remove()
- [ ] shuffle

If i'm doing something wrong please tell me 🙏 