### PR TITLE
refactor(http): use `symfony/process` to run `tempest serve`

### DIFF
--- a/src/Tempest/Http/src/Commands/ServeCommand.php
+++ b/src/Tempest/Http/src/Commands/ServeCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Http\Commands;
 
+use Symfony\Component\Process\Process;
 use Tempest\Console\ConsoleCommand;
 
 final readonly class ServeCommand
@@ -14,8 +15,19 @@ final readonly class ServeCommand
     )]
     public function __invoke(string $host = 'localhost', int $port = 8000, string $publicDir = 'public/'): void
     {
-        putenv("TEMPEST_PUBLIC_DIR={$publicDir}");
         $routerFile = __DIR__ . '/router.php';
-        passthru("php -S {$host}:{$port} -t {$publicDir} {$routerFile}");
+
+        $process = new Process(
+            command: ['php', '-S', "{$host}:{$port}", $routerFile],
+            cwd: $publicDir,
+        );
+
+        $process->start(function ($type, $buffer): void {
+            echo $buffer;
+        });
+
+        while ($process->isRunning()) {
+            usleep(500 * 1000);
+        }
     }
 }

--- a/src/Tempest/Http/src/Commands/router.php
+++ b/src/Tempest/Http/src/Commands/router.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-$publicPath = getcwd() . '/' . rtrim($_ENV['TEMPEST_PUBLIC_DIR'], '/');
+$publicPath = getcwd();
 
 if (file_exists($publicPath . $_SERVER['REQUEST_URI'])) {
     return false;


### PR DESCRIPTION
During a separate discussion on discord. Aiden brought to my attention env-variables shouldn't be used for this.

I drew inspiration from [laravel serve](https://github.com/laravel/framework/blob/37f96f1d6b515f55ea7dfef144fd41519cca38b6/src/Illuminate/Foundation/Console/ServeCommand.php#L103). Which doesn't use an env-var, but uses the `cwd` of the sub-process instead.

The while-loop with a `usleep` is also inspired by laravel's serve command. I couldn't find an easier way to start a subprocess (like `passtru`) for which I could alter the `cwd`