### PR TITLE
build: improve release script

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -69,13 +69,8 @@ function suggestNextVersions(string $current): array
     ]);
 }
 
-function releaseTag(string $tag): void
+function executeCommands(array $commands): void
 {
-    $commands = [
-        "git tag {$tag}",
-        "git push origin tag {$tag}",
-    ];
-
     foreach ($commands as $command) {
         exec($command, result_code: $code);
 
@@ -83,7 +78,7 @@ function releaseTag(string $tag): void
             continue;
         }
 
-        throw new Exception("Pushing of git tag failed.");
+        throw new Exception("Command failed: {$command}");
     }
 }
 
@@ -112,7 +107,9 @@ try {
             ->toArray(),
     );
 
-    $tag = (string) str($new)->afterLast(': ')->prepend('v');
+    $isMajor = str_contains($new, 'major');
+    $version = (string) str($new)->afterLast(': ');
+    $tag = "v{$version}";
 
     $console->writeln();
     if (! $console->confirm("The next tag will be <u><strong>{$tag}</strong></u><question>. Release?")) {
@@ -121,16 +118,24 @@ try {
     }
 
     $console->writeln();
-    $console->writeln();
-    $console->writeln();
     $console->info('Releasing...');
 
-    releaseTag($tag);
+    if ($isMajor) {
+        executeCommands([
+            "./vendor/bin/monorepo-builder bump-interdependency {$version}",
+            "./vendor/bin/monorepo-builder validate",
+            "git commit -am 'chore: release $tag'",
+        ]);
+    }
+
+    executeCommands([
+        "git tag {$tag}",
+        "git push origin tag {$tag}",
+    ]);
 
     $console->writeln();
     $console->success("Released {$tag}");
 
     exit;
-
 } catch (InterruptException) {
 }

--- a/composer.json
+++ b/composer.json
@@ -141,6 +141,10 @@
         "phpstan": "vendor/bin/phpstan analyse src tests --memory-limit=1G",
         "rector": "vendor/bin/rector process --no-ansi",
         "merge": "vendor/bin/monorepo-builder merge",
+        "release": [
+            "composer qa",
+            "./bin/release"
+        ],
         "qa": [
             "composer merge",
             "./bin/validate-packages",


### PR DESCRIPTION
This pull request improves on https://github.com/tempestphp/tempest-framework/pull/545 by adding a few steps when a major release happens:

- Inter-dependencies will be bumped through monorepo-builder
- Dependencies will be checked through monorepo-builder
- A release commit with the new dependencies will happen

The rest of the flow is unchanged. I added a `composer release` script as well—maybe `composer qa` should be called directly from within the release script, but we'd make it dependent on composer script that could be changed anytime, then.

Notes:
- I'm not sure if the dependency versions should go back to `dev-main` after the actual release
- `monorepo-builder validate` fails because `tempest/highlighter` has version mismatches inside a few packages in the repository