### PR TITLE
feat(log): allow usage of multiple same log channels

### DIFF
--- a/src/Tempest/Log/src/GenericLogger.php
+++ b/src/Tempest/Log/src/GenericLogger.php
@@ -10,7 +10,7 @@ use Stringable;
 
 final class GenericLogger implements Logger
 {
-    /** @var array<class-string, Monolog> */
+    /** @var array<int, Monolog> */
     private array $drivers = [];
 
     public function __construct(
@@ -74,14 +74,14 @@ final class GenericLogger implements Logger
 
     private function resolveDriver(LogChannel $channel, Level $level): Monolog
     {
-        if (! isset($this->drivers[$channel::class])) {
-            $this->drivers[$channel::class] = new Monolog(
+        if (! isset($this->drivers[spl_object_id($channel)])) {
+            $this->drivers[spl_object_id($channel)] = new Monolog(
                 name: $this->logConfig->prefix,
                 handlers: $channel->getHandlers($level),
                 processors: $channel->getProcessors(),
             );
         }
 
-        return $this->drivers[$channel::class];
+        return $this->drivers[spl_object_id($channel)];
     }
 }

--- a/src/Tempest/Log/tests/GenericLoggerTest.php
+++ b/src/Tempest/Log/tests/GenericLoggerTest.php
@@ -35,6 +35,17 @@ final class GenericLoggerTest extends TestCase
         $this->assertStringContainsString('test', file_get_contents($filePath));
     }
 
+    protected function tearDown(): void
+    {
+        $files = glob(__DIR__ . '/logs/*.log');
+
+        foreach ($files as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+    }
+
     public function test_daily_log_channel_works(): void
     {
         $filePath = __DIR__ . '/logs/tempest-' . date('Y-m-d') . '.log';
@@ -71,5 +82,27 @@ final class GenericLoggerTest extends TestCase
         $this->assertFileExists($filePath);
 
         $this->assertStringContainsString('test', file_get_contents($filePath));
+    }
+
+    public function test_multiple_same_log_channels_works(): void
+    {
+        $filePath = __DIR__ . '/logs/multiple-tempest1.log';
+        $secondFilePath = __DIR__ . '/logs/multiple-tempest2.log';
+
+        $config = new LogConfig(
+            channels: [
+                new AppendLogChannel($filePath),
+                new AppendLogChannel($secondFilePath),
+            ],
+        );
+
+        $logger = new GenericLogger($config);
+        $logger->info('test');
+
+        $this->assertFileExists($filePath);
+        $this->assertStringContainsString('test', file_get_contents($filePath));
+
+        $this->assertFileExists($secondFilePath);
+        $this->assertStringContainsString('test', file_get_contents($secondFilePath));
     }
 }


### PR DESCRIPTION
Right now, it isn't possible to correctly declare `AppendLogChannel` more than once in `LogConfig`. It will result in same log, being logged in same channel multiple times.

This changes this behaviour, by storing `Monolog` instance by `spl_object_id`, not class name.