### PR TITLE
feat(console): add "make:response" command

### DIFF
--- a/src/Tempest/Http/src/Commands/MakeResponseCommand.php
+++ b/src/Tempest/Http/src/Commands/MakeResponseCommand.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Tempest\Http\Commands;
 
-use Tempest\Http\Stubs\ResponseStub;
-use Tempest\Generation\Exceptions\FileGenerationFailedException;
-use Tempest\Generation\Exceptions\FileGenerationAbortedException;
-use Tempest\Generation\DataObjects\StubFile;
-use Tempest\Core\PublishesFiles;
-use Tempest\Console\ConsoleCommand;
 use Tempest\Console\ConsoleArgument;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Core\PublishesFiles;
+use Tempest\Generation\DataObjects\StubFile;
+use Tempest\Generation\Exceptions\FileGenerationAbortedException;
+use Tempest\Generation\Exceptions\FileGenerationFailedException;
+use Tempest\Http\Stubs\ResponseStub;
 
 final class MakeResponseCommand
 {

--- a/src/Tempest/Http/src/Commands/MakeResponseCommand.php
+++ b/src/Tempest/Http/src/Commands/MakeResponseCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Commands;
+
+use Tempest\Http\Stubs\ResponseStub;
+use Tempest\Generation\Exceptions\FileGenerationFailedException;
+use Tempest\Generation\Exceptions\FileGenerationAbortedException;
+use Tempest\Generation\DataObjects\StubFile;
+use Tempest\Core\PublishesFiles;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Console\ConsoleArgument;
+
+final class MakeResponseCommand
+{
+    use PublishesFiles;
+
+    #[ConsoleCommand(
+        name: 'make:response',
+        description: 'Creates a new response class',
+        aliases: ['response:make', 'response:create', 'create:response'],
+    )]
+    public function __invoke(
+        #[ConsoleArgument(
+            help: 'The name of the response class to create',
+        )]
+        string $className,
+    ): void {
+        $suggestedPath = $this->getSuggestedPath($className);
+        $targetPath = $this->promptTargetPath($suggestedPath);
+        $shouldOverride = $this->askForOverride($targetPath);
+
+        try {
+            $this->stubFileGenerator->generateClassFile(
+                stubFile: StubFile::from(ResponseStub::class),
+                targetPath: $targetPath,
+                shouldOverride: $shouldOverride,
+            );
+
+            $this->success(sprintf('Response successfully created at "%s".', $targetPath));
+        } catch (FileGenerationAbortedException|FileGenerationFailedException $e) {
+            $this->error($e->getMessage());
+        }
+    }
+}

--- a/src/Tempest/Http/src/Stubs/ResponseStub.php
+++ b/src/Tempest/Http/src/Stubs/ResponseStub.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Stubs;
+
+use Tempest\Http\IsResponse;
+use Tempest\Http\Response;
+use Tempest\Http\Status;
+
+final class ResponseStub implements Response
+{
+    use IsResponse;
+
+    public function __construct() {
+        $this->setStatus(Status::OK);
+        $this->addHeader('Content-Type', 'application/json');
+    }
+}

--- a/src/Tempest/Http/src/Stubs/ResponseStub.php
+++ b/src/Tempest/Http/src/Stubs/ResponseStub.php
@@ -12,7 +12,8 @@ final class ResponseStub implements Response
 {
     use IsResponse;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->setStatus(Status::OK);
         $this->addHeader('Content-Type', 'application/json');
     }

--- a/tests/Integration/Http/MakeResponseCommandTest.php
+++ b/tests/Integration/Http/MakeResponseCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Http;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Core\ComposerNamespace;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+/**
+ * @internal
+ */
+final class MakeResponseCommandTest extends FrameworkIntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->installer->configure(
+            __DIR__ . '/install',
+            new ComposerNamespace('App\\', __DIR__ . '/install/App')
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->installer->clean();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    #[DataProvider('command_input_provider')]
+    public function make_command(
+        string $commandArgs,
+        string $expectedPath,
+        string $expectedNamespace
+    ): void {
+        $this->console
+            ->call("make:response {$commandArgs}")
+            ->submit();
+
+        $this->installer
+            ->assertFileExists($expectedPath)
+            ->assertFileContains($expectedPath, 'namespace ' . $expectedNamespace . ';')
+            ->assertFileContains($expectedPath, 'implements Response')
+            ->assertFileContains($expectedPath, 'use IsResponse');
+    }
+
+    public static function command_input_provider(): array
+    {
+        return [
+            'make_with_defaults' => [
+                'commandArgs' => 'BookCreatedResponse',
+                'expectedPath' => 'App/BookCreatedResponse.php',
+                'expectedNamespace' => 'App',
+            ],
+            'make_with_other_namespace' => [
+                'commandArgs' => 'Responses\\BookCreatedResponse',
+                'expectedPath' => 'App/Responses/BookCreatedResponse.php',
+                'expectedNamespace' => 'App\\Responses',
+            ],
+            'make_with_input_path' => [
+                'commandArgs' => 'Responses/BookCreatedResponse',
+                'expectedPath' => 'App/Responses/BookCreatedResponse.php',
+                'expectedNamespace' => 'App\\Responses',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR add a basic implementation of the "make:response" command.
Not sure if we must give code example in the generated file of if we must keep it empty.

It updates the TODO on #759