### PR TITLE
feat(support): add `every` to `ArrayHelper`

### DIFF
--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -726,9 +726,9 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     /**
      * Asserts whether all items in the instance pass the given `$callback`.
      *
-     * @param Closure(TValue, TKey): bool $callback 
-     * 
-     * @return `true` if the collection is empty.
+     * @param Closure(TValue, TKey): bool $callback
+     *
+     * @return bool If the collection is empty, returns `true`.
      */
     public function every(?Closure $callback = null): bool
     {

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -724,6 +724,26 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
+     * Asserts whether all items in the instance pass the given `$callback`.
+     *
+     * @param Closure(TValue, TKey): bool $callback 
+     * 
+     * @return `true` if the collection is empty.
+     */
+    public function every(?Closure $callback = null): bool
+    {
+        $callback ??= static fn (mixed $value) => ! is_null($value);
+
+        foreach ($this->array as $key => $value) {
+            if (! $callback($value, $key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Associates the given `$value` to the given `$key` on the instance.
      */
     public function set(string $key, mixed $value): self

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -1651,4 +1651,13 @@ final class ArrayHelperTest extends TestCase
             expected: [8, 9],
         );
     }
+
+    public function test_every(): void
+    {
+        $this->assertTrue(arr([])->every(fn (int $value) => ($value % 2) === 0));
+        $this->assertTrue(arr([2, 4, 6])->every(fn (int $value) => ($value % 2) === 0));
+        $this->assertFalse(arr([1, 2, 4, 6])->every(fn (int $value) => ($value % 2) === 0));
+        $this->assertTrue(arr([0, 1, true, false, ''])->every());
+        $this->assertFalse(arr([0, 1, true, false, '', null])->every());
+    }
 }


### PR DESCRIPTION
This pull request adds the `every` method to `ArrayHelper`. It works like the JavaScript one.

```php
arr([2, 4, 6])->every(fn (int $value) => ($value % 2) === 0); // true
```