### PR TITLE
perf(routing): replace recursion in favor of iteration

### DIFF
--- a/src/Tempest/Http/src/Routing/Construction/RoutingTree.php
+++ b/src/Tempest/Http/src/Routing/Construction/RoutingTree.php
@@ -22,10 +22,14 @@ final class RoutingTree
         $method = $markedRoute->route->method;
 
         // Find the root tree node based on HTTP method
-        $root = $this->roots[$method->value] ??= RouteTreeNode::createRootRoute();
+        $node = $this->roots[$method->value] ??= RouteTreeNode::createRootRoute();
 
-        // Add path to tree using recursion
-        $root->addPath($markedRoute->route->split(), $markedRoute);
+        // Traverse the tree and find the node for each route segment
+        foreach ($markedRoute->route->split() as $routeSegment) {
+            $node = $node->findOrCreateNodeForSegment($routeSegment);
+        }
+
+        $node->setTargetRoute($markedRoute);
     }
 
     /** @return array<string, string> */


### PR DESCRIPTION
# What

Refactor the adding of routes to the routing tree by replacing recursion with iteration.

Recursion is pretty inefficient in PHP. This relatively small refactor is roughly 10% faster

# Benchmarks

## This branch

```
+------------------------+-----------------------------------------+-----+------+-----+----------+---------+--------+
| benchmark              | subject                                 | set | revs | its | mem_peak | mode    | rstdev |
+------------------------+-----------------------------------------+-----+------+-----+----------+---------+--------+
| RouteConfiguratorBench | benchRouteConfigConstructionRouteAdding |     | 1000 | 5   | 2.100mb  | 1.016ms | ±0.32% |
+------------------------+-----------------------------------------+-----+------+-----+----------+---------+--------+

```


## Main

```
+------------------------+-----------------------------------------+-----+------+-----+----------+---------+--------+
| benchmark              | subject                                 | set | revs | its | mem_peak | mode    | rstdev |
+------------------------+-----------------------------------------+-----+------+-----+----------+---------+--------+
| RouteConfiguratorBench | benchRouteConfigConstructionRouteAdding |     | 1000 | 5   | 2.101mb  | 1.101ms | ±0.94% |
+------------------------+-----------------------------------------+-----+------+-----+----------+---------+--------+
``` 
