### PR TITLE
feat(console): accept `BackedEnum` as command arguments

### DIFF
--- a/src/Tempest/Console/src/Actions/RenderConsoleCommand.php
+++ b/src/Tempest/Console/src/Actions/RenderConsoleCommand.php
@@ -32,6 +32,10 @@ final readonly class RenderConsoleCommand
 
     private function renderArgument(ConsoleArgumentDefinition $argument): string
     {
+        if ($argument->isBackedEnum()) {
+            return $this->renderEnumArgument($argument);
+        }
+
         $name = str($argument->name)
             ->prepend('<em>')
             ->append('</em>');
@@ -52,5 +56,25 @@ final readonly class RenderConsoleCommand
             is_array($argument->default) => "[{$asString}=array]",
             default => "[{$asString}={$argument->default}]"
         };
+    }
+
+    private function renderEnumArgument(ConsoleArgumentDefinition $argument): string
+    {
+        $enum = $argument->type;
+        $values = $enum::cases();
+        $parts = [];
+
+        foreach ($values as $value) {
+            $parts[] = $value->value;
+        }
+
+        $partsAsString = ' {<em>' . implode('|', $parts) . '</em>}';
+        $line = "<em>{$argument->name}</em>";
+
+        if ($argument->hasDefault) {
+            return "[{$line}={$argument->default->value}{$partsAsString}]";
+        }
+
+        return "<{$line}{$partsAsString}>";
     }
 }

--- a/src/Tempest/Console/src/Actions/RenderConsoleCommand.php
+++ b/src/Tempest/Console/src/Actions/RenderConsoleCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Console\Actions;
 
+use BackedEnum;
 use Tempest\Console\Console;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Input\ConsoleArgumentDefinition;
@@ -60,13 +61,10 @@ final readonly class RenderConsoleCommand
 
     private function renderEnumArgument(ConsoleArgumentDefinition $argument): string
     {
-        $enum = $argument->type;
-        $values = $enum::cases();
-        $parts = [];
-
-        foreach ($values as $value) {
-            $parts[] = $value->value;
-        }
+        $parts = array_map(
+            callback: fn (BackedEnum $case) => $case->value,
+            array: $argument->type::cases()
+        );
 
         $partsAsString = ' {<em>' . implode('|', $parts) . '</em>}';
         $line = "<em>{$argument->name}</em>";

--- a/src/Tempest/Console/src/Exceptions/InvalidEnumArgument.php
+++ b/src/Tempest/Console/src/Exceptions/InvalidEnumArgument.php
@@ -25,10 +25,9 @@ final class InvalidEnumArgument extends ConsoleException
 
     public function render(Console $console): void
     {
-        if (is_string($this->value)) {
+        if (is_string($this->value) || is_numeric($this->value)) {
             $value = "`{$this->value}`";
         } else {
-            // rather unreachable, but just in case
             $value = 'of type `' . gettype($this->value) . '`';
         }
 

--- a/src/Tempest/Console/src/Exceptions/InvalidEnumArgument.php
+++ b/src/Tempest/Console/src/Exceptions/InvalidEnumArgument.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Exceptions;
+
+use function array_map;
+use BackedEnum;
+use function gettype;
+use function implode;
+use function is_string;
+use Tempest\Console\Console;
+
+final class InvalidEnumArgument extends ConsoleException
+{
+    /**
+     * @param class-string<BackedEnum> $argumentType
+     */
+    public function __construct(
+        private string $argumentName,
+        private string $argumentType,
+        private mixed $value,
+    ) {
+    }
+
+    public function render(Console $console): void
+    {
+        if (is_string($this->value)) {
+            $value = "`{$this->value}`";
+        } else {
+            // rather unreachable, but just in case
+            $value = 'of type `' . gettype($this->value) . '`';
+        }
+
+        $cases = array_map(
+            callback: fn (BackedEnum $case) => $case->value,
+            array: $this->argumentType::cases(),
+        );
+        $console->error("Invalid argument {$value} for `{$this->argumentName}` argument, valid values are: " . implode(', ', $cases));
+    }
+}

--- a/src/Tempest/Console/src/Input/ConsoleArgumentBag.php
+++ b/src/Tempest/Console/src/Input/ConsoleArgumentBag.php
@@ -114,21 +114,25 @@ final class ConsoleArgumentBag
         ConsoleArgumentDefinition $argumentDefinition,
         ConsoleInputArgument $argument,
     ): ConsoleInputArgument {
-        if ($argumentDefinition->isBackedEnum()) {
-            $resolved = $argumentDefinition->type::tryFrom($argument->value);
-
-            if ($resolved === null) {
-                throw new InvalidEnumArgument(
-                    $argumentDefinition->name,
-                    $argumentDefinition->type,
-                    $argument->value,
-                );
-            }
-
-            $argument->value = $resolved;
+        if (! $argumentDefinition->isBackedEnum()) {
+            return $argument;
         }
 
-        return $argument;
+        $resolved = $argumentDefinition->type::tryFrom($argument->value);
+
+        if ($resolved === null) {
+            throw new InvalidEnumArgument(
+                $argumentDefinition->name,
+                $argumentDefinition->type,
+                $argument->value,
+            );
+        }
+
+        return new ConsoleInputArgument(
+            name: $argumentDefinition->name,
+            position: $argumentDefinition->position,
+            value: $resolved,
+        );
     }
 
     public function findArrayFor(ConsoleArgumentDefinition $argumentDefinition): ?ConsoleInputArgument

--- a/src/Tempest/Console/src/Input/ConsoleArgumentDefinition.php
+++ b/src/Tempest/Console/src/Input/ConsoleArgumentDefinition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Console\Input;
 
+use BackedEnum;
 use Tempest\Console\ConsoleArgument;
 use Tempest\Reflection\ParameterReflector;
 use function Tempest\Support\str;
@@ -69,5 +70,10 @@ final readonly class ConsoleArgumentDefinition
         }
 
         return $normalizedName->toString();
+    }
+
+    public function isBackedEnum(): bool
+    {
+        return is_subclass_of($this->type, BackedEnum::class);
     }
 }

--- a/tests/Integration/Console/ConsoleArgumentBagTest.php
+++ b/tests/Integration/Console/ConsoleArgumentBagTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tests\Tempest\Integration\Console;
 
 use PHPUnit\Framework\Attributes\TestWith;
+use Tempest\Console\Exceptions\InvalidEnumArgument;
 use Tempest\Console\Input\ConsoleArgumentBag;
 use Tempest\Console\Input\ConsoleArgumentDefinition;
+use Tests\Tempest\Integration\Console\Fixtures\TestStringEnum;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 /**
@@ -136,6 +138,49 @@ final class ConsoleArgumentBagTest extends FrameworkIntegrationTestCase
         );
 
         $this->assertSame($expected, $bag->findFor($definition)->value);
+    }
+
+    public function test_backed_enum_input(): void
+    {
+        $argv = [
+            'tempest',
+            'test',
+            '--type=a',
+        ];
+
+        $bag = new ConsoleArgumentBag($argv);
+
+        $definition = new ConsoleArgumentDefinition(
+            name: 'type',
+            type: TestStringEnum::class,
+            default: null,
+            hasDefault: false,
+            position: 0,
+        );
+
+        $this->assertSame(TestStringEnum::A, $bag->findFor($definition)->value);
+    }
+
+    public function test_invalid_backed_enum_input(): void
+    {
+        $argv = [
+            'tempest',
+            'test',
+            '--type=invalid',
+        ];
+
+        $bag = new ConsoleArgumentBag($argv);
+
+        $definition = new ConsoleArgumentDefinition(
+            name: 'type',
+            type: TestStringEnum::class,
+            default: null,
+            hasDefault: false,
+            position: 0,
+        );
+
+        $this->expectException(InvalidEnumArgument::class);
+        $bag->findFor($definition);
     }
 
     public function test_name_mapping(): void

--- a/tests/Integration/Console/Fixtures/MyConsole.php
+++ b/tests/Integration/Console/Fixtures/MyConsole.php
@@ -14,6 +14,8 @@ final class MyConsole
     )]
     public function handle(
         string $path,
+        TestStringEnum $type,
+        TestStringEnum $fallback = TestStringEnum::A,
         int    $times = 1,
         bool   $force = false,
     ): void {

--- a/tests/Integration/Console/Fixtures/TestStringEnum.php
+++ b/tests/Integration/Console/Fixtures/TestStringEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Console\Fixtures;
+
+enum TestStringEnum: string
+{
+    case A = 'a';
+    case B = 'b';
+    case C = 'c';
+}

--- a/tests/Integration/Console/RenderConsoleCommandTest.php
+++ b/tests/Integration/Console/RenderConsoleCommandTest.php
@@ -46,7 +46,7 @@ final class RenderConsoleCommandTest extends FrameworkIntegrationTestCase
         (new RenderConsoleCommand($console))($consoleCommand);
 
         $this->assertSame(
-            'test <path> [times=1] [--force=false] - description',
+            'test <path> <type {a|b|c}> [fallback=a {a|b|c}] [times=1] [--force=false] - description',
             trim($output->getBufferWithoutFormatting()[0]),
         );
     }


### PR DESCRIPTION
This pull request brings possibility of using enums as command arguments.

So this will be possible
```php
enum Type: string
{
    case JSON = 'json';
    case TEXT = 'text';
}

class MyCommand
{
    #[ConsoleCommand('cmd')]
    public function __invoke(Type $type): void {}
}
```

Call
```
./tempest cmd --type=json
```

in case of wrong value:
```
Invalid argument `invalid` for `type` argument, valid values are: json, text
```

And definition will be displayed as
```
cmd <type {json|text}>
```