### PR TITLE
feat(debug): emit `ItemsDebugged` on debug

### DIFF
--- a/src/Tempest/Debug/src/ItemsDebugged.php
+++ b/src/Tempest/Debug/src/ItemsDebugged.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Debug;
+
+final class ItemsDebugged
+{
+    public function __construct(
+        public array $items,
+    ) {
+    }
+}

--- a/src/Tempest/Debug/src/functions.php
+++ b/src/Tempest/Debug/src/functions.php
@@ -40,6 +40,17 @@ namespace {
         }
     }
 
+    if (! function_exists('le')) {
+        /**
+         * Emits a `ItemsDebugged` event.
+         * @see \Tempest\Debug\Debug::log()
+         */
+        function le(mixed ...$input): void
+        {
+            Debug::resolve()->log($input, writeToOut: false, writeToLog: false);
+        }
+    }
+
     if (! function_exists('dd')) {
         /**
          * Writes the given `$input` to the logs, dumps it, and stops the execution of the script.

--- a/tests/Integration/Debug/DebugTest.php
+++ b/tests/Integration/Debug/DebugTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Debug;
+
+use stdClass;
+use Tempest\Debug\Debug;
+use Tempest\Debug\ItemsDebugged;
+use Tempest\EventBus\EventBus;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+/**
+ * @internal
+ */
+final class DebugTest extends FrameworkIntegrationTestCase
+{
+    public function test_event(): void
+    {
+        $class = new stdClass();
+
+        $eventBus = $this->container->get(EventBus::class);
+        $eventBus->listen(ItemsDebugged::class, function (ItemsDebugged $event) use ($class): void {
+            $this->assertSame(['foo', $class], $event->items);
+        });
+
+        Debug::resolve()->log(['foo', $class], writeToLog: false, writeToOut: false);
+    }
+}


### PR DESCRIPTION
Similarly to https://github.com/tempestphp/tempest-framework/pull/795, this pull request adds a `ItemsDebugged` event that is emitted when items are debugged through `Tempest\Debug`.

A new `le` (log event) function has also been added. It doesn't write to `STDOUT` nor a log file.

Very happy to change the name of the event and the function! Please suggest.