### PR TITLE
feat(console): support string keys in `MultipleChoiceComponent`

### DIFF
--- a/src/Tempest/Console/src/Components/Interactive/MultipleChoiceComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/MultipleChoiceComponent.php
@@ -15,7 +15,7 @@ final class MultipleChoiceComponent implements InteractiveConsoleComponent, HasS
 {
     public array $selectedOptions = [];
 
-    public int $activeOption;
+    public int|string $activeOption;
 
     public function __construct(
         public string $question,
@@ -46,12 +46,12 @@ final class MultipleChoiceComponent implements InteractiveConsoleComponent, HasS
         return "Press <em>space</em> to select, <em>enter</em> to confirm, <em>ctrl+c</em> to cancel";
     }
 
-    public function isActive(int $key): bool
+    public function isActive(int|string $key): bool
     {
         return $this->activeOption === $key;
     }
 
-    public function isSelected(int $key): bool
+    public function isSelected(int|string $key): bool
     {
         return $this->selectedOptions[$key] ?? false;
     }
@@ -69,7 +69,7 @@ final class MultipleChoiceComponent implements InteractiveConsoleComponent, HasS
 
         foreach ($this->options as $key => $option) {
             if ($this->isSelected($key)) {
-                $result[] = $option;
+                $result[$key] = $option;
             }
         }
 
@@ -80,22 +80,26 @@ final class MultipleChoiceComponent implements InteractiveConsoleComponent, HasS
     #[HandlesKey(Key::LEFT)]
     public function up(): void
     {
-        $this->activeOption = $this->activeOption - 1;
+        $previousValue = prev($this->options);
 
-        if ($this->activeOption < 0) {
-            $this->activeOption = count($this->options) - 1;
+        if ($previousValue === false) {
+            end($this->options);
         }
+
+        $this->activeOption = key($this->options);
     }
 
     #[HandlesKey(Key::DOWN)]
     #[HandlesKey(Key::RIGHT)]
     public function down(): void
     {
-        $this->activeOption = $this->activeOption + 1;
+        $nextValue = next($this->options);
 
-        if ($this->activeOption > count($this->options) - 1) {
-            $this->activeOption = 0;
+        if ($nextValue === false) {
+            reset($this->options);
         }
+
+        $this->activeOption = key($this->options);
     }
 
     public function getStaticComponent(): StaticConsoleComponent

--- a/tests/Integration/Console/Components/MultipleChoiceComponentTest.php
+++ b/tests/Integration/Console/Components/MultipleChoiceComponentTest.php
@@ -52,4 +52,50 @@ final class MultipleChoiceComponentTest extends TestCase
 
         $this->assertSame(['a', 'b'],  $component->enter());
     }
+
+    public function test_supports_key_values(): void
+    {
+        $component = new MultipleChoiceComponent('Label', [
+            'foo' => '1. Foo',
+            'bar' => '2. Bar',
+        ]);
+
+        $this->assertStringEqualsStringIgnoringLineEndings(
+            <<<'TXT'
+            <question>Label</question>
+            > [ ]<em> 1. Foo</em>
+              [ ] 2. Bar
+            TXT,
+            $component->render(),
+        );
+
+        $component->down();
+        $this->assertStringContainsString('> [ ]<em> 2. Bar</em>', $component->render());
+        $this->assertStringContainsString('[ ] 1. Foo', $component->render());
+
+        $component->toggleSelected();
+        $this->assertStringContainsString('> [x]<em> 2. Bar</em>', $component->render());
+
+        $component->toggleSelected();
+        $this->assertStringContainsString('> [ ]<em> 2. Bar</em>', $component->render());
+
+        $component->up();
+        $component->toggleSelected();
+        $this->assertStringContainsString('> [x]<em> 1. Foo</em>', $component->render());
+
+        $component->down();
+        $component->toggleSelected();
+
+        $component->up();
+        $component->up();
+        $this->assertStringContainsString('> [x]<em> 2. Bar</em>', $component->render());
+
+        $component->down();
+        $this->assertStringContainsString('> [x]<em> 1. Foo</em>', $component->render());
+
+        $this->assertSame([
+            'foo' => '1. Foo',
+            'bar' => '2. Bar',
+        ], $component->enter());
+    }
 }


### PR DESCRIPTION
This pull request adds support for using string keys in the options array of `MultipleChoiceComponent`. 

This is useful to have the component display something but return a different value (see https://github.com/tempestphp/tempest-framework/pull/513).