### PR TITLE
fix(view): check the type of the node

### DIFF
--- a/src/Tempest/View/src/Elements/ElementFactory.php
+++ b/src/Tempest/View/src/Elements/ElementFactory.php
@@ -13,6 +13,7 @@ use Tempest\View\Element;
 use Tempest\View\Renderers\TempestViewCompiler;
 use Tempest\View\ViewComponent;
 use Tempest\View\ViewConfig;
+use const XML_ELEMENT_NODE;
 
 final class ElementFactory
 {

--- a/src/Tempest/View/src/Elements/ElementFactory.php
+++ b/src/Tempest/View/src/Elements/ElementFactory.php
@@ -51,7 +51,11 @@ final class ElementFactory
             );
         }
 
-        $tagName = $node->tagName ? strtolower($node->tagName) : null;
+        $tagName = null;
+
+        if ($node->nodeType == XML_ELEMENT_NODE) {
+            $tagName =strtolower($node->tagName);
+        }
 
         $attributes = [];
 

--- a/src/Tempest/View/src/Elements/ElementFactory.php
+++ b/src/Tempest/View/src/Elements/ElementFactory.php
@@ -54,7 +54,7 @@ final class ElementFactory
         $tagName = null;
 
         if ($node->nodeType == XML_ELEMENT_NODE) {
-            $tagName =strtolower($node->tagName);
+            $tagName = strtolower($node->tagName);
         }
 
         $attributes = [];


### PR DESCRIPTION
Everything in xml is a node - text, lines, comments... So a `DOMNode` can be a tag, but it can be something else too. 

With this, we're sure that `$node` is a `DOMElement`, and then can use safely `$tagName` property.

