### PR TITLE
Feat/add str start helper

### DIFF
--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -183,6 +183,16 @@ final readonly class StringHelper implements Stringable
     }
 
     /**
+     * Prefix the instance with the given string.
+     */
+    public function start(string $prefix): self
+    {
+        return new self(
+            $prefix.preg_replace('/^(?:'.preg_quote($prefix, '/').')+/u', replacement: '', subject: $this->string)
+        );
+    }
+
+    /**
      * Returns the remainder of the string after the first occurrence of the given value.
      */
     public function after(Stringable|string|array $search): self

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -475,4 +475,10 @@ b'));
         $this->assertSame('value', str('value]')->unwrap('[', ']', strict: false)->toString());
         $this->assertSame('Scott', str('Scott Kennedy')->unwrap(before: 'Leon ', after: ' Kennedy', strict: false)->toString());
     }
+
+    public function test_start(): void
+    {
+        $this->assertSame('Leon Scott Kennedy', str('Scott Kennedy')->start('Leon ')->toString());
+        $this->assertSame('Leon Scott Kennedy', str('Leon Scott Kennedy')->start('Leon ')->toString());
+    }
 }


### PR DESCRIPTION
Inline with the `finish()` string helper, this function allow the developer to specify a prefix (start) for the string. 