### PR TITLE
fix(http): use document root instead of env in `tempest serve`

### DIFF
--- a/src/Tempest/Http/src/Commands/ServeCommand.php
+++ b/src/Tempest/Http/src/Commands/ServeCommand.php
@@ -14,7 +14,6 @@ final readonly class ServeCommand
     )]
     public function __invoke(string $host = 'localhost', int $port = 8000, string $publicDir = 'public/'): void
     {
-        putenv("TEMPEST_PUBLIC_DIR={$publicDir}");
         $routerFile = __DIR__ . '/router.php';
         passthru("php -S {$host}:{$port} -t {$publicDir} {$routerFile}");
     }

--- a/src/Tempest/Http/src/Commands/router.php
+++ b/src/Tempest/Http/src/Commands/router.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-$publicPath = getcwd() . '/' . rtrim($_ENV['TEMPEST_PUBLIC_DIR'], '/');
+$publicPath = $_SERVER['DOCUMENT_ROOT'];
 
 if (file_exists($publicPath . $_SERVER['REQUEST_URI'])) {
     return false;


### PR DESCRIPTION
This https://github.com/tempestphp/tempest-framework/issues/704 pull request added router for `./tempest serve` to correctly handle paths with file extension.

It uses `putenv` but on default php environment `$_ENV` is not populated.
It depends on `php.ini` setting `variables_order` that often is set to `GPCS` instead of `EGPCS`.

But `php` cli allows to set `$_SERVER['DOCUMENT_ROOT']` with `-t` flag, so we can use it to pass public path to router.