### PR TITLE
feat(framework): extend http testing methods

### DIFF
--- a/src/Tempest/Framework/Testing/Http/HttpRouterTester.php
+++ b/src/Tempest/Framework/Testing/Http/HttpRouterTester.php
@@ -32,11 +32,95 @@ final class HttpRouterTester
         );
     }
 
+    public function head(string $uri, array $headers = []): TestResponseHelper
+    {
+        return $this->sendRequest(
+            new GenericRequest(
+                method: Method::HEAD,
+                uri: $uri,
+                body: [],
+                headers: $headers,
+            ),
+        );
+    }
+
     public function post(string $uri, array $body = [], array $headers = []): TestResponseHelper
     {
         return $this->sendRequest(
             new GenericRequest(
                 method: Method::POST,
+                uri: $uri,
+                body: $body,
+                headers: $headers,
+            ),
+        );
+    }
+
+    public function put(string $uri, array $body = [], array $headers = []): TestResponseHelper
+    {
+        return $this->sendRequest(
+            new GenericRequest(
+                method: Method::PUT,
+                uri: $uri,
+                body: $body,
+                headers: $headers,
+            ),
+        );
+    }
+
+    public function delete(string $uri, array $body = [], array $headers = []): TestResponseHelper
+    {
+        return $this->sendRequest(
+            new GenericRequest(
+                method: Method::DELETE,
+                uri: $uri,
+                body: $body,
+                headers: $headers,
+            ),
+        );
+    }
+
+    public function connect(string $uri, array $body = [], array $headers = []): TestResponseHelper
+    {
+        return $this->sendRequest(
+            new GenericRequest(
+                method: Method::CONNECT,
+                uri: $uri,
+                body: $body,
+                headers: $headers,
+            ),
+        );
+    }
+
+    public function options(string $uri, array $body = [], array $headers = []): TestResponseHelper
+    {
+        return $this->sendRequest(
+            new GenericRequest(
+                method: Method::OPTIONS,
+                uri: $uri,
+                body: $body,
+                headers: $headers,
+            ),
+        );
+    }
+
+    public function trace(string $uri, array $body = [], array $headers = []): TestResponseHelper
+    {
+        return $this->sendRequest(
+            new GenericRequest(
+                method: Method::TRACE,
+                uri: $uri,
+                body: $body,
+                headers: $headers,
+            ),
+        );
+    }
+
+    public function patch(string $uri, array $body = [], array $headers = []): TestResponseHelper
+    {
+        return $this->sendRequest(
+            new GenericRequest(
+                method: Method::PATCH,
                 uri: $uri,
                 body: $body,
                 headers: $headers,

--- a/src/Tempest/Http/src/Connect.php
+++ b/src/Tempest/Http/src/Connect.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http;
+
+use Attribute;
+
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
+final class Connect extends Route
+{
+    public function __construct(
+        string $uri,
+
+        /**
+         * @template MiddlewareClass of \Tempest\Http\HttpMiddleware
+         * @var class-string<MiddlewareClass>[] $middleware
+         */
+        array $middleware = [],
+    ) {
+        parent::__construct(
+            uri: $uri,
+            method: Method::CONNECT,
+            middleware: $middleware,
+        );
+    }
+}

--- a/src/Tempest/Http/src/Head.php
+++ b/src/Tempest/Http/src/Head.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http;
+
+use Attribute;
+
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
+final class Head extends Route
+{
+    public function __construct(
+        string $uri,
+
+        /**
+         * @template MiddlewareClass of \Tempest\Http\HttpMiddleware
+         * @var class-string<MiddlewareClass>[] $middleware
+         */
+        array $middleware = [],
+    ) {
+        parent::__construct(
+            uri: $uri,
+            method: Method::HEAD,
+            middleware: $middleware,
+        );
+    }
+}

--- a/src/Tempest/Http/src/Options.php
+++ b/src/Tempest/Http/src/Options.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http;
+
+use Attribute;
+
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
+final class Options extends Route
+{
+    public function __construct(
+        string $uri,
+
+        /**
+         * @template MiddlewareClass of \Tempest\Http\HttpMiddleware
+         * @var class-string<MiddlewareClass>[] $middleware
+         */
+        array $middleware = [],
+    ) {
+        parent::__construct(
+            uri: $uri,
+            method: Method::OPTIONS,
+            middleware: $middleware,
+        );
+    }
+}

--- a/src/Tempest/Http/src/Trace.php
+++ b/src/Tempest/Http/src/Trace.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http;
+
+use Attribute;
+
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD)]
+final class Trace extends Route
+{
+    public function __construct(
+        string $uri,
+
+        /**
+         * @template MiddlewareClass of \Tempest\Http\HttpMiddleware
+         * @var class-string<MiddlewareClass>[] $middleware
+         */
+        array $middleware = [],
+    ) {
+        parent::__construct(
+            uri: $uri,
+            method: Method::TRACE,
+            middleware: $middleware,
+        );
+    }
+}

--- a/tests/Fixtures/Controllers/TestController.php
+++ b/tests/Fixtures/Controllers/TestController.php
@@ -4,13 +4,21 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Fixtures\Controllers;
 
+use Tempest\Http\Connect;
+use Tempest\Http\Delete;
 use Tempest\Http\Get;
+use Tempest\Http\Head;
+use Tempest\Http\Options;
+use Tempest\Http\Patch;
+use Tempest\Http\Post;
+use Tempest\Http\Put;
 use Tempest\Http\Response;
 use Tempest\Http\Responses\Created;
 use Tempest\Http\Responses\NotFound;
 use Tempest\Http\Responses\Ok;
 use Tempest\Http\Responses\Redirect;
 use Tempest\Http\Responses\ServerError;
+use Tempest\Http\Trace;
 use function Tempest\view;
 use Tempest\View\View;
 use Tests\Tempest\Fixtures\Views\ViewWithResponseData;
@@ -36,6 +44,14 @@ final readonly class TestController
     }
 
     #[Get(uri: '/test')]
+    #[Head(uri: '/test')]
+    #[Post(uri: '/test')]
+    #[Put(uri: '/test')]
+    #[Delete(uri: '/test')]
+    #[Connect(uri: '/test')]
+    #[Options(uri: '/test')]
+    #[Trace(uri: '/test')]
+    #[Patch(uri: '/test')]
     public function __invoke(): Response
     {
         return new Ok('test');

--- a/tests/Integration/Testing/Http/HttpRouterTesterIntegrationTest.php
+++ b/tests/Integration/Testing/Http/HttpRouterTesterIntegrationTest.php
@@ -29,4 +29,148 @@ final class HttpRouterTesterIntegrationTest extends FrameworkIntegrationTestCase
             ->get('/this-route-does-not-exist')
             ->assertOk();
     }
+
+    public function test_head_requests(): void
+    {
+        $this
+            ->http
+            ->head('/test')
+            ->assertOk();
+    }
+
+    public function test_head_requests_failure(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this
+            ->http
+            ->head('/this-route-does-not-exist')
+            ->assertOk();
+    }
+
+    public function test_post_requests(): void
+    {
+        $this
+            ->http
+            ->post('/test')
+            ->assertOk();
+    }
+
+    public function test_post_requests_failure(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this
+            ->http
+            ->post('/this-route-does-not-exist')
+            ->assertOk();
+    }
+
+    public function test_put_requests(): void
+    {
+        $this
+            ->http
+            ->put('/test')
+            ->assertOk();
+    }
+
+    public function test_put_requests_failure(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this
+            ->http
+            ->put('/this-route-does-not-exist')
+            ->assertOk();
+    }
+
+    public function test_delete_requests(): void
+    {
+        $this
+            ->http
+            ->delete('/test')
+            ->assertOk();
+    }
+
+    public function test_delete_requests_failure(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this
+            ->http
+            ->delete('/this-route-does-not-exist')
+            ->assertOk();
+    }
+
+    public function test_connect_requests(): void
+    {
+        $this
+            ->http
+            ->connect('/test')
+            ->assertOk();
+    }
+
+    public function test_connect_requests_failure(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this
+            ->http
+            ->connect('/this-route-does-not-exist')
+            ->assertOk();
+    }
+
+    public function test_options_requests(): void
+    {
+        $this
+            ->http
+            ->options('/test')
+            ->assertOk();
+    }
+
+    public function test_options_requests_failure(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this
+            ->http
+            ->options('/this-route-does-not-exist')
+            ->assertOk();
+    }
+
+    public function test_trace_requests(): void
+    {
+        $this
+            ->http
+            ->trace('/test')
+            ->assertOk();
+    }
+
+    public function test_trace_requests_failure(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this
+            ->http
+            ->trace('/this-route-does-not-exist')
+            ->assertOk();
+    }
+
+    public function test_patch_requests(): void
+    {
+        $this
+            ->http
+            ->patch('/test')
+            ->assertOk();
+    }
+
+    public function test_patch_requests_failure(): void
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $this
+            ->http
+            ->patch('/this-route-does-not-exist')
+            ->assertOk();
+    }
 }


### PR DESCRIPTION
When writing documentation for https://github.com/tempestphp/tempest-app/pull/8 I noticed not all HTTP methods are supported by the `HttpRouterTester`. This adds all methods which were already described in `Tempest\Http\Method` enum.