### PR TITLE
fix(http): use default log config only if no config is provided

### DIFF
--- a/src/Tempest/Console/src/ConsoleApplication.php
+++ b/src/Tempest/Console/src/ConsoleApplication.php
@@ -40,8 +40,14 @@ final readonly class ConsoleApplication implements Application
         $consoleConfig->name = $name;
 
         $logConfig = $container->get(LogConfig::class);
-        $logConfig->debugLogPath = PathHelper::make($container->get(Kernel::class)->root, '/log/debug.log');
-        $logConfig->channels[] = new AppendLogChannel(PathHelper::make($container->get(Kernel::class)->root, '/log/tempest.log'));
+
+        if (
+            $logConfig->debugLogPath === null
+            && $logConfig->channels === []
+        ) {
+            $logConfig->debugLogPath = PathHelper::make($container->get(Kernel::class)->root, '/log/debug.log');
+            $logConfig->channels[] = new AppendLogChannel(PathHelper::make($container->get(Kernel::class)->root, '/log/tempest.log'));
+        }
 
         return $application;
     }

--- a/src/Tempest/Http/src/HttpApplication.php
+++ b/src/Tempest/Http/src/HttpApplication.php
@@ -35,9 +35,16 @@ final readonly class HttpApplication implements Application
 
         // Application-specific setup
         $logConfig = $container->get(LogConfig::class);
-        $logConfig->debugLogPath = PathHelper::make($container->get(Kernel::class)->root, '/log/debug.log');
-        $logConfig->serverLogPath = env('SERVER_LOG');
-        $logConfig->channels[] = new AppendLogChannel(PathHelper::make($root, '/log/tempest.log'));
+
+        if (
+            $logConfig->debugLogPath === null
+            && $logConfig->serverLogPath === null
+            && $logConfig->channels === []
+        ) {
+            $logConfig->debugLogPath = PathHelper::make($container->get(Kernel::class)->root, '/log/debug.log');
+            $logConfig->serverLogPath = env('SERVER_LOG');
+            $logConfig->channels[] = new AppendLogChannel(PathHelper::make($root, '/log/tempest.log'));
+        }
 
         return $application;
     }


### PR DESCRIPTION
Currently tempest always adds `AppendLogChannel` and hardcoded paths, even if user provided `LogConfig`.

I think better way would be to publish `log.config.php` with sane defaults with framework, but I feel it will bring discussion about project directory structure and probably better to just avoid it for now?

Also, as this code currently lives in `HttpApplication` boot method, I don't feel comfortable with calling this in test.