### PR TITLE
fix(support): support keys with dots in `ArrayHelper#get`

### DIFF
--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -675,6 +675,12 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     {
         $value = $this->array;
 
+        if (isset($value[$key])) {
+            return is_array($value[$key])
+                ? new self($value[$key])
+                : $value[$key];
+        }
+
         $keys = is_int($key)
             ? [$key]
             : explode('.', $key);
@@ -700,6 +706,10 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     public function has(int|string $key): bool
     {
         $array = $this->array;
+
+        if (isset($array[$key])) {
+            return true;
+        }
 
         $keys = is_int($key)
             ? [$key]

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -66,7 +66,7 @@ final class ArrayHelperTest extends TestCase
         $this->assertFalse(isset($array['a']));
     }
 
-    public function test_arr_get(): void
+    public function test_get_dot(): void
     {
         $array = [
             'a' => [
@@ -78,6 +78,17 @@ final class ArrayHelperTest extends TestCase
         $this->assertInstanceOf(ArrayHelper::class, arr($array)->get('a'));
         $this->assertNull(arr($array)->get('a.x'));
         $this->assertSame('default', arr($array)->get('a.x', 'default'));
+    }
+
+    public function test_get(): void
+    {
+        $array = [
+            'b.c' => 'd',
+            'a' => 'b',
+        ];
+
+        $this->assertSame('d', arr($array)->get('b.c'));
+        $this->assertSame('b', arr($array)->get('a'));
     }
 
     public function test_arr_has(): void
@@ -888,10 +899,10 @@ final class ArrayHelperTest extends TestCase
         );
 
         $this->assertSame(
-            $collection
+            actual: $collection
                 ->add('name')
                 ->toArray(),
-            [1, 2, '', null, false, [], 'name'],
+            expected: [1, 2, '', null, false, [], 'name'],
         );
     }
 


### PR DESCRIPTION
This pull request fixes `ArrayHelper#get` so that it supports keys with dots in them. Prior to this PR, the following did not pass:

```php
$array = [
    'src/main.ts' => '...',
];

$this->assertSame('...', arr($array)->get('src/main.ts'));
```