### PR TITLE
feat(support): add implode()/explode() methods in string helper

### DIFF
--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -371,9 +371,9 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return ! $this->isEmpty();
     }
 
-    public function implode(string $glue): string
+    public function implode(string $glue): StringHelper
     {
-        return implode($glue, $this->array);
+        return str(implode($glue, $this->array));
     }
 
     /**

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -421,4 +421,15 @@ final readonly class StringHelper implements Stringable
 
         return $value;
     }
+
+    /**
+     * Explode the string into an ArrayHelper by a delimiter.
+     *
+     * @param string $delimiter The delimiter to explode the string by.
+     *
+     * @return ArrayHelper
+     */
+    public function explode( string $delimiter ): ArrayHelper {
+        return new ArrayHelper(explode($delimiter, $this->string));
+    }
 }

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -429,7 +429,8 @@ final readonly class StringHelper implements Stringable
      *
      * @return ArrayHelper
      */
-    public function explode( string $separator = ' ' ): ArrayHelper {
+    public function explode(string $separator = ' '): ArrayHelper
+    {
         return ArrayHelper::explode($this->string, $separator);
     }
 
@@ -441,10 +442,12 @@ final readonly class StringHelper implements Stringable
      *
      * @return self The imploded string.
      */
-    public static function implode( array|ArrayHelper $array, string $separator = ' ' ): self {
+    public static function implode(array|ArrayHelper $array, string $separator = ' '): self
+    {
         $array = ($array instanceof ArrayHelper)
             ? $array->toArray()
             : $array;
+
         return new self(implode($separator, $array));
     }
 }

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -423,13 +423,13 @@ final readonly class StringHelper implements Stringable
     }
 
     /**
-     * Explode the string into an ArrayHelper by a delimiter.
+     * Explode the string into an ArrayHelper by a separator.
      *
-     * @param string $delimiter The delimiter to explode the string by.
+     * @param string $separator The separator to explode the string by.
      *
      * @return ArrayHelper
      */
-    public function explode( string $delimiter ): ArrayHelper {
-        return new ArrayHelper(explode($delimiter, $this->string));
+    public function explode( string $separator = ' ' ): ArrayHelper {
+        return ArrayHelper::explode($this->string, $separator);
     }
 }

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -432,4 +432,19 @@ final readonly class StringHelper implements Stringable
     public function explode( string $separator = ' ' ): ArrayHelper {
         return ArrayHelper::explode($this->string, $separator);
     }
+
+    /**
+     * Implode the array into a string by a separator.
+     *
+     * @param array|ArrayHelper $array The array to implode.
+     * @param string $separator The separator to implode the array by.
+     *
+     * @return self The imploded string.
+     */
+    public static function implode( array|ArrayHelper $array, string $separator = ' ' ): self {
+        $array = ($array instanceof ArrayHelper)
+            ? $array->toArray()
+            : $array;
+        return new self(implode($separator, $array));
+    }
 }

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -426,8 +426,6 @@ final readonly class StringHelper implements Stringable
      * Explode the string into an ArrayHelper by a separator.
      *
      * @param string $separator The separator to explode the string by.
-     *
-     * @return ArrayHelper
      */
     public function explode(string $separator = ' '): ArrayHelper
     {

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -141,7 +141,7 @@ final class ArrayHelperTest extends TestCase
 
     public function test_implode(): void
     {
-        $this->assertSame('a,b,c', arr(['a', 'b', 'c'])->implode(','));
+        $this->assertEquals(str('a,b,c'), arr(['a', 'b', 'c'])->implode(','));
     }
 
     public function test_pop(): void

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -6,6 +6,9 @@ namespace Tempest\Support\Tests;
 
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Tempest\Support\StringHelper;
+
+use function Tempest\Support\arr;
 use function Tempest\Support\str;
 
 /**
@@ -407,5 +410,12 @@ final class StringHelperTest extends TestCase
     public function test_explode(): void {
         $this->assertSame(['path', 'to', 'tempest'], str('path/to/tempest')->explode('/')->toArray());
         $this->assertSame(['john', 'doe'], str('john doe')->explode()->toArray());
+    }
+
+    public function test_implode(): void {
+        $this->assertSame('path/to/tempest', StringHelper::implode(['path', 'to', 'tempest'], '/')->toString());
+        $this->assertSame('john doe', StringHelper::implode(['john', 'doe'])->toString());
+        $this->assertSame('path/to/tempest', StringHelper::implode(arr(['path', 'to', 'tempest']), '/')->toString());
+        $this->assertSame('john doe', StringHelper::implode(arr(['john', 'doe']))->toString());
     }
 }

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -403,4 +403,9 @@ final class StringHelperTest extends TestCase
         $expected = [];
         $this->assertSame($expected, $matches);
     }
+
+    public function test_explode(): void {
+        $this->assertSame(['path', 'to', 'tempest'], str('path/to/tempest')->explode('/')->toArray());
+        $this->assertSame(['john', 'doe'], str('john doe')->explode()->toArray());
+    }
 }

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -6,10 +6,9 @@ namespace Tempest\Support\Tests;
 
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
-use Tempest\Support\StringHelper;
-
 use function Tempest\Support\arr;
 use function Tempest\Support\str;
+use Tempest\Support\StringHelper;
 
 /**
  * @internal
@@ -407,12 +406,14 @@ final class StringHelperTest extends TestCase
         $this->assertSame($expected, $matches);
     }
 
-    public function test_explode(): void {
+    public function test_explode(): void
+    {
         $this->assertSame(['path', 'to', 'tempest'], str('path/to/tempest')->explode('/')->toArray());
         $this->assertSame(['john', 'doe'], str('john doe')->explode()->toArray());
     }
 
-    public function test_implode(): void {
+    public function test_implode(): void
+    {
         $this->assertSame('path/to/tempest', StringHelper::implode(['path', 'to', 'tempest'], '/')->toString());
         $this->assertSame('john doe', StringHelper::implode(['john', 'doe'])->toString());
         $this->assertSame('path/to/tempest', StringHelper::implode(arr(['path', 'to', 'tempest']), '/')->toString());


### PR DESCRIPTION
This PR add both `implode()` and `explode()` method in string helper with consistency regarding the ones in array helper.

It also update the return type of `implode()` in array helper to `StringHelper` object for consistency