### PR TITLE
feat(view): add raw html element

### DIFF
--- a/src/Tempest/View/src/Components/XForm.php
+++ b/src/Tempest/View/src/Components/XForm.php
@@ -7,7 +7,7 @@ namespace Tempest\View\Components;
 use Tempest\View\Elements\ViewComponentElement;
 use Tempest\View\ViewComponent;
 
-final readonly class Form implements ViewComponent
+final readonly class XForm implements ViewComponent
 {
     public static function getName(): string
     {

--- a/src/Tempest/View/src/Components/XInput.php
+++ b/src/Tempest/View/src/Components/XInput.php
@@ -9,7 +9,7 @@ use Tempest\Validation\Rule;
 use Tempest\View\Elements\ViewComponentElement;
 use Tempest\View\ViewComponent;
 
-final readonly class Input implements ViewComponent
+final readonly class XInput implements ViewComponent
 {
     public function __construct(
         private Session $session,

--- a/src/Tempest/View/src/Components/XSubmit.php
+++ b/src/Tempest/View/src/Components/XSubmit.php
@@ -7,7 +7,7 @@ namespace Tempest\View\Components;
 use Tempest\View\Elements\ViewComponentElement;
 use Tempest\View\ViewComponent;
 
-final readonly class Submit implements ViewComponent
+final readonly class XSubmit implements ViewComponent
 {
     public static function getName(): string
     {

--- a/src/Tempest/View/src/Elements/ElementFactory.php
+++ b/src/Tempest/View/src/Elements/ElementFactory.php
@@ -63,8 +63,11 @@ final class ElementFactory
 
         if (! $node instanceof DOMElement
             || $node->tagName === 'pre'
-            || $node->tagName === 'code') {
+            || $node->tagName === 'code'
+            || $node->tagName === 'x-raw'
+        ) {
             $content = '';
+
             foreach ($node->childNodes as $child) {
                 $content .= $node->ownerDocument->saveHTML($child);
             }
@@ -82,9 +85,9 @@ final class ElementFactory
             }
 
             $element = new ViewComponentElement(
-                $this->compiler,
-                $viewComponentClass,
-                $attributes,
+                compiler: $this->compiler,
+                viewComponent: $viewComponentClass,
+                attributes: $attributes,
             );
         } elseif ($node->tagName === 'x-slot') {
             $element = new SlotElement(

--- a/src/Tempest/View/src/Elements/RawElement.php
+++ b/src/Tempest/View/src/Elements/RawElement.php
@@ -21,7 +21,7 @@ final class RawElement implements Element
 
     public function compile(): string
     {
-        if ($this->tag === null) {
+        if ($this->tag === null || $this->tag === 'x-raw') {
             return $this->content;
         }
 

--- a/tests/Integration/View/TempestViewRendererTest.php
+++ b/tests/Integration/View/TempestViewRendererTest.php
@@ -416,4 +416,11 @@ HTML, foo: []),
         $html = $this->render(view('<x-view-component-with-multiple-attributes :a="\'a\'" b="b"></x-view-component-with-multiple-attributes>'));
         $this->assertStringEqualsStringIgnoringLineEndings($expected, $html);
     }
+
+    public function test_raw_component(): void
+    {
+        $html = $this->render('<x-raw><div :prop="$foo">{{ $bar }}</div></x-raw>');
+
+        $this->assertStringEqualsStringIgnoringLineEndings('<div :prop="$foo">{{ $bar }}</div>', $html);
+    }
 }

--- a/tests/Integration/View/ViewComponentDiscoveryTest.php
+++ b/tests/Integration/View/ViewComponentDiscoveryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\View;
 
-use Tempest\View\Components\Input;
+use Tempest\View\Components\XInput;
 use Tempest\View\Exceptions\DuplicateViewComponent;
 use Tempest\View\ViewComponentDiscovery;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -22,7 +22,7 @@ final class ViewComponentDiscoveryTest extends FrameworkIntegrationTestCase
             $discovery->discoverPath(__DIR__ . '/duplicateComponent.view.php');
         } catch (DuplicateViewComponent $duplicateViewComponent) {
             $this->assertStringContainsString(__DIR__ . '/duplicateComponent.view.php', $duplicateViewComponent->getMessage());
-            $this->assertStringContainsString(Input::class, $duplicateViewComponent->getMessage());
+            $this->assertStringContainsString(XInput::class, $duplicateViewComponent->getMessage());
             $this->assertStringContainsString('x-input', $duplicateViewComponent->getMessage());
         }
     }


### PR DESCRIPTION
Adds the ability to wrap any kind of HTML in `x-raw` so that Tempest's view compiler will ignore it.