### PR TITLE
feat(container): add `has` and `unregister`

### DIFF
--- a/src/Tempest/Container/src/Container.php
+++ b/src/Tempest/Container/src/Container.php
@@ -12,6 +12,8 @@ interface Container
 {
     public function register(string $className, callable $definition): self;
 
+    public function unregister(string $className): self;
+
     public function singleton(string $className, mixed $definition, ?string $tag = null): self;
 
     public function config(object $config): self;

--- a/src/Tempest/Container/src/Container.php
+++ b/src/Tempest/Container/src/Container.php
@@ -25,6 +25,8 @@ interface Container
      */
     public function get(string $className, ?string $tag = null, mixed ...$params): mixed;
 
+    public function has(string $className, ?string $tag = null): bool;
+
     public function invoke(MethodReflector|FunctionReflector|callable|string $method, mixed ...$params): mixed;
 
     /**

--- a/src/Tempest/Container/src/GenericContainer.php
+++ b/src/Tempest/Container/src/GenericContainer.php
@@ -89,6 +89,12 @@ final class GenericContainer implements Container
         return $this;
     }
 
+    public function has(string $className, ?string $tag = null): bool
+    {
+        return isset($this->definitions[$className])
+            || isset($this->singletons[$this->resolveTaggedName($className, $tag)]);
+    }
+
     public function singleton(string $className, mixed $definition, ?string $tag = null): self
     {
         $className = $this->resolveTaggedName($className, $tag);

--- a/src/Tempest/Container/src/GenericContainer.php
+++ b/src/Tempest/Container/src/GenericContainer.php
@@ -81,6 +81,14 @@ final class GenericContainer implements Container
         return $this;
     }
 
+    public function unregister(string $className): self
+    {
+        unset($this->definitions[$className]);
+        unset($this->singletons[$className]);
+
+        return $this;
+    }
+
     public function singleton(string $className, mixed $definition, ?string $tag = null): self
     {
         $className = $this->resolveTaggedName($className, $tag);

--- a/src/Tempest/Container/tests/ContainerTest.php
+++ b/src/Tempest/Container/tests/ContainerTest.php
@@ -7,6 +7,7 @@ namespace Tempest\Container\Tests;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Tempest\Container\Exceptions\CannotAutowireException;
+use Tempest\Container\Exceptions\CannotInstantiateDependencyException;
 use Tempest\Container\Exceptions\CannotResolveTaggedDependency;
 use Tempest\Container\Exceptions\CircularDependencyException;
 use Tempest\Container\Exceptions\InvalidCallableException;
@@ -29,8 +30,10 @@ use Tempest\Container\Tests\Fixtures\ContainerObjectE;
 use Tempest\Container\Tests\Fixtures\ContainerObjectEInitializer;
 use Tempest\Container\Tests\Fixtures\DependencyWithBuiltinDependencies;
 use Tempest\Container\Tests\Fixtures\DependencyWithTaggedDependency;
+use Tempest\Container\Tests\Fixtures\ImplementsInterfaceA;
 use Tempest\Container\Tests\Fixtures\InjectA;
 use Tempest\Container\Tests\Fixtures\InjectB;
+use Tempest\Container\Tests\Fixtures\InterfaceA;
 use Tempest\Container\Tests\Fixtures\IntersectionInitializer;
 use Tempest\Container\Tests\Fixtures\InvokableClass;
 use Tempest\Container\Tests\Fixtures\InvokableClassWithParameters;
@@ -389,5 +392,36 @@ final class ContainerTest extends TestCase
         $a = $container->get(InjectA::class);
 
         $this->assertInstanceOf(InjectB::class, $a->getB());
+    }
+
+    public function test_unregister(): void
+    {
+        $container = new GenericContainer();
+
+        $container->register(InterfaceA::class, fn () => new ImplementsInterfaceA());
+
+        $this->assertInstanceOf(ImplementsInterfaceA::class, $container->get(InterfaceA::class));
+
+        $container->unregister(InterfaceA::class);
+
+        $this->expectException(CannotInstantiateDependencyException::class);
+
+        $container->get(InterfaceA::class);
+    }
+
+    public function test_unregister_singleton(): void
+    {
+        $container = new GenericContainer();
+
+        $container->singleton(InterfaceA::class, $instance = new ImplementsInterfaceA());
+
+        $this->assertInstanceOf(ImplementsInterfaceA::class, $container->get(InterfaceA::class));
+        $this->assertSame($instance, $container->get(InterfaceA::class));
+
+        $container->unregister(InterfaceA::class);
+
+        $this->expectException(CannotInstantiateDependencyException::class);
+
+        $container->get(InterfaceA::class);
     }
 }

--- a/src/Tempest/Container/tests/ContainerTest.php
+++ b/src/Tempest/Container/tests/ContainerTest.php
@@ -424,4 +424,41 @@ final class ContainerTest extends TestCase
 
         $container->get(InterfaceA::class);
     }
+
+    public function test_has(): void
+    {
+        $container = new GenericContainer();
+
+        $this->assertFalse($container->has(InterfaceA::class));
+
+        $container->register(InterfaceA::class, fn () => new ImplementsInterfaceA());
+
+        $this->assertTrue($container->has(InterfaceA::class));
+    }
+
+    public function test_has_singleton(): void
+    {
+        $container = new GenericContainer();
+
+        $this->assertFalse($container->has(InterfaceA::class));
+
+        $container->singleton(InterfaceA::class, new ImplementsInterfaceA());
+
+        $this->assertTrue($container->has(InterfaceA::class));
+    }
+
+    public function test_has_tagged_singleton(): void
+    {
+        $container = new GenericContainer();
+
+        $this->assertFalse($container->has(TaggedDependency::class, 'web'));
+
+        $container->singleton(
+            TaggedDependency::class,
+            new TaggedDependency('web'),
+            tag: 'web',
+        );
+
+        $this->assertTrue($container->has(TaggedDependency::class, 'web'));
+    }
 }

--- a/src/Tempest/Container/tests/Fixtures/ImplementsInterfaceA.php
+++ b/src/Tempest/Container/tests/Fixtures/ImplementsInterfaceA.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Tests\Fixtures;
+
+final class ImplementsInterfaceA implements InterfaceA
+{
+    public function __invoke(): void
+    {
+    }
+}

--- a/src/Tempest/Container/tests/Fixtures/InterfaceA.php
+++ b/src/Tempest/Container/tests/Fixtures/InterfaceA.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Tests\Fixtures;
+
+interface InterfaceA
+{
+}


### PR DESCRIPTION
This pull request adds the ability to unregister bindings, as well as checking for the existence of a binding.

```php
$this->container->register(SomeInterface::class, fn () => new SomeImplementation());
$this->container->has(SomeInterface::class); // true

$this->container->unregister(SomeInterface::class);
$this->container->has(SomeInterface::class); // false
```

Both `has` and `unregister` act on normal bindings and singletons. I think it would be pretty uncommon to have both a classic binding and a singleton with the same name, so this avoids having two extra methods for checking the type of the binding.

> [!NOTE]
> The `has` method only checks for the existence of a binding. `has` may return `false` even though `get` would succeed because of autowiring.