### PR TITLE
test(view): add test that attribute dashes are preserved

### DIFF
--- a/tests/Integration/View/ViewTest.php
+++ b/tests/Integration/View/ViewTest.php
@@ -53,4 +53,18 @@ HTML;
             ->assertHasHeader('x-from-view')
             ->assertStatus(Status::CREATED);
     }
+
+    public function test_render_element_with_attribute_with_dash(): void
+    {
+        $view = view(<<<HTML
+    <div data-theme="tempest"></div>
+    HTML);
+
+        $html = $this->render($view);
+
+        $this->assertStringContainsString(
+            '<div data-theme="tempest"></div>',
+            $html
+        );
+    }
 }


### PR DESCRIPTION
I often use data attributes for doing styling, and inertia for example requires a `data-page="bunchofjsondata` to work, right now that doesn't seem to work :( (my guess is there is someplace where it is camelCased).

So this PR adds a (failing) test for that :)