### PR TITLE
fix(support): support calling `first` and `last` on empty `ArrayHelper`

### DIFF
--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -409,6 +409,10 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      */
     public function last(?Closure $filter = null): mixed
     {
+        if ($this->array === []) {
+            return null;
+        }
+
         if ($filter === null) {
             return $this->array[array_key_last($this->array)];
         }

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -384,6 +384,10 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      */
     public function first(?Closure $filter = null): mixed
     {
+        if ($this->array === []) {
+            return null;
+        }
+
         if ($filter === null) {
             return $this->array[array_key_first($this->array)];
         }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -184,6 +184,7 @@ final class ArrayHelperTest extends TestCase
     public function test_first(): void
     {
         $this->assertSame('a', arr(['a', 'b', 'c'])->first());
+        $this->assertSame(null, arr()->first());
     }
 
     public function test_is_empty(): void

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -178,6 +178,7 @@ final class ArrayHelperTest extends TestCase
 
     public function test_last(): void
     {
+        $this->assertSame(null, arr()->last());
         $this->assertSame('c', arr(['a', 'b', 'c'])->last());
     }
 


### PR DESCRIPTION
Fixes #684

This pull request fixes exceptions thrown when calling `first` and `last` on an empty `ArrayHelper` instance.

```php
arr()->first(); // null
arr()->last(); // null
```