### PR TITLE
feat(console): support negative arguments

### DIFF
--- a/tests/Integration/Console/ConsoleArgumentBagTest.php
+++ b/tests/Integration/Console/ConsoleArgumentBagTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Console;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use Tempest\Console\Input\ConsoleArgumentBag;
 use Tempest\Console\Input\ConsoleArgumentDefinition;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -106,5 +107,35 @@ final class ConsoleArgumentBagTest extends FrameworkIntegrationTestCase
         $this->console
             ->call('array_input --input=a')
             ->assertContains('["a"]');
+    }
+
+    #[TestWith(['foo', false])]
+    #[TestWith(['bar', true])]
+    #[TestWith(['baz', false])]
+    #[TestWith(['qux', true])]
+    #[TestWith(['bux', true])]
+    public function test_negative_input(string $name, bool $expected): void
+    {
+        $argv = [
+            'tempest',
+            'test',
+            '--no-foo',
+            '--qux',
+            '--bux=true',
+            '--no-bar=false',
+            '--baz=false',
+        ];
+
+        $bag = new ConsoleArgumentBag($argv);
+
+        $definition = new ConsoleArgumentDefinition(
+            name: $name,
+            type: 'bool',
+            default: null,
+            hasDefault: false,
+            position: 0,
+        );
+
+        $this->assertSame($expected, $bag->findFor($definition)->value);
     }
 }

--- a/tests/Integration/Console/Input/ConsoleInputArgumentTest.php
+++ b/tests/Integration/Console/Input/ConsoleInputArgumentTest.php
@@ -31,5 +31,32 @@ final class ConsoleInputArgumentTest extends TestCase
 
         $input = ConsoleInputArgument::fromString('--flag="abc"');
         $this->assertSame('abc', $input->value);
+
+        $input = ConsoleInputArgument::fromString('--foo-bar="baz"');
+        $this->assertSame('foo-bar', $input->name);
+        $this->assertSame('baz', $input->value);
+
+        $input = ConsoleInputArgument::fromString('--fooBar');
+        $this->assertSame('foo-bar', $input->name);
+
+        $input = ConsoleInputArgument::fromString('--noFooBar');
+        $this->assertSame('foo-bar', $input->name);
+        $this->assertSame(false, $input->value);
+
+        $input = ConsoleInputArgument::fromString('--no-interaction');
+        $this->assertSame('interaction', $input->name);
+        $this->assertSame(false, $input->value);
+
+        $input = ConsoleInputArgument::fromString('--no-interaction=true');
+        $this->assertSame('interaction', $input->name);
+        $this->assertSame(false, $input->value);
+
+        $input = ConsoleInputArgument::fromString('--no-interaction=false');
+        $this->assertSame('interaction', $input->name);
+        $this->assertSame(true, $input->value);
+
+        $input = ConsoleInputArgument::fromString('--no-foo=baz');
+        $this->assertSame('no-foo', $input->name);
+        $this->assertSame('baz', $input->value);
     }
 }


### PR DESCRIPTION
This pull request adds support for converting boolean flags that start with `--no` to their non-negative version.

For instance, the flag `--no-interaction` will be parsed as `$interaction = false`. This is a common practice in JavaScript and Rust CLIs, and a practical feature, both user and developer wise, to handle boolean flags in multiple ways, whichever feels more natural.

Non-boolean flags will be handled as before, keeping the `no-` prefix.

Here are a few examples:

| Flag                     | Name          | Value   |
| ------------------------ | ------------- | ------- |
| `--no-interaction`       | `interaction` | `false` |
| `--noInteraction`        | `interaction` | `false` |
| `--interaction`          | `interaction` | `true`  |
| `--interaction=false`    | `interaction` | `false` |
| `--interaction=true`     | `interaction` | `true`  |
| `--no-interaction=true`  | `interaction` | `false` |
| `--no-interaction=false` | `interaction` | `true`  |