### PR TITLE
fix(commandbus): disallow having two `#[CommandHandler]` for the same command

### DIFF
--- a/src/Tempest/CommandBus/src/CommandBusConfig.php
+++ b/src/Tempest/CommandBus/src/CommandBusConfig.php
@@ -17,8 +17,15 @@ final class CommandBusConfig
     ) {
     }
 
+    /**
+     * @throws CommandHandlerAlreadyExists
+     */
     public function addHandler(CommandHandler $commandHandler, string $commandName, MethodReflector $handler): self
     {
+        if (array_key_exists($commandName, $this->handlers)) {
+            throw new CommandHandlerAlreadyExists($commandName, new: $handler, existing: $this->handlers[$commandName]->handler);
+        }
+
         $this->handlers[$commandName] = $commandHandler
             ->setCommandName($commandName)
             ->setHandler($handler);

--- a/src/Tempest/CommandBus/src/CommandHandlerAlreadyExists.php
+++ b/src/Tempest/CommandBus/src/CommandHandlerAlreadyExists.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\CommandBus;
+
+use Exception;
+use Tempest\Reflection\MethodReflector;
+
+final class CommandHandlerAlreadyExists extends Exception
+{
+    public function __construct(string $commandName, MethodReflector $new, MethodReflector $existing)
+    {
+        parent::__construct("Cannot add handler {$new->getShortName()}, {$existing->getShortName()} already handles {$commandName}.");
+    }
+}

--- a/src/Tempest/CommandBus/tests/Fixtures/CreateUserCommandHandler.php
+++ b/src/Tempest/CommandBus/tests/Fixtures/CreateUserCommandHandler.php
@@ -18,4 +18,10 @@ final class CreateUserCommandHandler
         $this->firstName = $command->firstName;
         $this->lastName = $command->lastName;
     }
+
+    #[CommandHandler]
+    public function double(CreateUserCommand $command): void
+    {
+        // throws a CommandHandlerAlreadyExists exception since the command is already being handled by the __invoke method
+    }
 }


### PR DESCRIPTION
Fixes #683 