### PR TITLE
chore: cs-fixer updates

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -25,6 +25,7 @@ return (new PhpCsFixer\Config())
         'no_leading_import_slash' => true,
         'fully_qualified_strict_types' => [
             'import_symbols' => true,
+            'phpdoc_tags' => [],
         ],
         'global_namespace_import' => [
             'import_classes' => true,


### PR DESCRIPTION
The newest CS fixer update (https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.65.0) adds some new features that make it so more phpdoc types are imported. The problem is that our ORM relies on the FQCN to be present in docblocks. That's why I've made this config adjustment