### PR TITLE
refactor(console): update `make:controller` command parameters to be simpler

### DIFF
--- a/src/Tempest/Database/src/Commands/MakeModelCommand.php
+++ b/src/Tempest/Database/src/Commands/MakeModelCommand.php
@@ -39,7 +39,7 @@ final class MakeModelCommand
                 shouldOverride: $shouldOverride,
             );
 
-            $this->console->success(sprintf('File successfully created at "%s".', $targetPath));
+            $this->console->success(sprintf('Model successfully created at "%s".', $targetPath));
         } catch (FileGenerationAbortedException|FileGenerationFailedException $e) {
             $this->console->error($e->getMessage());
         }

--- a/src/Tempest/Http/src/Commands/MakeControllerCommand.php
+++ b/src/Tempest/Http/src/Commands/MakeControllerCommand.php
@@ -27,10 +27,12 @@ final class MakeControllerCommand
         )]
         string $className,
         #[ConsoleArgument(
+            name: 'path',
             help: 'The path of the route',
         )]
         ?string $controllerPath = null,
         #[ConsoleArgument(
+            name: 'view',
             help: 'The name of the view returned from the controller',
         )]
         ?string $controllerView = null,
@@ -50,7 +52,7 @@ final class MakeControllerCommand
                 ],
             );
 
-            $this->success(sprintf('File successfully created at "%s".', $targetPath));
+            $this->success(sprintf('Controller successfully created at "%s".', $targetPath));
         } catch (FileGenerationAbortedException|FileGenerationFailedException $e) {
             $this->error($e->getMessage());
         }


### PR DESCRIPTION
This PR refactor the `make:controller` parameters name to be easier to read.

Also, to be consistant with other make commands and to avoid another PR for this, I've updated the success message of `make:controller` and `make:model` to be more explicit