### PR TITLE
feat(support): add more methods to `ArrayHelper` and `StringHelper`

### DIFF
--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -811,6 +811,37 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
+     * Flattens the instance to a single-level array, or until the specified `$depth` is reached.
+     *
+     * ### Example
+     * ```php
+     * arr(['foo', ['bar', 'baz']])->flatten(); // ['foo', 'bar', 'baz']
+     * ```
+     */
+    public function flatten(int|float $depth = INF): self
+    {
+        $result = [];
+
+        foreach ($this->array as $item) {
+            if (! is_array($item)) {
+                $result[] = $item;
+
+                continue;
+            }
+
+            $values = $depth === 1
+                ? array_values($item)
+                : arr($item)->flatten($depth - 1);
+
+            foreach ($values as $value) {
+                $result[] = $value;
+            }
+        }
+
+        return new self($result);
+    }
+
+    /**
      * Dumps the instance.
      */
     public function dump(mixed ...$dumps): self

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -432,6 +432,10 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
             return new self([(string) $string]);
         }
 
+        if ((string) $string === '') {
+            return new self();
+        }
+
         return new self(explode($separator, (string) $string));
     }
 
@@ -654,11 +658,13 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      *
      * @return mixed|ArrayHelper
      */
-    public function get(string $key, mixed $default = null): mixed
+    public function get(int|string $key, mixed $default = null): mixed
     {
         $value = $this->array;
 
-        $keys = explode('.', $key);
+        $keys = is_int($key)
+            ? [$key]
+            : explode('.', $key);
 
         foreach ($keys as $key) {
             if (! isset($value[$key])) {
@@ -678,11 +684,13 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     /**
      * Asserts whether a value identified by the specified `$key` exists.
      */
-    public function has(string $key): bool
+    public function has(int|string $key): bool
     {
         $array = $this->array;
 
-        $keys = explode('.', $key);
+        $keys = is_int($key)
+            ? [$key]
+            : explode('.', $key);
 
         foreach ($keys as $key) {
             if (! isset($array[$key])) {

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -455,7 +455,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      * Returns the first item in the instance that matches the given `$filter`.
      * If `$filter` is `null`, returns the first item.
      *
-     * @param Closure(TValue $value, TKey $key)|null: bool $filter
+     * @param null|Closure(TValue $value, TKey $key): bool $filter
      *
      * @return TValue
      */
@@ -482,7 +482,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      * Returns the last item in the instance that matches the given `$filter`.
      * If `$filter` is `null`, returns the last item.
      *
-     * @param Closure(TValue $value, TKey $key)|null: bool $filter
+     * @param null|Closure(TValue $value, TKey $key): bool $filter
      *
      * @return TValue
      */

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -39,6 +39,8 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
             $this->array = $input;
         } elseif ($input instanceof self) {
             $this->array = $input->array;
+        } elseif ($input === null) {
+            $this->array = [];
         } else {
             $this->array = [$input];
         }

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -842,6 +842,16 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
+     * Returns a new instance of the array, with each item transformed by the given callback, then flattens it by the specified depth.
+     *
+     * @param Closure(mixed $value, mixed $key): mixed $map
+     */
+    public function flatMap(Closure $map, int|float $depth = 1): self
+    {
+        return $this->map($map)->flatten($depth);
+    }
+
+    /**
      * Dumps the instance.
      */
     public function dump(mixed ...$dumps): self

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -453,7 +453,9 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      * Returns the first item in the instance that matches the given `$filter`.
      * If `$filter` is `null`, returns the first item.
      *
-     * @param Closure(mixed $value, mixed $key): bool $filter
+     * @param Closure(TValue $value, TKey $key)|null: bool $filter
+     *
+     * @return TValue
      */
     public function first(?Closure $filter = null): mixed
     {
@@ -478,7 +480,9 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
      * Returns the last item in the instance that matches the given `$filter`.
      * If `$filter` is `null`, returns the last item.
      *
-     * @param Closure(mixed $value, mixed $key): bool $filter
+     * @param Closure(TValue $value, TKey $key)|null: bool $filter
+     *
+     * @return TValue
      */
     public function last(?Closure $filter = null): mixed
     {
@@ -612,7 +616,11 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     /**
      * Returns a new instance of the array, with each item transformed by the given callback.
      *
-     * @param Closure(mixed $value, mixed $key): mixed $map
+     * @template TMapValue
+     *
+     * @param  Closure(TValue, TKey): TMapValue $map
+     *
+     * @return static<TKey, TMapValue>
      */
     public function map(Closure $map): self
     {
@@ -844,7 +852,11 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     /**
      * Returns a new instance of the array, with each item transformed by the given callback, then flattens it by the specified depth.
      *
-     * @param Closure(mixed $value, mixed $key): mixed $map
+     * @template TMapValue
+     *
+     * @param  Closure(TValue, TKey): TMapValue[] $map
+     *
+     * @return static<TKey, TMapValue>
      */
     public function flatMap(Closure $map, int|float $depth = 1): self
     {

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -717,6 +717,21 @@ final readonly class StringHelper implements Stringable
     }
 
     /**
+     * Inserts the specified `$string` at the specified `$position`.
+     *
+     * ### Example
+     * ```php
+     * str('Lorem ipsum sit amet')->insert(11, ' dolor'); // Lorem ipsum dolor sit amet
+     * ```
+     */
+    public function insert(int $position, string $string): self
+    {
+        return new self(
+            mb_substr($this->string, 0, $position) . $string . mb_substr($this->string, $position)
+        );
+    }
+
+    /**
      * Implodes the given array into a string by a separator.
      */
     public static function implode(array|ArrayHelper $parts, string $glue = ' '): self

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -763,10 +763,10 @@ final readonly class StringHelper implements Stringable
      *
      * ### Example
      * ```php
-     * str('Lorem ipsum sit amet')->insert(11, ' dolor'); // Lorem ipsum dolor sit amet
+     * str('Lorem ipsum sit amet')->insertAt(11, ' dolor'); // Lorem ipsum dolor sit amet
      * ```
      */
-    public function insert(int $position, string $string): self
+    public function insertAt(int $position, string $string): self
     {
         return new self(
             mb_substr($this->string, 0, $position) . $string . mb_substr($this->string, $position)

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -636,6 +636,23 @@ final readonly class StringHelper implements Stringable
         return new self(implode(PHP_EOL, $lines));
     }
 
+    /**
+     * Limits the number of characters of the instance.
+     *
+     * ### Example
+     * ```php
+     * str('Lorem ipsum')->limit(5, end: '...'); // Lorem...
+     * ```
+     */
+    public function limit(int $characters, string $end = ''): self
+    {
+        if (mb_strwidth($this->string, 'UTF-8') <= $characters) {
+            return $this;
+        }
+
+        return new self(rtrim(mb_strimwidth($this->string, 0, $characters, '', 'UTF-8')) . $end);
+    }
+
     private function normalizeString(mixed $value): mixed
     {
         if ($value instanceof Stringable) {

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -679,6 +679,24 @@ final readonly class StringHelper implements Stringable
         return $this->substr(0, $length);
     }
 
+    /**
+     * Splits the instance into chunks of the specified `$length`.
+     */
+    public function split(int $length): ArrayHelper
+    {
+        if ($length <= 0) {
+            return new ArrayHelper();
+        }
+
+        $chunks = [];
+
+        foreach (str_split($this->string, $length) as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        return new ArrayHelper($chunks);
+    }
+
     private function normalizeString(mixed $value): mixed
     {
         if ($value instanceof Stringable) {

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -690,6 +690,10 @@ final readonly class StringHelper implements Stringable
             return new ArrayHelper();
         }
 
+        if ($this->equals('')) {
+            return new ArrayHelper(['']);
+        }
+
         $chunks = [];
 
         foreach (str_split($this->string, $length) as $chunk) {

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -484,6 +484,24 @@ final readonly class StringHelper implements Stringable
     }
 
     /**
+     * Replaces the portion of the specified `$length` at the specified `$position` with the specified `$replace`.
+     *
+     * ### Example
+     * ```php
+     * str('Lorem dolor')->replaceAt(6, 5, 'ipsum'); // Lorem ipsum
+     * ```
+     */
+    public function replaceAt(int $position, int $length, Stringable|string $replace): self
+    {
+        if ($length < 0) {
+            $position += $length;
+            $length = abs($length);
+        }
+
+        return new self(substr_replace($this->string, (string) $replace, $position, $length));
+    }
+
+    /**
      * Appends the given strings to the instance.
      */
     public function append(string|Stringable ...$append): self

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -667,6 +667,18 @@ final readonly class StringHelper implements Stringable
         return new self(mb_substr($this->string, $start, $length));
     }
 
+    /**
+     * Takes the specified amount of characters. If `$length` is negative, starts from the end.
+     */
+    public function take(int $length): self
+    {
+        if ($length < 0) {
+            return $this->substr($length);
+        }
+
+        return $this->substr(0, $length);
+    }
+
     private function normalizeString(mixed $value): mixed
     {
         if ($value instanceof Stringable) {

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -14,9 +14,11 @@ use function trim;
 
 final readonly class StringHelper implements Stringable
 {
-    public function __construct(
-        private string $string = '',
-    ) {
+    private string $string;
+
+    public function __construct(?string $string = '')
+    {
+        $this->string = $string ?? '';
     }
 
     /**

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -739,6 +739,26 @@ final readonly class StringHelper implements Stringable
     }
 
     /**
+     * Strips HTML and PHP tags from the instance.
+     *
+     * @param null|string|string[] $allowed Allowed tags.
+     *
+     * ### Example
+     * ```php
+     * str('<p>Lorem ipsum</p>')->stripTags(); // Lorem ipsum
+     * str('<p>Lorem <strong>ipsum</strong></p>')->stripTags(allowed: 'strong'); // Lorem <strong>ipsum</strong>
+     * ```
+     */
+    public function stripTags(null|string|array $allowed = null): self
+    {
+        $allowed = arr($allowed)
+            ->map(fn (string $tag) => str($tag)->wrap('<', '>')->toString())
+            ->toArray();
+
+        return new self(strip_tags($this->string, $allowed));
+    }
+
+    /**
      * Inserts the specified `$string` at the specified `$position`.
      *
      * ### Example

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -653,6 +653,20 @@ final readonly class StringHelper implements Stringable
         return new self(rtrim(mb_strimwidth($this->string, 0, $characters, '', 'UTF-8')) . $end);
     }
 
+    /**
+     * Gets parts of the instance.
+     *
+     * ### Example
+     * ```php
+     * str('Lorem ipsum')->substr(0, length: 5); // Lorem
+     * str('Lorem ipsum')->substr(6); // ipsum
+     * ```
+     */
+    public function substr(int $start, ?int $length = null): self
+    {
+        return new self(mb_substr($this->string, $start, $length));
+    }
+
     private function normalizeString(mixed $value): mixed
     {
         if ($value instanceof Stringable) {

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -657,20 +657,20 @@ final readonly class StringHelper implements Stringable
     }
 
     /**
-     * Limits the number of characters of the instance.
+     * Truncates the instance to the specified amount of characters.
      *
      * ### Example
      * ```php
-     * str('Lorem ipsum')->limit(5, end: '...'); // Lorem...
+     * str('Lorem ipsum')->truncate(5, end: '...'); // Lorem...
      * ```
      */
-    public function limit(int $characters, string $end = ''): self
+    public function truncate(int $characters, string $end = ''): self
     {
         if (mb_strwidth($this->string, 'UTF-8') <= $characters) {
             return $this;
         }
 
-        return new self(rtrim(mb_strimwidth($this->string, 0, $characters, '', 'UTF-8')) . $end);
+        return new self(rtrim(mb_strimwidth($this->string, 0, $characters, encoding: 'UTF-8')) . $end);
     }
 
     /**

--- a/src/Tempest/Support/src/functions.php
+++ b/src/Tempest/Support/src/functions.php
@@ -6,7 +6,7 @@ namespace Tempest\Support {
     /**
      * Creates an instance of {@see StringHelper} using the given `$string`.
      */
-    function str(string $string = ''): StringHelper
+    function str(?string $string = ''): StringHelper
     {
         return new StringHelper($string);
     }

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -1395,6 +1395,53 @@ final class ArrayHelperTest extends TestCase
         $this->assertTrue(arr([['#foo', ['#bar', ['#baz']]], '#zap'])->flatten(depth: 2)->equals(['#foo', '#bar', ['#baz'], '#zap']));
     }
 
+    public function test_flatmap(): void
+    {
+        // basic
+        $this->assertTrue(
+            arr([
+                ['name' => 'Makise', 'hobbies' => ['Science', 'Programming']],
+                ['name' => 'Okabe', 'hobbies' => ['Science', 'Anime']],
+            ])->flatMap(fn (array $person) => $person['hobbies'])
+                ->equals(['Science', 'Programming', 'Science', 'Anime']),
+        );
+
+        // deeply nested
+        $likes = arr([
+            ['name' => 'Enzo', 'likes' => [
+                'manga' => ['Tower of God', 'The Beginning After The End'],
+                'languages' => ['PHP', 'TypeScript'],
+            ]],
+            ['name' => 'Jon', 'likes' => [
+                'manga' => ['One Piece', 'Naruto'],
+                'languages' => ['Python'],
+            ]],
+        ]);
+
+        $this->assertTrue(
+            $likes->flatMap(fn (array $person) => $person['likes'], depth: 1)
+                ->equals([
+                    ['Tower of God', 'The Beginning After The End'],
+                    ['PHP', 'TypeScript'],
+                    ['One Piece', 'Naruto'],
+                    ['Python'],
+                ]),
+        );
+
+        $this->assertTrue(
+            $likes->flatMap(fn (array $person) => $person['likes'], depth: INF)
+                ->equals([
+                    'Tower of God',
+                    'The Beginning After The End',
+                    'PHP',
+                    'TypeScript',
+                    'One Piece',
+                    'Naruto',
+                    'Python',
+                ]),
+        );
+    }
+
     public function test_basic_reduce(): void
     {
         $collection = arr([

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -1382,6 +1382,19 @@ final class ArrayHelperTest extends TestCase
         );
     }
 
+    public function test_flatten(): void
+    {
+        $this->assertTrue(arr(['#foo', '#bar', '#baz'])->flatten()->equals(['#foo', '#bar', '#baz']));
+        $this->assertTrue(arr([['#foo', '#bar'], '#baz'])->flatten()->equals(['#foo', '#bar', '#baz']));
+        $this->assertTrue(arr([['#foo', null], '#baz', null])->flatten()->equals(['#foo', null, '#baz', null]));
+        $this->assertTrue(arr([['#foo', '#bar'], ['#baz']])->flatten()->equals(['#foo', '#bar', '#baz']));
+        $this->assertTrue(arr([['#foo', ['#bar']], ['#baz']])->flatten()->equals(['#foo', '#bar', '#baz']));
+        $this->assertTrue(arr([['#foo', ['#bar', ['#baz']]], '#zap'])->flatten()->equals(['#foo', '#bar', '#baz', '#zap']));
+
+        $this->assertTrue(arr([['#foo', ['#bar', ['#baz']]], '#zap'])->flatten(depth: 1)->equals(['#foo', ['#bar', ['#baz']], '#zap']));
+        $this->assertTrue(arr([['#foo', ['#bar', ['#baz']]], '#zap'])->flatten(depth: 2)->equals(['#foo', '#bar', ['#baz'], '#zap']));
+    }
+
     public function test_basic_reduce(): void
     {
         $collection = arr([

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -510,4 +510,14 @@ b'));
         // negative
         $this->assertSame('ipsum', str('Lorem ipsum')->take(-5)->toString());
     }
+
+    public function test_split(): void
+    {
+        $this->assertSame([], str()->split(1)->toArray());
+        $this->assertSame([], str('123')->split(-1)->toArray());
+        $this->assertSame(['1', '2', '3'], str('123')->split(1)->toArray());
+        $this->assertSame(['123'], str('123')->split(1000)->toArray());
+        $this->assertSame(['foo', 'bar', 'baz'], str('foobarbaz')->split(3)->toArray());
+        $this->assertSame(['foo', 'bar', 'baz', '22'], str('foobarbaz22')->split(3)->toArray());
+    }
 }

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -522,16 +522,16 @@ b'));
         $this->assertSame(['foo', 'bar', 'baz', '22'], str('foobarbaz22')->split(3)->toArray());
     }
 
-    public function test_insert(): void
+    public function test_insert_at(): void
     {
-        $this->assertSame('foo', str()->insert(0, 'foo')->toString());
-        $this->assertSame('foo', str()->insert(-1, 'foo')->toString());
-        $this->assertSame('foo', str()->insert(100, 'foo')->toString());
-        $this->assertSame('foo', str()->insert(-100, 'foo')->toString());
-        $this->assertSame('foobar', str('bar')->insert(0, 'foo')->toString());
-        $this->assertSame('barfoo', str('bar')->insert(3, 'foo')->toString());
-        $this->assertSame('foobarbaz', str('foobaz')->insert(3, 'bar')->toString());
-        $this->assertSame('123', str('13')->insert(-1, '2')->toString());
+        $this->assertSame('foo', str()->insertAt(0, 'foo')->toString());
+        $this->assertSame('foo', str()->insertAt(-1, 'foo')->toString());
+        $this->assertSame('foo', str()->insertAt(100, 'foo')->toString());
+        $this->assertSame('foo', str()->insertAt(-100, 'foo')->toString());
+        $this->assertSame('foobar', str('bar')->insertAt(0, 'foo')->toString());
+        $this->assertSame('barfoo', str('bar')->insertAt(3, 'foo')->toString());
+        $this->assertSame('foobarbaz', str('foobaz')->insertAt(3, 'bar')->toString());
+        $this->assertSame('123', str('13')->insertAt(-1, '2')->toString());
     }
 
     public function test_replace_at(): void

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -500,4 +500,14 @@ b'));
         $this->assertSame('ipsum', str('Lorem ipsum')->substr(-5)->toString());
         $this->assertSame('ipsum', str('Lorem ipsum')->substr(-5, length: 5)->toString());
     }
+
+    public function test_take(): void
+    {
+        // positive
+        $this->assertSame('Lorem', str('Lorem ipsum')->take(5)->toString());
+        $this->assertSame('Lorem ipsum', str('Lorem ipsum')->take(100)->toString());
+
+        // negative
+        $this->assertSame('ipsum', str('Lorem ipsum')->take(-5)->toString());
+    }
 }

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -520,4 +520,16 @@ b'));
         $this->assertSame(['foo', 'bar', 'baz'], str('foobarbaz')->split(3)->toArray());
         $this->assertSame(['foo', 'bar', 'baz', '22'], str('foobarbaz22')->split(3)->toArray());
     }
+
+    public function test_insert(): void
+    {
+        $this->assertSame('foo', str()->insert(0, 'foo')->toString());
+        $this->assertSame('foo', str()->insert(-1, 'foo')->toString());
+        $this->assertSame('foo', str()->insert(100, 'foo')->toString());
+        $this->assertSame('foo', str()->insert(-100, 'foo')->toString());
+        $this->assertSame('foobar', str('bar')->insert(0, 'foo')->toString());
+        $this->assertSame('barfoo', str('bar')->insert(3, 'foo')->toString());
+        $this->assertSame('foobarbaz', str('foobaz')->insert(3, 'bar')->toString());
+        $this->assertSame('123', str('13')->insert(-1, '2')->toString());
+    }
 }

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -491,4 +491,13 @@ b'));
         $this->assertSame('Lorem ipsum', str('Lorem ipsum')->limit(100)->toString());
         $this->assertSame('Lorem ipsum', str('Lorem ipsum')->limit(100, end: '...')->toString());
     }
+
+    public function test_substr(): void
+    {
+        $this->assertSame('Lorem', str('Lorem ipsum')->substr(0, length: 5)->toString());
+        $this->assertSame('ipsum', str('Lorem ipsum')->substr(6, length: 5)->toString());
+        $this->assertSame('ipsum', str('Lorem ipsum')->substr(6)->toString());
+        $this->assertSame('ipsum', str('Lorem ipsum')->substr(-5)->toString());
+        $this->assertSame('ipsum', str('Lorem ipsum')->substr(-5, length: 5)->toString());
+    }
 }

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -546,4 +546,15 @@ b'));
         $this->assertSame('ab1d', str('abcd')->replaceAt(-1, -1, '1')->toString());
         $this->assertSame('abc', str('abc')->replaceAt(3, 1, '')->toString());
     }
+
+    public function test_strip_tags(): void
+    {
+        $this->assertSame('Hello World', str('<p>Hello World</p>')->stripTags()->toString());
+        $this->assertSame('Hello World', str('<p>Hello <strong>World</strong></p>')->stripTags()->toString());
+        $this->assertSame('Hello <strong>World</strong>', str('<p>Hello <strong>World</strong></p>')->stripTags(allowed: '<strong>')->toString());
+        $this->assertSame('<p>Hello World</p>', str('<p>Hello <strong>World</strong></p>')->stripTags(allowed: '<p>')->toString());
+
+        $this->assertSame('Hello <strong>World</strong>', str('<p>Hello <strong>World</strong></p>')->stripTags(allowed: 'strong')->toString());
+        $this->assertSame('<p>Hello World</p>', str('<p>Hello <strong>World</strong></p>')->stripTags(allowed: 'p')->toString());
+    }
 }

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -533,4 +533,17 @@ b'));
         $this->assertSame('foobarbaz', str('foobaz')->insert(3, 'bar')->toString());
         $this->assertSame('123', str('13')->insert(-1, '2')->toString());
     }
+
+    public function test_replace_at(): void
+    {
+        $this->assertSame('foobar', str('foo2bar')->replaceAt(4, -1, '')->toString());
+        $this->assertSame('foobar', str('foo2bar')->replaceAt(3, 1, '')->toString());
+        $this->assertSame('fooquxbar', str('foo2bar')->replaceAt(3, 1, 'qux')->toString());
+        $this->assertSame('foobarbaz', str('barbaz')->replaceAt(0, 0, 'foo')->toString());
+        $this->assertSame('barbazfoo', str('barbaz')->replaceAt(6, 0, 'foo')->toString());
+        $this->assertSame('bar', str('foo')->replaceAt(0, 3, 'bar')->toString());
+        $this->assertSame('abc1', str('abcd')->replaceAt(-1, 1, '1')->toString());
+        $this->assertSame('ab1d', str('abcd')->replaceAt(-1, -1, '1')->toString());
+        $this->assertSame('abc', str('abc')->replaceAt(3, 1, '')->toString());
+    }
 }

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -481,4 +481,14 @@ b'));
         $this->assertSame('Leon Scott Kennedy', str('Scott Kennedy')->start('Leon ')->toString());
         $this->assertSame('Leon Scott Kennedy', str('Leon Scott Kennedy')->start('Leon ')->toString());
     }
+
+    public function test_limit(): void
+    {
+        $this->assertSame('Lorem', str('Lorem ipsum')->limit(5)->toString());
+        $this->assertSame('Lorem...', str('Lorem ipsum')->limit(5, end: '...')->toString());
+        $this->assertSame('...', str('Lorem ipsum')->limit(0, end: '...')->toString());
+        $this->assertSame('L...', str('Lorem ipsum')->limit(1, end: '...')->toString());
+        $this->assertSame('Lorem ipsum', str('Lorem ipsum')->limit(100)->toString());
+        $this->assertSame('Lorem ipsum', str('Lorem ipsum')->limit(100, end: '...')->toString());
+    }
 }

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -513,7 +513,8 @@ b'));
 
     public function test_split(): void
     {
-        $this->assertSame([], str()->split(1)->toArray());
+        $this->assertSame([PHP_EOL], str(PHP_EOL)->split(100)->toArray());
+        $this->assertSame([''], str('')->split(1)->toArray());
         $this->assertSame([], str('123')->split(-1)->toArray());
         $this->assertSame(['1', '2', '3'], str('123')->split(1)->toArray());
         $this->assertSame(['123'], str('123')->split(1000)->toArray());

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -484,12 +484,12 @@ b'));
 
     public function test_limit(): void
     {
-        $this->assertSame('Lorem', str('Lorem ipsum')->limit(5)->toString());
-        $this->assertSame('Lorem...', str('Lorem ipsum')->limit(5, end: '...')->toString());
-        $this->assertSame('...', str('Lorem ipsum')->limit(0, end: '...')->toString());
-        $this->assertSame('L...', str('Lorem ipsum')->limit(1, end: '...')->toString());
-        $this->assertSame('Lorem ipsum', str('Lorem ipsum')->limit(100)->toString());
-        $this->assertSame('Lorem ipsum', str('Lorem ipsum')->limit(100, end: '...')->toString());
+        $this->assertSame('Lorem', str('Lorem ipsum')->truncate(5)->toString());
+        $this->assertSame('Lorem...', str('Lorem ipsum')->truncate(5, end: '...')->toString());
+        $this->assertSame('...', str('Lorem ipsum')->truncate(0, end: '...')->toString());
+        $this->assertSame('L...', str('Lorem ipsum')->truncate(1, end: '...')->toString());
+        $this->assertSame('Lorem ipsum', str('Lorem ipsum')->truncate(100)->toString());
+        $this->assertSame('Lorem ipsum', str('Lorem ipsum')->truncate(100, end: '...')->toString());
     }
 
     public function test_substr(): void


### PR DESCRIPTION
This pull request adds many methods to `ArrayHelper` and `StringHelper`. This is stuff I had the need for when working on an upcoming console components overhaul PR.

Normally, I would send multiple PRs for each change, but there are too many. Reviewing this PR commit-by-commit might be easier.

### Changes to `ArrayHelper`

- `arr(null)` instanciates an empty instance instead of `[null]`
- Added generics to `first` and `last`
- Added `int` support to `get` and `has`
- Added `flatten` and `flatMap`

### Changes to `StringHelper`

- Instanciating `StringHelper` with `null` will no longer crash
- Added `replaceAt`, for replacing a portion of a string with another a the specified position
- Added `insert`, which inserts a string at the specified position
- Added `limit`, for truncating a string
- Added `substr`, which proxies `mb_substr`
- Added `take`, which keeps only the specified amount of characters
- Added `split`, which chunks the string using `str_split`
- Added `stripTags`, for stripping HTML tags in a string