### PR TITLE
chore: update issue template to use php 8.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -14,7 +14,7 @@ body:
   attributes:
     label: PHP Version
     description: Provide the PHP version that you are using.
-    options: ['8.3']
+    options: ['8.4']
     multiple: true
   validations:
     required: true


### PR DESCRIPTION
In the Github bug report issue template, PHP 8.3 was the only available PHP version. Since tempest requires a minimum of 8.4 now, I've updated the option.