### PR TITLE
feat(console): support dynamic style injections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,6 +117,7 @@
             "Tempest\\Cache\\Tests\\": "src/Tempest/Cache/tests",
             "Tempest\\Clock\\Tests\\": "src/Tempest/Clock/tests",
             "Tempest\\CommandBus\\Tests\\": "src/Tempest/CommandBus/tests",
+            "Tempest\\Console\\Tests\\": "src/Tempest/Console/tests",
             "Tempest\\Container\\Tests\\": "src/Tempest/Container/tests",
             "Tempest\\Core\\Tests\\": "src/Tempest/Core/tests",
             "Tempest\\Database\\Tests\\": "src/Tempest/Database/tests",

--- a/src/Tempest/Console/composer.json
+++ b/src/Tempest/Console/composer.json
@@ -21,6 +21,11 @@
             "Tempest\\Console\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tempest\\Console\\Tests\\": "tests"
+        }
+    },
     "bin": [
         "bin/tempest"
     ]

--- a/src/Tempest/Console/src/Highlight/DynamicTokenType.php
+++ b/src/Tempest/Console/src/Highlight/DynamicTokenType.php
@@ -11,30 +11,22 @@ use function Tempest\Support\str;
 final readonly class DynamicTokenType implements TokenType
 {
     public function __construct(
-        private string $tag,
-        private string $mod,
+        private string $style,
     ) {
     }
 
     public function getStyle(): TerminalStyle
     {
+        $normalizedStyle = str($this->style)
+            ->lower()
+            ->replace(['_', '-'], '');
+
         foreach (TerminalStyle::cases() as $case) {
-            $styleName = str($case->name)->lower();
+            $normalizedCase = str($case->name)
+                ->lower()
+                ->replace(['_', '-'], '');
 
-            if ($this->tag === 'mod' && $styleName->replace('_', '')->equals($this->mod)) {
-                return $case;
-            }
-
-            if (! $styleName->startsWith("{$this->tag}_")) {
-                continue;
-            }
-
-            $mod = $styleName
-                ->replaceStart('fg_', '')
-                ->replaceStart('bg_', '')
-                ->replace('_', '');
-
-            if ($mod->equals($this->mod)) {
+            if ($normalizedCase->equals($normalizedStyle)) {
                 return $case;
             }
         }

--- a/src/Tempest/Console/src/Highlight/DynamicTokenType.php
+++ b/src/Tempest/Console/src/Highlight/DynamicTokenType.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Highlight;
+
+use Tempest\Highlight\Themes\TerminalStyle;
+use Tempest\Highlight\Tokens\TokenType;
+use function Tempest\Support\str;
+
+final readonly class DynamicTokenType implements TokenType
+{
+    public function __construct(
+        private string $tag,
+        private string $mod,
+    ) {
+    }
+
+    public function getStyle(): TerminalStyle
+    {
+        foreach (TerminalStyle::cases() as $case) {
+            $styleName = str($case->name)->lower();
+
+            if ($this->tag === 'mod' && $styleName->equals($this->mod)) {
+                return $case;
+            }
+
+            if (! $styleName->startsWith("{$this->tag}_")) {
+                continue;
+            }
+
+            $mod = $styleName
+                ->replaceStart('fg_', '')
+                ->replaceStart('bg_', '')
+                ->replace('_', '');
+
+            if ($mod->equals($this->mod)) {
+                return $case;
+            }
+        }
+
+        return TerminalStyle::RESET;
+    }
+
+    public function getValue(): string
+    {
+        return '';
+    }
+
+    public function canContain(TokenType $other): bool
+    {
+        return false;
+    }
+}

--- a/src/Tempest/Console/src/Highlight/DynamicTokenType.php
+++ b/src/Tempest/Console/src/Highlight/DynamicTokenType.php
@@ -21,7 +21,7 @@ final readonly class DynamicTokenType implements TokenType
         foreach (TerminalStyle::cases() as $case) {
             $styleName = str($case->name)->lower();
 
-            if ($this->tag === 'mod' && $styleName->equals($this->mod)) {
+            if ($this->tag === 'mod' && $styleName->replace('_', '')->equals($this->mod)) {
                 return $case;
             }
 

--- a/src/Tempest/Console/src/Highlight/TempestConsoleLanguage/Injections/DynamicInjection.php
+++ b/src/Tempest/Console/src/Highlight/TempestConsoleLanguage/Injections/DynamicInjection.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Highlight\TempestConsoleLanguage\Injections;
+
+use Tempest\Console\Highlight\ConsoleTokenType;
+use Tempest\Console\Highlight\DynamicTokenType;
+use Tempest\Highlight\Highlighter;
+use Tempest\Highlight\Injection;
+use Tempest\Highlight\ParsedInjection;
+
+final readonly class DynamicInjection implements Injection
+{
+    public function getTokenType(): ConsoleTokenType
+    {
+        return ConsoleTokenType::COMMENT;
+    }
+
+    public function parse(string $content, Highlighter $highlighter): ParsedInjection
+    {
+        $pattern = '/(?<match>\<(?<tag>mod|fg|bg)=(?<mod>[a-zA-Z]+)\>(.|\n)*?\<\/\k<tag>\>)/';
+
+        $result = preg_replace_callback(
+            pattern: $pattern,
+            callback: function ($matches) use ($highlighter, $pattern) {
+                $content = $matches['match'] ?? '';
+
+                if (! $content) {
+                    return $matches[0];
+                }
+
+                $tag = $matches['tag'];
+                $mod = $matches['mod'];
+                $token = new DynamicTokenType($tag, $mod);
+                $theme = $highlighter->getTheme();
+
+                $result = str_replace(
+                    search: $content,
+                    replace: str_replace(
+                        search: ["<{$tag}={$mod}>", "</{$tag}>"],
+                        replace: [$theme->before($token), $theme->after($token)],
+                        subject: $content
+                    ),
+                    subject: $matches[0],
+                );
+
+                if (preg_match($pattern, $result)) {
+                    return $this->parse($result, $highlighter)->content;
+                }
+
+                return $result;
+            },
+            subject: $content,
+        );
+
+        return new ParsedInjection($result ?? $content);
+    }
+}

--- a/src/Tempest/Console/src/Highlight/TempestConsoleLanguage/Injections/DynamicInjection.php
+++ b/src/Tempest/Console/src/Highlight/TempestConsoleLanguage/Injections/DynamicInjection.php
@@ -24,12 +24,7 @@ final readonly class DynamicInjection implements Injection
         $result = preg_replace_callback(
             pattern: $pattern,
             callback: function ($matches) use ($highlighter, $pattern) {
-                $content = $matches['match'] ?? '';
-
-                if (! $content) {
-                    return $matches[0];
-                }
-
+                $content = $matches['match'];
                 $tag = $matches['tag'];
                 $mod = $matches['mod'];
                 $token = new DynamicTokenType($tag, $mod);

--- a/src/Tempest/Console/src/Highlight/TempestConsoleLanguage/TempestConsoleLanguage.php
+++ b/src/Tempest/Console/src/Highlight/TempestConsoleLanguage/TempestConsoleLanguage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Console\Highlight\TempestConsoleLanguage;
 
 use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\CommentInjection;
+use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\DynamicInjection;
 use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\EmphasizeInjection;
 use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\ErrorInjection;
 use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\H1Injection;
@@ -39,6 +40,7 @@ final readonly class TempestConsoleLanguage implements Language
             new H1Injection(),
             new H2Injection(),
             new SuccessInjection(),
+            new DynamicInjection(),
         ];
     }
 

--- a/src/Tempest/Console/src/Highlight/TempestTerminalTheme.php
+++ b/src/Tempest/Console/src/Highlight/TempestTerminalTheme.php
@@ -16,6 +16,10 @@ final readonly class TempestTerminalTheme implements TerminalTheme
 
     public function before(TokenType $tokenType): string
     {
+        if ($tokenType instanceof DynamicTokenType) {
+            return $this->style($tokenType->getStyle());
+        }
+
         return match ($tokenType) {
             TokenTypeEnum::KEYWORD => $this->style(TerminalStyle::FG_DARK_BLUE),
             TokenTypeEnum::PROPERTY => $this->style(TerminalStyle::FG_DARK_GREEN),

--- a/src/Tempest/Console/tests/TempestConsoleLanguage/Injections/DynamicInjectionTest.php
+++ b/src/Tempest/Console/tests/TempestConsoleLanguage/Injections/DynamicInjectionTest.php
@@ -23,6 +23,7 @@ final class DynamicInjectionTest extends TestCase
     #[TestWith(['<mod=bold>foo</mod>', "\e[1mfoo\e[0m"])]
     #[TestWith(['<mod=underline>foo</mod>', "\e[4mfoo\e[0m"])]
     #[TestWith(['<mod=reset>foo</mod>', "\e[0mfoo\e[0m"])]
+    #[TestWith(['<mod=reversetext>foo</mod>', "\e[7mfoo\e[0m"])]
     #[TestWith(['<bg=darkcyan><fg=cyan><mod=underline>Tempest</mod></fg></bg>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
     #[Test]
     public function language(string $content, string $expected): void

--- a/src/Tempest/Console/tests/TempestConsoleLanguage/Injections/DynamicInjectionTest.php
+++ b/src/Tempest/Console/tests/TempestConsoleLanguage/Injections/DynamicInjectionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Tests\TempestConsoleLanguage\Injections;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\DynamicInjection;
+use Tempest\Console\Highlight\TempestTerminalTheme;
+use Tempest\Highlight\Highlighter;
+
+/**
+ * @internal
+ */
+final class DynamicInjectionTest extends TestCase
+{
+    #[TestWith(['<fg=cyan>foo</fg>', "\e[96mfoo\e[0m"])]
+    #[TestWith(['<fg=darkcyan>foo</fg>', "\e[36mfoo\e[0m"])]
+    #[TestWith(['<bg=red>foo</bg>', "\e[101mfoo\e[0m"])]
+    #[TestWith(['<bg=darkred>foo</bg>', "\e[41mfoo\e[0m"])]
+    #[TestWith(['<mod=bold>foo</mod>', "\e[1mfoo\e[0m"])]
+    #[TestWith(['<mod=underline>foo</mod>', "\e[4mfoo\e[0m"])]
+    #[TestWith(['<mod=reset>foo</mod>', "\e[0mfoo\e[0m"])]
+    #[TestWith(['<bg=darkcyan><fg=cyan><mod=underline>Tempest</mod></fg></bg>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
+    #[Test]
+    public function language(string $content, string $expected): void
+    {
+        $highlighter = new Highlighter(new TempestTerminalTheme());
+
+        $this->assertSame(
+            $expected,
+            (new DynamicInjection())->parse($content, $highlighter)->content,
+        );
+    }
+}

--- a/src/Tempest/Console/tests/TempestConsoleLanguage/Injections/DynamicInjectionTest.php
+++ b/src/Tempest/Console/tests/TempestConsoleLanguage/Injections/DynamicInjectionTest.php
@@ -16,15 +16,15 @@ use Tempest\Highlight\Highlighter;
  */
 final class DynamicInjectionTest extends TestCase
 {
-    #[TestWith(['<fg=cyan>foo</fg>', "\e[96mfoo\e[0m"])]
-    #[TestWith(['<fg=darkcyan>foo</fg>', "\e[36mfoo\e[0m"])]
-    #[TestWith(['<bg=red>foo</bg>', "\e[101mfoo\e[0m"])]
-    #[TestWith(['<bg=darkred>foo</bg>', "\e[41mfoo\e[0m"])]
-    #[TestWith(['<mod=bold>foo</mod>', "\e[1mfoo\e[0m"])]
-    #[TestWith(['<mod=underline>foo</mod>', "\e[4mfoo\e[0m"])]
-    #[TestWith(['<mod=reset>foo</mod>', "\e[0mfoo\e[0m"])]
-    #[TestWith(['<mod=reversetext>foo</mod>', "\e[7mfoo\e[0m"])]
-    #[TestWith(['<bg=darkcyan><fg=cyan><mod=underline>Tempest</mod></fg></bg>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
+    #[TestWith(['<style="fg-cyan">foo</style>', "\e[96mfoo\e[0m"])]
+    #[TestWith(['<style="bg-red">foo</style>', "\e[101mfoo\e[0m"])]
+    #[TestWith(['<style="bold">foo</style>', "\e[1mfoo\e[0m"])]
+    #[TestWith(['<style="underline">foo</style>', "\e[4mfoo\e[0m"])]
+    #[TestWith(['<style="reset">foo</style>', "\e[0mfoo\e[0m"])]
+    #[TestWith(['<style="reverse-text">foo</style>', "\e[7mfoo\e[0m"])]
+    #[TestWith(['<style="bg-darkcyan fg-cyan underline">Tempest</style>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
+    #[TestWith(['<style="bg-dark-cyan fg-cyan underline">Tempest</style>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
+    #[TestWith(['<style="fg-cyan"><style="bg-dark-red">foo</style></style>', "\e[96m\e[41mfoo\e[0m\e[0m"])]
     #[Test]
     public function language(string $content, string $expected): void
     {

--- a/tests/Integration/Console/Highlight/TempestConsoleLanguage/TempestConsoleLanguageTest.php
+++ b/tests/Integration/Console/Highlight/TempestConsoleLanguage/TempestConsoleLanguageTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Console\Highlight\LogLanguage;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Tempest\Console\Highlight\TempestConsoleLanguage\TempestConsoleLanguage;
+use Tempest\Console\Highlight\TempestTerminalTheme;
+use Tempest\Highlight\Highlighter;
+
+/**
+ * @internal
+ */
+final class TempestConsoleLanguageTest extends TestCase
+{
+    #[TestWith(['<fg=cyan>foo</fg>', "\e[96mfoo\e[0m"])]
+    #[TestWith(['<fg=darkcyan>foo</fg>', "\e[36mfoo\e[0m"])]
+    #[TestWith(['<bg=red>foo</bg>', "\e[101mfoo\e[0m"])]
+    #[TestWith(['<bg=darkred>foo</bg>', "\e[41mfoo\e[0m"])]
+    #[TestWith(['<mod=bold>foo</mod>', "\e[1mfoo\e[0m"])]
+    #[TestWith(['<mod=underline>foo</mod>', "\e[4mfoo\e[0m"])]
+    #[TestWith(['<mod=reset>foo</mod>', "\e[0mfoo\e[0m"])]
+    #[TestWith(['<bg=darkcyan><fg=cyan><mod=underline>Tempest</mod></fg></bg>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
+    #[Test]
+    public function language(string $content, string $expected): void
+    {
+        $highlighter = new Highlighter(new TempestTerminalTheme());
+
+        $this->assertSame(
+            $expected,
+            $highlighter->parse($content, new TempestConsoleLanguage())
+        );
+    }
+}

--- a/tests/Integration/Console/Highlight/TempestConsoleLanguage/TempestConsoleLanguageTest.php
+++ b/tests/Integration/Console/Highlight/TempestConsoleLanguage/TempestConsoleLanguageTest.php
@@ -16,15 +16,15 @@ use Tempest\Highlight\Highlighter;
  */
 final class TempestConsoleLanguageTest extends TestCase
 {
-    #[TestWith(['<fg=cyan>foo</fg>', "\e[96mfoo\e[0m"])]
-    #[TestWith(['<fg=darkcyan>foo</fg>', "\e[36mfoo\e[0m"])]
-    #[TestWith(['<bg=red>foo</bg>', "\e[101mfoo\e[0m"])]
-    #[TestWith(['<bg=darkred>foo</bg>', "\e[41mfoo\e[0m"])]
-    #[TestWith(['<mod=bold>foo</mod>', "\e[1mfoo\e[0m"])]
-    #[TestWith(['<mod=underline>foo</mod>', "\e[4mfoo\e[0m"])]
-    #[TestWith(['<mod=reset>foo</mod>', "\e[0mfoo\e[0m"])]
-    #[TestWith(['<mod=reversetext>foo</mod>', "\e[7mfoo\e[0m"])]
-    #[TestWith(['<bg=darkcyan><fg=cyan><mod=underline>Tempest</mod></fg></bg>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
+    #[TestWith(['<style="fg-cyan">foo</style>', "\e[96mfoo\e[0m"])]
+    #[TestWith(['<style="bg-red">foo</style>', "\e[101mfoo\e[0m"])]
+    #[TestWith(['<style="bold">foo</style>', "\e[1mfoo\e[0m"])]
+    #[TestWith(['<style="underline">foo</style>', "\e[4mfoo\e[0m"])]
+    #[TestWith(['<style="reset">foo</style>', "\e[0mfoo\e[0m"])]
+    #[TestWith(['<style="reverse-text">foo</style>', "\e[7mfoo\e[0m"])]
+    #[TestWith(['<style="bg-darkcyan fg-cyan underline">Tempest</style>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
+    #[TestWith(['<style="bg-dark-cyan fg-cyan underline">Tempest</style>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
+    #[TestWith(['<style="fg-cyan"><style="bg-dark-red">foo</style></style>', "\e[96m\e[41mfoo\e[0m\e[0m"])]
     #[Test]
     public function language(string $content, string $expected): void
     {

--- a/tests/Integration/Console/Highlight/TempestConsoleLanguage/TempestConsoleLanguageTest.php
+++ b/tests/Integration/Console/Highlight/TempestConsoleLanguage/TempestConsoleLanguageTest.php
@@ -23,6 +23,7 @@ final class TempestConsoleLanguageTest extends TestCase
     #[TestWith(['<mod=bold>foo</mod>', "\e[1mfoo\e[0m"])]
     #[TestWith(['<mod=underline>foo</mod>', "\e[4mfoo\e[0m"])]
     #[TestWith(['<mod=reset>foo</mod>', "\e[0mfoo\e[0m"])]
+    #[TestWith(['<mod=reversetext>foo</mod>', "\e[7mfoo\e[0m"])]
     #[TestWith(['<bg=darkcyan><fg=cyan><mod=underline>Tempest</mod></fg></bg>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
     #[Test]
     public function language(string $content, string $expected): void


### PR DESCRIPTION
This pull request adds support for dynamic style injections, responding to the need to write arbitrary styles. 

For context, I have this need in my upcoming "prompts" pull request—I am currently adding injections as I see the need for them, but I need too many colors (eg. `danger`, `warning`, `hint`, `dim`...) which don't really fit the semantic injection paradigm we have now.

Essentially, the following is now possible:

```php
$this->console->write('<style="fg-cyan bg-white underline">Tempest</style>');
```

<details>
<summary>Before edit</summary>

```php
// foreground color
$this->console->write('<fg=cyan>Tempest</fg>');
$this->console->write('<fg=darkcyan>Tempest</fg>');

// background color
$this->console->write('<bg=cyan>Tempest</bg>');
$this->console->write('<bg=darkcyan>Tempest</bg>');

// modifiers
$this->console->write('<mod=underline>Tempest</mod>');
$this->console->write('<mod=bold>Tempest</mod>');
```

</details>

This works by adding a new `DynamicInjection` injection, which will parse the tag and styles and will look for a corresponding values in the `TerminalStyle` enum from `tempest/highlight`.

See also: https://github.com/tempestphp/highlight/pull/162