### PR TITLE
feat(support): add `HtmlHelper` class

### DIFF
--- a/src/Tempest/Support/src/HtmlHelper.php
+++ b/src/Tempest/Support/src/HtmlHelper.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support;
+
+final class HtmlHelper
+{
+    public static function createTag(string $tag, array $attributes = [], ?string $content = null): string
+    {
+        $attributes = self::compileAttributes($attributes);
+
+        if ($content || ! self::isSelfClosing($tag)) {
+            return sprintf('<%s%s>%s</%s>', $tag, $attributes, $content ?? '', $tag);
+        }
+
+        return sprintf('<%s%s />', $tag, $attributes);
+    }
+
+    public static function isSelfClosing(string $tag): bool
+    {
+        return in_array($tag, [
+            'area',
+            'base',
+            'br',
+            'col',
+            'embed',
+            'hr',
+            'img',
+            'input',
+            'link',
+            'meta',
+            'param',
+            'source',
+            'track',
+            'wbr',
+        ], strict: true);
+    }
+
+    /**
+     * Compiles an attribute list to a string of `key="value"`.
+     * @param array<string,string> $attributes
+     */
+    private static function compileAttributes(array $attributes): string
+    {
+        return arr($attributes)
+            ->filter(fn (mixed $value) => ! in_array($value, [false, null], strict: true))
+            ->map(fn (mixed $value, int|string $key) => $value === true ? $key : $key . '="' . $value . '"')
+            ->values()
+            ->implode(' ')
+            ->when(
+                condition: fn ($string) => $string->length() !== 0,
+                callback: fn ($string) => $string->prepend(' '),
+            )
+            ->toString();
+    }
+}

--- a/src/Tempest/Support/tests/HtmlHelperTest.php
+++ b/src/Tempest/Support/tests/HtmlHelperTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\HtmlHelper;
+
+/**
+ * @internal
+ */
+final class HtmlHelperTest extends TestCase
+{
+    public function test_create_tag(): void
+    {
+        $this->assertSame(
+            expected: '<div></div>',
+            actual: HtmlHelper::createTag('div'),
+        );
+
+        $this->assertSame(
+            expected: '<button type="submit">OK</button>',
+            actual: HtmlHelper::createTag('button', ['type' => 'submit'], 'OK'),
+        );
+
+        $this->assertSame(
+            expected: '<a href="https://example.com">Link</a>',
+            actual: HtmlHelper::createTag('a', ['href' => 'https://example.com'], 'Link'),
+        );
+
+        $this->assertSame(
+            expected: '<script src="https://example.com/script.js"></script>',
+            actual: HtmlHelper::createTag('script', ['src' => 'https://example.com/script.js']),
+        );
+
+        $this->assertSame(
+            expected: '<link href="https://example.com/style.css" rel="stylesheet" />',
+            actual: HtmlHelper::createTag('link', ['href' => 'https://example.com/style.css', 'rel' => 'stylesheet']),
+        );
+
+        $this->assertSame(
+            expected: '<img src="https://example.com/image.jpg" alt="An image" />',
+            actual: HtmlHelper::createTag('img', ['src' => 'https://example.com/image.jpg', 'alt' => 'An image']),
+        );
+
+        $this->assertSame(
+            expected: '<input type="checkbox" checked />',
+            actual: HtmlHelper::createTag('input', ['type' => 'checkbox', 'checked' => true]),
+        );
+
+        $this->assertSame(
+            expected: '<input type="checkbox" />',
+            actual: HtmlHelper::createTag('input', ['type' => 'checkbox', 'checked' => false]),
+        );
+    }
+}


### PR DESCRIPTION
This pull request introduces a `HtmlHelper` class, which purpose is to help working with HTML.

For now, its only method is `createTag`. It properly boolean handles attributes and self-closing tags.

```php
HtmlHelper::createTag('script', [
  'src' => 'https://localhost:5137/@vite/client',
]);
```

See https://github.com/tempestphp/tempest-framework/pull/829