### PR TITLE
feat(console): allow calling console commands via fqcn

### DIFF
--- a/src/Tempest/Console/src/Actions/ExecuteConsoleCommand.php
+++ b/src/Tempest/Console/src/Actions/ExecuteConsoleCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Console\Actions;
 
+use Tempest\Console\ConsoleCommand;
 use Tempest\Console\ConsoleConfig;
 use Tempest\Console\ConsoleInputBuilder;
 use Tempest\Console\ConsoleMiddlewareCallable;
@@ -11,6 +12,7 @@ use Tempest\Console\ExitCode;
 use Tempest\Console\Initializers\Invocation;
 use Tempest\Console\Input\ConsoleArgumentBag;
 use Tempest\Container\Container;
+use Throwable;
 
 final readonly class ExecuteConsoleCommand
 {
@@ -18,17 +20,23 @@ final readonly class ExecuteConsoleCommand
         private Container $container,
         private ConsoleConfig $consoleConfig,
         private ConsoleArgumentBag $argumentBag,
+        private ResolveConsoleCommand $resolveConsoleCommand,
     ) {
     }
 
-    public function __invoke(string $commandName): ExitCode|int
+    public function __invoke(string|array $command, string|array $arguments = []): ExitCode|int
     {
-        $callable = $this->getCallable($this->resolveCommandMiddleware($commandName));
+        [$commandName, $arguments] = $this->resolveCommandAndArguments($command, $arguments);
 
-        $this->argumentBag->setCommandName($commandName);
+        $consoleCommand = $this->resolveConsoleCommand($command) ?? $this->resolveConsoleCommand($commandName);
+        $callable = $this->getCallable($consoleCommand?->middleware ?? []);
+
+        $this->argumentBag->setCommandName($consoleCommand?->getName() ?? $commandName);
+        $this->argumentBag->addMany($arguments);
 
         return $callable(new Invocation(
             argumentBag: $this->argumentBag,
+            consoleCommand: $consoleCommand,
         ));
     }
 
@@ -37,9 +45,7 @@ final readonly class ExecuteConsoleCommand
         $callable = new ConsoleMiddlewareCallable(function (Invocation $invocation) {
             $consoleCommand = $invocation->consoleCommand;
 
-            $handler = $consoleCommand->handler;
-
-            $consoleCommandClass = $this->container->get($handler->getDeclaringClass()->getName());
+            $consoleCommandClass = $this->container->get($consoleCommand->handler->getDeclaringClass()->getName());
 
             $inputBuilder = new ConsoleInputBuilder($consoleCommand, $invocation->argumentBag);
 
@@ -62,10 +68,33 @@ final readonly class ExecuteConsoleCommand
         return $callable;
     }
 
-    private function resolveCommandMiddleware(string $commandName): array
+    private function resolveConsoleCommand(string|array $commandName): ?ConsoleCommand
     {
-        $consoleCommand = $this->consoleConfig->commands[$commandName] ?? null;
+        try {
+            return ($this->resolveConsoleCommand)($commandName);
+        } catch (Throwable) {
+            return null;
+        }
+    }
 
-        return $consoleCommand->middleware ?? [];
+    /** @return array{string,array} */
+    private function resolveCommandAndArguments(string|array $command, array $arguments = []): array
+    {
+        $commandName = $command;
+
+        if (is_array($command)) {
+            $commandName = $command[0] ?? '';
+        } elseif (str_contains($command, ' ')) {
+            $commandName = explode(' ', $command)[0];
+            $arguments = [
+                ...(array_slice(explode(' ', trim($command)) ?? [], offset: 1)),
+                ...$arguments,
+            ];
+        }
+
+        return [
+            $commandName,
+            $arguments,
+        ];
     }
 }

--- a/src/Tempest/Console/src/Actions/ExecuteConsoleCommand.php
+++ b/src/Tempest/Console/src/Actions/ExecuteConsoleCommand.php
@@ -87,7 +87,7 @@ final readonly class ExecuteConsoleCommand
         } elseif (str_contains($command, ' ')) {
             $commandName = explode(' ', $command)[0];
             $arguments = [
-                ...(array_slice(explode(' ', trim($command)) ?? [], offset: 1)),
+                ...(array_slice(explode(' ', trim($command)), offset: 1)),
                 ...$arguments,
             ];
         }

--- a/src/Tempest/Console/src/Actions/ResolveConsoleCommand.php
+++ b/src/Tempest/Console/src/Actions/ResolveConsoleCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Actions;
+
+use Exception;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Console\ConsoleConfig;
+
+final class ResolveConsoleCommand
+{
+    public function __construct(
+        private readonly ConsoleConfig $consoleConfig,
+    ) {
+    }
+
+    public function __invoke(array|string $command): ConsoleCommand
+    {
+        if (is_string($command) && array_key_exists($command, $this->consoleConfig->commands)) {
+            return $this->consoleConfig->commands[$command];
+        }
+
+        if (is_string($command) && class_exists($command)) {
+            $command = [$command, '__invoke'];
+        }
+
+        if (is_array($command)) {
+            $command = array_find(
+                array: $this->consoleConfig->commands,
+                callback: fn (ConsoleCommand $consoleCommand) =>
+                    $consoleCommand->handler->getDeclaringClass()->getName() === $command[0]
+                        && $consoleCommand->handler->getName() === $command[1],
+            );
+
+            if ($command !== null) {
+                return $command;
+            }
+        }
+
+        throw new Exception('Command not found.');
+    }
+}

--- a/src/Tempest/Console/src/Console.php
+++ b/src/Tempest/Console/src/Console.php
@@ -11,7 +11,7 @@ use Tempest\Support\ArrayHelper;
 
 interface Console
 {
-    public function call(string $command): ExitCode|int;
+    public function call(string|array $command, string|array $arguments = []): ExitCode|int;
 
     public function readln(): string;
 

--- a/src/Tempest/Console/src/GenericConsole.php
+++ b/src/Tempest/Console/src/GenericConsole.php
@@ -47,9 +47,9 @@ final class GenericConsole implements Console
     ) {
     }
 
-    public function call(string $command): ExitCode|int
+    public function call(string|array $command, string|array $arguments = []): ExitCode|int
     {
-        return ($this->executeConsoleCommand)($command);
+        return ($this->executeConsoleCommand)($command, $arguments);
     }
 
     public function setComponentRenderer(InteractiveComponentRenderer $componentRenderer): self

--- a/src/Tempest/Console/src/Input/ConsoleArgumentBag.php
+++ b/src/Tempest/Console/src/Input/ConsoleArgumentBag.php
@@ -36,22 +36,7 @@ final class ConsoleArgumentBag
 
         $this->path = [$cli, $commandName];
 
-        foreach ($arguments as $argument) {
-            if (str_starts_with($argument, '-') && ! str_starts_with($argument, '--')) {
-                $flags = str_split($argument);
-                unset($flags[0]);
-
-                foreach ($flags as $flag) {
-                    $arguments[] = "-{$flag}";
-                }
-            }
-        }
-
-        foreach (array_values($arguments) as $position => $argument) {
-            $this->add(
-                ConsoleInputArgument::fromString($argument, $position),
-            );
-        }
+        $this->addMany($arguments);
     }
 
     /**
@@ -155,6 +140,30 @@ final class ConsoleArgumentBag
     public function add(ConsoleInputArgument $argument): self
     {
         $this->arguments[] = $argument;
+
+        return $this;
+    }
+
+    public function addMany(array $arguments): self
+    {
+        foreach ($arguments as $argument) {
+            if (str_starts_with($argument, '-') && ! str_starts_with($argument, '--')) {
+                $flags = str_split($argument);
+                unset($flags[0]);
+
+                foreach ($flags as $flag) {
+                    $arguments[] = "-{$flag}";
+                }
+            }
+        }
+
+        $position = count($this->arguments);
+
+        foreach (array_values($arguments) as $index => $argument) {
+            $this->add(
+                ConsoleInputArgument::fromString($argument, $position + $index),
+            );
+        }
 
         return $this;
     }

--- a/src/Tempest/Console/src/Testing/ConsoleTester.php
+++ b/src/Tempest/Console/src/Testing/ConsoleTester.php
@@ -79,22 +79,13 @@ final class ConsoleTester
                 $clone->exitCode = $command($console) ?? ExitCode::SUCCESS;
             });
         } else {
-            $fiber = new Fiber(function () use ($command, $arguments, $clone, $console, $memoryOutputBuffer, $memoryInputBuffer): void {
-                // The original `ConsoleArgumentBag` contains the arguments used
-                // to run this test suite, so it needs to be replaced.
+            $fiber = new Fiber(function () use ($command, $arguments, $clone): void {
                 $clone->container->singleton(ConsoleArgumentBag::class, new ConsoleArgumentBag(['tempest']));
-
-                // We then need to recreate a console instance, so the
-                // proper `ConsoleArgumentBag` gets injected into it.
-                $console = new GenericConsole(
-                    output: $memoryOutputBuffer,
-                    input: $memoryInputBuffer,
-                    highlighter: $clone->container->get(Highlighter::class, 'console'),
-                    executeConsoleCommand: $clone->container->get(ExecuteConsoleCommand::class),
-                    argumentBag: $clone->container->get(ConsoleArgumentBag::class),
+                $clone->exitCode = $this->container->invoke(
+                    ExecuteConsoleCommand::class,
+                    command: $command,
+                    arguments: $arguments,
                 );
-
-                $clone->exitCode = $console->call($command, $arguments);
             });
         }
 

--- a/src/Tempest/Console/src/Testing/ConsoleTester.php
+++ b/src/Tempest/Console/src/Testing/ConsoleTester.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Tempest\Console\Testing;
 
 use Closure;
-use Exception;
 use Fiber;
 use PHPUnit\Framework\Assert;
 use Tempest\Console\Actions\ExecuteConsoleCommand;
 use Tempest\Console\Components\InteractiveComponentRenderer;
 use Tempest\Console\Console;
-use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Exceptions\ConsoleErrorHandler;
 use Tempest\Console\ExitCode;
 use Tempest\Console\GenericConsole;
@@ -24,7 +22,6 @@ use Tempest\Console\OutputBuffer;
 use Tempest\Container\Container;
 use Tempest\Core\AppConfig;
 use Tempest\Highlight\Highlighter;
-use Tempest\Reflection\MethodReflector;
 
 final class ConsoleTester
 {
@@ -43,7 +40,7 @@ final class ConsoleTester
     ) {
     }
 
-    public function call(string|Closure|array $command): self
+    public function call(string|Closure|array $command, string|array $arguments = []): self
     {
         $clone = clone $this;
 
@@ -82,30 +79,22 @@ final class ConsoleTester
                 $clone->exitCode = $command($console) ?? ExitCode::SUCCESS;
             });
         } else {
-            if (is_string($command) && class_exists($command)) {
-                $command = [$command, '__invoke'];
-            }
+            $fiber = new Fiber(function () use ($command, $arguments, $clone, $console, $memoryOutputBuffer, $memoryInputBuffer): void {
+                // The original `ConsoleArgumentBag` contains the arguments used
+                // to run this test suite, so it needs to be replaced.
+                $clone->container->singleton(ConsoleArgumentBag::class, new ConsoleArgumentBag(['tempest']));
 
-            if (is_array($command) || class_exists($command)) {
-                $handler = MethodReflector::fromParts(...$command);
+                // We then need to recreate a console instance, so the
+                // proper `ConsoleArgumentBag` gets injected into it.
+                $console = new GenericConsole(
+                    output: $memoryOutputBuffer,
+                    input: $memoryInputBuffer,
+                    highlighter: $clone->container->get(Highlighter::class, 'console'),
+                    executeConsoleCommand: $clone->container->get(ExecuteConsoleCommand::class),
+                    argumentBag: $clone->container->get(ConsoleArgumentBag::class),
+                );
 
-                $attribute = $handler->getAttribute(ConsoleCommand::class);
-
-                if ($attribute === null) {
-                    throw new Exception("Could not resolve console command from {$command[0]}::{$command[1]}");
-                }
-
-                $attribute->setHandler($handler);
-
-                $command = $attribute->getName();
-            }
-
-            $fiber = new Fiber(function () use ($command, $clone): void {
-                $argumentBag = new ConsoleArgumentBag(['tempest', ...explode(' ', $command)]);
-
-                $clone->container->singleton(ConsoleArgumentBag::class, $argumentBag);
-
-                $clone->exitCode = ($this->container->get(ExecuteConsoleCommand::class))($argumentBag->getCommandName());
+                $clone->exitCode = $console->call($command, $arguments);
             });
         }
 

--- a/tests/Integration/Console/Actions/ExecuteConsoleCommandTest.php
+++ b/tests/Integration/Console/Actions/ExecuteConsoleCommandTest.php
@@ -44,4 +44,13 @@ final class ExecuteConsoleCommandTest extends FrameworkIntegrationTestCase
             ->call(ArrayInputCommand::class, ['--input=a', '--input=b'])
             ->assertSee('["a","b"]');
     }
+
+    public function test_command_with_positional_argument_with_space(): void
+    {
+        $this->markTestSkipped('Failing test.');
+
+        // $this->console
+        //     ->call('complex a "b b" c --flag')
+        //     ->assertSee('ab bc');
+    }
 }

--- a/tests/Integration/Console/Actions/ExecuteConsoleCommandTest.php
+++ b/tests/Integration/Console/Actions/ExecuteConsoleCommandTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Console\Actions;
 
+use Tempest\Console\GenericConsole;
+use Tests\Tempest\Integration\Console\Fixtures\ArrayInputCommand;
+use Tests\Tempest\Integration\Console\Fixtures\CommandWithMiddleware;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 /**
@@ -17,5 +20,28 @@ final class ExecuteConsoleCommandTest extends FrameworkIntegrationTestCase
             ->call('with:middleware')
             ->assertContains('from middleware')
             ->assertContains('from command');
+    }
+
+    public function test_command_specific_middleware_through_console(): void
+    {
+        $this->console
+            ->call(fn (GenericConsole $console) => $console->call('with:middleware'))
+            ->assertContains('from middleware')
+            ->assertContains('from command');
+    }
+
+    public function test_call_command_by_class_name(): void
+    {
+        $this->console
+            ->call(CommandWithMiddleware::class)
+            ->assertContains('from middleware')
+            ->assertContains('from command');
+    }
+
+    public function test_call_command_by_class_name_with_parameters(): void
+    {
+        $this->console
+            ->call(ArrayInputCommand::class, ['--input=a', '--input=b'])
+            ->assertSee('["a","b"]');
     }
 }

--- a/tests/Integration/Console/Actions/ResolveConsoleCommandTest.php
+++ b/tests/Integration/Console/Actions/ResolveConsoleCommandTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Console\Actions;
+
+use Tempest\Console\Actions\ResolveConsoleCommand;
+use Tempest\Console\ConsoleCommand;
+use Tests\Tempest\Integration\Console\Fixtures\ArrayInputCommand;
+use Tests\Tempest\Integration\Console\Fixtures\CommandWithMiddleware;
+use Tests\Tempest\Integration\Console\Fixtures\CommandWithNonCommandMethods;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+/**
+ * @internal
+ */
+final class ResolveConsoleCommandTest extends FrameworkIntegrationTestCase
+{
+    public function test_resolve_string_command(): void
+    {
+        $command = $this->container->invoke(ResolveConsoleCommand::class, command: 'array_input');
+
+        $this->assertInstanceOf(ConsoleCommand::class, $command);
+        $this->assertSame(ArrayInputCommand::class, $command->handler->getDeclaringClass()->getName());
+        $this->assertSame('array_input', $command->getName());
+    }
+
+    public function test_resolve_string_with_colon_command(): void
+    {
+        $command = $this->container->invoke(ResolveConsoleCommand::class, command: 'with:middleware');
+
+        $this->assertInstanceOf(ConsoleCommand::class, $command);
+        $this->assertSame(CommandWithMiddleware::class, $command->handler->getDeclaringClass()->getName());
+        $this->assertSame('with:middleware', $command->getName());
+    }
+
+    public function test_resolve_fqcn_command(): void
+    {
+        $command = $this->container->invoke(ResolveConsoleCommand::class, command: CommandWithMiddleware::class);
+
+        $this->assertInstanceOf(ConsoleCommand::class, $command);
+        $this->assertSame(CommandWithMiddleware::class, $command->handler->getDeclaringClass()->getName());
+        $this->assertSame('with:middleware', $command->getName());
+    }
+
+    public function test_resolve_array_command(): void
+    {
+        $command = $this->container->invoke(ResolveConsoleCommand::class, command: [CommandWithMiddleware::class, '__invoke']);
+
+        $this->assertInstanceOf(ConsoleCommand::class, $command);
+        $this->assertSame(CommandWithMiddleware::class, $command->handler->getDeclaringClass()->getName());
+        $this->assertSame('with:middleware', $command->getName());
+    }
+
+    public function test_resolve_implicit_string_command(): void
+    {
+        $command = $this->container->invoke(ResolveConsoleCommand::class, command: 'test:not-empty');
+
+        $this->assertInstanceOf(ConsoleCommand::class, $command);
+        $this->assertSame(CommandWithNonCommandMethods::class, $command->handler->getDeclaringClass()->getName());
+        $this->assertSame('test:not-empty', $command->getName());
+    }
+
+    public function test_resolve_array_with_method_command(): void
+    {
+        $command = $this->container->invoke(ResolveConsoleCommand::class, command: [CommandWithNonCommandMethods::class, 'do']);
+
+        $this->assertInstanceOf(ConsoleCommand::class, $command);
+        $this->assertSame(CommandWithNonCommandMethods::class, $command->handler->getDeclaringClass()->getName());
+        $this->assertSame('test:not-empty', $command->getName());
+    }
+
+    public function test_non_console_command_throw(): void
+    {
+        $this->expectExceptionMessage('Command not found.');
+
+        $this->container->invoke(ResolveConsoleCommand::class, command: [CommandWithNonCommandMethods::class, 'empty']);
+    }
+}

--- a/tests/Integration/Console/Fixtures/CommandWithNonCommandMethods.php
+++ b/tests/Integration/Console/Fixtures/CommandWithNonCommandMethods.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Console\Fixtures;
+
+use Tempest\Console\ConsoleCommand;
+
+final class CommandWithNonCommandMethods
+{
+    public function __invoke(): void
+    {
+    }
+
+    #[ConsoleCommand('test:not-empty')]
+    public function do(): void
+    {
+    }
+
+    public function empty(): void
+    {
+    }
+}

--- a/tests/Integration/Console/Middleware/OverviewMiddlewareTest.php
+++ b/tests/Integration/Console/Middleware/OverviewMiddlewareTest.php
@@ -27,11 +27,11 @@ final class OverviewMiddlewareTest extends FrameworkIntegrationTestCase
     public function test_overview_with_hidden(): void
     {
         $this->console
-            ->call('-a')
+            ->call('', ['-a'])
             ->assertContains('hidden');
 
         $this->console
-            ->call('--all')
+           ->call('', ['--all'])
             ->assertContains('hidden');
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,3 +5,4 @@ declare(strict_types=1);
 require_once __DIR__ . '/../vendor/autoload.php';
 
 passthru('php tempest discovery:generate');
+echo PHP_EOL;


### PR DESCRIPTION
This pull request adds support for calling console commands with the following syntaxes:

```php
$this->console->call(MyCommand::class);
$this->console->call([MyCommand::class, 'method']);
$this->console->call(MyCommand::class, arguments: ['arg1', '--flag']);
```

Previously, only the following syntax was allowed:
```php
$this->console->call('my-command arg1 --flag');
```

An inconsistency with `ConsoleTester#call` and `GenericConsole#call` has also been fixed. The former already allowed the FQCN and array syntaxes, while the later did not. They now use the same resolving logic.

Since calling a command with parameters in a single string is still allowed to preserve existing functionalities, there are a lot more changes in this pull request that it could have if the parameters could only be added via the `$arguments` parameter.

> [!CAUTION]
> Both the current and previous implementation will not work with arguments that contain spaces, since we do not use PHP's argument parser and instead explode by space.

<details>
<summary>Examples</summary>

### PHP argument parser

![CleanShot 2024-12-07 at 02 39 20@2x](https://github.com/user-attachments/assets/c8be217c-78c4-4af8-9385-dfefb9fc5933)

### Our naive implementation

![CleanShot 2024-12-07 at 02 40 27@2x](https://github.com/user-attachments/assets/1ee7310f-edcf-4125-9e77-eebcc95de68d)

</details>