### PR TITLE
feat(core): add `TEMPEST_START` constant

### DIFF
--- a/src/Tempest/Core/src/Kernel.php
+++ b/src/Tempest/Core/src/Kernel.php
@@ -39,6 +39,8 @@ final class Kernel
         array $discoveryLocations = [],
         ?Container $container = null,
     ): self {
+        define('TEMPEST_START', value: hrtime(true));
+
         return (new self(
             root: $root,
             discoveryLocations: $discoveryLocations,

--- a/tests/Integration/Core/KernelTest.php
+++ b/tests/Integration/Core/KernelTest.php
@@ -34,4 +34,14 @@ final class KernelTest extends TestCase
         $this->assertInstanceOf(TestDependency::class, $test);
         $this->assertSame('test', $test->input);
     }
+
+    public function test_kernel_start(): void
+    {
+        Kernel::boot(
+            root: getcwd(),
+            discoveryLocations: [],
+        );
+
+        $this->assertTrue(defined('TEMPEST_START'));
+    }
 }


### PR DESCRIPTION
This pull request adds a `TEMPEST_START` constant which holds the system's [high-resolution time](https://www.php.net/manual/en/function.hrtime.php) for performance measuring purposes.

```php
echo (hrtime(true) - TEMPEST_START) * 1e-6; // 244.245834
```