### PR TITLE
feat(support): add `append` and `prepend` to `ArrayHelper`

### DIFF
--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -259,6 +259,38 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     }
 
     /**
+     * Prepends the specified values to the instance.
+     *
+     * @param TValue $value
+     */
+    public function prepend(mixed ...$values): self
+    {
+        $array = $this->array;
+
+        foreach (array_reverse($values) as $value) {
+            $array = [$value, ...$array];
+        }
+
+        return new self($array);
+    }
+
+    /**
+     * Appends the specified values to the instance.
+     *
+     * @param TValue $value
+     */
+    public function append(mixed ...$values): self
+    {
+        $array = $this->array;
+
+        foreach ($values as $value) {
+            $array = [...$array, $value];
+        }
+
+        return new self($array);
+    }
+
+    /**
      * @alias of `add`.
      */
     public function push(mixed $value): self

--- a/src/Tempest/Support/src/ArrayHelper.php
+++ b/src/Tempest/Support/src/ArrayHelper.php
@@ -261,7 +261,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     /**
      * Prepends the specified values to the instance.
      *
-     * @param TValue $value
+     * @param TValue $values
      */
     public function prepend(mixed ...$values): self
     {
@@ -277,7 +277,7 @@ final class ArrayHelper implements Iterator, ArrayAccess, Serializable, Countabl
     /**
      * Appends the specified values to the instance.
      *
-     * @param TValue $value
+     * @param TValue $values
      */
     public function append(mixed ...$values): self
     {

--- a/src/Tempest/Support/tests/ArrayHelperTest.php
+++ b/src/Tempest/Support/tests/ArrayHelperTest.php
@@ -1655,4 +1655,44 @@ final class ArrayHelperTest extends TestCase
         $this->assertTrue(arr([0, 1, true, false, ''])->every());
         $this->assertFalse(arr([0, 1, true, false, '', null])->every());
     }
+
+    public function test_append(): void
+    {
+        $collection = arr(['foo', 'bar']);
+
+        $this->assertSame(
+            actual: $collection->append('foo')->toArray(),
+            expected: ['foo', 'bar', 'foo'],
+        );
+
+        $this->assertSame(
+            actual: $collection->append(1, 'b')->toArray(),
+            expected: ['foo', 'bar', 1, 'b'],
+        );
+
+        $this->assertSame(
+            actual: $collection->append(['a' => 'b'])->toArray(),
+            expected: ['foo', 'bar', ['a' => 'b']],
+        );
+    }
+
+    public function test_prepend(): void
+    {
+        $collection = arr(['foo', 'bar']);
+
+        $this->assertSame(
+            actual: $collection->prepend('foo')->toArray(),
+            expected: ['foo', 'foo', 'bar'],
+        );
+
+        $this->assertSame(
+            actual: $collection->prepend(1, 'b')->toArray(),
+            expected: [1, 'b', 'foo', 'bar'],
+        );
+
+        $this->assertSame(
+            actual: $collection->prepend(['a' => 'b'])->toArray(),
+            expected: [['a' => 'b'], 'foo', 'bar'],
+        );
+    }
 }


### PR DESCRIPTION
This pull request adds the `prepend` and `append` methods to `ArrayHelper`.

```php
arr()
  ->prepend($first)
  ->append($last);
```