### PR TITLE
fix: change order of scripts in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -152,8 +152,8 @@
             "composer merge",
             "./bin/validate-packages",
             "./tempest discovery:clear",
-            "composer csfixer",
             "composer rector",
+            "composer csfixer",
             "composer phpunit",
             "composer phpstan"
         ]


### PR DESCRIPTION
As noted in #784, running Rector _after_ PHP CS Fixer can cause the code style check to fail. Switching these two around in the `composer qa` script ensures that Rector runs _first_ (potentially changing code), and PHP CS Fixer comes in _after_ to clean it up and format it.