### PR TITLE
feat(console): provide command suggestions when using `:` shorthands

### DIFF
--- a/src/Tempest/Cache/src/CacheClearCommand.php
+++ b/src/Tempest/Cache/src/CacheClearCommand.php
@@ -18,7 +18,7 @@ final readonly class CacheClearCommand
     ) {
     }
 
-    #[ConsoleCommand(name: 'cache:clear', description: 'Clears all or specified caches', aliases: ['cc'])]
+    #[ConsoleCommand(name: 'cache:clear', description: 'Clears all or specified caches')]
     public function __invoke(bool $all = false): void
     {
         $caches = $this->cacheConfig->caches;

--- a/src/Tempest/Cache/src/CacheStatusCommand.php
+++ b/src/Tempest/Cache/src/CacheStatusCommand.php
@@ -20,7 +20,7 @@ final readonly class CacheStatusCommand
     ) {
     }
 
-    #[ConsoleCommand(name: 'cache:status', description: 'Shows which caches are enabled', aliases: ['cs'])]
+    #[ConsoleCommand(name: 'cache:status', description: 'Shows which caches are enabled')]
     public function __invoke(): void
     {
         $caches = $this->cacheConfig->caches;

--- a/src/Tempest/Console/src/Commands/TailDebugLogCommand.php
+++ b/src/Tempest/Console/src/Commands/TailDebugLogCommand.php
@@ -22,7 +22,7 @@ final readonly class TailDebugLogCommand
     ) {
     }
 
-    #[ConsoleCommand('tail:debug', description: 'Tails the debug log', aliases: ['td'])]
+    #[ConsoleCommand('tail:debug', description: 'Tails the debug log')]
     public function __invoke(): void
     {
         $debugLogPath = $this->logConfig->debugLogPath;

--- a/src/Tempest/Console/src/Commands/TailProjectLogCommand.php
+++ b/src/Tempest/Console/src/Commands/TailProjectLogCommand.php
@@ -23,7 +23,7 @@ final readonly class TailProjectLogCommand
     ) {
     }
 
-    #[ConsoleCommand('tail:project', description: 'Tails the project log', aliases: ['tp'])]
+    #[ConsoleCommand('tail:project', description: 'Tails the project log')]
     public function __invoke(): void
     {
         $appendLogChannel = null;

--- a/src/Tempest/Console/src/Commands/TailServerLogCommand.php
+++ b/src/Tempest/Console/src/Commands/TailServerLogCommand.php
@@ -22,7 +22,7 @@ final readonly class TailServerLogCommand
     ) {
     }
 
-    #[ConsoleCommand('tail:server', description: 'Tails the server log', aliases: ['ts'])]
+    #[ConsoleCommand('tail:server', description: 'Tails the server log')]
     public function __invoke(): void
     {
         $serverLogPath = $this->logConfig->serverLogPath;

--- a/src/Tempest/Core/src/Commands/DiscoveryClearCommand.php
+++ b/src/Tempest/Core/src/Commands/DiscoveryClearCommand.php
@@ -16,11 +16,7 @@ final readonly class DiscoveryClearCommand
     ) {
     }
 
-    #[ConsoleCommand(
-        name: 'discovery:clear',
-        description: 'Clears all cached discovery files',
-        aliases: ['dc'],
-    )]
+    #[ConsoleCommand(name: 'discovery:clear', description: 'Clears all cached discovery files')]
     public function __invoke(): void
     {
         $this->discoveryCache->clear();

--- a/src/Tempest/Core/src/Commands/DiscoveryGenerateCommand.php
+++ b/src/Tempest/Core/src/Commands/DiscoveryGenerateCommand.php
@@ -24,11 +24,7 @@ final readonly class DiscoveryGenerateCommand
     ) {
     }
 
-    #[ConsoleCommand(
-        name: 'discovery:generate',
-        description: 'Compile and cache all discovery according to the configured discovery caching strategy',
-        aliases: ['dg'],
-    )]
+    #[ConsoleCommand(name: 'discovery:generate', description: 'Compile and cache all discovery according to the configured discovery caching strategy')]
     public function __invoke(): void
     {
         $strategy = $this->resolveDiscoveryCacheStrategy();

--- a/src/Tempest/Core/src/Commands/DiscoveryStatusCommand.php
+++ b/src/Tempest/Core/src/Commands/DiscoveryStatusCommand.php
@@ -18,11 +18,7 @@ final readonly class DiscoveryStatusCommand
     ) {
     }
 
-    #[ConsoleCommand(
-        name: 'discovery:status',
-        description: 'Lists all discovery locations and discovery classes',
-        aliases: ['ds'],
-    )]
+    #[ConsoleCommand(name: 'discovery:status', description: 'Lists all discovery locations and discovery classes')]
     public function __invoke(): void
     {
         $this->console->writeln('<h2>Registered discovery classes</h2>');

--- a/src/Tempest/Framework/Commands/ConfigShowCommand.php
+++ b/src/Tempest/Framework/Commands/ConfigShowCommand.php
@@ -31,11 +31,7 @@ final readonly class ConfigShowCommand
     ) {
     }
 
-    #[ConsoleCommand(
-        name: 'config:show',
-        description: 'Show resolved configuration',
-        aliases: ['config'],
-    )]
+    #[ConsoleCommand(name: 'config:show', description: 'Show resolved configuration', aliases: ['config'])]
     public function __invoke(
         ConfigShowFormat $format = ConfigShowFormat::PRETTY,
         ?bool $search = false,

--- a/tests/Integration/Console/Middleware/ResolveOrRescueMiddlewareTest.php
+++ b/tests/Integration/Console/Middleware/ResolveOrRescueMiddlewareTest.php
@@ -23,6 +23,10 @@ final class ResolveOrRescueMiddlewareTest extends FrameworkIntegrationTestCase
         $this->console
             ->call('bascovery:status')
             ->assertSee('Did you mean discovery:status?');
+
+        $this->console
+            ->call('c:cl')
+            ->assertSee('Did you mean cache:clear?');
     }
 
     #[Test]


### PR DESCRIPTION
This pull request adds support for using the `:` shorthand when running console commands.

For instance, typing `tempest ca:cl` will now suggest `cache:clear`. This is a functionality that the Symfony console component has (so does Composer and Laravel).

I use this shorthand all the time, and I thought it was missing in Tempest, especially seeing all these commands with hardcoded shorthands (eg. `cache:clear` -> `cc`).

## Some questions

- With this implementation, Tempest will still ask for confirmation before running a matched command. Should we run the command if there is a sole result?
- Should we remove the hardcoded aliases if so?

## How it looks

https://github.com/user-attachments/assets/158d28c8-7617-43e7-9c35-b90d5253f130

In comparison, here's how it look in Laravel:


https://github.com/user-attachments/assets/1c6f31ed-9730-4389-8991-9f43e10bb522



