### PR TITLE
feat(support): add `HtmlString` class

### DIFF
--- a/src/Tempest/Support/src/HtmlString.php
+++ b/src/Tempest/Support/src/HtmlString.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support;
+
+use Stringable;
+
+final readonly class HtmlString implements Stringable
+{
+    public function __construct(
+        private string $value,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+    public function toStringHelper(): StringHelper
+    {
+        return new StringHelper($this->value);
+    }
+
+    public static function createTag(string $tag, array $attributes = [], ?string $content = null): self
+    {
+        $attributes = self::compileAttributes($attributes);
+
+        if ($content || ! self::isSelfClosingTag($tag)) {
+            return new self(sprintf('<%s%s>%s</%s>', $tag, $attributes, $content ?? '', $tag));
+        }
+
+        return new self(sprintf('<%s%s />', $tag, $attributes));
+    }
+
+    public static function isSelfClosingTag(string $tag): bool
+    {
+        return in_array($tag, [
+            'area',
+            'base',
+            'br',
+            'col',
+            'embed',
+            'hr',
+            'img',
+            'input',
+            'link',
+            'meta',
+            'param',
+            'source',
+            'track',
+            'wbr',
+        ], strict: true);
+    }
+
+    /**
+     * Compiles an attribute list to a string of `key="value"`.
+     * @param array<string,string> $attributes
+     */
+    private static function compileAttributes(array $attributes): string
+    {
+        return arr($attributes)
+            ->filter(fn (mixed $value) => ! in_array($value, [false, null], strict: true))
+            ->map(fn (mixed $value, int|string $key) => $value === true ? $key : $key . '="' . $value . '"')
+            ->values()
+            ->implode(' ')
+            ->when(
+                condition: fn ($string) => $string->length() !== 0,
+                callback: fn ($string) => $string->prepend(' '),
+            )
+            ->toString();
+    }
+}

--- a/src/Tempest/Support/src/StringHelper.php
+++ b/src/Tempest/Support/src/StringHelper.php
@@ -26,6 +26,14 @@ final readonly class StringHelper implements Stringable
     }
 
     /**
+     * Converts the instance to a {@see \Tempest\Support\HtmlString}.
+     */
+    public function toHtmlString(): HtmlString
+    {
+        return new HtmlString($this->string);
+    }
+
+    /**
      * Converts the instance to a string.
      */
     public function toString(): string

--- a/src/Tempest/Support/tests/HtmlStringTest.php
+++ b/src/Tempest/Support/tests/HtmlStringTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use Tempest\Support\HtmlString;
+use Tempest\Support\StringHelper;
+
+/**
+ * @internal
+ */
+final class HtmlStringTest extends TestCase
+{
+    public function test_convertions(): void
+    {
+        $this->assertInstanceOf(HtmlString::class, HtmlString::createTag('div'));
+        $this->assertInstanceOf(Stringable::class, HtmlString::createTag('div'));
+        $this->assertInstanceOf(StringHelper::class, HtmlString::createTag('div')->toStringHelper());
+        $this->assertSame('<div></div>', HtmlString::createTag('div')->toStringHelper()->toString());
+    }
+
+    public function test_create_tag(): void
+    {
+        $this->assertSame(
+            expected: '<div></div>',
+            actual: (string) HtmlString::createTag('div'),
+        );
+
+        $this->assertSame(
+            expected: '<button type="submit">OK</button>',
+            actual: (string) HtmlString::createTag('button', ['type' => 'submit'], 'OK'),
+        );
+
+        $this->assertSame(
+            expected: '<a href="https://example.com">Link</a>',
+            actual: (string) HtmlString::createTag('a', ['href' => 'https://example.com'], 'Link'),
+        );
+
+        $this->assertSame(
+            expected: '<script src="https://example.com/script.js"></script>',
+            actual: (string) HtmlString::createTag('script', ['src' => 'https://example.com/script.js']),
+        );
+
+        $this->assertSame(
+            expected: '<link href="https://example.com/style.css" rel="stylesheet" />',
+            actual: (string) HtmlString::createTag('link', ['href' => 'https://example.com/style.css', 'rel' => 'stylesheet']),
+        );
+
+        $this->assertSame(
+            expected: '<img src="https://example.com/image.jpg" alt="An image" />',
+            actual: (string) HtmlString::createTag('img', ['src' => 'https://example.com/image.jpg', 'alt' => 'An image']),
+        );
+
+        $this->assertSame(
+            expected: '<input type="checkbox" checked />',
+            actual: (string) HtmlString::createTag('input', ['type' => 'checkbox', 'checked' => true]),
+        );
+
+        $this->assertSame(
+            expected: '<input type="checkbox" />',
+            actual: (string) HtmlString::createTag('input', ['type' => 'checkbox', 'checked' => false]),
+        );
+    }
+}

--- a/src/Tempest/Support/tests/StringHelperTest.php
+++ b/src/Tempest/Support/tests/StringHelperTest.php
@@ -6,6 +6,7 @@ namespace Tempest\Support\Tests;
 
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Tempest\Support\HtmlString;
 use Tempest\Support\StringHelper;
 use function Tempest\Support\arr;
 use function Tempest\Support\str;
@@ -600,5 +601,11 @@ b'));
         $this->assertSame('foo       ', str(' foo')->alignLeft(10)->toString());
         $this->assertSame('  foo     ', str(' foo')->alignLeft(10, padding: 2)->toString());
         $this->assertSame('  foo  ', str('foo')->alignLeft(2, padding: 2)->toString());
+    }
+
+    public function test_to_html_string(): void
+    {
+        $this->assertInstanceOf(HtmlString::class, str('foo')->toHtmlString());
+        $this->assertSame('foo', (string) str('foo')->toHtmlString());
     }
 }

--- a/src/Tempest/View/src/Renderers/TempestViewRenderer.php
+++ b/src/Tempest/View/src/Renderers/TempestViewRenderer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\View\Renderers;
 
 use Stringable;
+use Tempest\Support\HtmlString;
 use Tempest\View\Exceptions\ViewCompilationError;
 use Tempest\View\GenericView;
 use Tempest\View\View;
@@ -96,8 +97,12 @@ final class TempestViewRenderer implements ViewRenderer
         return trim(ob_get_clean());
     }
 
-    public function escape(null|string|Stringable $value): string
+    public function escape(null|string|HtmlString|Stringable $value): string
     {
+        if ($value instanceof HtmlString) {
+            return (string) $value;
+        }
+
         return htmlentities((string) $value);
     }
 }

--- a/tests/Integration/View/TempestViewRendererTest.php
+++ b/tests/Integration/View/TempestViewRendererTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\View;
 
+use Tempest\Support\HtmlString;
 use Tempest\View\Exceptions\InvalidElement;
 use Tempest\View\ViewCache;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -285,6 +286,20 @@ final class TempestViewRendererTest extends FrameworkIntegrationTestCase
             &lt;H1&gt;HI&lt;/H1&gt;
             <h1>hi</h1>
             HTML, $html);
+    }
+
+    public function test_html_string(): void
+    {
+        $html = $this->render(view(__DIR__ . '/../../Fixtures/Views/raw-escaped.view.php', var: HtmlString::createTag('h1', content: 'hi')));
+
+        $this->assertStringEqualsStringIgnoringLineEndings(
+            expected: <<<'HTML'
+                <h1>hi</h1>
+                &lt;H1&gt;HI&lt;/H1&gt;
+                <h1>hi</h1>
+                HTML,
+            actual: $html,
+        );
     }
 
     public function test_no_double_else_attributes(): void


### PR DESCRIPTION
Second take on https://github.com/tempestphp/tempest-framework/pull/830

---

This pull request introduces a `HtmlString` class. This class can be passed to Tempest's view renderer and its content won't be escaped as for other strings.

It has the ability to be converted to `StringHelper`, and `StringHelper` can also be converted to `HtmlString`:

```php
$html = new HtmlString('<h1></h1>');
$string = $html->toStringHelper();
$html = $string->toHtmlString();
```

It also has a `createTag` static constructor, which creates an HTML tag with properly-parsed attributes:

```php
HtmlString::createTag('script', [
  'src' => 'https://localhost:5137/@vite/client',
]);
```