### PR TITLE
fix(http): fix so referer header is resolved depending on request class in invalid response

### DIFF
--- a/tests/Integration/Http/Responses/InvalidTest.php
+++ b/tests/Integration/Http/Responses/InvalidTest.php
@@ -20,11 +20,39 @@ use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
  */
 final class InvalidTest extends FrameworkIntegrationTestCase
 {
-    public function test_invalid(): void
+    public function test_invalid_with_psr_request(): void
     {
         /** @var PsrRequest $request */
         $request = map(new GenericRequest(Method::GET, '/original', ['foo' => 'bar']))->with(RequestToPsrRequestMapper::class);
         $request = $request->withHeader('Referer', '/original');
+
+        $response = new Invalid(
+            $request,
+            [
+                'foo' => [
+                    new NotEmpty(),
+                ],
+            ]
+        );
+
+        $this->assertSame(Status::FOUND, $response->getStatus());
+        $this->assertSame('/original', $response->getHeader('Location')->values[0]);
+
+        $session = $this->container->get(Session::class);
+
+        $this->assertArrayHasKey('foo', $session->get(Session::VALIDATION_ERRORS));
+        $this->assertArrayHasKey('foo', $session->get(Session::ORIGINAL_VALUES));
+    }
+
+    public function test_invalid_with_request()
+    {
+        $request = new GenericRequest(
+            method: Method::GET,
+            uri: '/original',
+            body: ['foo' => 'bar'],
+            headers: ['referer' => '/original']
+        );
+
 
         $response = new Invalid(
             $request,


### PR DESCRIPTION
This PR fixes `Call to undefined method Tempest\Http\GenericRequest::getHeader()` error that happens when the request is not an instance of `PsrRequest` when you return a `Invalid` response.

This also happens when you throw a `ValidationException` from a controller. (and according to the signature it should work 😬)

