### PR TITLE
fix(console): handle nested `style` tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/uid": "^7.1",
         "symfony/var-dumper": "^7.1",
         "symfony/var-exporter": "^7.1",
-        "tempest/highlight": "^2.11",
+        "tempest/highlight": "^2.11.2",
         "vlucas/phpdotenv": "^5.6"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/uid": "^7.1",
         "symfony/var-dumper": "^7.1",
         "symfony/var-exporter": "^7.1",
-        "tempest/highlight": "^2.0",
+        "tempest/highlight": "^2.11",
         "vlucas/phpdotenv": "^5.6"
     },
     "require-dev": {

--- a/src/Tempest/Console/composer.json
+++ b/src/Tempest/Console/composer.json
@@ -9,7 +9,7 @@
         "tempest/core": "dev-main",
         "tempest/container": "dev-main",
         "tempest/debug": "dev-main",
-        "tempest/highlight": "^2.11",
+        "tempest/highlight": "^2.11.2",
         "tempest/log": "dev-main",
         "tempest/reflection": "dev-main",
         "tempest/support": "dev-main",

--- a/src/Tempest/Console/composer.json
+++ b/src/Tempest/Console/composer.json
@@ -9,7 +9,7 @@
         "tempest/core": "dev-main",
         "tempest/container": "dev-main",
         "tempest/debug": "dev-main",
-        "tempest/highlight": "^2.0",
+        "tempest/highlight": "^2.11",
         "tempest/log": "dev-main",
         "tempest/reflection": "dev-main",
         "tempest/support": "dev-main",

--- a/src/Tempest/Console/src/Highlight/DynamicTokenType.php
+++ b/src/Tempest/Console/src/Highlight/DynamicTokenType.php
@@ -15,7 +15,7 @@ final readonly class DynamicTokenType implements TokenType
     ) {
     }
 
-    public function getStyle(): TerminalStyle
+    public function getBeforeStyle(): TerminalStyle|string
     {
         $normalizedStyle = str($this->style)
             ->lower()
@@ -32,6 +32,56 @@ final readonly class DynamicTokenType implements TokenType
         }
 
         return TerminalStyle::RESET;
+    }
+
+    public function getAfterStyle(): TerminalStyle|string
+    {
+        return match ($this->getBeforeStyle()) {
+            // Mods
+            TerminalStyle::BOLD => TerminalStyle::RESET_INTENSITY,
+            TerminalStyle::DIM => TerminalStyle::RESET_INTENSITY,
+            TerminalStyle::ITALIC => TerminalStyle::RESET_ITALIC,
+            TerminalStyle::HIDDEN => TerminalStyle::VISIBLE,
+            TerminalStyle::UNDERLINE => TerminalStyle::RESET_UNDERLINE,
+            TerminalStyle::OVERLINE => TerminalStyle::RESET_OVERLINE,
+            TerminalStyle::STRIKETHROUGH => TerminalStyle::RESET_STRIKETHROUGH,
+            TerminalStyle::REVERSE_TEXT => TerminalStyle::NON_REVERSE_TEXT,
+            // Foregrounds
+            TerminalStyle::FG_BLACK,
+            TerminalStyle::FG_DARK_RED,
+            TerminalStyle::FG_DARK_GREEN,
+            TerminalStyle::FG_DARK_YELLOW,
+            TerminalStyle::FG_DARK_BLUE,
+            TerminalStyle::FG_DARK_MAGENTA,
+            TerminalStyle::FG_DARK_CYAN,
+            TerminalStyle::FG_LIGHT_GRAY,
+            TerminalStyle::FG_GRAY,
+            TerminalStyle::FG_RED,
+            TerminalStyle::FG_GREEN,
+            TerminalStyle::FG_YELLOW,
+            TerminalStyle::FG_BLUE,
+            TerminalStyle::FG_MAGENTA,
+            TerminalStyle::FG_CYAN,
+            TerminalStyle::FG_WHITE => "39m",
+            // Backgrounds
+            TerminalStyle::BG_BLACK,
+            TerminalStyle::BG_DARK_RED,
+            TerminalStyle::BG_DARK_GREEN,
+            TerminalStyle::BG_DARK_YELLOW,
+            TerminalStyle::BG_DARK_BLUE,
+            TerminalStyle::BG_DARK_MAGENTA,
+            TerminalStyle::BG_DARK_CYAN,
+            TerminalStyle::BG_LIGHT_GRAY,
+            TerminalStyle::BG_GRAY,
+            TerminalStyle::BG_RED,
+            TerminalStyle::BG_GREEN,
+            TerminalStyle::BG_YELLOW,
+            TerminalStyle::BG_BLUE,
+            TerminalStyle::BG_MAGENTA,
+            TerminalStyle::BG_CYAN,
+            TerminalStyle::BG_WHITE => "49m",
+            default => TerminalStyle::RESET,
+        };
     }
 
     public function getValue(): string

--- a/src/Tempest/Console/src/Highlight/DynamicTokenType.php
+++ b/src/Tempest/Console/src/Highlight/DynamicTokenType.php
@@ -15,7 +15,7 @@ final readonly class DynamicTokenType implements TokenType
     ) {
     }
 
-    public function getBeforeStyle(): TerminalStyle|string
+    public function getBeforeStyle(): TerminalStyle
     {
         $normalizedStyle = str($this->style)
             ->lower()
@@ -34,7 +34,7 @@ final readonly class DynamicTokenType implements TokenType
         return TerminalStyle::RESET;
     }
 
-    public function getAfterStyle(): TerminalStyle|string
+    public function getAfterStyle(): TerminalStyle
     {
         return match ($this->getBeforeStyle()) {
             // Mods
@@ -45,7 +45,7 @@ final readonly class DynamicTokenType implements TokenType
             TerminalStyle::UNDERLINE => TerminalStyle::RESET_UNDERLINE,
             TerminalStyle::OVERLINE => TerminalStyle::RESET_OVERLINE,
             TerminalStyle::STRIKETHROUGH => TerminalStyle::RESET_STRIKETHROUGH,
-            TerminalStyle::REVERSE_TEXT => TerminalStyle::NON_REVERSE_TEXT,
+            TerminalStyle::REVERSE_TEXT => TerminalStyle::RESET_REVERSE_TEXT,
             // Foregrounds
             TerminalStyle::FG_BLACK,
             TerminalStyle::FG_DARK_RED,
@@ -62,7 +62,7 @@ final readonly class DynamicTokenType implements TokenType
             TerminalStyle::FG_BLUE,
             TerminalStyle::FG_MAGENTA,
             TerminalStyle::FG_CYAN,
-            TerminalStyle::FG_WHITE => "39m",
+            TerminalStyle::FG_WHITE => TerminalStyle::RESET_FOREGROUND,
             // Backgrounds
             TerminalStyle::BG_BLACK,
             TerminalStyle::BG_DARK_RED,
@@ -79,7 +79,7 @@ final readonly class DynamicTokenType implements TokenType
             TerminalStyle::BG_BLUE,
             TerminalStyle::BG_MAGENTA,
             TerminalStyle::BG_CYAN,
-            TerminalStyle::BG_WHITE => "49m",
+            TerminalStyle::BG_WHITE => TerminalStyle::RESET_BACKGROUND,
             default => TerminalStyle::RESET,
         };
     }

--- a/src/Tempest/Console/src/Highlight/TempestTerminalTheme.php
+++ b/src/Tempest/Console/src/Highlight/TempestTerminalTheme.php
@@ -56,13 +56,12 @@ final readonly class TempestTerminalTheme implements TerminalTheme
         } . TerminalStyle::RESET();
     }
 
-    // TODO: only accept TerminalStyle once `tempest/highlight` is up-to-date
-    private function style(string|TerminalStyle ...$styles): string
+    private function style(TerminalStyle ...$styles): string
     {
         return implode(
             '',
             array_map(
-                fn (string|TerminalStyle $style) => TerminalStyle::ESC->value . (is_string($style) ? $style : $style->value),
+                fn (TerminalStyle $style) => TerminalStyle::ESC->value .  $style->value,
                 $styles,
             ),
         );

--- a/src/Tempest/Console/src/Highlight/TempestTerminalTheme.php
+++ b/src/Tempest/Console/src/Highlight/TempestTerminalTheme.php
@@ -17,7 +17,7 @@ final readonly class TempestTerminalTheme implements TerminalTheme
     public function before(TokenType $tokenType): string
     {
         if ($tokenType instanceof DynamicTokenType) {
-            return $this->style($tokenType->getStyle());
+            return $this->style($tokenType->getBeforeStyle());
         }
 
         return match ($tokenType) {
@@ -42,6 +42,10 @@ final readonly class TempestTerminalTheme implements TerminalTheme
 
     public function after(TokenType $tokenType): string
     {
+        if ($tokenType instanceof DynamicTokenType) {
+            return $this->style($tokenType->getAfterStyle());
+        }
+
         return match ($tokenType) {
             ConsoleTokenType::ERROR,
             ConsoleTokenType::QUESTION,
@@ -52,12 +56,13 @@ final readonly class TempestTerminalTheme implements TerminalTheme
         } . TerminalStyle::RESET();
     }
 
-    private function style(TerminalStyle ...$styles): string
+    // TODO: only accept TerminalStyle once `tempest/highlight` is up-to-date
+    private function style(string|TerminalStyle ...$styles): string
     {
         return implode(
             '',
             array_map(
-                fn (TerminalStyle $style) => TerminalStyle::ESC->value . $style->value,
+                fn (string|TerminalStyle $style) => TerminalStyle::ESC->value . (is_string($style) ? $style : $style->value),
                 $styles,
             ),
         );

--- a/src/Tempest/Console/tests/TempestConsoleLanguage/Injections/DynamicInjectionTest.php
+++ b/src/Tempest/Console/tests/TempestConsoleLanguage/Injections/DynamicInjectionTest.php
@@ -16,15 +16,18 @@ use Tempest\Highlight\Highlighter;
  */
 final class DynamicInjectionTest extends TestCase
 {
-    #[TestWith(['<style="fg-cyan">foo</style>', "\e[96mfoo\e[0m"])]
-    #[TestWith(['<style="bg-red">foo</style>', "\e[101mfoo\e[0m"])]
-    #[TestWith(['<style="bold">foo</style>', "\e[1mfoo\e[0m"])]
-    #[TestWith(['<style="underline">foo</style>', "\e[4mfoo\e[0m"])]
+    #[TestWith(['<style="fg-cyan">foo</style>', "\e[96mfoo\e[39m"])]
+    #[TestWith(['<style="bg-red">foo</style>', "\e[101mfoo\e[49m"])]
+    #[TestWith(['<style="bold">foo</style>', "\e[1mfoo\e[22m"])]
+    #[TestWith(['<style="underline">foo</style>', "\e[4mfoo\e[24m"])]
     #[TestWith(['<style="reset">foo</style>', "\e[0mfoo\e[0m"])]
-    #[TestWith(['<style="reverse-text">foo</style>', "\e[7mfoo\e[0m"])]
-    #[TestWith(['<style="bg-darkcyan fg-cyan underline">Tempest</style>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
-    #[TestWith(['<style="bg-dark-cyan fg-cyan underline">Tempest</style>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
-    #[TestWith(['<style="fg-cyan"><style="bg-dark-red">foo</style></style>', "\e[96m\e[41mfoo\e[0m\e[0m"])]
+    #[TestWith(['<style="reverse-text">foo</style>', "\e[7mfoo\e[27m"])]
+    #[TestWith(['<style="bg-darkcyan fg-cyan underline">Tempest</style>', "\e[46m\e[96m\e[4mTempest\e[49m\e[39m\e[24m"])]
+    #[TestWith(['<style="bg-dark-cyan fg-cyan underline">Tempest</style>', "\e[46m\e[96m\e[4mTempest\e[49m\e[39m\e[24m"])]
+    #[TestWith(['<style="fg-cyan"><style="bg-dark-red">foo</style></style>', "\e[96m\e[41mfoo\e[49m\e[39m"])]
+    #[TestWith(['<style="dim"><style="bg-dark-red fg-white">foo</style></style>', "\e[2m\e[41m\e[97mfoo\e[49m\e[39m\e[22m"])]
+    #[TestWith(['<style="fg-cyan">cyan</style>unstyled<style="bg-dark-red">dark red</style>', "\e[96mcyan\e[39munstyled\e[41mdark red\e[49m"])]
+    #[TestWith(['<style="dim"><style="fg-gray">dim-gray</style> just-gray</style>', "\e[2m\e[90mdim-gray\e[39m just-gray\e[22m"])]
     #[Test]
     public function language(string $content, string $expected): void
     {

--- a/src/Tempest/Debug/composer.json
+++ b/src/Tempest/Debug/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^8.3",
-        "tempest/highlight": "^2.11",
+        "tempest/highlight": "^2.11.2",
         "symfony/var-dumper": "^7.1"
     },
     "autoload": {

--- a/src/Tempest/Debug/composer.json
+++ b/src/Tempest/Debug/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^8.3",
-        "tempest/highlight": "^2.0",
+        "tempest/highlight": "^2.11",
         "symfony/var-dumper": "^7.1"
     },
     "autoload": {

--- a/src/Tempest/Http/composer.json
+++ b/src/Tempest/Http/composer.json
@@ -11,7 +11,7 @@
         "tempest/view": "dev-main",
         "tempest/mapper": "dev-main",
         "tempest/container": "dev-main",
-        "tempest/highlight": "^2.0",
+        "tempest/highlight": "^2.11",
         "laminas/laminas-diactoros": "^3.3",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0|^2.0",

--- a/src/Tempest/Http/composer.json
+++ b/src/Tempest/Http/composer.json
@@ -11,7 +11,7 @@
         "tempest/view": "dev-main",
         "tempest/mapper": "dev-main",
         "tempest/container": "dev-main",
-        "tempest/highlight": "^2.11",
+        "tempest/highlight": "^2.11.2",
         "laminas/laminas-diactoros": "^3.3",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0|^2.0",

--- a/tests/Integration/Console/Highlight/TempestConsoleLanguage/TempestConsoleLanguageTest.php
+++ b/tests/Integration/Console/Highlight/TempestConsoleLanguage/TempestConsoleLanguageTest.php
@@ -16,15 +16,18 @@ use Tempest\Highlight\Highlighter;
  */
 final class TempestConsoleLanguageTest extends TestCase
 {
-    #[TestWith(['<style="fg-cyan">foo</style>', "\e[96mfoo\e[0m"])]
-    #[TestWith(['<style="bg-red">foo</style>', "\e[101mfoo\e[0m"])]
-    #[TestWith(['<style="bold">foo</style>', "\e[1mfoo\e[0m"])]
-    #[TestWith(['<style="underline">foo</style>', "\e[4mfoo\e[0m"])]
+    #[TestWith(['<style="fg-cyan">foo</style>', "\e[96mfoo\e[39m"])]
+    #[TestWith(['<style="bg-red">foo</style>', "\e[101mfoo\e[49m"])]
+    #[TestWith(['<style="bold">foo</style>', "\e[1mfoo\e[22m"])]
+    #[TestWith(['<style="underline">foo</style>', "\e[4mfoo\e[24m"])]
     #[TestWith(['<style="reset">foo</style>', "\e[0mfoo\e[0m"])]
-    #[TestWith(['<style="reverse-text">foo</style>', "\e[7mfoo\e[0m"])]
-    #[TestWith(['<style="bg-darkcyan fg-cyan underline">Tempest</style>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
-    #[TestWith(['<style="bg-dark-cyan fg-cyan underline">Tempest</style>', "\e[46m\e[96m\e[4mTempest\e[0m\e[0m\e[0m"])]
-    #[TestWith(['<style="fg-cyan"><style="bg-dark-red">foo</style></style>', "\e[96m\e[41mfoo\e[0m\e[0m"])]
+    #[TestWith(['<style="reverse-text">foo</style>', "\e[7mfoo\e[27m"])]
+    #[TestWith(['<style="bg-darkcyan fg-cyan underline">Tempest</style>', "\e[46m\e[96m\e[4mTempest\e[49m\e[39m\e[24m"])]
+    #[TestWith(['<style="bg-dark-cyan fg-cyan underline">Tempest</style>', "\e[46m\e[96m\e[4mTempest\e[49m\e[39m\e[24m"])]
+    #[TestWith(['<style="fg-cyan"><style="bg-dark-red">foo</style></style>', "\e[96m\e[41mfoo\e[49m\e[39m"])]
+    #[TestWith(['<style="dim"><style="bg-dark-red fg-white">foo</style></style>', "\e[2m\e[41m\e[97mfoo\e[49m\e[39m\e[22m"])]
+    #[TestWith(['<style="fg-cyan">cyan</style>unstyled<style="bg-dark-red">dark red</style>', "\e[96mcyan\e[39munstyled\e[41mdark red\e[49m"])]
+    #[TestWith(['<style="dim"><style="fg-gray">dim-gray</style> just-gray</style>', "\e[2m\e[90mdim-gray\e[39m just-gray\e[22m"])]
     #[Test]
     public function language(string $content, string $expected): void
     {


### PR DESCRIPTION
This pull request is a follow-up of #703. It improves support for nested `<style>` tags and better handles ending tags (`</style>`).

&nbsp;

## Nesting <style>

The first change is the support for nested `<style>` tags. I changed the regular expression to use a negative lookahead (`(?!\<style)`) that prevents matching nested `<style>` tags. Without this, the following would be matched as one block:

```
<style="dim">[<style="fg-cyan">cyan</style>]</style>
```

The replacement would then miss styles. Now, it properly matches two distinct blocks.

&nbsp;

## Handling resets

The second change is an update to how `</style>` resets the current style. Instead of using `0m` to reset all styles, it will use more specific reset codes depending on the opening tag.

For instance:

```
<style="dim"><style="fg-gray">dim-gray</style> just-dim</style>
```

Previously, after the first `</style>`, all colors and modifiers would be reset, so `just-dim` would use the default text style.

Now, `</style>` will reset the foreground color only, keeping the previous `dim` modifier intact, so `just-dim` will still be dimmed.

&nbsp;

> [!NOTE]
> This pull request depends on https://github.com/tempestphp/highlight/pull/163 for the new reset cases on `TerminalStyle`.
> Once `tempest/highlight` is tagged a new version, I'll update this PR with the new version and refactor the part of the code where I used strings instead of the missing `TerminalStyle` cases.
