### PR TITLE
feat(console): support "no prompt" mode

### DIFF
--- a/src/Tempest/Console/src/Components/Interactive/MultipleChoiceComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/MultipleChoiceComponent.php
@@ -20,7 +20,12 @@ final class MultipleChoiceComponent implements InteractiveConsoleComponent, HasS
     public function __construct(
         public string $question,
         public array $options,
+        public array $default = [],
     ) {
+        foreach ($this->default as $key => $value) {
+            $this->selectedOptions[array_is_list($options) ? $key : $value] = true;
+        }
+
         $this->activeOption = array_key_first($this->options);
     }
 
@@ -105,8 +110,9 @@ final class MultipleChoiceComponent implements InteractiveConsoleComponent, HasS
     public function getStaticComponent(): StaticConsoleComponent
     {
         return new StaticMultipleChoiceComponent(
-            $this->question,
-            $this->options,
+            question: $this->question,
+            options: $this->options,
+            default: $this->default,
         );
     }
 }

--- a/src/Tempest/Console/src/Components/Interactive/SearchComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/SearchComponent.php
@@ -28,6 +28,7 @@ final class SearchComponent implements InteractiveConsoleComponent, HasCursor, H
     public function __construct(
         public string $label,
         public Closure $search,
+        public ?string $default = null
     ) {
         $this->cursorPosition = new Point(2, 1);
     }
@@ -67,6 +68,10 @@ final class SearchComponent implements InteractiveConsoleComponent, HasCursor, H
     public function enter(): ?string
     {
         $selected = $this->options[$this->selectedOption] ?? null;
+
+        if (! $selected && $this->default) {
+            return $this->default;
+        }
 
         if (! $selected) {
             return null;
@@ -168,6 +173,7 @@ final class SearchComponent implements InteractiveConsoleComponent, HasCursor, H
         return new StaticSearchComponent(
             label: $this->label,
             search: $this->search,
+            default: $this->default,
         );
     }
 }

--- a/src/Tempest/Console/src/Components/Interactive/TextBoxComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/TextBoxComponent.php
@@ -118,6 +118,9 @@ final class TextBoxComponent implements InteractiveConsoleComponent, HasCursor, 
 
     public function getStaticComponent(): StaticConsoleComponent
     {
-        return new StaticTextBoxComponent($this->label);
+        return new StaticTextBoxComponent(
+            label: $this->label,
+            default: $this->default
+        );
     }
 }

--- a/src/Tempest/Console/src/Components/Static/StaticConfirmComponent.php
+++ b/src/Tempest/Console/src/Components/Static/StaticConfirmComponent.php
@@ -17,6 +17,10 @@ final readonly class StaticConfirmComponent implements StaticConsoleComponent
 
     public function render(Console $console): bool
     {
+        if (! $console->supportsPrompting()) {
+            return $this->default;
+        }
+
         $answer = $console->ask(
             question: $this->question,
             options: ['yes', 'no'],

--- a/src/Tempest/Console/src/Components/Static/StaticMultipleChoiceComponent.php
+++ b/src/Tempest/Console/src/Components/Static/StaticMultipleChoiceComponent.php
@@ -12,15 +12,22 @@ final readonly class StaticMultipleChoiceComponent implements StaticConsoleCompo
     public function __construct(
         public string $question,
         public array $options,
+        public array $default = [],
     ) {
     }
 
     public function render(Console $console): array
     {
+        if (! $console->supportsPrompting()) {
+            return array_is_list($this->options)
+                ? array_filter($this->default, fn (mixed $value) => in_array($value, $this->options))
+                : array_filter($this->default, fn (mixed $value) => array_key_exists($value, $this->options));
+        }
+
         do {
             $answer = $this->askQuestion($console);
 
-            $answerAsString = implode(', ', $answer);
+            $answerAsString = implode(', ', $answer) ?: 'no option';
 
             $confirm = $console->confirm(
                 question: "You picked {$answerAsString}; continue?",

--- a/src/Tempest/Console/src/Components/Static/StaticSearchComponent.php
+++ b/src/Tempest/Console/src/Components/Static/StaticSearchComponent.php
@@ -10,16 +10,22 @@ use Tempest\Console\StaticConsoleComponent;
 
 final readonly class StaticSearchComponent implements StaticConsoleComponent
 {
-    public const string SEARCH_AGAIN = 'Search again';
+    private const string SEARCH_AGAIN = 'Search again';
+    private const string CANCEL = 'Cancel';
 
     public function __construct(
         public string $label,
         public Closure $search,
+        public ?string $default = null,
     ) {
     }
 
-    public function render(Console $console): string
+    public function render(Console $console): ?string
     {
+        if (! $console->supportsPrompting()) {
+            return $this->default;
+        }
+
         $answer = null;
 
         while ($answer === null) {
@@ -27,13 +33,17 @@ final readonly class StaticSearchComponent implements StaticConsoleComponent
 
             $options = ($this->search)($query);
 
-            $options = [self::SEARCH_AGAIN, ...$options];
+            $options = [self::SEARCH_AGAIN, ...(count($options) === 0 ? [self::CANCEL] : []), ...$options];
 
             $answer = $console->ask(
                 question: 'Please select a result',
                 options: $options,
                 asList: true,
             );
+
+            if ($answer === self::CANCEL) {
+                return $this->default;
+            }
 
             if ($answer === self::SEARCH_AGAIN) {
                 $answer = null;

--- a/src/Tempest/Console/src/Components/Static/StaticSearchComponent.php
+++ b/src/Tempest/Console/src/Components/Static/StaticSearchComponent.php
@@ -11,6 +11,7 @@ use Tempest\Console\StaticConsoleComponent;
 final readonly class StaticSearchComponent implements StaticConsoleComponent
 {
     private const string SEARCH_AGAIN = 'Search again';
+
     private const string CANCEL = 'Cancel';
 
     public function __construct(

--- a/src/Tempest/Console/src/Components/Static/StaticSingleChoiceComponent.php
+++ b/src/Tempest/Console/src/Components/Static/StaticSingleChoiceComponent.php
@@ -17,8 +17,12 @@ final readonly class StaticSingleChoiceComponent implements StaticConsoleCompone
     ) {
     }
 
-    public function render(Console $console): string
+    public function render(Console $console): ?string
     {
+        if (! $console->supportsPrompting()) {
+            return $this->default;
+        }
+
         $console->write("<h2>{$this->question}</h2> ");
 
         $parsedOptions = [];

--- a/src/Tempest/Console/src/Components/Static/StaticTextBoxComponent.php
+++ b/src/Tempest/Console/src/Components/Static/StaticTextBoxComponent.php
@@ -11,13 +11,18 @@ final readonly class StaticTextBoxComponent implements StaticConsoleComponent
 {
     public function __construct(
         public string $label,
+        public ?string $default = null,
     ) {
     }
 
-    public function render(Console $console): string
+    public function render(Console $console): ?string
     {
+        if (! $console->supportsPrompting()) {
+            return $this->default;
+        }
+
         $console->write("<question>{$this->label}</question> ");
 
-        return trim($console->readln());
+        return trim($console->readln()) ?: $this->default;
     }
 }

--- a/src/Tempest/Console/src/Console.php
+++ b/src/Tempest/Console/src/Console.php
@@ -34,7 +34,7 @@ interface Console
         bool $multiple = false,
         bool $asList = false,
         array $validation = [],
-    ): string|array;
+    ): null|string|array;
 
     public function confirm(string $question, bool $default = false): bool;
 
@@ -56,4 +56,12 @@ interface Console
     public function when(mixed $expression, callable $callback): self;
 
     public function withLabel(string $label): self;
+
+    public function supportsTty(): bool;
+
+    public function supportsPrompting(): bool;
+
+    public function disableTty(): self;
+
+    public function disablePrompting(): self;
 }

--- a/src/Tempest/Console/src/Console.php
+++ b/src/Tempest/Console/src/Console.php
@@ -45,7 +45,7 @@ interface Console
     /**
      * @param Closure(string $search): array $search
      */
-    public function search(string $label, Closure $search): mixed;
+    public function search(string $label, Closure $search, ?string $default = null): mixed;
 
     public function info(string $line): self;
 

--- a/src/Tempest/Console/src/GenericConsole.php
+++ b/src/Tempest/Console/src/GenericConsole.php
@@ -16,6 +16,7 @@ use Tempest\Console\Components\Interactive\TextBoxComponent;
 use Tempest\Console\Components\InteractiveComponentRenderer;
 use Tempest\Console\Exceptions\UnsupportedComponent;
 use Tempest\Console\Highlight\TempestConsoleLanguage\TempestConsoleLanguage;
+use Tempest\Console\Input\ConsoleArgumentBag;
 use Tempest\Container\Tag;
 use Tempest\Highlight\Highlighter;
 
@@ -25,6 +26,10 @@ final class GenericConsole implements Console
 
     private bool $isForced = false;
 
+    private bool $supportsTty = true;
+
+    private bool $supportsPrompting = true;
+
     private ?InteractiveComponentRenderer $componentRenderer = null;
 
     public function __construct(
@@ -33,6 +38,7 @@ final class GenericConsole implements Console
         #[Tag('console')]
         private readonly Highlighter $highlighter,
         private readonly ExecuteConsoleCommand $executeConsoleCommand,
+        private readonly ConsoleArgumentBag $argumentBag
     ) {
     }
 
@@ -55,13 +61,35 @@ final class GenericConsole implements Console
         return $this;
     }
 
+    public function disableTty(): self
+    {
+        $this->supportsTty = false;
+
+        return $this;
+    }
+
+    public function disablePrompting(): self
+    {
+        $this->supportsPrompting = false;
+
+        return $this;
+    }
+
     public function read(int $bytes): string
     {
+        if (! $this->supportsPrompting()) {
+            return '';
+        }
+
         return $this->input->read($bytes);
     }
 
     public function readln(): string
     {
+        if (! $this->supportsPrompting()) {
+            return '';
+        }
+
         return $this->input->readln();
     }
 
@@ -124,7 +152,7 @@ final class GenericConsole implements Console
 
     public function component(InteractiveConsoleComponent $component, array $validation = []): mixed
     {
-        if ($this->interactiveSupported()) {
+        if ($this->supportsTty()) {
             return $this->componentRenderer->render($this, $component, $validation);
         }
 
@@ -142,13 +170,14 @@ final class GenericConsole implements Console
         bool $multiple = false,
         bool $asList = false,
         array $validation = [],
-    ): string|array {
+    ): null|string|array {
         if ($options === null || $options === []) {
             $component = new TextBoxComponent($question, $default);
         } elseif ($multiple) {
             $component = new MultipleChoiceComponent(
                 question: $question,
                 options: $options,
+                default: is_array($default) ? $default : [$default],
             );
         } else {
             $component = new SingleChoiceComponent(
@@ -202,12 +231,33 @@ final class GenericConsole implements Console
         return $this->component(new SearchComponent($label, $search));
     }
 
-    private function interactiveSupported(): bool
+    public function supportsTty(): bool
     {
+        if ($this->supportsTty === false) {
+            return false;
+        }
+
         if ($this->componentRenderer === null) {
             return false;
         }
 
+        if (! $this->supportsPrompting()) {
+            return false;
+        }
+
         return (bool) shell_exec('which tput && which stty');
+    }
+
+    public function supportsPrompting(): bool
+    {
+        if ($this->supportsPrompting === false) {
+            return false;
+        }
+
+        if ($this->argumentBag->get('interaction')?->value === false) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Tempest/Console/src/GenericConsole.php
+++ b/src/Tempest/Console/src/GenericConsole.php
@@ -226,9 +226,9 @@ final class GenericConsole implements Console
         return $this->component(new ProgressBarComponent($data, $handler));
     }
 
-    public function search(string $label, Closure $search): mixed
+    public function search(string $label, Closure $search, ?string $default = null): mixed
     {
-        return $this->component(new SearchComponent($label, $search));
+        return $this->component(new SearchComponent($label, $search, $default));
     }
 
     public function supportsTty(): bool

--- a/src/Tempest/Console/src/Initializers/ConsoleInitializer.php
+++ b/src/Tempest/Console/src/Initializers/ConsoleInitializer.php
@@ -40,6 +40,7 @@ final class ConsoleInitializer implements Initializer
             input: new UnsupportedInputBuffer(),
             highlighter: $container->get(Highlighter::class, tag: 'console'),
             executeConsoleCommand: $container->get(ExecuteConsoleCommand::class),
+            argumentBag: $container->get(ConsoleArgumentBag::class),
         );
     }
 
@@ -50,6 +51,7 @@ final class ConsoleInitializer implements Initializer
             input: $container->get(StdinInputBuffer::class),
             highlighter: $container->get(Highlighter::class, tag: 'console'),
             executeConsoleCommand: $container->get(ExecuteConsoleCommand::class),
+            argumentBag: $container->get(ConsoleArgumentBag::class),
         ))->setComponentRenderer($container->get(InteractiveComponentRenderer::class));
     }
 }

--- a/src/Tempest/Console/src/Input/MemoryInputBuffer.php
+++ b/src/Tempest/Console/src/Input/MemoryInputBuffer.php
@@ -27,7 +27,7 @@ final class MemoryInputBuffer implements InputBuffer
                 : (string) $line;
         }
 
-        $this->fiber->resume();
+        $this->fiber?->resume();
     }
 
     public function read(int $bytes): string

--- a/src/Tempest/Console/src/Testing/ConsoleTester.php
+++ b/src/Tempest/Console/src/Testing/ConsoleTester.php
@@ -296,7 +296,7 @@ final class ConsoleTester
 
     public function dd(): self
     {
-        dd($this->output->asFormattedString());
+        ld($this->output->asFormattedString());
 
         return $this;
     }

--- a/src/Tempest/Console/src/Testing/ConsoleTester.php
+++ b/src/Tempest/Console/src/Testing/ConsoleTester.php
@@ -36,6 +36,8 @@ final class ConsoleTester
 
     private ?ExitCode $exitCode = null;
 
+    private bool $withPrompting = true;
+
     public function __construct(
         private readonly Container $container,
     ) {
@@ -56,7 +58,12 @@ final class ConsoleTester
             input: $memoryInputBuffer,
             highlighter: $clone->container->get(Highlighter::class, 'console'),
             executeConsoleCommand: $clone->container->get(ExecuteConsoleCommand::class),
+            argumentBag: $clone->container->get(ConsoleArgumentBag::class),
         );
+
+        if ($this->withPrompting === false) {
+            $console->disablePrompting();
+        }
 
         if ($this->componentRenderer !== null) {
             $console->setComponentRenderer($this->componentRenderer);
@@ -269,6 +276,27 @@ final class ConsoleTester
     public function assertInvalid(): self
     {
         $this->assertExitCode(ExitCode::INVALID);
+
+        return $this;
+    }
+
+    public function withoutPrompting(): self
+    {
+        $this->withPrompting = false;
+
+        return $this;
+    }
+
+    public function withPrompting(): self
+    {
+        $this->withPrompting = true;
+
+        return $this;
+    }
+
+    public function dd(): self
+    {
+        dd($this->output->asFormattedString());
 
         return $this;
     }

--- a/tests/Integration/Console/Components/MultipleChoiceComponentTest.php
+++ b/tests/Integration/Console/Components/MultipleChoiceComponentTest.php
@@ -98,4 +98,22 @@ final class MultipleChoiceComponentTest extends TestCase
             'bar' => '2. Bar',
         ], $component->enter());
     }
+
+    public function test_supports_defaults(): void
+    {
+        $component = new MultipleChoiceComponent(
+            question: 'whatever',
+            options: [
+                'foo' => '1. Foo',
+                'bar' => '2. Bar',
+                'baz' => '3. Baz',
+            ],
+            default: ['foo', 'baz']
+        );
+
+        $this->assertSame([
+            'foo' => '1. Foo',
+            'baz' => '3. Baz',
+        ], $component->enter());
+    }
 }

--- a/tests/Integration/Console/Components/SearchComponentTest.php
+++ b/tests/Integration/Console/Components/SearchComponentTest.php
@@ -92,6 +92,15 @@ final class SearchComponentTest extends FrameworkIntegrationTestCase
         $this->assertSame('Paul', $result);
     }
 
+    public function test_supports_default_value(): void
+    {
+        $component = new SearchComponent('Search', $this->search(...));
+        $this->assertSame(null, $component->enter());
+
+        $component = new SearchComponent('Search', $this->search(...), default: 'foo');
+        $this->assertSame('foo', $component->enter());
+    }
+
     public function search(string $query): array
     {
         if ($query === '') {

--- a/tests/Integration/Console/Components/Static/StaticConfirmComponentTest.php
+++ b/tests/Integration/Console/Components/Static/StaticConfirmComponentTest.php
@@ -68,4 +68,18 @@ final class StaticConfirmComponentTest extends FrameworkIntegrationTestCase
             ->input(Key::ENTER)
             ->assertContains('not continued');
     }
+
+    public function test_with_default_without_prompting(): void
+    {
+        $this->console
+            ->withoutPrompting()
+            ->call(function (Console $console): void {
+                if ($console->confirm('continue', default: true)) {
+                    $console->writeln('continued');
+                } else {
+                    $console->writeln('not continued');
+                }
+            })
+            ->assertContains('continued');
+    }
 }

--- a/tests/Integration/Console/Components/Static/StaticMultipleChoiceComponentTest.php
+++ b/tests/Integration/Console/Components/Static/StaticMultipleChoiceComponentTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Console\Components\Static;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use Tempest\Console\Console;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
@@ -48,5 +49,43 @@ final class StaticMultipleChoiceComponentTest extends FrameworkIntegrationTestCa
             ->assertContains('You picked a, b;')
             ->submit('yes')
             ->assertContains('["a","b"]');
+    }
+
+    #[TestWith([['a', 'b', 'c'], ['b', 'k'], ['b']])]
+    #[TestWith([['foo' => 'foo1', 'bar' => 'bar2'], ['foo', 'baz'], ['foo']])]
+    #[TestWith([['foo' => 'foo1', 'bar' => 'bar2'], ['foo1'], []])]
+    public function test_supports_defaults_without_prompting(array $options, array $default, array $expected): void
+    {
+        $this->console
+            ->withoutPrompting()
+            ->call(function (Console $console) use ($options, $default): void {
+                $answer = $console->ask(
+                    question: 'test',
+                    options: $options,
+                    default: $default,
+                    multiple: true
+                );
+
+                $console->writeln(json_encode($answer));
+            })
+            ->assertContains(json_encode($expected));
+    }
+
+    public function test_supports_defaults_with_prompting(): void
+    {
+        $this->console
+            ->call(function (Console $console): void {
+                $answer = $console->ask(
+                    question: 'test',
+                    options: ['foo', 'bar'],
+                    default: ['foo'],
+                    multiple: true
+                );
+
+                $console->writeln(json_encode($answer));
+            })
+            ->submit()
+            ->submit()
+            ->assertContains(json_encode([])); // defaults are not compatible with no-tty-prompting
     }
 }

--- a/tests/Integration/Console/Components/Static/StaticSearchComponentTest.php
+++ b/tests/Integration/Console/Components/Static/StaticSearchComponentTest.php
@@ -46,11 +46,89 @@ TXT,
             ->assertContains("Hello Brent");
     }
 
-    private function search(string $query): array
+    public function test_no_answer(): void
+    {
+        $this->console
+            ->call(function (Console $console): void {
+                $result = $console->search(
+                    label: 'Search',
+                    search: $this->search(...),
+                );
+
+                $console->write($result ?? '<no answer>');
+            })
+            ->submit()
+            ->assertContains(
+                text: <<<TXT
+                - [0] Search again
+                - [1] Cancel
+                TXT,
+                ignoreLineEndings: true
+            )
+            ->submit(1)
+            ->assertContains('<no answer>');
+    }
+
+    public function test_default_answer(): void
+    {
+        $this->console
+            ->call(function (Console $console): void {
+                $result = $console->search(
+                    label: 'Search',
+                    search: $this->search(...),
+                    default: 'foo'
+                );
+
+                $console->write($result);
+            })
+            ->submit()
+            ->assertContains(
+                text: <<<TXT
+                - [0] Search again
+                - [1] Cancel
+                TXT,
+                ignoreLineEndings: true
+            )
+            ->submit(1)
+            ->assertContains('foo');
+    }
+
+    public function test_without_prompting(): void
+    {
+        $this->console
+            ->withoutPrompting()
+            ->call(function (Console $console): void {
+                $result = $console->search(
+                    label: 'Search',
+                    search: $this->search(...),
+                );
+
+                $console->write($result ?? '<no answer>');
+            })
+            ->assertContains('<no answer>');
+    }
+
+    public function test_default_answer_without_prompting(): void
+    {
+        $this->console
+            ->withoutPrompting()
+            ->call(function (Console $console): void {
+                $result = $console->search(
+                    label: 'Search',
+                    search: $this->search(...),
+                    default: 'foo'
+                );
+
+                $console->write($result);
+            })
+            ->assertContains('foo');
+    }
+
+    private function search(?string $query): array
     {
         $data = ['Brent', 'Paul', 'Aidan', 'Roman'];
 
-        if ($query === '') {
+        if (! $query) {
             return [];
         }
 

--- a/tests/Integration/Console/Components/Static/StaticSingleChoiceComponentTest.php
+++ b/tests/Integration/Console/Components/Static/StaticSingleChoiceComponentTest.php
@@ -62,4 +62,16 @@ final class StaticSingleChoiceComponentTest extends FrameworkIntegrationTestCase
             ->input(Key::ENTER)
             ->assertContains('picked b');
     }
+
+    public function test_with_default_option_without_prompting(): void
+    {
+        $this->console
+            ->withoutPrompting()
+            ->call(function (Console $console): void {
+                $answer = $console->ask('test', ['a', 'b'], default: 'b');
+
+                $console->writeln("picked {$answer}");
+            })
+            ->assertContains('picked b');
+    }
 }

--- a/tests/Integration/Console/Components/Static/StaticTextBoxComponentTest.php
+++ b/tests/Integration/Console/Components/Static/StaticTextBoxComponentTest.php
@@ -23,4 +23,28 @@ final class StaticTextBoxComponentTest extends FrameworkIntegrationTestCase
             ->submit('Brent')
             ->assertContains("Hello Brent");
     }
+
+    public function test_supports_default(): void
+    {
+        $this->console
+            ->call(function (Console $console): void {
+                $name = $console->ask('test', default: 'Brent');
+
+                $console->writeln("Hello {$name}");
+            })
+            ->submit()
+            ->assertContains("Hello Brent");
+    }
+
+    public function test_supports_default_without_prompting(): void
+    {
+        $this->console
+            ->withoutPrompting()
+            ->call(function (Console $console): void {
+                $name = $console->ask('test', default: 'Brent');
+
+                $console->writeln("Hello {$name}");
+            })
+            ->assertContains("Hello Brent");
+    }
 }

--- a/tests/Integration/Console/RenderConsoleCommandTest.php
+++ b/tests/Integration/Console/RenderConsoleCommandTest.php
@@ -10,6 +10,7 @@ use Tempest\Console\Actions\RenderConsoleCommand;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\GenericConsole;
 use Tempest\Console\Highlight\TextTerminalTheme;
+use Tempest\Console\Input\ConsoleArgumentBag;
 use Tempest\Console\Input\UnsupportedInputBuffer;
 use Tempest\Console\Output\MemoryOutputBuffer;
 use Tempest\Highlight\Highlighter;
@@ -38,7 +39,8 @@ final class RenderConsoleCommandTest extends FrameworkIntegrationTestCase
             output: $output,
             input: new UnsupportedInputBuffer(),
             highlighter: $highlighter,
-            executeConsoleCommand: $this->container->get(ExecuteConsoleCommand::class)
+            executeConsoleCommand: $this->container->get(ExecuteConsoleCommand::class),
+            argumentBag: $this->container->get(ConsoleArgumentBag::class),
         );
 
         (new RenderConsoleCommand($console))($consoleCommand);


### PR DESCRIPTION
This pull request implements a "no prompt" mode. This mode can be enabled by passing the `--no-interaction` flag to any command.

That mode disables all user interactions with the console. Instead, default values will be used when provided, otherwise `null` or empty arrays will be returned by input components.

To support this mode, some components and their static version needed a new `default` option, which this pull request includes.

Additional changes:
- The `Console` interface has a new `disablePrompting` and `disableTty` method to, well, disable prompting and TTY programmatically.
- The `interactiveSupported` is renamed to `supportsTty`, and `supportsPrompting` has been added. Both have been added to the interface and made public.
- The `ConsoleTester` class has a new `withoutPrompting` method to ease testing.
- I also added a `dd` method to `ConsoleTester`, which is quite unrelated but I always try to reach for it.