### PR TITLE
ci: improve release script

### DIFF
--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -18,19 +18,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # - name: Generate changelog
-      #   uses: orhun/git-cliff-action@v4
-      #   env:
-      #     OUTPUT: CHANGELOG.md
-      #     GITHUB_REPO: ${{ github.repository }}
-
-      # - name: Update changelog
-      #   uses: stefanzweifel/git-auto-commit-action@v5
-      #   with:
-      #     file_pattern: 'CHANGELOG.md'
-      #     commit_message: "chore: update changelog"
-      #     branch: main
-
       - name: Generate release notes
         uses: orhun/git-cliff-action@v4
         id: generate_release_notes

--- a/.github/workflows/publish-javascript-packages.yml
+++ b/.github/workflows/publish-javascript-packages.yml
@@ -1,0 +1,43 @@
+name: Release JavaScript packages
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node for npm publishing
+        uses: actions/setup-node@v4
+        with:
+          node-version: current
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run tests
+        run: bun run test
+
+      - name: Build packages
+        run: bun run build
+
+      - name: Publish packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          for package in packages/*; do
+            if [ -d "$package" ] && [ -f "$package/package.json" ]; then
+              cd "$package"
+              echo "Publishing package in $package"
+              bun publish --access public
+              cd ../..
+            fi
+          done

--- a/bin/release
+++ b/bin/release
@@ -3,6 +3,17 @@
 
 declare(strict_types=1);
 
+/**
+ * This script:
+ * - Prompts for the next version
+ * - Bumps the Kernel version
+ * - Bumps the versions of PHP packages
+ * - Bumps the versions of JavaScript packages
+ * - Updates the changelog
+ * - Commits and push a new tag, which triggers GitHub Actions
+ * - Cleans up release artefacts
+ */
+
 use Composer\Semver\VersionParser;
 use Tempest\Console\Console;
 use Tempest\Console\ConsoleApplication;
@@ -13,27 +24,149 @@ use function Tempest\Support\str;
 
 require_once getcwd() . '/vendor/autoload.php';
 
-function ensureAccess(string $remote, string $branch): void
+/**
+ * Bumps the constant version in the Kernel class.
+ */
+function bumpKernelVersion(string $version): void
 {
+    $kernel = __DIR__ . '/../src/Tempest/Core/src/Kernel.php';
+    $content = preg_replace(
+        pattern: '/public const VERSION = \'.*\';/',
+        replacement: "public const VERSION = '{$version}';",
+        subject: file_get_contents($kernel),
+    );
+
+    file_put_contents($kernel, $content);
+}
+
+/**
+ * Forcibly sets the specified package to the specified version in all `composer.json` files.
+ */
+function setPhpDependencyVersion(string $package, string $version): void
+{
+    foreach (glob(__DIR__ . '/../src/Tempest/*/composer.json') as $path) {
+        updateJsonFile(
+            path: $path,
+            callback: function (array $content) use ($version, $package) {
+                $content['require'][$package] = $version;
+
+                return $content;
+            },
+        );
+    }
+}
+
+/**
+ * Updates `composer.json` files so this tag correctly pins the correct versions.
+ */
+function bumpPhpPackages(string $version, bool $isMajor): void
+{
+    // Bumps dependencies
+    executeCommands("./vendor/bin/monorepo-builder bump-interdependency {$version}");
+
+    // Finds all `composer.json` files in `src/Tempest`, and revert the `tempest/highlight` dependency to the saved version
+    setPhpDependencyVersion(
+        package: 'tempest/highlight',
+        version: json_decode(file_get_contents(__DIR__ . '/../composer.json'), associative: true)['require']['tempest/highlight'],
+    );
+
+    // Validates
+    executeCommands('./vendor/bin/monorepo-builder validate');
+}
+
+/**
+ * Cleans up anything that needs to be after the release. This will be committed.
+ */
+function cleanUpAfterRelease(): void
+{
+    // We want to still be able to `require tempest/package:dev-main`, so we need
+    // to update back all composer files to use `dev-main` instead of a fixed version.
+    executeCommands('./vendor/bin/monorepo-builder bump-interdependency dev-main');
+
+    // Finds all `composer.json` files in `src/Tempest`, and revert the `tempest/highlight` dependency to the saved version
+    setPhpDependencyVersion(
+        package: 'tempest/highlight',
+        version: json_decode(file_get_contents(__DIR__ . '/../composer.json'), associative: true)['require']['tempest/highlight'],
+    );
+
+    // Validates
+    executeCommands('./vendor/bin/monorepo-builder validate');
+}
+
+/**
+ * Bumps versions in all `package.json`.
+ */
+function bumpJavaScriptPackages(string $version): void
+{
+    $rootPackageJson = json_decode(file_get_contents(__DIR__ . '/../package.json'), associative: true);
+    $packages = [];
+
+    foreach ($rootPackageJson['workspaces'] as $pattern) {
+        foreach (glob($pattern, GLOB_ONLYDIR) as $dir) {
+            $packageJsonPath = __DIR__ . '/../' . $dir . '/package.json';
+
+            if (file_exists($packageJsonPath)) {
+                $packages[] = realpath($packageJsonPath);
+            }
+        }
+    }
+
+    foreach ($packages as $package) {
+        updateJsonFile(
+            path: $package,
+            callback: function (array $content) use ($version) {
+                $content['version'] = $version;
+
+                return $content;
+            },
+        );
+    }
+}
+
+/**
+ * Updates the `CHANGELOG.md` file.
+ */
+function updateChangelog(string $version): void
+{
+    file_put_contents(
+        filename: __DIR__ . '/../CHANGELOG.md',
+        data: shell_exec("bunx git-cliff --tag {$version}"),
+    );
+}
+
+/**
+ * Ensure the release script can run.
+ */
+function performPreReleaseChecks(string $remote, string $branch): void
+{
+    if (empty(shell_exec('which bun'))) {
+        throw new Exception('This script requires `bun` to be installed.');
+    }
+
     if (! empty(shell_exec('git status --porcelain 2>&1'))) {
         throw new Exception('Repository must be in a clean state to release.');
     }
 
-    if (! str_starts_with(shell_exec('git rev-parse --abbrev-ref --symbolic-full-name @{u}'), "$remote/$branch")) {
-        throw new Exception("You must be on the $remote/$branch branch to release.");
+    if (! str_starts_with(shell_exec('git rev-parse --abbrev-ref --symbolic-full-name @{u}'), "{$remote}/{$branch}")) {
+        throw new Exception("You must be on the {$remote}/{$branch} branch to release.");
+    }
+
+    if ($behindCount = trim(shell_exec("git rev-list HEAD..{$remote}/{$branch} --count") ?? '0') !== '0') {
+        throw new Exception("Local branch is behind {$remote}/{$branch} by {$behindCount} commits. Please pull first.");
     }
 }
 
+/**
+ * Gets the current version.
+ */
 function getCurrentVersion(): string
 {
     return exec('git describe --tags --abbrev=0');
 }
 
-function normalizeVersion(string $version): string
-{
-    return preg_replace('/^(\d+\.\d+\.\d+)\.0(-|$|\+)/', '$1$2', new VersionParser()->normalize($version));
-}
-
+/**
+ * Suggests a semver-valid version.
+ */
 function suggestNextVersions(string $current): array
 {
     $version = normalizeVersion($current);
@@ -69,12 +202,17 @@ function suggestNextVersions(string $current): array
     ]);
 }
 
-function releaseTag(string $tag): void
+function normalizeVersion(string $version): string
 {
-    $commands = [
-        "git tag {$tag}",
-        "git push origin tag {$tag}",
-    ];
+    return preg_replace('/^(\d+\.\d+\.\d+)\.0(-|$|\+)/', '$1$2', new VersionParser()->normalize($version));
+}
+
+/**
+ * Executes the given shell commands.
+ */
+function executeCommands(string|array $commands): void
+{
+    $commands = is_array($commands) ? $commands : [$commands];
 
     foreach ($commands as $command) {
         exec($command, result_code: $code);
@@ -83,8 +221,60 @@ function releaseTag(string $tag): void
             continue;
         }
 
-        throw new Exception("Pushing of git tag failed.");
+        throw new Exception("Command failed: {$command}");
     }
+}
+
+/**
+ * Creates a commit with the current changes.
+ */
+function commit(string $message): void
+{
+    executeCommands([
+        'git add --all',
+        "git commit -m '{$message}'",
+    ]);
+}
+
+/**
+ * Updates a JSON file, preserving indentation.
+ */
+function updateJsonFile(string $path, Closure $callback): void
+{
+    $content = file_get_contents($path);
+    $indent = detectIndent($content);
+    $content = $callback(json_decode($content, associative: true), $indent);
+    $content = preg_replace_callback(
+        '/^ +/m',
+        fn ($m) => str_repeat($indent, \strlen($m[0]) / 4),
+        json_encode($content, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES),
+    );
+
+    file_put_contents($path, $content . "\n");
+}
+
+/**
+ * Detects the indentation of a raw JSON file.
+ */
+function detectIndent(string $raw, string $default = '    '): string
+{
+    try {
+        return explode('"', explode("\n", $raw)[1])[0] ?? $default;
+    } catch (Throwable) {
+        return $default;
+    }
+}
+
+/**
+ * Makes sure the tag doesn't exist before continuing.
+ */
+function ensureTagDoesNotExist(string $version): void
+{
+    if (! trim(shell_exec("git tag -l {$version}") ?? '')) {
+        return;
+    }
+
+    throw new Exception("Tag {$version} already exists.");
 }
 
 /*
@@ -96,41 +286,80 @@ function releaseTag(string $tag): void
 try {
     ConsoleApplication::boot();
 
-    ensureAccess('origin', 'main');
+    performPreReleaseChecks('origin', 'main');
 
     $console = get(Console::class);
-
     $console->writeln();
-    $console->info(sprintf("Current version is <u><strong>%s</strong></u>", $current = getCurrentVersion()));
+    $console->info(sprintf('Current version is <em>%s</em>.', $current = getCurrentVersion()));
 
-    $console->writeln();
     $new = $console->ask(
-        question: "What should the new version be?",
+        question: 'What should the new version be?',
         options: arr(suggestNextVersions($current))
             ->map(fn (string $version, string $type) => (string) str($type)->replace('_', ' ')->append(': ', $version))
             ->values()
             ->toArray(),
     );
 
-    $tag = (string) str($new)->afterLast(': ')->prepend('v');
+    $isMajor = str_contains($new, 'major');
+    $version = (string) str($new)->afterLast(': ');
+    $tag = "v{$version}";
 
-    $console->writeln();
-    if (! $console->confirm("The next tag will be <u><strong>{$tag}</strong></u><question>. Release?")) {
+    // Check the tag
+    ensureTagDoesNotExist($tag);
+
+    if (! $console->confirm("The next tag will be <em>{$tag}</em>. Release?")) {
         $console->error('Cancelled.');
         exit;
     }
 
-    $console->writeln();
-    $console->writeln();
-    $console->writeln();
-    $console->info('Releasing...');
+    // Bump PHP packages
+    $console->task(
+        label: 'Bumping PHP packages',
+        handler: fn () => [
+            bumpKernelVersion($version),
+            bumpPhpPackages($version, $isMajor),
+        ],
+    );
 
-    releaseTag($tag);
+    // Bump JavaScript packages
+    $console->task(
+        label: 'Bumping JavaScript packages',
+        handler: fn () => bumpJavaScriptPackages($version),
+    );
 
-    $console->writeln();
-    $console->success("Released {$tag}");
+    // Update changelog
+    $console->task(
+        label: 'Updating changelog',
+        handler: fn () => updateChangelog($version),
+    );
+
+    // Push tags
+    $console->task(
+        label: 'Releasing',
+        handler: fn () => [
+            commit("chore: release {$tag}"),
+            executeCommands([
+                "git tag {$tag}",
+                "git push origin tag {$tag}",
+            ]),
+        ],
+    );
+
+    // Clean up
+    $console->task(
+        label: 'Cleaning up',
+        handler: fn () => [
+            cleanUpAfterRelease(),
+            commit('chore: post-release clean up'),
+            executeCommands('git push'),
+        ],
+    );
+
+    $console->success(sprintf(
+        'Released <em>%1$s</em>. The <href="https://github.com/tempestphp/tempest-framework/releases/tag/%1$s">GitHub release</href> will be created automatically in a few seconds.',
+        $tag,
+    ));
 
     exit;
-
 } catch (InterruptException) {
 }

--- a/cliff.toml
+++ b/cliff.toml
@@ -45,7 +45,7 @@ body = """
 """
 
 [git]
-skip_tags = "(0\\.0\\.\\d)|(1\\.0-alpha1)"
+skip_tags = "(0\\.0\\.\\d)|1\\.0\\.0-alpha\\.1"
 commit_parsers = [
   { field = "breaking", pattern = "true", group = "<!-- -1 -->🚨 Breaking changes" },
   { message = "^feat", group = "<!-- 0 -->🚀 Features" },

--- a/composer.json
+++ b/composer.json
@@ -166,6 +166,10 @@
         "phpstan": "vendor/bin/phpstan analyse src tests --memory-limit=1G",
         "rector": "vendor/bin/rector process --no-ansi",
         "merge": "vendor/bin/monorepo-builder merge",
+        "release": [
+            "composer qa",
+            "./bin/release"
+        ],
         "qa": [
             "composer merge",
             "./bin/validate-packages",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,5 @@
 import defineEslintConfig from '@innocenzi/eslint-config'
 
 export default defineEslintConfig({
-	ignores: ['.github', 'public', '*.json'],
+	ignores: ['.github', 'public', '*.json', '**/composer.json'],
 })

--- a/src/Tempest/Core/src/Kernel.php
+++ b/src/Tempest/Core/src/Kernel.php
@@ -20,6 +20,8 @@ use Whoops\Run;
 
 final class Kernel
 {
+    public const VERSION = '1.0.0-alpha.4';
+
     public readonly Container $container;
 
     public bool $discoveryCache;


### PR DESCRIPTION
This pull request attempts to make the release script actually usable. To do this, we need:
- ~~To implement `bumpPhpPackages` and `cleanUpAfterRelease`.~~
- [x] To add a `NPM_TOKEN` to the GitHub Actions for release the JavaScript packages. I will give it to you in DMs @brendt.

The release script will:
- [x] Prompt for the next version
- [x] Bump `Kernel::VERSION` (which I just added, for use in PHP)
- [x] Bump PHP packages (see above)
- [x] Bump JavaScript packages
- [x] Update `CHANGELOG.md`
- [x] Commit and push the new tag, which will trigger the "create a GH release" and the "release JavaScript packages" workflows
- [x] Clean up PHP packages after release (see above)
- [x] Commit after the clean up

Related: https://github.com/tempestphp/tempest-framework/pull/587, https://github.com/tempestphp/tempest-framework/issues/676