### PR TITLE
feat(console): add support for printing hyperlinks

### DIFF
--- a/src/Tempest/Console/src/Highlight/TempestConsoleLanguage/Injections/LinkInjection.php
+++ b/src/Tempest/Console/src/Highlight/TempestConsoleLanguage/Injections/LinkInjection.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Highlight\TempestConsoleLanguage\Injections;
+
+use Tempest\Highlight\Highlighter;
+use Tempest\Highlight\Injection;
+use Tempest\Highlight\ParsedInjection;
+use function Tempest\Support\str;
+
+final readonly class LinkInjection implements Injection
+{
+    public function parse(string $content, Highlighter $highlighter): ParsedInjection
+    {
+        return new ParsedInjection(preg_replace_callback(
+            subject: $content,
+            pattern: '/(?<match>\<href=\"(?<href>.+)\"\>(?:(?!\<href).)*?\<\/href\>)/',
+            callback: function (array $matches) {
+                $match = $matches['match'];
+                $href = $matches['href'];
+
+                return str($match)
+                    ->replaceFirst("<href=\"{$href}\">", "\x1b]8;;{$href}\x1b\\")
+                    ->replaceLast('</href>', "\x1b]8;;\x1b\\")
+                    ->toString();
+            },
+        ));
+    }
+}

--- a/src/Tempest/Console/src/Highlight/TempestConsoleLanguage/TempestConsoleLanguage.php
+++ b/src/Tempest/Console/src/Highlight/TempestConsoleLanguage/TempestConsoleLanguage.php
@@ -8,6 +8,7 @@ use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\DynamicInjection
 use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\EmphasizeInjection;
 use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\H1Injection;
 use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\H2Injection;
+use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\LinkInjection;
 use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\StrongInjection;
 use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\UnderlineInjection;
 use Tempest\Highlight\Language;
@@ -27,6 +28,7 @@ final readonly class TempestConsoleLanguage implements Language
     public function getInjections(): array
     {
         return [
+            new LinkInjection(),
             new EmphasizeInjection(),
             new StrongInjection(),
             new UnderlineInjection(),

--- a/src/Tempest/Console/tests/TempestConsoleLanguage/Injections/LinkInjectionTest.php
+++ b/src/Tempest/Console/tests/TempestConsoleLanguage/Injections/LinkInjectionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Tests\TempestConsoleLanguage\Injections;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Tempest\Console\Highlight\TempestConsoleLanguage\Injections\LinkInjection;
+use Tempest\Console\Highlight\TempestTerminalTheme;
+use Tempest\Highlight\Highlighter;
+
+/**
+ * @internal
+ */
+final class LinkInjectionTest extends TestCase
+{
+    #[Test]
+    #[TestWith(['<href="https://tempestphp.com">Tempest</href>', "\e]8;;https://tempestphp.com\e\Tempest\e]8;;\e\\"])]
+    #[TestWith(['<href="http://example.com/path?param=value!@#$%^&*()_+-={}:<>?,./">My link</href>', "\e]8;;http://example.com/path?param=value!@#$%^&*()_+-={}:<>?,./\e\My link\e]8;;\e\\"])]
+    #[TestWith(['<href="tel:+1234567890">My link</href>', "\e]8;;tel:+1234567890\e\My link\e]8;;\e\\"])]
+    #[TestWith(['<href="mailto:user@example.com">My link</href>', "\e]8;;mailto:user@example.com\e\My link\e]8;;\e\\"])]
+    public function language(string $content, string $expected): void
+    {
+        $highlighter = new Highlighter(new TempestTerminalTheme());
+
+        $this->assertSame(
+            $expected,
+            (new LinkInjection())->parse($content, $highlighter)->content,
+        );
+    }
+}

--- a/tests/Integration/Console/Highlight/TempestConsoleLanguage/TempestConsoleLanguageTest.php
+++ b/tests/Integration/Console/Highlight/TempestConsoleLanguage/TempestConsoleLanguageTest.php
@@ -29,6 +29,10 @@ final class TempestConsoleLanguageTest extends TestCase
     #[TestWith(['<style="dim"><style="bg-dark-red fg-white">foo</style></style>', "\e[2m\e[41m\e[97mfoo\e[49m\e[39m\e[22m"])]
     #[TestWith(['<style="fg-cyan">cyan</style>unstyled<style="bg-dark-red">dark red</style>', "\e[96mcyan\e[39munstyled\e[41mdark red\e[49m"])]
     #[TestWith(['<style="dim"><style="fg-gray">dim-gray</style> just-gray</style>', "\e[2m\e[90mdim-gray\e[39m just-gray\e[22m"])]
+    #[TestWith(['<em>Tempest</em>', "\e[1m\e[4mTempest\e[22m\e[24m"])]
+    #[TestWith(['<href="https://tempestphp.com">Tempest</href>', "\e]8;;https://tempestphp.com\e\Tempest\e]8;;\e\\"])]
+    #[TestWith(['<em><href="https://tempestphp.com">Tempest</href></em>', "\e[1m\e[4m\e]8;;https://tempestphp.com\e\Tempest\e]8;;\e\\\e[22m\e[24m"])]
+    #[TestWith(['<style="fg-cyan"><href="https://tempestphp.com">Tempest</href></style>', "\e[96m\e]8;;https://tempestphp.com\e\Tempest\e]8;;\e\\\e[39m"])]
     public function language(string $content, string $expected): void
     {
         $highlighter = new Highlighter(new TempestTerminalTheme());


### PR DESCRIPTION
This pull request adds support for printing hyperlinks, with a simple `href` syntax:

```php
$this->console->writeln(
    'Visit the <href="https://tempestphp.com">Tempest website</href> for more information.'
);
```

On supporting terminals, the "Tempest website" part will be clickable.