### PR TITLE
feat(console): ensure `tempest serve` supports routes with file extension

### DIFF
--- a/src/Tempest/Http/src/Commands/ServeCommand.php
+++ b/src/Tempest/Http/src/Commands/ServeCommand.php
@@ -14,6 +14,8 @@ final readonly class ServeCommand
     )]
     public function __invoke(string $host = 'localhost', int $port = 8000, string $publicDir = 'public/'): void
     {
-        passthru("php -S {$host}:{$port} -t {$publicDir}");
+        putenv("TEMPEST_PUBLIC_DIR={$publicDir}");
+        $routerFile = __DIR__ . '/router.php';
+        passthru("php -S {$host}:{$port} -t {$publicDir} {$routerFile}");
     }
 }

--- a/src/Tempest/Http/src/Commands/router.php
+++ b/src/Tempest/Http/src/Commands/router.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+$publicPath = getcwd() . '/' . rtrim($_ENV['TEMPEST_PUBLIC_DIR'], '/');
+
+if (file_exists($publicPath . $_SERVER['REQUEST_URI'])) {
+    return false;
+}
+
+require_once $publicPath . '/index.php';


### PR DESCRIPTION
# What

- extends `tempest serve` with a router script to control what it will serve as static file and what will continue through tempest
- The old/current implementation doesn't allow routes with known file extensions (eg `.json`) to hit tempest  even if the file does not exist

# How to test

- Add an route `#[Get('/example/{file}')]` to a known controller
- run `tempest serve` and try accessing the route through `curl http://localhost:8000/example/my_file.json` 
  - On my branch this will work
  - On main this will result in a 404 (given that `example/my_file.json` doesn't exist)