### PR TITLE
refactor(core): call invokable classes with `invoke`

### DIFF
--- a/src/Tempest/Core/src/Kernel.php
+++ b/src/Tempest/Core/src/Kernel.php
@@ -118,21 +118,21 @@ final class Kernel
 
     public function loadDiscoveryLocations(): self
     {
-        ($this->container->get(LoadDiscoveryLocations::class))();
+        $this->container->invoke(LoadDiscoveryLocations::class);
 
         return $this;
     }
 
     public function loadDiscovery(): self
     {
-        ($this->container->get(LoadDiscoveryClasses::class))();
+        $this->container->invoke(LoadDiscoveryClasses::class);
 
         return $this;
     }
 
     public function loadConfig(): self
     {
-        $this->container->get(LoadConfig::class)();
+        $this->container->invoke(LoadConfig::class);
 
         return $this;
     }
@@ -160,7 +160,7 @@ final class Kernel
 
     public function finishDeferredTasks(): self
     {
-        ($this->container->get(FinishDeferredTasks::class))();
+        $this->container->invoke(FinishDeferredTasks::class);
 
         return $this;
     }

--- a/tests/Integration/Core/DeferredTasksTest.php
+++ b/tests/Integration/Core/DeferredTasksTest.php
@@ -22,7 +22,7 @@ final class DeferredTasksTest extends FrameworkIntegrationTestCase
             ->get(uri(DeferController::class))
             ->assertOk();
 
-        $this->container->get(FinishDeferredTasks::class)();
+        $this->container->invoke(FinishDeferredTasks::class);
 
         $this->assertTrue(DeferController::$executed);
     }


### PR DESCRIPTION
This is a minor refactor that uses `Container#invoke` instead of the usual parenthesis call syntax, which can be missed when reading.