### PR TITLE
feat(support): add inline documentation on helper classes

### DIFF
--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -600,8 +600,6 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
 
     /**
      * Asserts whether a value identified by the specified `$key` exists.
-     *
-     * @return mixed|ArrayHelper
      */
     public function has(string $key): bool
     {

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -26,11 +26,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
 {
     use IsIterable;
 
-    /**
-     * The underlying array.
-     *
-     * @var array<TKey, TValue>
-     */
+    /** @var array<TKey, TValue> */
     private array $array;
 
     /**
@@ -49,7 +45,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Get a value from the array and remove it.
+     * Gets a value from the array and remove it.
      *
      * @param array-key $key
      */
@@ -63,7 +59,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Shuffle the array.
+     * Shuffles the array.
      *
      * @return self<TKey, TValue>
      */
@@ -73,7 +69,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * @alias of remove.
+     * @alias of `remove`.
      */
     public function forget(string|int|array $keys): self
     {
@@ -81,7 +77,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Remove items from the array.
+     * Removes the specified items from the array.
      *
      * @param array-key|array<array-key> $keys The keys of the items to remove.
      *
@@ -99,8 +95,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Determines if the array is a list.
-     *
+     * Asserts whether the array is a list.
      * An array is a list if its keys consist of consecutive numbers.
      */
     public function isList(): bool
@@ -109,9 +104,8 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Determines if the array is an associative.
-     *
-     * An array is associative if its keys doesn't consist of consecutive numbers.
+     * Asserts whether the array is a associative.
+     * An array is associative if its keys do not consist of consecutive numbers.
      */
     public function isAssoc(): bool
     {
@@ -119,12 +113,12 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Get one or a specified number of random values from the array.
+     * Gets one or a specified number of random values from the array.
      *
      * @param int $number The number of random values to get.
-     * @param bool $preserveKey Whether to preserve the keys of the original array. ( won't work if $number is 1 as it will return a single value )
+     * @param bool $preserveKey Whether to include the keys of the original array.
      *
-     * @return self<TKey, TValue>|mixed The random values or single value if $number is 1.
+     * @return self<TKey, TValue>|mixed The random values, or a single value if `$number` is 1.
      */
     public function random(int $number = 1, bool $preserveKey = false): mixed
     {
@@ -157,7 +151,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Retrieve values from a given key in each sub-array of the current array.
+     * Retrieves values from a given key in each sub-array of the current array.
      * Optionally, you can pass a second parameter to also get the keys following the same pattern.
      *
      * @param string $value The key to assign the values from, support dot notation.
@@ -192,7 +186,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * @alias of add.
+     * @alias of `add`.
      */
     public function push(mixed $value): self
     {
@@ -200,8 +194,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Add an item at the end of the array.
-     *
+     * Appends the specified value to the array.
      *
      * @return self<TKey, TValue>
      */
@@ -213,8 +206,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Pad the array to the specified size with a value.
-     *
+     * Pads the array to the specified size with a value.
      *
      * @return self<TKey, TValue>
      */
@@ -224,7 +216,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Reverse the keys and values of the array.
+     * Reverses the keys and values of the array.
      *
      * @return self<TValue&array-key, TKey>
      */
@@ -234,16 +226,16 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Keep only the unique items in the array.
+     * Returns a new instance with only unique items from the original array.
      *
      * @param string|null $key The key to use as the uniqueness criteria in nested arrays.
-     * @param bool $should_be_strict Whether the comparison should be strict, only used when giving a key parameter.
+     * @param bool $shouldBeStrict Whether the comparison should be strict, only used when giving a key parameter.
      *
      * @return self<TKey, TValue>
      */
-    public function unique(?string $key = null, bool $should_be_strict = false): self
+    public function unique(?string $key = null, bool $shouldBeStrict = false): self
     {
-        if (is_null($key) && $should_be_strict === false) {
+        if (is_null($key) && $shouldBeStrict === false) {
             return new self(array_unique($this->array, flags: SORT_REGULAR));
         }
 
@@ -263,7 +255,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
                 continue;
             }
 
-            if (in_array($filterValue, $uniqueFilteredValues, strict: $should_be_strict)) {
+            if (in_array($filterValue, $uniqueFilteredValues, strict: $shouldBeStrict)) {
                 continue;
             }
 
@@ -275,7 +267,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Keep only the items that are not present in any of the given arrays.
+     * Returns a new instance of the array with only the items that are not present in any of the given arrays.
      *
      * @param array<TKey, TValue>|self<TKey, TValue> ...$arrays
      *
@@ -289,7 +281,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Keep only the items whose keys are not present in any of the given arrays.
+     * Returns a new instance of the array with only the items whose keys are not present in any of the given arrays.
      *
      * @param array<TKey, TValue>|self<TKey, TValue> ...$arrays
      *
@@ -303,7 +295,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Keep only the items that are present in all of the given arrays.
+     * Returns a new instance of the array with only the items that are present in all of the given arrays.
      *
      * @param array<TKey, TValue>|self<TKey, TValue> ...$arrays
      *
@@ -317,7 +309,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Keep only the items whose keys are present in all of the given arrays.
+     * Returns a new instance of the array with only the items whose keys are present in all of the given arrays.
      *
      * @param array<TKey, TValue>|self<TKey, TValue> ...$arrays
      *
@@ -331,7 +323,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Merge the array with the given arrays.
+     * Merges the array with the given arrays.
      *
      * @param array<TKey, TValue>|self<TKey, TValue> ...$arrays The arrays to merge.
      *
@@ -345,7 +337,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * Create a new array with this current array values as keys and the given values as values.
+     * Creates a new array with this current array values as keys and the given values as values.
      *
      * @template TCombineValue
      *
@@ -362,6 +354,9 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self(array_combine($this->array, $values));
     }
 
+    /**
+     * Creates an array from the specified `$string`, split by the given `$separator`.
+     */
     public static function explode(string|Stringable $string, string $separator = ' '): self
     {
         if ($separator === '') {
@@ -371,6 +366,9 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self(explode($separator, (string) $string));
     }
 
+    /**
+     * Asserts whether this instance is equal to the given array.
+     */
     public function equals(array|self $other): bool
     {
         $other = is_array($other) ? $other : $other->array;
@@ -378,7 +376,12 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return $this->array === $other;
     }
 
-    /** @param Closure(mixed $value, mixed $key): bool $filter */
+    /**
+     * Returns the first item in the instance that matches the given `$filter`.
+     * If `$filter` is `null`, returns the first item.
+     *
+     * @param Closure(mixed $value, mixed $key): bool $filter
+     */
     public function first(?Closure $filter = null): mixed
     {
         if ($filter === null) {
@@ -394,7 +397,12 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return null;
     }
 
-    /** @param Closure(mixed $value, mixed $key): bool $filter */
+    /**
+     * Returns the last item in the instance that matches the given `$filter`.
+     * If `$filter` is `null`, returns the last item.
+     *
+     * @param Closure(mixed $value, mixed $key): bool $filter
+     */
     public function last(?Closure $filter = null): mixed
     {
         if ($filter === null) {
@@ -410,7 +418,11 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return null;
     }
 
-    /** @param mixed $value The popped value will be stored in this variable */
+    /**
+     * Returns an instance of the array without the last value.
+     *
+     * @param mixed $value The popped value will be stored in this variable
+     */
     public function pop(mixed &$value): self
     {
         $value = $this->last();
@@ -418,7 +430,11 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self(array_slice($this->array, 0, -1));
     }
 
-    /** @param mixed $value The unshifted value will be stored in this variable */
+    /**
+     * Returns an instance of the array without the first value.
+     *
+     * @param mixed $value The unshifted value will be stored in this variable
+     */
     public function unshift(mixed &$value): self
     {
         $value = $this->first();
@@ -426,28 +442,40 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self(array_slice($this->array, 1));
     }
 
+    /**
+     * Returns a new instance of the array in reverse order.
+     */
     public function reverse(): self
     {
         return new self(array_reverse($this->array));
     }
 
+    /**
+     * Asserts whether the array is empty.
+     */
     public function isEmpty(): bool
     {
         return empty($this->array);
     }
 
+    /**
+     * Asserts whether the array is not empty.
+     */
     public function isNotEmpty(): bool
     {
         return ! $this->isEmpty();
     }
 
+    /**
+     * Returns an instance of `StringHelper` with the values of the instance joined with the given `$glue`.
+     */
     public function implode(string $glue): StringHelper
     {
         return str(implode($glue, $this->array));
     }
 
     /**
-     * Create a new array with the keys of this array as values.
+     * Returns a new instance with the keys of this array as values.
      *
      * @return self<array-key, TKey>
      */
@@ -456,12 +484,22 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self(array_keys($this->array));
     }
 
+    /**
+     * Returns a new instance of this array without its keys.
+     *
+     * @return self<int, TValue>
+     */
     public function values(): self
     {
         return new self(array_values($this->array));
     }
 
-    /** @param null|Closure(mixed $value, mixed $key): bool $filter */
+    /**
+     * Returns a new instance of this array with only the items that pass the given `$filter`.
+     * If `$filter` is `null`, the new instance will contain only values that are not `false` or `null`.
+     *
+     * @param null|Closure(mixed $value, mixed $key): bool $filter
+     */
     public function filter(?Closure $filter = null): self
     {
         $array = [];
@@ -476,7 +514,11 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self($array);
     }
 
-    /** @param Closure(mixed $value, mixed $key): void $each */
+    /**
+     * Applies the given callback to all items of the instance.
+     *
+     * @param Closure(mixed $value, mixed $key): void $each
+     */
     public function each(Closure $each): self
     {
         foreach ($this as $key => $value) {
@@ -486,7 +528,11 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return $this;
     }
 
-    /** @param Closure(mixed $value, mixed $key): mixed $map */
+    /**
+     * Returns a new instance of the array, with each item transformed by the given callback.
+     *
+     * @param Closure(mixed $value, mixed $key): mixed $map
+     */
     public function map(Closure $map): self
     {
         $array = [];
@@ -498,7 +544,17 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self($array);
     }
 
-    /** @param Closure(mixed $value, mixed $key): Generator $map */
+    /**
+     * Returns a new instance of the array, with each item transformed by the given callback.
+     * The callback must return a generator, associating a key and a value.
+     *
+     * ### Example
+     * ```php
+     * arr(['a', 'b'])->mapWithKeys(fn (mixed $value, mixed $key) => yield $key => $value);
+     * ```
+     *
+     * @param Closure(mixed $value, mixed $key): Generator $map
+     */
     public function mapWithKeys(Closure $map): self
     {
         $array = [];
@@ -516,7 +572,11 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return new self($array);
     }
 
-    /** @return mixed|ArrayHelper */
+    /**
+     * Gets the value identified by the specified `$key`, or `$default` if no such value exists.
+     *
+     * @return mixed|ArrayHelper
+     */
     public function get(string $key, mixed $default = null): mixed
     {
         $value = $this->array;
@@ -538,6 +598,11 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return $value;
     }
 
+    /**
+     * Asserts whether a value identified by the specified `$key` exists.
+     *
+     * @return mixed|ArrayHelper
+     */
     public function has(string $key): bool
     {
         $array = $this->array;
@@ -555,11 +620,17 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return true;
     }
 
+    /**
+     * Asserts whether the instance contains an item that can be identified by `$search`.
+     */
     public function contains(mixed $search): bool
     {
-        return $this->first(fn ($value) => $value === $search) !== null;
+        return $this->first(fn (mixed $value) => $value === $search) !== null;
     }
 
+    /**
+     * Associates the given `$value` to the given `$key` on the instance.
+     */
     public function set(string $key, mixed $value): self
     {
         $array = $this->array;
@@ -597,13 +668,16 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
-     * @alias self::set()
+     * @alias of `set`
      */
     public function put(string $key, mixed $value): self
     {
         return $this->set($key, $value);
     }
 
+    /**
+     * Converts the dot-notated keys of the instance to a set of nested arrays.
+     */
     public function unwrap(): self
     {
         $unwrapValue = function (string|int $key, mixed $value) {
@@ -653,6 +727,9 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return str($last);
     }
 
+    /**
+     * Dumps the instance.
+     */
     public function dump(mixed ...$dumps): self
     {
         lw($this->array, ...$dumps);
@@ -660,12 +737,17 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
         return $this;
     }
 
+    /**
+     * Dumps the instance and stops the execution of the script.
+     */
     public function dd(mixed ...$dd): void
     {
         ld($this->array, ...$dd);
     }
 
     /**
+     * Returns the underlying array of the instance.
+     *
      * @return array<TKey, TValue>
      */
     public function toArray(): array
@@ -674,6 +756,10 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
+     * Maps the items of the instance to the given object.
+     *
+     * @see Tempest\map()
+     *
      * @template T
      * @param class-string<T> $to
      * @return self<T>

--- a/src/Tempest/Support/src/LanguageHelper.php
+++ b/src/Tempest/Support/src/LanguageHelper.php
@@ -10,11 +10,17 @@ use Tempest\Support\Pluralizer\Pluralizer;
 
 final class LanguageHelper
 {
+    /**
+     * Converts the given string to its English plural form.
+     */
     public static function pluralize(string $value, int|array|Countable $count = 2): string
     {
         return get(Pluralizer::class)->pluralize($value, $count);
     }
 
+    /**
+     * Converts the given string to its English singular form.
+     */
     public static function singularize(string $value): string
     {
         return get(Pluralizer::class)->singularize($value);

--- a/src/Tempest/Support/src/PathHelper.php
+++ b/src/Tempest/Support/src/PathHelper.php
@@ -6,6 +6,9 @@ namespace Tempest\Support;
 
 final readonly class PathHelper
 {
+    /**
+     * Returns a valid path from the specified portions.
+     */
     public static function make(string ...$paths): string
     {
         // Split paths items on forward and backward slashes

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -19,36 +19,57 @@ final readonly class StringHelper implements Stringable
     ) {
     }
 
+    /**
+     * Converts the instance to a string.
+     */
     public function toString(): string
     {
         return $this->string;
     }
 
+    /**
+     * Converts the instance to a string.
+     */
     public function __toString(): string
     {
         return $this->string;
     }
 
+    /**
+     * Asserts whether the instance is equal to the given instance or string.
+     */
     public function equals(string|Stringable $other): bool
     {
         return $this->string === (string) $other;
     }
 
+    /**
+     * Converts the instance to title case.
+     */
     public function title(): self
     {
         return new self(mb_convert_case($this->string, MB_CASE_TITLE, 'UTF-8'));
     }
 
+    /**
+     * Converts the instance to lower case.
+     */
     public function lower(): self
     {
         return new self(mb_strtolower($this->string, 'UTF-8'));
     }
 
+    /**
+     * Converts the instance to upper case.
+     */
     public function upper(): self
     {
         return new self(mb_strtoupper($this->string, 'UTF-8'));
     }
 
+    /**
+     * Converts the instance to snake case.
+     */
     public function snake(string $delimiter = '_'): self
     {
         $string = $this->string;
@@ -69,11 +90,17 @@ final readonly class StringHelper implements Stringable
         return (new self($string))->deduplicate($delimiter);
     }
 
+    /**
+     * Converts the instance to kebab case.
+     */
     public function kebab(): self
     {
         return $this->snake('-');
     }
 
+    /**
+     * Converts the instance to pascal case.
+     */
     public function pascal(): self
     {
         $words = explode(' ', str_replace(['-', '_'], ' ', $this->string));
@@ -84,11 +111,17 @@ final readonly class StringHelper implements Stringable
         return new self(implode('', $studlyWords));
     }
 
+    /**
+     * Converts the instance to camel case.
+     */
     public function camel(): self
     {
         return new self(lcfirst((string)$this->pascal()));
     }
 
+    /**
+     * Replaces consecutive instances of a given character with a single character.
+     */
     public function deduplicate(string|array $characters = ' '): self
     {
         $string = $this->string;
@@ -100,11 +133,17 @@ final readonly class StringHelper implements Stringable
         return new self($string);
     }
 
+    /**
+     * Converts the instance to its English plural form.
+     */
     public function pluralize(int|array|Countable $count = 2): self
     {
         return new self(LanguageHelper::pluralize($this->string, $count));
     }
 
+    /**
+     * Converts the last word to its English plural form.
+     */
     public function pluralizeLast(int|array|Countable $count = 2): self
     {
         $parts = preg_split('/(.)(?=[A-Z])/u', $this->string, -1, PREG_SPLIT_DELIM_CAPTURE);
@@ -116,6 +155,9 @@ final readonly class StringHelper implements Stringable
         return new self($string);
     }
 
+    /**
+     * Creates a random alpha-numeric string of the given length.
+     */
     public function random(int $length = 16): self
     {
         $string = '';
@@ -130,6 +172,9 @@ final readonly class StringHelper implements Stringable
         return new self($string);
     }
 
+    /**
+     * Caps the instance with the given string.
+     */
     public function finish(string $cap): self
     {
         return new self(
@@ -137,6 +182,9 @@ final readonly class StringHelper implements Stringable
         );
     }
 
+    /**
+     * Returns the remainder of the string after the first occurrence of the given value.
+     */
     public function after(Stringable|string|array $search): self
     {
         $search = $this->normalizeString($search);
@@ -166,6 +214,9 @@ final readonly class StringHelper implements Stringable
         return new self($string);
     }
 
+    /**
+     * Returns the remainder of the string after the last occurrence of the given value.
+     */
     public function afterLast(Stringable|string|array $search): self
     {
         $search = $this->normalizeString($search);
@@ -195,6 +246,9 @@ final readonly class StringHelper implements Stringable
         return new self($string);
     }
 
+    /**
+     * Returns the portion of the string before the first occurrence of the given value.
+     */
     public function before(Stringable|string|array $search): self
     {
         $search = $this->normalizeString($search);
@@ -222,6 +276,9 @@ final readonly class StringHelper implements Stringable
         return new self($string);
     }
 
+    /**
+     * Returns the portion of the string before the last occurrence of the given value.
+     */
     public function beforeLast(Stringable|string|array $search): self
     {
         $search = $this->normalizeString($search);
@@ -249,6 +306,9 @@ final readonly class StringHelper implements Stringable
         return new self($string);
     }
 
+    /**
+     * Returns the portion of the string between the widest possible instances of the given strings.
+     */
     public function between(string|Stringable $from, string|Stringable $to): self
     {
         $from = $this->normalizeString($from);
@@ -261,31 +321,49 @@ final readonly class StringHelper implements Stringable
         return $this->after($from)->beforeLast($to);
     }
 
+    /**
+     * Removes all whitespace (or specified characters) from both ends of the instance.
+     */
     public function trim(string $characters = " \n\r\t\v\0"): self
     {
         return new self(trim($this->string, $characters));
     }
 
+    /**
+     * Removes all whitespace (or specified characters) from the start of the instance.
+     */
     public function ltrim(string $characters = " \n\r\t\v\0"): self
     {
         return new self(ltrim($this->string, $characters));
     }
 
+    /**
+     * Removes all whitespace (or specified characters) from the end of the instance.
+     */
     public function rtrim(string $characters = " \n\r\t\v\0"): self
     {
         return new self(rtrim($this->string, $characters));
     }
 
+    /**
+     * Returns the multi-bytes length of the instance.
+     */
     public function length(): int
     {
         return mb_strlen($this->string);
     }
 
+    /**
+     * Returns the base name of the instance, assuming the instance is a class name.
+     */
     public function classBasename(): self
     {
         return new self(basename(str_replace('\\', '/', $this->string)));
     }
 
+    /**
+     * Asserts whether the instance starts with one of the given needles.
+     */
     public function startsWith(Stringable|string|array $needles): bool
     {
         if (! is_array($needles)) {
@@ -301,6 +379,9 @@ final readonly class StringHelper implements Stringable
         return false;
     }
 
+    /**
+     * Asserts whether the instance ends with one of the given `$needles`.
+     */
     public function endsWith(Stringable|string|array $needles): bool
     {
         if (! is_array($needles)) {
@@ -316,6 +397,9 @@ final readonly class StringHelper implements Stringable
         return false;
     }
 
+    /**
+     * Replaces the first occurence of `$search` with `$replace`.
+     */
     public function replaceFirst(Stringable|string $search, Stringable|string $replace): self
     {
         $search = $this->normalizeString($search);
@@ -333,6 +417,9 @@ final readonly class StringHelper implements Stringable
         return new self(substr_replace($this->string, $replace, $position, strlen($search)));
     }
 
+    /**
+     * Replaces the last occurence of `$search` with `$replace`.
+     */
     public function replaceLast(Stringable|string $search, Stringable|string $replace): self
     {
         $search = $this->normalizeString($search);
@@ -350,6 +437,9 @@ final readonly class StringHelper implements Stringable
         return new self(substr_replace($this->string, $replace, $position, strlen($search)));
     }
 
+    /**
+     * Replaces `$search` with `$replace` if `$search` is at the end of the instance.
+     */
     public function replaceEnd(Stringable|string $search, Stringable|string $replace): self
     {
         $search = $this->normalizeString($search);
@@ -365,6 +455,9 @@ final readonly class StringHelper implements Stringable
         return $this->replaceLast($search, $replace);
     }
 
+    /**
+     * Replaces `$search` with `$replace` if `$search` is at the start of the instance.
+     */
     public function replaceStart(Stringable|string $search, Stringable|string $replace): self
     {
         if ($search === '') {
@@ -378,16 +471,25 @@ final readonly class StringHelper implements Stringable
         return $this->replaceFirst($search, $replace);
     }
 
+    /**
+     * Appends the given strings to the instance.
+     */
     public function append(string|Stringable ...$append): self
     {
         return new self($this->string . implode('', $append));
     }
 
+    /**
+     * Prepends the given strings to the instance.
+     */
     public function prepend(string|Stringable ...$prepend): self
     {
         return new self(implode('', $prepend) . $this->string);
     }
 
+    /**
+     * Replaces all occurrences of the given `$search` with `$replace`.
+     */
     public function replace(Stringable|string|array $search, Stringable|string|array $replace): self
     {
         $search = $this->normalizeString($search);
@@ -396,6 +498,9 @@ final readonly class StringHelper implements Stringable
         return new self(str_replace($search, $replace, $this->string));
     }
 
+    /**
+     * Replaces the patterns matching the given regular expression.
+     */
     public function replaceRegex(string|array $regex, string|array|callable $replace): self
     {
         if (is_callable($replace)) {
@@ -405,6 +510,9 @@ final readonly class StringHelper implements Stringable
         return new self(preg_replace($regex, $replace, $this->string));
     }
 
+    /**
+     * Gets the first portion of the instance that matches the given regular expression.
+     */
     public function match(string $regex): array
     {
         preg_match($regex, $this->string, $matches);
@@ -412,6 +520,9 @@ final readonly class StringHelper implements Stringable
         return $matches;
     }
 
+    /**
+     * Gets all portions of the instance that match the given regular expression.
+     */
     public function matchAll(string $regex, int $flags = 0, int $offset = 0): array
     {
         $result = preg_match_all($regex, $this->string, $matches, $flags, $offset);
@@ -423,16 +534,25 @@ final readonly class StringHelper implements Stringable
         return $matches;
     }
 
+    /**
+     * Asserts whether the instance matches the given regular expression.
+     */
     public function matches(string $regex): bool
     {
         return ($this->match($regex)[0] ?? null) !== null;
     }
 
+    /**
+     * Dumps the instance and stops the execution of the script.
+     */
     public function dd(mixed ...$dd): void
     {
         ld($this->string, ...$dd);
     }
 
+    /**
+     * Dumps the instance.
+     */
     public function dump(mixed ...$dumps): self
     {
         lw($this->string, ...$dumps);
@@ -440,6 +560,9 @@ final readonly class StringHelper implements Stringable
         return $this;
     }
 
+    /**
+     * Extracts an excerpt from the instance.
+     */
     public function excerpt(int $from, int $to, bool $asArray = false): self|ArrayHelper
     {
         $lines = explode(PHP_EOL, $this->string);
@@ -468,9 +591,7 @@ final readonly class StringHelper implements Stringable
     }
 
     /**
-     * Explode the string into an ArrayHelper by a separator.
-     *
-     * @param string $separator The separator to explode the string by.
+     * Explodes the string into an `ArrayHelper` instance by a separator.
      */
     public function explode(string $separator = ' '): ArrayHelper
     {
@@ -478,12 +599,7 @@ final readonly class StringHelper implements Stringable
     }
 
     /**
-     * Implode the array into a string by a separator.
-     *
-     * @param array|ArrayHelper $parts The array to implode.
-     * @param string $glue The separator to implode the array by.
-     *
-     * @return self The imploded string.
+     * Implodes the given array into a string by a separator.
      */
     public static function implode(array|ArrayHelper $parts, string $glue = ' '): self
     {

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -663,7 +663,7 @@ final class ArrayHelperTest extends TestCase
                 true,
                 'true',
             ])
-                ->unique(should_be_strict: false)
+                ->unique(shouldBeStrict: false)
                 ->values()
                 ->toArray(),
             expected: [
@@ -682,7 +682,7 @@ final class ArrayHelperTest extends TestCase
                 true,
                 'true',
             ])
-                ->unique(should_be_strict: true)
+                ->unique(shouldBeStrict: true)
                 ->values()
                 ->toArray(),
             expected: [
@@ -704,7 +704,7 @@ final class ArrayHelperTest extends TestCase
                 ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Doe'],
                 ['id' => 3, 'first_name' => 'Jane', 'last_name' => 'Duplicate'],
             ])
-                ->unique('id', should_be_strict: true)
+                ->unique('id', shouldBeStrict: true)
                 ->values()
                 ->toArray(),
             expected: [


### PR DESCRIPTION
This pull request adds inline documentation on all methods of `StringHelper`, `ArrayHelper` and `LanguageHelper`.

Not all method names are explicit enough to understand the behavior of the method, so inline documentation helps a lot.