### PR TITLE
feat(console): add `name` parameter to `#[ConsoleArgument]`

### DIFF
--- a/src/Tempest/Console/src/Actions/RenderConsoleCommand.php
+++ b/src/Tempest/Console/src/Actions/RenderConsoleCommand.php
@@ -7,7 +7,6 @@ namespace Tempest\Console\Actions;
 use Tempest\Console\Console;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Input\ConsoleArgumentDefinition;
-use Tempest\Reflection\ParameterReflector;
 
 final readonly class RenderConsoleCommand
 {
@@ -35,12 +34,12 @@ final readonly class RenderConsoleCommand
         $name = str($argument->name)
             ->prepend('<em>')
             ->append('</em>');
-        
+
         $asString = match($argument->type) {
             'bool' => "<em>--</em>{$name}",
             default => $name,
         };
-            
+
         if (! $argument->hasDefault) {
             return "<{$asString}>";
         }

--- a/src/Tempest/Console/src/Actions/RenderConsoleCommand.php
+++ b/src/Tempest/Console/src/Actions/RenderConsoleCommand.php
@@ -7,6 +7,7 @@ namespace Tempest\Console\Actions;
 use Tempest\Console\Console;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Input\ConsoleArgumentDefinition;
+use function Tempest\Support\str;
 
 final readonly class RenderConsoleCommand
 {

--- a/src/Tempest/Console/src/ConsoleArgument.php
+++ b/src/Tempest/Console/src/ConsoleArgument.php
@@ -10,6 +10,7 @@ use Attribute;
 final readonly class ConsoleArgument
 {
     public function __construct(
+        public ?string $name = null,
         public ?string $description = null,
         public string $help = '',
         public array $aliases = [],

--- a/src/Tempest/Console/src/Input/ConsoleArgumentDefinition.php
+++ b/src/Tempest/Console/src/Input/ConsoleArgumentDefinition.php
@@ -24,12 +24,12 @@ final readonly class ConsoleArgumentDefinition
     public static function fromParameter(ParameterReflector $parameter): ConsoleArgumentDefinition
     {
         $attribute = $parameter->getAttribute(ConsoleArgument::class);
-        $type      = $parameter->getType();
+        $type = $parameter->getType();
 
         return new ConsoleArgumentDefinition(
             name       : $attribute?->name ?? $parameter->getName(),
             type       : $type->getName(),
-            default    : $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue(): null,
+            default    : $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null,
             hasDefault : $parameter->isDefaultValueAvailable(),
             position   : $parameter->getPosition(),
             description: $attribute?->description,

--- a/src/Tempest/Console/src/Input/ConsoleArgumentDefinition.php
+++ b/src/Tempest/Console/src/Input/ConsoleArgumentDefinition.php
@@ -27,7 +27,7 @@ final readonly class ConsoleArgumentDefinition
         $attribute = $parameter->getAttribute(ConsoleArgument::class);
         $type = $parameter->getType();
         $default = $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null;
-        $boolean = $type?->getName() === 'bool' || is_bool($default);
+        $boolean = $type->getName() === 'bool' || is_bool($default);
 
         return new ConsoleArgumentDefinition(
             name: static::normalizeName($attribute?->name ?? $parameter->getName(), boolean: $boolean),

--- a/src/Tempest/Console/src/Input/ConsoleArgumentDefinition.php
+++ b/src/Tempest/Console/src/Input/ConsoleArgumentDefinition.php
@@ -6,6 +6,7 @@ namespace Tempest\Console\Input;
 
 use Tempest\Console\ConsoleArgument;
 use Tempest\Reflection\ParameterReflector;
+use function Tempest\Support\str;
 
 final readonly class ConsoleArgumentDefinition
 {
@@ -25,11 +26,13 @@ final readonly class ConsoleArgumentDefinition
     {
         $attribute = $parameter->getAttribute(ConsoleArgument::class);
         $type = $parameter->getType();
+        $default = $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null;
+        $boolean = $type?->getName() === 'bool' || is_bool($default);
 
         return new ConsoleArgumentDefinition(
-            name: $attribute?->name ?? $parameter->getName(),
+            name: static::normalizeName($attribute?->name ?? $parameter->getName(), boolean: $boolean),
             type: $type->getName(),
-            default: $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null,
+            default: $default,
             hasDefault: $parameter->isDefaultValueAvailable(),
             position: $parameter->getPosition(),
             description: $attribute?->description,
@@ -49,11 +52,22 @@ final readonly class ConsoleArgumentDefinition
         }
 
         foreach ([$this->name, ...$this->aliases] as $match) {
-            if ($argument->matches($match)) {
+            if ($argument->matches(static::normalizeName($match, $this->type === 'bool'))) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private static function normalizeName(string $name, bool $boolean): string
+    {
+        $normalizedName = str($name)->kebab();
+
+        if ($boolean) {
+            $normalizedName->replaceStart('no-', '');
+        }
+
+        return $normalizedName->toString();
     }
 }

--- a/src/Tempest/Console/src/Input/ConsoleArgumentDefinition.php
+++ b/src/Tempest/Console/src/Input/ConsoleArgumentDefinition.php
@@ -27,14 +27,14 @@ final readonly class ConsoleArgumentDefinition
         $type = $parameter->getType();
 
         return new ConsoleArgumentDefinition(
-            name       : $attribute?->name ?? $parameter->getName(),
-            type       : $type->getName(),
-            default    : $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null,
-            hasDefault : $parameter->isDefaultValueAvailable(),
-            position   : $parameter->getPosition(),
+            name: $attribute?->name ?? $parameter->getName(),
+            type: $type->getName(),
+            default: $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null,
+            hasDefault: $parameter->isDefaultValueAvailable(),
+            position: $parameter->getPosition(),
             description: $attribute?->description,
-            aliases    : $attribute->aliases ?? [],
-            help       : $attribute?->help,
+            aliases: $attribute->aliases ?? [],
+            help: $attribute?->help,
         );
     }
 

--- a/src/Tempest/Console/src/Input/ConsoleArgumentDefinition.php
+++ b/src/Tempest/Console/src/Input/ConsoleArgumentDefinition.php
@@ -24,18 +24,17 @@ final readonly class ConsoleArgumentDefinition
     public static function fromParameter(ParameterReflector $parameter): ConsoleArgumentDefinition
     {
         $attribute = $parameter->getAttribute(ConsoleArgument::class);
-
-        $type = $parameter->getType();
+        $type      = $parameter->getType();
 
         return new ConsoleArgumentDefinition(
-            name: $parameter->getName(),
-            type: $type->getName(),
-            default: $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null,
-            hasDefault: $parameter->isDefaultValueAvailable(),
-            position: $parameter->getPosition(),
+            name       : $attribute?->name ?? $parameter->getName(),
+            type       : $type->getName(),
+            default    : $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue(): null,
+            hasDefault : $parameter->isDefaultValueAvailable(),
+            position   : $parameter->getPosition(),
             description: $attribute?->description,
-            aliases: $attribute->aliases ?? [],
-            help: $attribute?->help,
+            aliases    : $attribute->aliases ?? [],
+            help       : $attribute?->help,
         );
     }
 

--- a/tests/Fixtures/Console/CommandWithArgumentName.php
+++ b/tests/Fixtures/Console/CommandWithArgumentName.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Tempest\Fixtures\Console;
 
 use Tempest\Console\ConsoleArgument;
@@ -16,8 +18,7 @@ final readonly class CommandWithArgumentName
         string $input,
         #[ConsoleArgument(name: 'new-flag')]
         bool $flag = false,
-    ): void
-    {
+    ): void {
         $this->writeln($input);
         $this->writeln($flag ? 'true' : 'false');
     }

--- a/tests/Fixtures/Console/CommandWithArgumentName.php
+++ b/tests/Fixtures/Console/CommandWithArgumentName.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Tempest\Fixtures\Console;
+
+use Tempest\Console\ConsoleArgument;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Console\HasConsole;
+
+final readonly class CommandWithArgumentName
+{
+    use HasConsole;
+
+    #[ConsoleCommand(name: 'command-with-argument-name')]
+    public function __invoke(
+        #[ConsoleArgument(name: 'new-name')]
+        string $input,
+        #[ConsoleArgument(name: 'new-flag')]
+        bool $flag = false,
+    ): void
+    {
+        $this->writeln($input);
+        $this->writeln($flag ? 'true' : 'false');
+    }
+}

--- a/tests/Fixtures/Console/CommandWithDifferentArguments.php
+++ b/tests/Fixtures/Console/CommandWithDifferentArguments.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Console;
+
+use Tempest\Console\ConsoleArgument;
+
+// tests/Integration/Console/Input/ConsoleArgumentDefinitionTest.php
+final readonly class CommandWithDifferentArguments
+{
+    public function __invoke(
+        string $string,
+        string $camelCaseString,
+        #[ConsoleArgument(name: 'my-kebab-string')]
+        string $renamedKebabString,
+        #[ConsoleArgument(name: 'myCamelString')]
+        string $renamedCamelString,
+        bool $bool,
+        bool $camelCaseBool,
+        string $camelCaseStringWithDefault = 'foo',
+        bool $camelCaseBoolWithTrueDefault = true,
+        bool $camelCaseBoolWithFalseDefault = false,
+    ): void {
+    }
+}

--- a/tests/Fixtures/Console/Hello.php
+++ b/tests/Fixtures/Console/Hello.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Fixtures\Console;
 
-use Tempest\Console\ConsoleCommand;
-use Tempest\Console\ConsoleArgument;
 use Tempest\Console\Console;
+use Tempest\Console\ConsoleArgument;
+use Tempest\Console\ConsoleCommand;
 
 final readonly class Hello
 {
@@ -31,8 +31,7 @@ final readonly class Hello
             name: 'custom-flag',
         )]
         bool $flag = false
-    ): void
-    {
+    ): void {
         $value = $optionalValue ?? 'null';
 
         $this->console->info("{$value}");

--- a/tests/Fixtures/Console/Hello.php
+++ b/tests/Fixtures/Console/Hello.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Fixtures\Console;
 
-use Tempest\Console\Console;
 use Tempest\Console\ConsoleCommand;
+use Tempest\Console\ConsoleArgument;
+use Tempest\Console\Console;
 
 final readonly class Hello
 {
@@ -23,7 +24,14 @@ final readonly class Hello
     }
 
     #[ConsoleCommand]
-    public function test(?int $optionalValue = null, bool $flag = false): void
+    public function test(
+        #[ConsoleArgument]
+        ?int $optionalValue = null,
+        #[ConsoleArgument(
+            name: 'custom-flag',
+        )]
+        bool $flag = false
+    ): void
     {
         $value = $optionalValue ?? 'null';
 

--- a/tests/Integration/Console/ConsoleArgumentBagTest.php
+++ b/tests/Integration/Console/ConsoleArgumentBagTest.php
@@ -54,8 +54,7 @@ final class ConsoleArgumentBagTest extends FrameworkIntegrationTestCase
         $this->console
             ->call('complex a --c=c --b=b --flag')
             ->assertContains('abc')
-            ->assertContains('true')
-        ;
+            ->assertContains('true');
     }
 
     public function test_combined_flags(): void
@@ -137,5 +136,13 @@ final class ConsoleArgumentBagTest extends FrameworkIntegrationTestCase
         );
 
         $this->assertSame($expected, $bag->findFor($definition)->value);
+    }
+
+    public function test_name_mapping(): void
+    {
+        $this->console
+            ->call('command-with-argument-name --new-name=foo --new-flag')
+            ->assertSee('foo')
+            ->assertSee('true');
     }
 }

--- a/tests/Integration/Console/Input/ConsoleArgumentDefinitionTest.php
+++ b/tests/Integration/Console/Input/ConsoleArgumentDefinitionTest.php
@@ -45,6 +45,6 @@ final class ConsoleArgumentDefinitionTest extends TestCase
             }
         }
 
-        throw new RuntimeException("Parameter not found: $name");
+        throw new RuntimeException("Parameter not found: {$name}");
     }
 }

--- a/tests/Integration/Console/Input/ConsoleArgumentDefinitionTest.php
+++ b/tests/Integration/Console/Input/ConsoleArgumentDefinitionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Console\Input;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Tempest\Console\Input\ConsoleArgumentDefinition;
+use Tempest\Reflection\ClassReflector;
+use Tempest\Reflection\ParameterReflector;
+use Tests\Tempest\Fixtures\Console\CommandWithDifferentArguments;
+
+/**
+ * @internal
+ */
+final class ConsoleArgumentDefinitionTest extends TestCase
+{
+    #[TestWith(['string', 'string', 'string', null])]
+    #[TestWith(['bool', 'bool', 'bool', null])]
+    #[TestWith(['camelCaseString', 'camel-case-string', 'string', null])]
+    #[TestWith(['camelCaseBool', 'camel-case-bool', 'bool', null])]
+    #[TestWith(['renamedCamelString', 'my-camel-string', 'string', null])]
+    #[TestWith(['renamedKebabString', 'my-kebab-string', 'string', null])]
+    #[TestWith(['camelCaseBool', 'camel-case-bool', 'bool', null])]
+    #[TestWith(['camelCaseStringWithDefault', 'camel-case-string-with-default', 'string', 'foo'])]
+    #[TestWith(['camelCaseBoolWithTrueDefault', 'camel-case-bool-with-true-default', 'bool', true])]
+    #[TestWith(['camelCaseBoolWithFalseDefault', 'camel-case-bool-with-false-default', 'bool', false])]
+    public function test_parse_named_arguments_with_types_and_defaults(string $originalParameter, string $expectedName, string $expectedType, mixed $expectedDefault): void
+    {
+        $definition = ConsoleArgumentDefinition::fromParameter($this->getParameter($originalParameter));
+        $this->assertSame($expectedName, $definition->name);
+        $this->assertSame($expectedType, $definition->type);
+        $this->assertSame($expectedDefault, $definition->default);
+    }
+
+    private function getParameter(string $name): ParameterReflector
+    {
+        $reflector = new ClassReflector(CommandWithDifferentArguments::class);
+
+        foreach ($reflector->getMethod('__invoke')->getParameters() as $parameter) {
+            if ($parameter->getName() === $name) {
+                return $parameter;
+            }
+        }
+
+        throw new RuntimeException("Parameter not found: $name");
+    }
+}

--- a/tests/Integration/Console/Middleware/OverviewMiddlewareTest.php
+++ b/tests/Integration/Console/Middleware/OverviewMiddlewareTest.php
@@ -20,7 +20,7 @@ final class OverviewMiddlewareTest extends FrameworkIntegrationTestCase
             ->assertContains('Hello')
             ->assertDoesNotContain('hidden')
             ->assertContains('hello:world <input>')
-            ->assertContains('hello:test [optionalValue=null] [--flag=false] - description')
+            ->assertContains('hello:test [optional-value=null] [--flag=false] - description')
             ->assertContains('testcommand:test');
     }
 


### PR DESCRIPTION
This PR allow `ConsoleArgument` Attribute to have a `name` parameter to override the method parameter name if wanted.

This Fix #588