### PR TITLE
fix: rector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "phpbench/phpbench": "84.x-dev",
         "phpstan/phpstan": "^1.10.0",
         "phpunit/phpunit": "^11.3.5",
-        "rector/rector": "^1.2",
+        "rector/rector": "1.2.8",
         "spatie/phpunit-snapshot-assertions": "^5.1.6",
         "spaze/phpstan-disallowed-calls": "^3.1",
         "symplify/monorepo-builder": "^11.2"


### PR DESCRIPTION
1.2.9 has a problem where it removes doc blocks that should not be removed