### PR TITLE
fix(phpstan): fix last phpstan issues

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,17 +1,2 @@
 parameters:
-	ignoreErrors:
-		-
-			message: "#^Tempest\\\\Console\\\\Exceptions\\\\ConsoleException should be final$#"
-			count: 1
-			path: src/Tempest/Console/src/Exceptions/ConsoleException.php
-
-		-
-			message: "#^Tempest\\\\Database\\\\Exceptions\\\\DatabaseException should be final$#"
-			count: 1
-			path: src/Tempest/Database/src/Exceptions/DatabaseException.php
-
-		-
-			message: "#^Tempest\\\\Generation\\\\Tests\\\\TestCase should be final$#"
-			count: 1
-			path: src/Tempest/Generation/tests/TestCase.php
-
+	ignoreErrors: []

--- a/tests/Architecture/ArchitectureTestCase.php
+++ b/tests/Architecture/ArchitectureTestCase.php
@@ -70,8 +70,8 @@ final class ArchitectureTestCase
             ->classes(Selector::AND(
                 Selector::inNamespace('Tempest'),
                 Selector::NOT(Selector::isInterface()),
+                Selector::NOT(Selector::isAbstract()),
                 Selector::NOT(Selector::classname(Route::class)),
-                Selector::NOT(Selector::classname(IntegrationTest::class)),
             ))
             ->shouldBeFinal();
     }


### PR DESCRIPTION
I found a solution for the last "class should be final" phpstan errors.

Normally you would either have a class which is known abstract or final. So I baked that rule in the existing architecture tests.

I also removed the exception for "integrationtest" since it already is abstract.