### PR TITLE
fix(http): correct HTTP 418 description and coverage

### DIFF
--- a/src/Tempest/Http/src/Status.php
+++ b/src/Tempest/Http/src/Status.php
@@ -131,7 +131,7 @@ enum Status: int
             415 => 'Unsupported Media Type',
             416 => 'Range Not Satisfiable',
             417 => 'Expectation Failed',
-            418 => "I'm a Teapot",
+            418 => "I'm a teapot",
             421 => 'Misdirected Request',
             422 => 'Unprocessable Content',
             423 => 'Locked',

--- a/src/Tempest/Http/src/Status.php
+++ b/src/Tempest/Http/src/Status.php
@@ -131,7 +131,7 @@ enum Status: int
             415 => 'Unsupported Media Type',
             416 => 'Range Not Satisfiable',
             417 => 'Expectation Failed',
-            418 => 'I Am A Teapot',
+            418 => "I'm a Teapot",
             421 => 'Misdirected Request',
             422 => 'Unprocessable Content',
             423 => 'Locked',

--- a/src/Tempest/Http/tests/StatusTest.php
+++ b/src/Tempest/Http/tests/StatusTest.php
@@ -13,10 +13,10 @@ use Tempest\Http\Status;
  */
 final class StatusTest extends TestCase
 {
-    private function descriptionToStatus(string $description): Status
+    private static function descriptionToStatus(string $description): Status
     {
         $description = strtoupper(
-            str_replace([' ', '-'], '_', $description),
+            str_replace("'", '', str_replace([' ', '-'], '_', $description)),
         );
 
         return Status::{$description};
@@ -28,7 +28,7 @@ final class StatusTest extends TestCase
         $status = Status::code($code);
 
         $this->assertSame(
-            $this->descriptionToStatus($description),
+            self::descriptionToStatus($description),
             $status,
         );
 
@@ -100,6 +100,7 @@ final class StatusTest extends TestCase
             [303, 'See Other'],
             [304, 'Not Modified'],
             [305, 'Use Proxy'],
+            [306, 'Unused'],
             [307, 'Temporary Redirect'],
             [308, 'Permanent Redirect'],
 
@@ -121,6 +122,7 @@ final class StatusTest extends TestCase
             [415, 'Unsupported Media Type'],
             [416, 'Range Not Satisfiable'],
             [417, 'Expectation Failed'],
+            [418, "I'm a Teapot"],
             [421, 'Misdirected Request'],
             [422, 'Unprocessable Content'],
             [423, 'Locked'],

--- a/src/Tempest/Http/tests/StatusTest.php
+++ b/src/Tempest/Http/tests/StatusTest.php
@@ -122,7 +122,7 @@ final class StatusTest extends TestCase
             [415, 'Unsupported Media Type'],
             [416, 'Range Not Satisfiable'],
             [417, 'Expectation Failed'],
-            [418, "I'm a Teapot"],
+            [418, "I'm a teapot"],
             [421, 'Misdirected Request'],
             [422, 'Unprocessable Content'],
             [423, 'Locked'],


### PR DESCRIPTION
Fixes https://github.com/tempestphp/tempest-framework/issues/778 .

Somebody has to fix the most important and widely used HTTP statuscodes out there. 

For anybody who doesn't know, [418 is a official HTTP status code](https://www.rfc-editor.org/rfc/rfc2324#section-2.3.2) introduces as an RFC during april fools  by the official networking working committee at that time. I don't know why and how, but it was accepted and it stuck. Recently there was a movement to remove it, but surprise surprise , after more than 10 years not only did people use it. People loved this small easter egg in a rigid spec of the foundation of our internet. 

[Read the RFC](https://www.rfc-editor.org/rfc/rfc2324) if you have the time, it is a proper laugh.
