### PR TITLE
feat(database): custom model query builder

### DIFF
--- a/src/Tempest/Database/src/Builder/ModelQueryBuilder.php
+++ b/src/Tempest/Database/src/Builder/ModelQueryBuilder.php
@@ -11,8 +11,9 @@ use function Tempest\map;
 
 /**
  * @template TModelClass of DatabaseModel
+ * @phpstan-ignore-next-line because this model query builder is extended
  */
-final class ModelQueryBuilder
+class ModelQueryBuilder
 {
     private ModelDefinition $modelDefinition;
 

--- a/src/Tempest/Database/src/IsDatabaseModel.php
+++ b/src/Tempest/Database/src/IsDatabaseModel.php
@@ -10,6 +10,7 @@ use Tempest\Database\Exceptions\MissingRelation;
 use Tempest\Database\Exceptions\MissingValue;
 use function Tempest\get;
 use function Tempest\make;
+use function Tempest\reflect;
 use Tempest\Reflection\ClassReflector;
 use Tempest\Reflection\PropertyReflector;
 
@@ -73,7 +74,11 @@ trait IsDatabaseModel
      */
     public static function query(): ModelQueryBuilder
     {
-        return new ModelQueryBuilder(self::class);
+        $queryBuilderAttribute = reflect(self::class)->getAttribute(QueryBuilder::class);
+
+        return $queryBuilderAttribute === null
+            ? new ModelQueryBuilder(self::class)
+            : new ($queryBuilderAttribute->builderClass)(self::class);
     }
 
     /** @return self[] */

--- a/src/Tempest/Database/src/QueryBuilder.php
+++ b/src/Tempest/Database/src/QueryBuilder.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class QueryBuilder
+{
+    public function __construct(public string $builderClass)
+    {
+    }
+}

--- a/src/Tempest/Database/tests/Builder/Fixtures/BarModel.php
+++ b/src/Tempest/Database/tests/Builder/Fixtures/BarModel.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Tests\Builder\Fixtures;
+
+use Tempest\Database\DatabaseModel;
+use Tempest\Database\IsDatabaseModel;
+
+final class BarModel implements DatabaseModel
+{
+    use IsDatabaseModel;
+}

--- a/src/Tempest/Database/tests/Builder/Fixtures/FooModel.php
+++ b/src/Tempest/Database/tests/Builder/Fixtures/FooModel.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Tests\Builder\Fixtures;
+
+use Tempest\Database\DatabaseModel;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\QueryBuilder;
+
+#[QueryBuilder(FooQueryBuilder::class)]
+final class FooModel implements DatabaseModel
+{
+    use IsDatabaseModel;
+}

--- a/src/Tempest/Database/tests/Builder/Fixtures/FooQueryBuilder.php
+++ b/src/Tempest/Database/tests/Builder/Fixtures/FooQueryBuilder.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Tests\Builder\Fixtures;
+
+use Tempest\Database\Builder\ModelQueryBuilder;
+
+final class FooQueryBuilder extends ModelQueryBuilder
+{
+}

--- a/src/Tempest/Database/tests/Builder/ModelQueryBuilderTest.php
+++ b/src/Tempest/Database/tests/Builder/ModelQueryBuilderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Tests\Builder;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Database\Builder\ModelQueryBuilder;
+use Tempest\Database\Tests\Builder\Fixtures\BarModel;
+use Tempest\Database\Tests\Builder\Fixtures\FooModel;
+use Tempest\Database\Tests\Builder\Fixtures\FooQueryBuilder;
+
+/**
+ * @internal
+ */
+final class ModelQueryBuilderTest extends TestCase
+{
+    public function test_default_query_builder(): void
+    {
+        $queryBuilder = BarModel::query();
+        $this->assertInstanceOf(ModelQueryBuilder::class, $queryBuilder);
+    }
+
+    public function test_custom_query_builder(): void
+    {
+        $queryBuilder = FooModel::query();
+        $this->assertInstanceOf(FooQueryBuilder::class, $queryBuilder);
+    }
+}


### PR DESCRIPTION
This PR introduces `QueryBuilder` attribute allows custom model query builder for resuable and complexity logic

```php
#[QueryBuilder(UserQueryBuilder::class)]
final class User implements DatabaseModel
{
    use IsDatabaseModel;
    // ...
}
```