### PR TITLE
feat(console): improve rescuing enum console parameters

### DIFF
--- a/src/Tempest/Console/src/Middleware/InvalidCommandMiddleware.php
+++ b/src/Tempest/Console/src/Middleware/InvalidCommandMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Console\Middleware;
 
+use BackedEnum;
 use Tempest\Console\Actions\ExecuteConsoleCommand;
 use Tempest\Console\Console;
 use Tempest\Console\ConsoleMiddleware;
@@ -13,8 +14,10 @@ use Tempest\Console\ExitCode;
 use Tempest\Console\Initializers\Invocation;
 use Tempest\Console\Input\ConsoleArgumentDefinition;
 use Tempest\Console\Input\ConsoleInputArgument;
+
 use function Tempest\Support\str;
 use Tempest\Validation\Rules\Boolean;
+use Tempest\Validation\Rules\Enum;
 use Tempest\Validation\Rules\NotEmpty;
 use Tempest\Validation\Rules\Numeric;
 
@@ -44,17 +47,24 @@ final readonly class InvalidCommandMiddleware implements ConsoleMiddleware
 
         /** @var ConsoleArgumentDefinition $argument */
         foreach ($exception->invalidArguments as $argument) {
+            $isEnum = is_a($argument->type, BackedEnum::class, allow_string: true);
             $value = $this->console->ask(
                 question: str($argument->name)->snake(' ')->upperFirst()->toString(),
                 default: (string) $argument->default,
                 hint: $argument->help ?? $argument->description,
-                validation: [
+                options: $isEnum
+                    ? $argument->type
+                    : null,
+                validation: array_filter([
+                    $isEnum
+                        ? new Enum($argument->type)
+                        : new NotEmpty(),
                     match ($argument->type) {
                         'bool' => new Boolean(),
                         'int' => new Numeric(),
-                        default => new NotEmpty(),
+                        default => null,
                     },
-                ]
+                ])
             );
 
             $invocation->argumentBag->add(new ConsoleInputArgument(

--- a/src/Tempest/Console/src/Middleware/InvalidCommandMiddleware.php
+++ b/src/Tempest/Console/src/Middleware/InvalidCommandMiddleware.php
@@ -14,7 +14,6 @@ use Tempest\Console\ExitCode;
 use Tempest\Console\Initializers\Invocation;
 use Tempest\Console\Input\ConsoleArgumentDefinition;
 use Tempest\Console\Input\ConsoleInputArgument;
-
 use function Tempest\Support\str;
 use Tempest\Validation\Rules\Boolean;
 use Tempest\Validation\Rules\Enum;

--- a/tests/Integration/Console/Fixtures/IntEnumCommand.php
+++ b/tests/Integration/Console/Fixtures/IntEnumCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Console\Fixtures;
+
+use Tempest\Console\Console;
+use Tempest\Console\ConsoleCommand;
+
+final readonly class IntEnumCommand
+{
+    public function __construct(private Console $console)
+    {
+    }
+
+    #[ConsoleCommand('int-enum-from-one-command')]
+    public function __invoke(TestIntEnumFromOne $enum): void
+    {
+        $this->console->writeln($enum->name);
+    }
+}

--- a/tests/Integration/Console/Fixtures/StringEnumCommand.php
+++ b/tests/Integration/Console/Fixtures/StringEnumCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Console\Fixtures;
+
+use Tempest\Console\Console;
+use Tempest\Console\ConsoleCommand;
+
+final readonly class StringEnumCommand
+{
+    public function __construct(private Console $console)
+    {
+    }
+
+    #[ConsoleCommand('string-enum-command')]
+    public function __invoke(TestStringEnum $enum): void
+    {
+        $this->console->writeln($enum->value);
+    }
+}

--- a/tests/Integration/Console/Fixtures/TestIntEnumFromOne.php
+++ b/tests/Integration/Console/Fixtures/TestIntEnumFromOne.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Console\Fixtures;
+
+// This doesn't start from zero
+enum TestIntEnumFromOne: int
+{
+    case A = 1;
+    case B = 2;
+    case C = 3;
+}

--- a/tests/Integration/Console/Middleware/InvalidCommandMiddlewareTest.php
+++ b/tests/Integration/Console/Middleware/InvalidCommandMiddlewareTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Console\Middleware;
 
+use Tempest\Console\Key;
 use Tests\Tempest\Integration\Console\Fixtures\ComplexCommand;
+use Tests\Tempest\Integration\Console\Fixtures\IntEnumCommand;
+use Tests\Tempest\Integration\Console\Fixtures\StringEnumCommand;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 /**
@@ -21,5 +24,27 @@ final class InvalidCommandMiddlewareTest extends FrameworkIntegrationTestCase
             ->submit('b')
             ->submit('c')
             ->assertContains('abc');
+    }
+
+    public function test_with_string_enum(): void
+    {
+        $this->console
+            ->call(StringEnumCommand::class)
+            ->assertContains('A')
+            ->assertContains('B')
+            ->assertContains('C')
+            ->input(1)
+            ->assertContains('b');
+    }
+
+    public function test_with_int_enum(): void
+    {
+        $this->console
+            ->call(IntEnumCommand::class)
+            ->assertContains('A')
+            ->assertContains('B')
+            ->assertContains('C')
+            ->input(1)
+            ->assertContains('B');
     }
 }

--- a/tests/Integration/Console/Middleware/InvalidCommandMiddlewareTest.php
+++ b/tests/Integration/Console/Middleware/InvalidCommandMiddlewareTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Console\Middleware;
 
-use Tempest\Console\Key;
 use Tests\Tempest\Integration\Console\Fixtures\ComplexCommand;
 use Tests\Tempest\Integration\Console\Fixtures\IntEnumCommand;
 use Tests\Tempest\Integration\Console\Fixtures\StringEnumCommand;


### PR DESCRIPTION
This pull request improves the rescuing of backed enum console parameters for console commands. Previously, they were treated as text input. After this PR, they are treated as choices.


https://github.com/user-attachments/assets/936e75d9-bd09-43f9-b8cf-f334c88a96be

Closes #807