### PR TITLE
fix(http): parse json body from request

### DIFF
--- a/src/Tempest/Framework/Testing/Http/HttpRouterTester.php
+++ b/src/Tempest/Framework/Testing/Http/HttpRouterTester.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Framework\Testing\Http;
 
 use Laminas\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\Stream;
 use Psr\Http\Message\ServerRequestInterface as PsrRequest;
 use Tempest\Container\Container;
 use Tempest\Http\GenericRequest;
@@ -16,6 +17,8 @@ use function Tempest\map;
 
 final class HttpRouterTester
 {
+    private array $createdHeaders = [];
+
     public function __construct(private Container $container)
     {
     }
@@ -61,19 +64,46 @@ final class HttpRouterTester
         array $headers = [],
         array $cookies = [],
         array $files = [],
+        string $rawBody = null,
     ): PsrRequest {
         $_SERVER['REQUEST_URI'] = $uri;
         $_SERVER['REQUEST_METHOD'] = $method->value;
 
         foreach ($headers as $key => $value) {
-            $key = strtoupper($key);
-
-            $_SERVER["HTTP_{$key}"] = $value;
+            $this->setHeader($key, $value);
         }
 
         $_COOKIE = $cookies;
         $_POST = $body;
 
-        return ServerRequestFactory::fromGlobals()->withUploadedFiles($files);
+        $request = ServerRequestFactory::fromGlobals()->withUploadedFiles($files);
+
+        if ($rawBody !== null) {
+            $stream = new Stream('php://temp', 'rw');
+            $stream->write($rawBody);
+            $stream->rewind();
+
+            $request = $request->withBody($stream);
+        }
+
+        return $request;
+    }
+
+    public function reset(): void
+    {
+        foreach ($this->createdHeaders as $key => $value) {
+            unset($_SERVER[$key]);
+        }
+
+        $this->createdHeaders = [];
+    }
+
+    private function setHeader(string $key, string $value): void
+    {
+        $key = strtoupper($key);
+        $headerKey = "HTTP_{$key}";
+
+        $_SERVER[$headerKey] = $value;
+        $this->createdHeaders[$headerKey] = $value;
     }
 }

--- a/src/Tempest/Framework/Testing/IntegrationTest.php
+++ b/src/Tempest/Framework/Testing/IntegrationTest.php
@@ -83,6 +83,8 @@ abstract class IntegrationTest extends TestCase
     {
         parent::tearDown();
 
+        $this->http->reset();
+
         unset($this->root);
         unset($this->discoveryLocations);
         unset($this->appConfig);

--- a/src/Tempest/Http/src/Json/JsonParserServerRequest.php
+++ b/src/Tempest/Http/src/Json/JsonParserServerRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Json;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Tempest\Http\ContentType;
+
+final readonly class JsonParserServerRequest
+{
+    public function __invoke(ServerRequestInterface $request): ServerRequestInterface
+    {
+        if (! in_array(ContentType::JSON->value, $request->getHeader(ContentType::HEADER))) {
+            return $request;
+        }
+
+        $parsedBody = json_decode($request->getBody()->getContents(), true) ?? [];
+
+        return $request->withParsedBody($parsedBody);
+    }
+}

--- a/src/Tempest/Http/src/Mappers/PsrRequestToRequestMapper.php
+++ b/src/Tempest/Http/src/Mappers/PsrRequestToRequestMapper.php
@@ -7,6 +7,7 @@ namespace Tempest\Http\Mappers;
 use Psr\Http\Message\ServerRequestInterface as PsrRequest;
 use Psr\Http\Message\UploadedFileInterface;
 use Tempest\Http\GenericRequest;
+use Tempest\Http\Json\JsonParserServerRequest;
 use Tempest\Http\Method;
 use Tempest\Http\Request;
 use Tempest\Http\Upload;
@@ -24,6 +25,8 @@ final readonly class PsrRequestToRequestMapper implements Mapper
     public function map(mixed $from, mixed $to): array|object
     {
         /** @var PsrRequest $from */
+        $from = (new JsonParserServerRequest())($from);
+
         /** @var class-string<\Tempest\Http\Request> $requestClass */
         $requestClass = is_object($to) ? $to::class : $to;
 

--- a/src/Tempest/Http/tests/Json/JsonParserServerRequestTest.php
+++ b/src/Tempest/Http/tests/Json/JsonParserServerRequestTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Json;
+
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\Stream;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @internal
+ */
+final class JsonParserServerRequestTest extends TestCase
+{
+    private JsonParserServerRequest $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new JsonParserServerRequest();
+    }
+
+    public function test_parse_json_body(): void
+    {
+        $request = $this->givenRequest('{"test": "test"}');
+
+        $request = ($this->parser)($request);
+
+        $this->assertEquals(['test' => 'test'], $request->getParsedBody());
+    }
+
+    public function test_parse_empty_json_body(): void
+    {
+        $request = $this->givenRequest('');
+
+        $request = ($this->parser)($request);
+
+        $this->assertEquals([], $request->getParsedBody());
+    }
+
+    public function test_parse_invalid_json_body(): void
+    {
+        $request = $this->givenRequest('invalid json string');
+
+        $request = ($this->parser)($request);
+
+        $this->assertEquals([], $request->getParsedBody());
+    }
+
+    private function givenRequest(string $body): ServerRequestInterface
+    {
+        $stream = new Stream('php://temp', 'rw');
+        $stream->write($body);
+        $stream->rewind();
+
+        return new ServerRequest(
+            body: $stream,
+            headers: ['Content-Type' => 'application/json'],
+        );
+    }
+}

--- a/tests/Integration/Mapper/PsrRequestToRequestMapperTest.php
+++ b/tests/Integration/Mapper/PsrRequestToRequestMapperTest.php
@@ -113,4 +113,23 @@ final class PsrRequestToRequestMapperTest extends FrameworkIntegrationTestCase
         $this->assertSame('hello', $upload->getClientFilename());
         $this->assertSame('application/octet-stream', $upload->getClientMediaType());
     }
+
+    public function test_json_parse(): void
+    {
+        $mapper = new PsrRequestToRequestMapper();
+
+        $request = $mapper->map(
+            from: $this->http->makePsrRequest(
+                uri: '/',
+                rawBody: '{"title": "a", "text": "b"}',
+                headers: ['content-type' => 'application/json'],
+            ),
+            to: PostRequest::class,
+        );
+
+        $this->assertInstanceOf(PostRequest::class, $request);
+        $this->assertEquals('a', $request->title);
+        $this->assertEquals('b', $request->text);
+        $this->assertEquals(['content-type' => 'application/json'], $request->getHeaders());
+    }
 }


### PR DESCRIPTION
Fix for: https://github.com/tempestphp/tempest-framework/issues/504

**This PR fixes a couple of issues:**

_Raw Body Mocking and Header Resetting in HttpRouterTester:_

- JSON body data doesn’t show up in global variables but in the `php://input` stream, so to test it, I've added `$rawBody` in `HttpRouterTester` to mock that body.
- Also found a problem during testing—headers were being set in global variables and sticking around across tests until the PHP process ends. Now, headers get reset between tests to avoid that.

_JSON Body Parser for Laminas Requests:_

- Added a `JsonParserServerRequest` class to handle JSON parsing in Laminas requests. This class grabs data from the body stream, parses it, and adds it to the request as `$parsedBody`.
- Thought about other ways to do this, like using `ServerRequestFilter` from Laminas, but that seems more for filtering.
- Middleware was another option, but Tempest middlewares are executed after mapping PsrRequest to Tempest Request