### PR TITLE
feat(support): improve types of `HasConditions`

### DIFF
--- a/src/Tempest/Console/src/Console.php
+++ b/src/Tempest/Console/src/Console.php
@@ -56,7 +56,17 @@ interface Console
 
     public function success(string $line): self;
 
-    public function when(mixed $expression, callable $callback): self;
+    /**
+     * @param mixed|Closure(self): bool $condition
+     * @param Closure(self): self $callback
+     */
+    public function when(mixed $condition, Closure $callback): self;
+
+    /**
+     * @param mixed|Closure(self): bool $condition
+     * @param Closure(self): self $callback
+    */
+    public function unless(mixed $condition, Closure $callback): self;
 
     public function withLabel(string $label): self;
 

--- a/src/Tempest/Console/src/Exceptions/ConsoleErrorHandler.php
+++ b/src/Tempest/Console/src/Exceptions/ConsoleErrorHandler.php
@@ -34,7 +34,7 @@ final readonly class ConsoleErrorHandler implements ErrorHandler
             ->writeln()
             ->error($throwable::class)
             ->when(
-                expression: $throwable->getMessage(),
+                condition: $throwable->getMessage(),
                 callback: fn (Console $console) => $console->error($throwable->getMessage()),
             )
             ->writeln($this->getSnippet($throwable->getFile(), $throwable->getLine()))

--- a/src/Tempest/Console/src/GenericConsole.php
+++ b/src/Tempest/Console/src/GenericConsole.php
@@ -20,9 +20,12 @@ use Tempest\Console\Input\ConsoleArgumentBag;
 use Tempest\Container\Tag;
 use Tempest\Highlight\Highlighter;
 use Tempest\Highlight\Language;
+use Tempest\Support\Conditions\HasConditions;
 
 final class GenericConsole implements Console
 {
+    use HasConditions;
+
     private ?string $label = null;
 
     private bool $isForced = false;
@@ -147,15 +150,6 @@ final class GenericConsole implements Console
         $clone->label = $label;
 
         return $clone;
-    }
-
-    public function when(mixed $expression, callable $callback): self
-    {
-        if ($expression) {
-            $callback($this);
-        }
-
-        return $this;
     }
 
     public function component(InteractiveConsoleComponent $component, array $validation = []): mixed

--- a/src/Tempest/Console/src/Middleware/OverviewMiddleware.php
+++ b/src/Tempest/Console/src/Middleware/OverviewMiddleware.php
@@ -66,8 +66,8 @@ final readonly class OverviewMiddleware implements ConsoleMiddleware
         }
 
         $this->console
-            ->when(
-                expression: ! $this->discoveryCache->isValid(),
+            ->unless(
+                condition: $this->discoveryCache->isValid(),
                 callback: fn (Console $console) => $console->writeln(PHP_EOL . '<error>Discovery cache invalid. Run discovery:generate to enable discovery caching.</error>')
             );
     }

--- a/src/Tempest/Core/src/Commands/DiscoveryStatusCommand.php
+++ b/src/Tempest/Core/src/Commands/DiscoveryStatusCommand.php
@@ -42,6 +42,6 @@ final readonly class DiscoveryStatusCommand
         $this->console
             ->writeln()
             ->when($this->discoveryCache->isEnabled(), fn (Console $console) => $console->success('Discovery cache enabled'))
-            ->when(! $this->discoveryCache->isEnabled(), fn (Console $console) => $console->error('Discovery cache disabled'));
+            ->unless($this->discoveryCache->isEnabled(), fn (Console $console) => $console->error('Discovery cache disabled'));
     }
 }

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -14,6 +14,7 @@ use Random\Randomizer;
 use Serializable;
 use Stringable;
 use function Tempest\map;
+use Tempest\Support\Conditions\HasConditions;
 
 /**
  * @template TKey of array-key
@@ -25,6 +26,7 @@ use function Tempest\map;
 final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countable
 {
     use IsIterable;
+    use HasConditions;
 
     /** @var array<TKey, TValue> */
     private array $array;

--- a/src/Tempest/Support/src/Conditions/HasConditions.php
+++ b/src/Tempest/Support/src/Conditions/HasConditions.php
@@ -4,14 +4,22 @@ declare(strict_types=1);
 
 namespace Tempest\Support\Conditions;
 
+use Closure;
+
 trait HasConditions
 {
     /**
+     * Applies the given `$callback` if the `$condition` is true.
      *
-     * @return $this
+     * @param mixed|Closure(static): bool $condition
+     * @param Closure(static): static $callback
      */
-    public function when(bool $condition, callable $callback): self
+    public function when(mixed $condition, Closure $callback): static
     {
+        if ($condition instanceof Closure) {
+            $condition = $condition($this);
+        }
+
         if ($condition) {
             $callback($this);
         }
@@ -19,8 +27,18 @@ trait HasConditions
         return $this;
     }
 
-    public function unless(bool $condition, callable $callback): self
+    /**
+     * Applies the given `$callback` if the `$condition` is false.
+     *
+     * @param mixed|Closure(static): bool $condition
+     * @param Closure(static): static $callback
+     */
+    public function unless(mixed $condition, Closure $callback): static
     {
+        if ($condition instanceof Closure) {
+            $condition = $condition($this);
+        }
+
         return $this->when(! $condition, $callback);
     }
 }

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace Tempest\Support;
 
+use Closure;
 use Countable;
 use function ltrim;
 use function preg_quote;
 use function preg_replace;
 use function rtrim;
 use Stringable;
+use Tempest\Support\Conditions\HasConditions;
 use function trim;
 
 final readonly class StringHelper implements Stringable
 {
+    use HasConditions;
+
     private string $string;
 
     public function __construct(Stringable|string|null $string = '')
@@ -771,6 +775,21 @@ final readonly class StringHelper implements Stringable
         return new self(
             mb_substr($this->string, 0, $position) . $string . mb_substr($this->string, $position)
         );
+    }
+
+    public function when(mixed $condition, Closure $callback): static
+    {
+        if ($condition instanceof Closure) {
+            $condition = $condition($this);
+        }
+
+        if ($condition) {
+            if (($result = $callback($this)) instanceof self) {
+                return $result;
+            }
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Tempest/Support/tests/Conditions/HasConditionsTest.php
+++ b/src/Tempest/Support/tests/Conditions/HasConditionsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Tests\Conditions;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Conditions\HasConditions;
+
+/**
+ * @internal
+ */
+final class HasConditionsTest extends TestCase
+{
+    public function test_when(): void
+    {
+        $class = new class () {
+            use HasConditions;
+
+            public bool $value = false;
+        };
+
+        $class->when(true, fn ($c) => $c->value = true); // @phpstan-ignore-line
+
+        $this->assertTrue($class->value);
+    }
+
+    public function test_when_with_callback(): void
+    {
+        $class = new class () {
+            use HasConditions;
+
+            public bool $value = false;
+        };
+
+        $class->when(fn () => true, fn ($c) => $c->value = true); // @phpstan-ignore-line
+
+        $this->assertTrue($class->value);
+    }
+
+    public function test_unless(): void
+    {
+        $class = new class () {
+            use HasConditions;
+
+            public bool $value = false;
+        };
+
+        $class->unless(true, fn ($c) => $c->value = true); // @phpstan-ignore-line
+
+        $this->assertFalse($class->value);
+    }
+
+    public function test_unless_with_callback(): void
+    {
+        $class = new class () {
+            use HasConditions;
+
+            public bool $value = false;
+        };
+
+        $class->unless(fn () => true, fn ($c) => $c->value = true); // @phpstan-ignore-line
+
+        $this->assertFalse($class->value);
+    }
+
+    public function test_returns_same_instance(): void
+    {
+        $class = new class () {
+            use HasConditions;
+
+            public string $string = 'foo';
+
+            public function append(string $string): static
+            {
+                $self = new self();
+                $self->string = $this->string . $string;
+
+                return $self;
+            }
+        };
+
+        $class->when(true, function ($c): void { // @phpstan-ignore-line
+            $c->append('bar');
+        });
+
+        $this->assertSame('foo', $class->string);
+    }
+}

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -557,4 +557,19 @@ b'));
         $this->assertSame('Hello <strong>World</strong>', str('<p>Hello <strong>World</strong></p>')->stripTags(allowed: 'strong')->toString());
         $this->assertSame('<p>Hello World</p>', str('<p>Hello <strong>World</strong></p>')->stripTags(allowed: 'p')->toString());
     }
+
+    public function test_when(): void
+    {
+        $this->assertTrue(str('foo')->when(true, fn ($s) => $s->append('bar'))->equals('foobar'));
+        $this->assertTrue(str('foo')->when(false, fn ($s) => $s->append('bar'))->equals('foo'));
+
+        $this->assertTrue(str('foo')->when(fn () => true, fn ($s) => $s->append('bar'))->equals('foobar'));
+        $this->assertTrue(str('foo')->when(fn () => false, fn ($s) => $s->append('bar'))->equals('foo'));
+
+        $this->assertTrue(str('foo')->when(fn ($s) => $s->startsWith('foo'), fn ($s) => $s->append('bar'))->equals('foobar'));
+        $this->assertTrue(str('foo')->when(fn ($s) => $s->startsWith('bar'), fn ($s) => $s->append('bar'))->equals('foo'));
+
+        $this->assertTrue(str('foo')->when(true, fn ($s) => $s->append('bar'))->equals('foobar'));
+        $this->assertTrue(str('foo')->when(false, fn ($s) => $s->append('bar'))->equals('foo'));
+    }
 }


### PR DESCRIPTION
This pull request improves the types of `when` and `unless` in `HasConditions`, and uses the trait in `Console` (instead of the sole `when` method) as well as `StringHelper` and `ArrayHelper`.