### PR TITLE
refactor(container): mark container exceptions with `ContainerException`

### DIFF
--- a/src/Tempest/Container/src/Exceptions/CannotAutowireException.php
+++ b/src/Tempest/Container/src/Exceptions/CannotAutowireException.php
@@ -8,7 +8,7 @@ use Exception;
 use Tempest\Container\Dependency;
 use Tempest\Container\DependencyChain;
 
-final class CannotAutowireException extends Exception
+final class CannotAutowireException extends Exception implements ContainerException
 {
     public function __construct(DependencyChain $chain, Dependency $brokenDependency)
     {

--- a/src/Tempest/Container/src/Exceptions/CannotInstantiateDependencyException.php
+++ b/src/Tempest/Container/src/Exceptions/CannotInstantiateDependencyException.php
@@ -8,7 +8,7 @@ use Exception;
 use Tempest\Container\DependencyChain;
 use Tempest\Reflection\ClassReflector;
 
-final class CannotInstantiateDependencyException extends Exception
+final class CannotInstantiateDependencyException extends Exception implements ContainerException
 {
     public function __construct(ClassReflector $class, DependencyChain $chain)
     {

--- a/src/Tempest/Container/src/Exceptions/CannotResolveTaggedDependency.php
+++ b/src/Tempest/Container/src/Exceptions/CannotResolveTaggedDependency.php
@@ -8,7 +8,7 @@ use Exception;
 use Tempest\Container\Dependency;
 use Tempest\Container\DependencyChain;
 
-final class CannotResolveTaggedDependency extends Exception
+final class CannotResolveTaggedDependency extends Exception implements ContainerException
 {
     public function __construct(DependencyChain $chain, Dependency $brokenDependency, string $tag)
     {

--- a/src/Tempest/Container/src/Exceptions/CircularDependencyException.php
+++ b/src/Tempest/Container/src/Exceptions/CircularDependencyException.php
@@ -8,7 +8,7 @@ use Exception;
 use Tempest\Container\Dependency;
 use Tempest\Container\DependencyChain;
 
-final class CircularDependencyException extends Exception
+final class CircularDependencyException extends Exception implements ContainerException
 {
     public function __construct(DependencyChain $chain, Dependency $circularDependency)
     {

--- a/src/Tempest/Container/src/Exceptions/ContainerException.php
+++ b/src/Tempest/Container/src/Exceptions/ContainerException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Exceptions;
+
+interface ContainerException
+{
+}

--- a/src/Tempest/Container/src/Exceptions/InvalidCallableException.php
+++ b/src/Tempest/Container/src/Exceptions/InvalidCallableException.php
@@ -7,7 +7,7 @@ namespace Tempest\Container\Exceptions;
 use Exception;
 use Tempest\Container\Dependency;
 
-final class InvalidCallableException extends Exception
+final class InvalidCallableException extends Exception implements ContainerException
 {
     public function __construct(Dependency $dependency)
     {

--- a/src/Tempest/Container/src/Exceptions/InvalidInitializerException.php
+++ b/src/Tempest/Container/src/Exceptions/InvalidInitializerException.php
@@ -6,7 +6,7 @@ namespace Tempest\Container\Exceptions;
 
 use Exception;
 
-final class InvalidInitializerException extends Exception
+final class InvalidInitializerException extends Exception implements ContainerException
 {
     public static function dynamicInitializerNotAllowed(string $initializerClassName): self
     {


### PR DESCRIPTION
This pull request introduces a marker interface, `ContainerException`. It's useful for catching only exceptions related to the container:

```php
try {
    $this->container->get(SomeDependency::class);
} catch (ContainerException) {
    // Do something
}
```

I am using this in https://github.com/tempestphp/tempest-framework/pull/829. Not merging immediately, as I know @brendt is not a fan of marker interfaces 👀 