### PR TITLE
feat(database): add json data type

### DIFF
--- a/src/Tempest/Database/src/Exceptions/InvalidDefaultValue.php
+++ b/src/Tempest/Database/src/Exceptions/InvalidDefaultValue.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Exceptions;
+
+use Exception;
+
+final class InvalidDefaultValue extends Exception
+{
+    public function __construct(string $field, string $value)
+    {
+        parent::__construct("Default value '{$value}' provided for {$field} is not valid");
+    }
+}

--- a/src/Tempest/Database/src/QueryStatements/CreateTableStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/CreateTableStatement.php
@@ -166,6 +166,20 @@ final class CreateTableStatement implements QueryStatement
         return $this;
     }
 
+    public function json(
+        string $name,
+        bool $nullable = false,
+        ?string $default = null
+    ): self {
+        $this->statements[] = new JsonStatement(
+            name: $name,
+            nullable: $nullable,
+            default: $default,
+        );
+
+        return $this;
+    }
+
     public function compile(DatabaseDialect $dialect): string
     {
         $compiled = sprintf(

--- a/src/Tempest/Database/src/QueryStatements/JsonStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/JsonStatement.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\QueryStatements;
+
+use Tempest\Database\DatabaseDialect;
+use Tempest\Database\QueryStatement;
+
+final readonly class JsonStatement implements QueryStatement
+{
+    public function __construct(
+        private string $name,
+        private bool $nullable = false,
+        private ?string $default = null,
+    ) {
+    }
+
+    public function compile(DatabaseDialect $dialect): string
+    {
+        return match($dialect) {
+            DatabaseDialect::MYSQL => sprintf(
+                '`%s` JSON %s',
+                $this->name,
+                $this->nullable ? '' : 'NOT NULL',
+            ),
+            DatabaseDialect::SQLITE => sprintf(
+                '`%s` TEXT %s %s',
+                $this->name,
+                $this->default ? "DEFAULT '{$this->default}'" : '',
+                $this->nullable ? '' : 'NOT NULL',
+            ),
+            DatabaseDialect::POSTGRESQL => sprintf(
+                '`%s` JSONB %s %s',
+                $this->name,
+                $this->default ? "DEFAULT (\"{$this->default}\")" : '',
+                $this->nullable ? '' : 'NOT NULL',
+            )
+        };
+    }
+}

--- a/src/Tempest/Database/src/QueryStatements/JsonStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/JsonStatement.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Database\QueryStatements;
 
 use Tempest\Database\DatabaseDialect;
+use Tempest\Database\Exceptions\InvalidDefaultValue;
 use Tempest\Database\QueryStatement;
 
 final readonly class JsonStatement implements QueryStatement
@@ -18,6 +19,10 @@ final readonly class JsonStatement implements QueryStatement
 
     public function compile(DatabaseDialect $dialect): string
     {
+        if ($this->default && false === json_validate($this->default)) {
+            throw new InvalidDefaultValue($this->name, $this->default);
+        }
+
         return match($dialect) {
             DatabaseDialect::MYSQL => sprintf(
                 '`%s` JSON %s',

--- a/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
@@ -33,7 +33,8 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
                     ->integer('integer', default: 1)
                     ->date('date', default: '2024-01-01')
                     ->datetime('datetime', default: '2024-01-01 00:00:00')
-                    ->boolean('is_active', default: true);
+                    ->boolean('is_active', default: true)
+                    ->json('json', default: '{"default": "foo"}');
             }
 
             public function down(): QueryStatement|null

--- a/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Database\QueryStatements;
 
+use Tempest\Database\Exceptions\InvalidDefaultValue;
 use Tempest\Database\Migration;
 use Tempest\Database\Migrations\CreateMigrationsTable;
 use Tempest\Database\QueryStatement;
@@ -50,5 +51,34 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
 
         // Make sure there are no errors
         $this->assertTrue(true);
+    }
+
+    public function test_invalid_json_default(): void
+    {
+        $migration = new class () implements Migration {
+            public function getName(): string
+            {
+                return '0';
+            }
+
+            public function up(): QueryStatement|null
+            {
+                return (new CreateTableStatement('table'))
+                    ->json('json', default: '{default: "invalid json"}');
+            }
+
+            public function down(): QueryStatement|null
+            {
+                return null;
+            }
+        };
+
+        $this->expectException(InvalidDefaultValue::class);
+        $this->expectExceptionMessage("Default value '{default: \"invalid json\"}' provided for json is not valid");
+
+        $this->migrate(
+            CreateMigrationsTable::class,
+            $migration
+        );
     }
 }


### PR DESCRIPTION
Part of #547 to add the `json` data type to the table statements

Latest versions of MySQL accept default value for `json` but this require a version check.
I didn't want to add this complexity (at least for this pr) as this was not done either for `text` type before

Do you think we should check if value provided as `default` is a valid json ? `json_validate` seems free to use as Tempest require 8.3+ 