### PR TITLE
feat(console): add backed enum support to `ask`

### DIFF
--- a/src/Tempest/Console/src/Components/Interactive/SearchComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/SearchComponent.php
@@ -45,7 +45,7 @@ final class SearchComponent implements InteractiveConsoleComponent, HasCursor, H
     ) {
         $this->bufferEnabled = ! $this->multiple;
         $this->buffer = new TextBuffer();
-        $this->renderer = new ChoiceRenderer(default: $default, multiple: $multiple);
+        $this->renderer = new ChoiceRenderer(default: (string) $default, multiple: $multiple);
         $this->options = new OptionCollection([]);
 
         if ($this->multiple) {

--- a/src/Tempest/Console/src/Components/Interactive/SingleChoiceComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/SingleChoiceComponent.php
@@ -35,12 +35,12 @@ final class SingleChoiceComponent implements InteractiveConsoleComponent, HasCur
     public function __construct(
         public string $label,
         iterable $options,
-        public ?string $default = null,
+        public null|int|string $default = null,
     ) {
         $this->bufferEnabled = false;
         $this->options = new OptionCollection($options);
         $this->buffer = new TextBuffer();
-        $this->renderer = new ChoiceRenderer(default: $default, multiple: false);
+        $this->renderer = new ChoiceRenderer(default: (string) $default, multiple: false);
         $this->updateQuery();
     }
 

--- a/src/Tempest/Console/src/Components/Interactive/TextInputComponent.php
+++ b/src/Tempest/Console/src/Components/Interactive/TextInputComponent.php
@@ -30,7 +30,7 @@ final class TextInputComponent implements InteractiveConsoleComponent, HasCursor
 
     public function __construct(
         public string $label,
-        public ?string $default = null,
+        public null|int|string $default = null,
         public ?string $placeholder = null,
         public ?string $hint = null,
         bool $multiline = false,

--- a/src/Tempest/Console/src/Console.php
+++ b/src/Tempest/Console/src/Console.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Tempest\Console;
 
+use BackedEnum;
 use Closure;
 use Tempest\Highlight\Language;
+use Tempest\Support\ArrayHelper;
 
 interface Console
 {
@@ -27,19 +29,20 @@ interface Console
     public function component(InteractiveConsoleComponent $component, array $validation = []): mixed;
 
     /**
+     * @param null|array|ArrayHelper|class-string<BackedEnum> $options
      * @param mixed|null $default
      * @param \Tempest\Validation\Rule[] $validation
      */
     public function ask(
         string $question,
-        ?array $options = null,
+        null|array|ArrayHelper|string $options = null,
         mixed $default = null,
         bool $multiple = false,
         bool $multiline = false,
         ?string $placeholder = null,
         ?string $hint = null,
         array $validation = [],
-    ): null|string|array;
+    ): null|int|string|array;
 
     public function confirm(string $question, bool $default = false, ?string $yes = null, ?string $no = null): bool;
 

--- a/tests/Integration/Console/Components/Static/StaticSingleChoiceComponentTest.php
+++ b/tests/Integration/Console/Components/Static/StaticSingleChoiceComponentTest.php
@@ -6,6 +6,7 @@ namespace Tests\Tempest\Integration\Console\Components\Static;
 
 use Tempest\Console\Console;
 use Tempest\Console\Key;
+use Tests\Tempest\Integration\Console\Fixtures\TestStringEnum;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 /**
@@ -39,31 +40,6 @@ final class StaticSingleChoiceComponentTest extends FrameworkIntegrationTestCase
             ->assertContains('picked b');
     }
 
-    public function test_as_list(): void
-    {
-        $this->console
-            ->call(function (Console $console): void {
-                $answer = $console->ask('test', ['a', 'b'], multiple: true);
-
-                $console->writeln("picked {$answer}");
-            })
-            ->submit(1)
-            ->assertContains('picked b');
-    }
-
-    public function test_as_list_with_default(): void
-    {
-        $this->console
-            ->call(function (Console $console): void {
-                $answer = json_encode($console->ask('test', ['a', 'b'], default: 'a', multiple: true));
-
-                $console->writeln("picked {$answer}");
-            })
-            ->input(Key::ENTER)
-            ->input('yes')
-            ->assertContains('picked ["a"]');
-    }
-
     public function test_with_default_option_without_prompting(): void
     {
         $this->console
@@ -73,6 +49,66 @@ final class StaticSingleChoiceComponentTest extends FrameworkIntegrationTestCase
 
                 $console->writeln("picked {$answer}");
             })
+            ->assertContains('picked b');
+    }
+
+    public function test_assoc_submit_key(): void
+    {
+        $this->console
+            ->call(function (Console $console): void {
+                $answer = $console->ask('test', ['a' => 'A', 'b' => 'B']);
+
+                $console->writeln("picked {$answer}");
+            })
+            ->submit(1)
+            ->assertContains('picked b');
+    }
+
+    public function test_assoc_submit_value(): void
+    {
+        $this->console
+            ->call(function (Console $console): void {
+                $answer = $console->ask('test', ['a' => 'A', 'b' => 'B']);
+
+                $console->writeln("picked {$answer}");
+            })
+            ->submit('B')
+            ->assertContains('picked b');
+    }
+
+    public function test_enum_submit_name(): void
+    {
+        $this->console
+            ->call(function (Console $console): void {
+                $answer = $console->ask('test', options: TestStringEnum::class);
+
+                $console->writeln("picked {$answer}");
+            })
+            ->submit('B')
+            ->assertContains('picked b');
+    }
+
+    public function test_enum_submit_index(): void
+    {
+        $this->console
+            ->call(function (Console $console): void {
+                $answer = $console->ask('test', options: TestStringEnum::class);
+
+                $console->writeln("picked {$answer}");
+            })
+            ->submit(1)
+            ->assertContains('picked b');
+    }
+
+    public function test_enum_default_value(): void
+    {
+        $this->console
+            ->call(function (Console $console): void {
+                $answer = $console->ask('test', options: TestStringEnum::class, default: TestStringEnum::B);
+
+                $console->writeln("picked {$answer}");
+            })
+            ->submit()
             ->assertContains('picked b');
     }
 }


### PR DESCRIPTION
This pull request adds support for passing a `BackedEnum` FQCN to `Console#ask`'s `options` parameter:

```php
$this->console->ask(
    question: 'Pick a value',
    options: StringBackedEnum::class,
    default: StringBackedEnum::FOO, // supports passing an enum as a default option as well
);
```