### PR TITLE
feat(support): support not specifying a value to `ArrayHelper::pop` and `ArrayHelper::unshift`

### DIFF
--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -423,7 +423,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      *
      * @param mixed $value The popped value will be stored in this variable
      */
-    public function pop(mixed &$value): self
+    public function pop(mixed &$value = null): self
     {
         $value = $this->last();
 
@@ -435,7 +435,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      *
      * @param mixed $value The unshifted value will be stored in this variable
      */
-    public function unshift(mixed &$value): self
+    public function unshift(mixed &$value = null): self
     {
         $value = $this->first();
 

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -166,6 +166,12 @@ final class ArrayHelperTest extends TestCase
 
         $this->assertSame('c', $value);
         $this->assertTrue($array->equals(['a', 'b']));
+
+        $this->assertTrue(arr(['a', 'b', 'c'])->pop()->equals(['a', 'b']));
+        $this->assertTrue(arr()->pop()->isEmpty());
+
+        arr()->pop($value);
+        $this->assertNull($value);
     }
 
     public function test_unshift(): void
@@ -174,6 +180,12 @@ final class ArrayHelperTest extends TestCase
 
         $this->assertSame('a', $value);
         $this->assertTrue($array->equals(['b', 'c']));
+
+        $this->assertTrue(arr(['a', 'b', 'c'])->unshift()->equals(['b', 'c']));
+        $this->assertTrue(arr()->unshift()->isEmpty());
+
+        arr()->unshift($value);
+        $this->assertNull($value);
     }
 
     public function test_last(): void


### PR DESCRIPTION
This pull request adds support for not specifying a value to `pop` and `unshift`.

```php
arr([1, 2, 3])->pop(); // [1, 2]
arr([1, 2, 3])->unshift(); // [2, 3]
```