### PR TITLE
refactor(http): move request resolution to middleware

### DIFF
--- a/src/Tempest/Http/src/GenericRouter.php
+++ b/src/Tempest/Http/src/GenericRouter.php
@@ -13,13 +13,11 @@ use Tempest\Http\Exceptions\ControllerActionHasNoReturn;
 use Tempest\Http\Exceptions\InvalidRouteException;
 use Tempest\Http\Exceptions\MissingControllerOutputException;
 use Tempest\Http\Mappers\RequestToPsrRequestMapper;
-use Tempest\Http\Responses\Invalid;
 use Tempest\Http\Responses\NotFound;
 use Tempest\Http\Responses\Ok;
 use function Tempest\map;
 use Tempest\Reflection\ClassReflector;
 use function Tempest\Support\str;
-use Tempest\Validation\Exceptions\ValidationException;
 use Tempest\View\View;
 
 /**
@@ -51,20 +49,12 @@ final class GenericRouter implements Router
             return new NotFound();
         }
 
-        $this->container->singleton(
-            MatchedRoute::class,
-            fn () => $matchedRoute,
-        );
+        $this->container->singleton(MatchedRoute::class, fn () => $matchedRoute);
+        $this->container->singleton(PsrRequest::class, fn () => $request);
 
         $callable = $this->getCallable($matchedRoute);
 
-        try {
-            $request = $this->resolveRequest($request, $matchedRoute);
-            $response = $callable($request);
-        } catch (ValidationException $validationException) {
-            // TODO: refactor to middleware
-            return new Invalid($request, $validationException->failingRules);
-        }
+        $response = $callable(map($request)->to(GenericRequest::class));
 
         if ($response === null) {
             throw new MissingControllerOutputException(
@@ -173,7 +163,7 @@ final class GenericRouter implements Router
             return [];
         }
 
-        $tokens = str($route->uri)->matchAll('#\{'. Route::ROUTE_PARAM_NAME_REGEX . Route::ROUTE_PARAM_CUSTOM_REGEX .'\}#', );
+        $tokens = str($route->uri)->matchAll('#\{' . Route::ROUTE_PARAM_NAME_REGEX . Route::ROUTE_PARAM_CUSTOM_REGEX . '\}#', );
 
         if (empty($tokens)) {
             return null;
@@ -251,39 +241,6 @@ final class GenericRouter implements Router
         }
 
         return new MatchedRoute($route, $routeParams);
-    }
-
-    private function resolveRequest(PsrRequest $psrRequest, MatchedRoute $matchedRoute): Request
-    {
-        // Let's find out if our input request data matches what the route's action needs
-        $requestClass = GenericRequest::class;
-
-        // We'll loop over all the handler's parameters
-        foreach ($matchedRoute->route->handler->getParameters() as $parameter) {
-
-            // If the parameter's type is an instance of Request…
-            if ($parameter->getType()->matches(Request::class)) {
-                // We'll use that specific request class
-                $requestClass = $parameter->getType()->getName();
-
-                break;
-            }
-        }
-
-        // We map the original request we got into this method to the right request class
-        /** @var Request $request */
-        $request = map($psrRequest)->to($requestClass);
-
-        // Next, we register this newly created request object in the container
-        // This makes it so that RequestInitializer is bypassed entirely when the controller action needs the request class
-        // Making it so that we don't need to set any $_SERVER variables and stuff like that
-        $this->container->singleton(Request::class, fn () => $request);
-        $this->container->singleton($request::class, fn () => $request);
-
-        // Finally, we validate the request
-        $request->validate();
-
-        return $request;
     }
 
     public function addMiddleware(string $middlewareClass): void

--- a/src/Tempest/Http/src/ResolveRequestMiddleware.php
+++ b/src/Tempest/Http/src/ResolveRequestMiddleware.php
@@ -23,7 +23,7 @@ final readonly class ResolveRequestMiddleware implements HttpMiddleware
         try {
             $wantedRequestClass = $this->getRequestClassFromRoute($this->container->get(MatchedRoute::class));
 
-            if ($wantedRequestClass === null) {
+            if (! $wantedRequestClass) {
                 return $next($request);
             }
 

--- a/src/Tempest/Http/src/ResolveRequestMiddleware.php
+++ b/src/Tempest/Http/src/ResolveRequestMiddleware.php
@@ -19,36 +19,48 @@ final readonly class ResolveRequestMiddleware implements HttpMiddleware
 
     public function __invoke(Request $request, callable $next): Response
     {
-        $requestClass = $request::class;
-
         // Let's find out if our input request data matches what the route's action needs
         try {
-            // We'll loop over all the handler's parameters
-            foreach ($this->container->get(MatchedRoute::class)->route->handler->getParameters() as $parameter) {
+            $wantedRequestClass = $this->getRequestClassFromRoute($this->container->get(MatchedRoute::class));
 
-                // If the parameter's type is an instance of Request…
-                if ($parameter->getType()->matches(Request::class)) {
-                    // We'll use that specific request class
-                    $requestClass = $parameter->getType()->getName();
-
-                    break;
-                }
+            if ($wantedRequestClass === null) {
+                return $next($request);
             }
 
             // If the request class is different from the one we have, we'll map it to the new one
-            if ($request::class !== $requestClass) {
+            if ($request::class !== $wantedRequestClass) {
                 /** @var Request */
-                $request = map($this->container->get(PsrRequest::class))->to($requestClass);
+                $request = map($this->container->get(PsrRequest::class))->to($wantedRequestClass);
             }
 
+            // We'll bind the request to the container
             $this->container->singleton(Request::class, fn () => $request);
             $this->container->singleton($request::class, fn () => $request);
 
+            // Then we'll validate the request
             $request->validate();
 
             return $next($request);
         } catch (ValidationException $validationException) {
             return new Invalid($request, $validationException->failingRules);
         }
+    }
+
+    /**
+     * @return class-string<Request>|null
+     */
+    private function getRequestClassFromRoute(MatchedRoute $matchedRoute): ?string
+    {
+        // We'll loop over all the handler's parameters
+        foreach ($matchedRoute->route->handler->getParameters() as $parameter) {
+
+            // If the parameter's type is an instance of Request…
+            if ($parameter->getType()->matches(Request::class)) {
+                // We'll use that specific request class
+                return $parameter->getType()->getName();
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Tempest/Http/src/ResolveRequestMiddleware.php
+++ b/src/Tempest/Http/src/ResolveRequestMiddleware.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http;
+
+use Psr\Http\Message\ServerRequestInterface as PsrRequest;
+use Tempest\Container\Container;
+use Tempest\Http\Responses\Invalid;
+use function Tempest\map;
+use Tempest\Validation\Exceptions\ValidationException;
+
+final readonly class ResolveRequestMiddleware implements HttpMiddleware
+{
+    public function __construct(
+        private readonly Container $container,
+    ) {
+    }
+
+    public function __invoke(Request $request, callable $next): Response
+    {
+        $requestClass = $request::class;
+
+        // Let's find out if our input request data matches what the route's action needs
+        try {
+            // We'll loop over all the handler's parameters
+            foreach ($this->container->get(MatchedRoute::class)->route->handler->getParameters() as $parameter) {
+
+                // If the parameter's type is an instance of Request…
+                if ($parameter->getType()->matches(Request::class)) {
+                    // We'll use that specific request class
+                    $requestClass = $parameter->getType()->getName();
+
+                    break;
+                }
+            }
+
+            // If the request class is different from the one we have, we'll map it to the new one
+            if ($request::class !== $requestClass) {
+                /** @var Request */
+                $request = map($this->container->get(PsrRequest::class))->to($requestClass);
+            }
+
+            $this->container->singleton(Request::class, fn () => $request);
+            $this->container->singleton($request::class, fn () => $request);
+
+            $request->validate();
+
+            return $next($request);
+        } catch (ValidationException $validationException) {
+            return new Invalid($request, $validationException->failingRules);
+        }
+    }
+}

--- a/src/Tempest/Http/src/Responses/Invalid.php
+++ b/src/Tempest/Http/src/Responses/Invalid.php
@@ -21,15 +21,12 @@ final class Invalid implements Response
         /** @var \Tempest\Validation\Rule[][] $failingRules */
         array $failingRules = [],
     ) {
-        $referer = $request instanceof Request ?
-            $request->getHeaders()['Referer'] ?? null
-            : $request->getHeader('referer');
+        $referer = $request instanceof Request ? $request->getHeaders()['Referer'] ?? [] : $request->getHeader('referer');
+        $referer = (is_array($referer) ? $referer : [$referer])[0] ?? throw new Exception("No referer found, could not redirect (this shouldn't happen, please create a bug report)");
 
         $body = $request instanceof PsrRequest ? $request->getParsedBody() : $request->getBody();
 
-        $referer = is_array($referer) ? $referer : [$referer];
-
-        $this->addHeader('Location', $referer[0] ?? throw new Exception("No referer found, could not redirect (this shouldn't happen, please create a bug report)"));
+        $this->addHeader('Location', $referer);
         $this->status = Status::FOUND;
         $this->flash(Session::VALIDATION_ERRORS, $failingRules);
         $this->flash(Session::ORIGINAL_VALUES, $body);

--- a/src/Tempest/Http/src/Responses/Invalid.php
+++ b/src/Tempest/Http/src/Responses/Invalid.php
@@ -21,10 +21,15 @@ final class Invalid implements Response
         /** @var \Tempest\Validation\Rule[][] $failingRules */
         array $failingRules = [],
     ) {
-        $referer = $request->getHeader('referer')[0] ?? throw new Exception("No referer found, could not redirect (this shouldn't happen, please create a bug report)");
+        $referer = $request instanceof Request ?
+            $request->getHeaders()['Referer'] ?? null
+            : $request->getHeader('referer');
+
         $body = $request instanceof PsrRequest ? $request->getParsedBody() : $request->getBody();
 
-        $this->addHeader('Location', $referer);
+        $referer = is_array($referer) ? $referer : [$referer];
+
+        $this->addHeader('Location', $referer[0] ?? throw new Exception("No referer found, could not redirect (this shouldn't happen, please create a bug report)"));
         $this->status = Status::FOUND;
         $this->flash(Session::VALIDATION_ERRORS, $failingRules);
         $this->flash(Session::ORIGINAL_VALUES, $body);

--- a/src/Tempest/Http/src/RouterInitializer.php
+++ b/src/Tempest/Http/src/RouterInitializer.php
@@ -16,6 +16,7 @@ final readonly class RouterInitializer implements Initializer
     {
         $router = $container->get(GenericRouter::class);
 
+        $router->addMiddleware(ResolveRequestMiddleware::class);
         $router->addMiddleware(SetCookieMiddleware::class);
 
         return $router;


### PR DESCRIPTION
Saw the `todo` to refactor the request resolution to a middleware so I took a shot at it :)

Got som errors with the invalid response not getting "referer" header from `Request` instances so fixed that as well.

This solution will do one "unnecessary" mapping (if you don't want a generic request), and I don't really know how to get around that since the middleware handler needs an instance of `Request`.

Very new to routing and "framework code" so I understand if it's not the way to do it, just fun to try to contribute!

Thanks and have a nice day :D