### PR TITLE
fix(http): remove empty directories when running `static:clean`

### DIFF
--- a/src/Tempest/Http/src/Static/StaticCleanCommand.php
+++ b/src/Tempest/Http/src/Static/StaticCleanCommand.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tempest\Http\Static;
 
+use FilesystemIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
-use Tempest\Console\Console;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\HasConsole;
 use Tempest\Console\Middleware\CautionMiddleware;
@@ -19,7 +19,6 @@ final readonly class StaticCleanCommand
     use HasConsole;
 
     public function __construct(
-        private Console $console,
         private Kernel $kernel,
     ) {
     }
@@ -30,10 +29,20 @@ final readonly class StaticCleanCommand
     )]
     public function __invoke(): void
     {
+
+        $directoryIterator = new RecursiveDirectoryIterator($this->kernel->root.'/public');
+        $directoryIterator->setFlags(FilesystemIterator::SKIP_DOTS);
+
+        $this->removeFiles($directoryIterator);
+        $this->removeEmptyDirectories($directoryIterator);
+
+        $this->success('Done');
+    }
+
+    private function removeFiles(RecursiveDirectoryIterator $directoryIterator): void
+    {
         /** @var SplFileInfo[] $files */
         $files = [];
-
-        $directoryIterator = new RecursiveDirectoryIterator($this->kernel->root . '/public');
 
         /** @var SplFileInfo $file */
         foreach (new RecursiveIteratorIterator($directoryIterator) as $file) {
@@ -49,7 +58,25 @@ final readonly class StaticCleanCommand
 
             $this->writeln("- <u>{$pathName}</u> removed");
         }
+    }
 
-        $this->success('Done');
+    private function removeEmptyDirectories(RecursiveDirectoryIterator $directoryIterator): void
+    {
+        /** @var SplFileInfo $file */
+        foreach (new RecursiveIteratorIterator($directoryIterator, RecursiveIteratorIterator::CHILD_FIRST) as $file) {
+            if (! $file->isDir()) {
+                continue;
+            }
+
+            if (count(glob($file->getPathname().'/*')) > 0) {
+                continue;
+            }
+
+            rmdir($file->getPathname());
+
+            $pathName = str_replace('\\', '/', $file->getPathname());
+
+            $this->writeln("- <u>{$pathName}</u> directory removed");
+        }
     }
 }

--- a/tests/Integration/Http/Static/StaticCleanCommandTest.php
+++ b/tests/Integration/Http/Static/StaticCleanCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Integration\Http\Static;
+namespace Tests\Tempest\Integration\Http\Static;
 
 use Tempest\Core\AppConfig;
 use function Tempest\path;
@@ -29,5 +29,6 @@ final class StaticCleanCommandTest extends FrameworkIntegrationTestCase
 
         $this->assertFileDoesNotExist(path($root, '/public/static/a/b/index.html')->toString());
         $this->assertFileDoesNotExist(path($root, '/public/static/c/d/index.html')->toString());
+        $this->assertDirectoryDoesNotExist(path($root, '/public/static')->toString());
     }
 }


### PR DESCRIPTION
Fixes #777.

I opted to split the functionality out into private methods to keep it nice and readable. If that's unwanted, let me know and I'll change it back to all be contained within the `__invoke()` method.

---

- I also removed the unnecessary `$console` property from the command class. It's injected in the parent class and was unused anyway.
- I also fixed the namespace for the test.