### PR TITLE
feat(core): allow `defer` callbacks to receive parameters from container

### DIFF
--- a/src/Tempest/Core/src/Kernel/FinishDeferredTasks.php
+++ b/src/Tempest/Core/src/Kernel/FinishDeferredTasks.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace Tempest\Core\Kernel;
 
+use Tempest\Container\Container;
 use Tempest\Core\DeferredTasks;
 
 final readonly class FinishDeferredTasks
 {
     public function __construct(
         private DeferredTasks $deferredTasks,
+        private Container $container,
     ) {
     }
 
     public function __invoke(): void
     {
         foreach ($this->deferredTasks->getTasks() as $task) {
-            $task();
+            $this->container->invoke($task);
         }
     }
 }

--- a/tests/Integration/Core/DeferredTasksTest.php
+++ b/tests/Integration/Core/DeferredTasksTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Core;
 
+use Tempest\Container\Container;
 use Tempest\Core\Kernel\FinishDeferredTasks;
+use function Tempest\defer;
 use function Tempest\uri;
 use Tests\Tempest\Fixtures\Controllers\DeferController;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -22,8 +24,23 @@ final class DeferredTasksTest extends FrameworkIntegrationTestCase
             ->get(uri(DeferController::class))
             ->assertOk();
 
-        $this->container->get(FinishDeferredTasks::class)();
+        $this->container->invoke(FinishDeferredTasks::class);
 
         $this->assertTrue(DeferController::$executed);
+    }
+
+    public function test_deferred_tasks_are_executed_with_container_parameters(): void
+    {
+        $executed = false;
+
+        defer(function (Container $container) use (&$executed): void {
+            $container->invoke(function () use (&$executed): void {
+                $executed = true;
+            });
+        });
+
+        $this->container->invoke(FinishDeferredTasks::class);
+
+        $this->assertTrue($executed);
     }
 }


### PR DESCRIPTION
This pull request adds support for container-resolved parameter on `defer` closures:

```php
defer(function (AnalyticsService $service, Request $request) {
    $service->visit($request);
});
```