### PR TITLE
feat(console): add `make:config` command

### DIFF
--- a/src/Tempest/Console/src/Commands/MakeConfigCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeConfigCommand.php
@@ -65,6 +65,7 @@ final class MakeConfigCommand
             $stubPath = dirname( __DIR__ ) . '/Stubs';
             
             return match ($configType) {
+                ConfigType::VIEW => StubFile::from( $stubPath . '/view.config.stub.php'),
                 ConfigType::TWIG => StubFile::from( $stubPath . '/twig.config.stub.php'),
                 ConfigType::DATABASE => StubFile::from( $stubPath . '/database.config.stub.php'), // @phpstan-ignore match.alwaysTrue (Because this is a guardrail for the future implementations)
                 default => throw new InvalidArgumentException(sprintf('The "%s" config type has no supported stub file.', $configType->value)),

--- a/src/Tempest/Console/src/Commands/MakeConfigCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeConfigCommand.php
@@ -65,6 +65,7 @@ final class MakeConfigCommand
             $stubPath = dirname( __DIR__ ) . '/Stubs';
             
             return match ($configType) {
+                ConfigType::LOG => StubFile::from( $stubPath . '/log.config.stub.php'),
                 ConfigType::COMMAND_BUS => StubFile::from( $stubPath . '/command-bus.config.stub.php'),
                 ConfigType::EVENT_BUS => StubFile::from( $stubPath . '/event-bus.config.stub.php'),
                 ConfigType::VIEW => StubFile::from( $stubPath . '/view.config.stub.php'),

--- a/src/Tempest/Console/src/Commands/MakeConfigCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeConfigCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Commands;
+
+use InvalidArgumentException;
+use Tempest\Console\ConsoleArgument;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Console\Enums\ConfigType;
+use Tempest\Console\Enums\MiddlewareType;
+use Tempest\Console\Stubs\CommandBusMiddlewareStub;
+use Tempest\Console\Stubs\ConsoleMiddlewareStub;
+use Tempest\Console\Stubs\EventBusMiddlewareStub;
+use Tempest\Console\Stubs\HttpMiddlewareStub;
+use Tempest\Core\PublishesFiles;
+use Tempest\Generation\DataObjects\StubFile;
+use Tempest\Generation\Exceptions\FileGenerationAbortedException;
+use Tempest\Generation\Exceptions\FileGenerationFailedException;
+
+use function Tempest\root_path;
+use function Tempest\src_path;
+use function Tempest\Support\str;
+
+final class MakeConfigCommand
+{
+    use PublishesFiles;
+
+    #[ConsoleCommand(
+        name: 'make:config',
+        description: 'Creates a new config class',
+        aliases: ['config:make', 'config:create', 'create:config'],
+    )]
+    public function __invoke(
+        #[ConsoleArgument(
+            name: 'type',
+            help: 'The type of the config to create',
+        )]
+        ConfigType $configType,
+    ): void {
+        try {
+            $stubFile = $this->getStubFileFromConfigType($configType);
+            $suggestedPath = str( $this->getSuggestedPath( 'Dummy' ) )
+                ->replace( 'Dummy', $configType->value . '.config' )
+                ->toString();
+            $targetPath = $this->promptTargetPath($suggestedPath);
+            $shouldOverride = $this->askForOverride($targetPath);
+
+            $this->stubFileGenerator->generateRawFile(
+                stubFile: $stubFile,
+                targetPath: $targetPath,
+                shouldOverride: $shouldOverride,
+            );
+
+            $this->success(sprintf('Middleware successfully created at "%s".', $targetPath));
+        } catch (FileGenerationAbortedException|FileGenerationFailedException|InvalidArgumentException $e) {
+            $this->error($e->getMessage());
+        }
+    }
+
+    private function getStubFileFromConfigType(ConfigType $configType): StubFile
+    {
+        $stubPath = dirname( __DIR__ ) . '/Stubs';
+        
+        return match ($configType) {
+            ConfigType::DATABASE => StubFile::from( $stubPath . '/database.config.stub.php'), // @phpstan-ignore match.alwaysTrue (Because this is a guardrail for the future implementations)
+            default => throw new InvalidArgumentException(sprintf('The "%s" config type has no supported stub file.', $configType->value)),
+        };
+    }
+}

--- a/src/Tempest/Console/src/Commands/MakeConfigCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeConfigCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Console\Commands;
 
 use InvalidArgumentException;
+use ReflectionException;
 use Tempest\Console\ConsoleArgument;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Enums\ConfigType;
@@ -60,11 +61,16 @@ final class MakeConfigCommand
 
     private function getStubFileFromConfigType(ConfigType $configType): StubFile
     {
-        $stubPath = dirname( __DIR__ ) . '/Stubs';
-        
-        return match ($configType) {
-            ConfigType::DATABASE => StubFile::from( $stubPath . '/database.config.stub.php'), // @phpstan-ignore match.alwaysTrue (Because this is a guardrail for the future implementations)
-            default => throw new InvalidArgumentException(sprintf('The "%s" config type has no supported stub file.', $configType->value)),
-        };
+        try {
+            $stubPath = dirname( __DIR__ ) . '/Stubs';
+            
+            return match ($configType) {
+                ConfigType::TWIG => StubFile::from( $stubPath . '/twig.config.stub.php'),
+                ConfigType::DATABASE => StubFile::from( $stubPath . '/database.config.stub.php'), // @phpstan-ignore match.alwaysTrue (Because this is a guardrail for the future implementations)
+                default => throw new InvalidArgumentException(sprintf('The "%s" config type has no supported stub file.', $configType->value)),
+            };
+        } catch ( InvalidArgumentException $e ) {
+            throw new FileGenerationFailedException( sprintf( 'Cannot retrieve stub file: %s', $e->getMessage() ) );
+        }
     }
 }

--- a/src/Tempest/Console/src/Commands/MakeConfigCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeConfigCommand.php
@@ -66,6 +66,7 @@ final class MakeConfigCommand
             
             return match ($configType) {
                 ConfigType::VIEW => StubFile::from( $stubPath . '/view.config.stub.php'),
+                ConfigType::BLADE => StubFile::from( $stubPath . '/blade.config.stub.php'),
                 ConfigType::TWIG => StubFile::from( $stubPath . '/twig.config.stub.php'),
                 ConfigType::DATABASE => StubFile::from( $stubPath . '/database.config.stub.php'), // @phpstan-ignore match.alwaysTrue (Because this is a guardrail for the future implementations)
                 default => throw new InvalidArgumentException(sprintf('The "%s" config type has no supported stub file.', $configType->value)),

--- a/src/Tempest/Console/src/Commands/MakeConfigCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeConfigCommand.php
@@ -76,8 +76,8 @@ final class MakeConfigCommand
                 ConfigType::DATABASE => StubFile::from( $stubPath . '/database.config.stub.php'), // @phpstan-ignore match.alwaysTrue (Because this is a guardrail for the future implementations)
                 default => throw new InvalidArgumentException(sprintf('The "%s" config type has no supported stub file.', $configType->value)),
             };
-        } catch ( InvalidArgumentException $e ) {
-            throw new FileGenerationFailedException( sprintf( 'Cannot retrieve stub file: %s', $e->getMessage() ) );
+        } catch ( InvalidArgumentException $invalidArgumentException ) {
+            throw new FileGenerationFailedException( sprintf( 'Cannot retrieve stub file: %s', $invalidArgumentException->getMessage() ) );
         }
     }
 }

--- a/src/Tempest/Console/src/Commands/MakeConfigCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeConfigCommand.php
@@ -65,6 +65,7 @@ final class MakeConfigCommand
             $stubPath = dirname( __DIR__ ) . '/Stubs';
             
             return match ($configType) {
+                ConfigType::EVENT_BUS => StubFile::from( $stubPath . '/event-bus.config.stub.php'),
                 ConfigType::VIEW => StubFile::from( $stubPath . '/view.config.stub.php'),
                 ConfigType::BLADE => StubFile::from( $stubPath . '/blade.config.stub.php'),
                 ConfigType::TWIG => StubFile::from( $stubPath . '/twig.config.stub.php'),

--- a/src/Tempest/Console/src/Commands/MakeConfigCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeConfigCommand.php
@@ -65,6 +65,7 @@ final class MakeConfigCommand
             $stubPath = dirname( __DIR__ ) . '/Stubs';
             
             return match ($configType) {
+                ConfigType::CONSOLE => StubFile::from( $stubPath . '/console.config.stub.php'),
                 ConfigType::CACHE => StubFile::from( $stubPath . '/cache.config.stub.php'),
                 ConfigType::LOG => StubFile::from( $stubPath . '/log.config.stub.php'),
                 ConfigType::COMMAND_BUS => StubFile::from( $stubPath . '/command-bus.config.stub.php'),

--- a/src/Tempest/Console/src/Commands/MakeConfigCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeConfigCommand.php
@@ -5,22 +5,13 @@ declare(strict_types=1);
 namespace Tempest\Console\Commands;
 
 use InvalidArgumentException;
-use ReflectionException;
 use Tempest\Console\ConsoleArgument;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Enums\ConfigType;
-use Tempest\Console\Enums\MiddlewareType;
-use Tempest\Console\Stubs\CommandBusMiddlewareStub;
-use Tempest\Console\Stubs\ConsoleMiddlewareStub;
-use Tempest\Console\Stubs\EventBusMiddlewareStub;
-use Tempest\Console\Stubs\HttpMiddlewareStub;
 use Tempest\Core\PublishesFiles;
 use Tempest\Generation\DataObjects\StubFile;
 use Tempest\Generation\Exceptions\FileGenerationAbortedException;
 use Tempest\Generation\Exceptions\FileGenerationFailedException;
-
-use function Tempest\root_path;
-use function Tempest\src_path;
 use function Tempest\Support\str;
 
 final class MakeConfigCommand
@@ -41,8 +32,8 @@ final class MakeConfigCommand
     ): void {
         try {
             $stubFile = $this->getStubFileFromConfigType($configType);
-            $suggestedPath = str( $this->getSuggestedPath( 'Dummy' ) )
-                ->replace( 'Dummy', $configType->value . '.config' )
+            $suggestedPath = str($this->getSuggestedPath('Dummy'))
+                ->replace('Dummy', $configType->value . '.config')
                 ->toString();
             $targetPath = $this->promptTargetPath($suggestedPath);
             $shouldOverride = $this->askForOverride($targetPath);
@@ -62,22 +53,22 @@ final class MakeConfigCommand
     private function getStubFileFromConfigType(ConfigType $configType): StubFile
     {
         try {
-            $stubPath = dirname( __DIR__ ) . '/Stubs';
-            
+            $stubPath = dirname(__DIR__) . '/Stubs';
+
             return match ($configType) {
-                ConfigType::CONSOLE => StubFile::from( $stubPath . '/console.config.stub.php'),
-                ConfigType::CACHE => StubFile::from( $stubPath . '/cache.config.stub.php'),
-                ConfigType::LOG => StubFile::from( $stubPath . '/log.config.stub.php'),
-                ConfigType::COMMAND_BUS => StubFile::from( $stubPath . '/command-bus.config.stub.php'),
-                ConfigType::EVENT_BUS => StubFile::from( $stubPath . '/event-bus.config.stub.php'),
-                ConfigType::VIEW => StubFile::from( $stubPath . '/view.config.stub.php'),
-                ConfigType::BLADE => StubFile::from( $stubPath . '/blade.config.stub.php'),
-                ConfigType::TWIG => StubFile::from( $stubPath . '/twig.config.stub.php'),
-                ConfigType::DATABASE => StubFile::from( $stubPath . '/database.config.stub.php'), // @phpstan-ignore match.alwaysTrue (Because this is a guardrail for the future implementations)
+                ConfigType::CONSOLE => StubFile::from($stubPath . '/console.config.stub.php'),
+                ConfigType::CACHE => StubFile::from($stubPath . '/cache.config.stub.php'),
+                ConfigType::LOG => StubFile::from($stubPath . '/log.config.stub.php'),
+                ConfigType::COMMAND_BUS => StubFile::from($stubPath . '/command-bus.config.stub.php'),
+                ConfigType::EVENT_BUS => StubFile::from($stubPath . '/event-bus.config.stub.php'),
+                ConfigType::VIEW => StubFile::from($stubPath . '/view.config.stub.php'),
+                ConfigType::BLADE => StubFile::from($stubPath . '/blade.config.stub.php'),
+                ConfigType::TWIG => StubFile::from($stubPath . '/twig.config.stub.php'),
+                ConfigType::DATABASE => StubFile::from($stubPath . '/database.config.stub.php'), // @phpstan-ignore match.alwaysTrue (Because this is a guardrail for the future implementations)
                 default => throw new InvalidArgumentException(sprintf('The "%s" config type has no supported stub file.', $configType->value)),
             };
-        } catch ( InvalidArgumentException $invalidArgumentException ) {
-            throw new FileGenerationFailedException( sprintf( 'Cannot retrieve stub file: %s', $invalidArgumentException->getMessage() ) );
+        } catch (InvalidArgumentException $invalidArgumentException) {
+            throw new FileGenerationFailedException(sprintf('Cannot retrieve stub file: %s', $invalidArgumentException->getMessage()));
         }
     }
 }

--- a/src/Tempest/Console/src/Commands/MakeConfigCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeConfigCommand.php
@@ -65,6 +65,7 @@ final class MakeConfigCommand
             $stubPath = dirname( __DIR__ ) . '/Stubs';
             
             return match ($configType) {
+                ConfigType::CACHE => StubFile::from( $stubPath . '/cache.config.stub.php'),
                 ConfigType::LOG => StubFile::from( $stubPath . '/log.config.stub.php'),
                 ConfigType::COMMAND_BUS => StubFile::from( $stubPath . '/command-bus.config.stub.php'),
                 ConfigType::EVENT_BUS => StubFile::from( $stubPath . '/event-bus.config.stub.php'),

--- a/src/Tempest/Console/src/Commands/MakeConfigCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeConfigCommand.php
@@ -65,6 +65,7 @@ final class MakeConfigCommand
             $stubPath = dirname( __DIR__ ) . '/Stubs';
             
             return match ($configType) {
+                ConfigType::COMMAND_BUS => StubFile::from( $stubPath . '/command-bus.config.stub.php'),
                 ConfigType::EVENT_BUS => StubFile::from( $stubPath . '/event-bus.config.stub.php'),
                 ConfigType::VIEW => StubFile::from( $stubPath . '/view.config.stub.php'),
                 ConfigType::BLADE => StubFile::from( $stubPath . '/blade.config.stub.php'),

--- a/src/Tempest/Console/src/Enums/ConfigType.php
+++ b/src/Tempest/Console/src/Enums/ConfigType.php
@@ -11,5 +11,6 @@ enum ConfigType: string
 {
     case DATABASE = 'database';
     case TWIG = 'twig';
+    case BLADE = 'blade';
     case VIEW = 'view';
 }

--- a/src/Tempest/Console/src/Enums/ConfigType.php
+++ b/src/Tempest/Console/src/Enums/ConfigType.php
@@ -10,4 +10,5 @@ namespace Tempest\Console\Enums;
 enum ConfigType: string
 {
     case DATABASE = 'database';
+    case TWIG = 'twig';
 }

--- a/src/Tempest/Console/src/Enums/ConfigType.php
+++ b/src/Tempest/Console/src/Enums/ConfigType.php
@@ -11,4 +11,5 @@ enum ConfigType: string
 {
     case DATABASE = 'database';
     case TWIG = 'twig';
+    case VIEW = 'view';
 }

--- a/src/Tempest/Console/src/Enums/ConfigType.php
+++ b/src/Tempest/Console/src/Enums/ConfigType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Enums;
+
+/**
+ * Represents available config types in Tempest.
+ */
+enum ConfigType: string
+{
+    case DATABASE = 'database';
+}

--- a/src/Tempest/Console/src/Enums/ConfigType.php
+++ b/src/Tempest/Console/src/Enums/ConfigType.php
@@ -16,4 +16,5 @@ enum ConfigType: string
     case EVENT_BUS = 'event-bus';
     case COMMAND_BUS = 'command-bus';
     case LOG = 'log';
+    case CACHE = 'cache';
 }

--- a/src/Tempest/Console/src/Enums/ConfigType.php
+++ b/src/Tempest/Console/src/Enums/ConfigType.php
@@ -13,4 +13,5 @@ enum ConfigType: string
     case TWIG = 'twig';
     case BLADE = 'blade';
     case VIEW = 'view';
+    case EVENT_BUS = 'event-bus';
 }

--- a/src/Tempest/Console/src/Enums/ConfigType.php
+++ b/src/Tempest/Console/src/Enums/ConfigType.php
@@ -17,4 +17,5 @@ enum ConfigType: string
     case COMMAND_BUS = 'command-bus';
     case LOG = 'log';
     case CACHE = 'cache';
+    case CONSOLE = 'console';
 }

--- a/src/Tempest/Console/src/Enums/ConfigType.php
+++ b/src/Tempest/Console/src/Enums/ConfigType.php
@@ -15,4 +15,5 @@ enum ConfigType: string
     case VIEW = 'view';
     case EVENT_BUS = 'event-bus';
     case COMMAND_BUS = 'command-bus';
+    case LOG = 'log';
 }

--- a/src/Tempest/Console/src/Enums/ConfigType.php
+++ b/src/Tempest/Console/src/Enums/ConfigType.php
@@ -14,4 +14,5 @@ enum ConfigType: string
     case BLADE = 'blade';
     case VIEW = 'view';
     case EVENT_BUS = 'event-bus';
+    case COMMAND_BUS = 'command-bus';
 }

--- a/src/Tempest/Console/src/Stubs/blade.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/blade.config.stub.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Tempest\View\Renderers\BladeConfig;
+
+return new BladeConfig(
+    viewPaths: [
+        __DIR__ . '/../views/',
+    ],
+
+    cachePath: __DIR__ . '/../views/cache/',
+);

--- a/src/Tempest/Console/src/Stubs/blade.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/blade.config.stub.php
@@ -8,6 +8,5 @@ return new BladeConfig(
     viewPaths: [
         __DIR__ . '/../views/',
     ],
-
     cachePath: __DIR__ . '/../views/cache/',
 );

--- a/src/Tempest/Console/src/Stubs/cache.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/cache.config.stub.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Tempest\Cache\CacheConfig;
+
+return new CacheConfig(
+    projectCachePool: new FilesystemAdapter(
+        directory: __DIR__ . '/../../../../.cache'
+    )
+);

--- a/src/Tempest/Console/src/Stubs/cache.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/cache.config.stub.php
@@ -7,6 +7,6 @@ use Tempest\Cache\CacheConfig;
 
 return new CacheConfig(
     projectCachePool: new FilesystemAdapter(
-        directory: __DIR__ . '/../../../../.cache'
-    )
+        directory: __DIR__ . '/../../../../.cache',
+    ),
 );

--- a/src/Tempest/Console/src/Stubs/command-bus.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/command-bus.config.stub.php
@@ -7,5 +7,5 @@ use Tempest\CommandBus\CommandBusConfig;
 return new CommandBusConfig(
     middleware: [
         // Add your command bus middleware here.
-    ]
+    ],
 );

--- a/src/Tempest/Console/src/Stubs/command-bus.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/command-bus.config.stub.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Tempest\CommandBus\CommandBusConfig;
+
+return new CommandBusConfig(
+    middleware: [
+        // Add your command bus middleware here.
+    ]
+);

--- a/src/Tempest/Console/src/Stubs/console.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/console.config.stub.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use Tempest\Console\Middleware\ResolveOrRescueMiddleware;
-use Tempest\Console\Middleware\OverviewMiddleware;
-use Tempest\Console\Middleware\InvalidCommandMiddleware;
-use Tempest\Console\Middleware\HelpMiddleware;
-use Tempest\Console\Middleware\ConsoleExceptionMiddleware;
 use Tempest\Console\ConsoleConfig;
+use Tempest\Console\Middleware\ConsoleExceptionMiddleware;
+use Tempest\Console\Middleware\HelpMiddleware;
+use Tempest\Console\Middleware\InvalidCommandMiddleware;
+use Tempest\Console\Middleware\OverviewMiddleware;
+use Tempest\Console\Middleware\ResolveOrRescueMiddleware;
 
 return new ConsoleConfig(
     name: 'Console Name',
@@ -17,5 +17,5 @@ return new ConsoleConfig(
         ResolveOrRescueMiddleware::class,
         InvalidCommandMiddleware::class,
         HelpMiddleware::class,
-    ]
+    ],
 );

--- a/src/Tempest/Console/src/Stubs/console.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/console.config.stub.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Tempest\Console\Middleware\ResolveOrRescueMiddleware;
+use Tempest\Console\Middleware\OverviewMiddleware;
+use Tempest\Console\Middleware\InvalidCommandMiddleware;
+use Tempest\Console\Middleware\HelpMiddleware;
+use Tempest\Console\Middleware\ConsoleExceptionMiddleware;
+use Tempest\Console\ConsoleConfig;
+
+return new ConsoleConfig(
+    name: 'Console Name',
+    middleware: [
+        OverviewMiddleware::class,
+        ConsoleExceptionMiddleware::class,
+        ResolveOrRescueMiddleware::class,
+        InvalidCommandMiddleware::class,
+        HelpMiddleware::class,
+    ]
+);

--- a/src/Tempest/Console/src/Stubs/database.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/database.config.stub.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Tempest\Database\Connections\MySqlConnection;
 use Tempest\Database\DatabaseConfig;
-
 use function Tempest\env;
 
 return new DatabaseConfig(
@@ -14,5 +13,5 @@ return new DatabaseConfig(
         username: env('DB_USERNAME'),
         password: env('DB_PASSWORD'),
         database: env('DB_DATABASE'),
-    )
+    ),
 );

--- a/src/Tempest/Console/src/Stubs/database.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/database.config.stub.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Tempest\Database\Connections\MySqlConnection;
+use Tempest\Database\DatabaseConfig;
+
+use function Tempest\env;
+
+return new DatabaseConfig(
+    connection: new MySqlConnection(
+        host: env('DB_HOST'),
+        port: env('DB_PORT'),
+        username: env('DB_USERNAME'),
+        password: env('DB_PASSWORD'),
+        database: env('DB_DATABASE'),
+    )
+);

--- a/src/Tempest/Console/src/Stubs/event-bus.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/event-bus.config.stub.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Tempest\EventBus\EventBusConfig;
+
+return new EventBusConfig(
+    middleware: [
+        // Add your event bus middleware here.
+    ]
+);

--- a/src/Tempest/Console/src/Stubs/event-bus.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/event-bus.config.stub.php
@@ -7,5 +7,5 @@ use Tempest\EventBus\EventBusConfig;
 return new EventBusConfig(
     middleware: [
         // Add your event bus middleware here.
-    ]
+    ],
 );

--- a/src/Tempest/Console/src/Stubs/log.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/log.config.stub.php
@@ -8,8 +8,8 @@ use Tempest\Log\LogConfig;
 return new LogConfig(
     channels: [
         new AppendLogChannel(
-            path: __DIR__ . '/../logs/project.log'
-        )
+            path: __DIR__ . '/../logs/project.log',
+        ),
     ],
     serverLogPath: '/path/to/nginx.log',
 );

--- a/src/Tempest/Console/src/Stubs/log.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/log.config.stub.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Tempest\Log\Channels\AppendLogChannel;
+use Tempest\Log\LogConfig;
+
+return new LogConfig(
+    channels: [
+        new AppendLogChannel(
+            path: __DIR__ . '/../logs/project.log'
+        )
+    ],
+    serverLogPath: '/path/to/nginx.log',
+);

--- a/src/Tempest/Console/src/Stubs/twig.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/twig.config.stub.php
@@ -1,0 +1,13 @@
+<?php
+
+use Tempest\View\Renderers\TwigConfig;
+
+declare(strict_types=1);
+
+return new TwigConfig(
+    viewPaths: [
+        __DIR__ . '/../views/',
+    ],
+
+    cachePath: __DIR__ . '/../views/cache/',
+);

--- a/src/Tempest/Console/src/Stubs/twig.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/twig.config.stub.php
@@ -1,8 +1,8 @@
 <?php
 
-use Tempest\View\Renderers\TwigConfig;
-
 declare(strict_types=1);
+
+use Tempest\View\Renderers\TwigConfig;
 
 return new TwigConfig(
     viewPaths: [

--- a/src/Tempest/Console/src/Stubs/twig.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/twig.config.stub.php
@@ -8,6 +8,5 @@ return new TwigConfig(
     viewPaths: [
         __DIR__ . '/../views/',
     ],
-
     cachePath: __DIR__ . '/../views/cache/',
 );

--- a/src/Tempest/Console/src/Stubs/view.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/view.config.stub.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Tempest\View\Renderers\TwigViewRenderer;
+use Tempest\View\Renderers\BladeViewRenderer;
+use Tempest\View\ViewConfig;
+
+return new ViewConfig(
+    rendererClass: TwigViewRenderer::class
+);

--- a/src/Tempest/Console/src/Stubs/view.config.stub.php
+++ b/src/Tempest/Console/src/Stubs/view.config.stub.php
@@ -3,9 +3,8 @@
 declare(strict_types=1);
 
 use Tempest\View\Renderers\TwigViewRenderer;
-use Tempest\View\Renderers\BladeViewRenderer;
 use Tempest\View\ViewConfig;
 
 return new ViewConfig(
-    rendererClass: TwigViewRenderer::class
+    rendererClass: TwigViewRenderer::class,
 );

--- a/src/Tempest/Database/src/Builder/ModelQueryBuilder.php
+++ b/src/Tempest/Database/src/Builder/ModelQueryBuilder.php
@@ -71,7 +71,7 @@ final class ModelQueryBuilder
     }
 
     /**
-     * @param \Closure(TModelClass[] $models): void $closure
+     * @param Closure(TModelClass[] $models): void $closure
      */
     public function chunk(Closure $closure, int $amountPerChunk = 200): void
     {

--- a/src/Tempest/Database/src/QueryStatements/AlterTableStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/AlterTableStatement.php
@@ -17,7 +17,8 @@ final class AlterTableStatement implements QueryStatement
         private readonly string $tableName,
         private array $statements = [],
         private array $createIndexStatements = [],
-    ) {}
+    ) {
+    }
 
     /** @param class-string<\Tempest\Database\DatabaseModel> $modelClass */
     public static function forModel(string $modelClass): self

--- a/src/Tempest/Database/src/QueryStatements/CreateTableStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/CreateTableStatement.php
@@ -17,7 +17,8 @@ final class CreateTableStatement implements QueryStatement
         private readonly string $tableName,
         private array $statements = [],
         private array $indexStatements = [],
-    ) {}
+    ) {
+    }
 
     /** @param class-string<\Tempest\Database\DatabaseModel> $modelClass */
     public static function forModel(string $modelClass): self
@@ -38,8 +39,7 @@ final class CreateTableStatement implements QueryStatement
         OnDelete $onDelete = OnDelete::RESTRICT,
         OnUpdate $onUpdate = OnUpdate::NO_ACTION,
         bool $nullable = false,
-    ): self
-    {
+    ): self {
         [$localTable, $localKey] = explode('.', $local);
 
         $this->integer($localKey, nullable: $nullable);
@@ -58,8 +58,7 @@ final class CreateTableStatement implements QueryStatement
         string $name,
         bool $nullable = false,
         ?string $default = null,
-    ): self
-    {
+    ): self {
         $this->statements[] = new TextStatement(
             name: $name,
             nullable: $nullable,
@@ -74,8 +73,7 @@ final class CreateTableStatement implements QueryStatement
         int $length = 255,
         bool $nullable = false,
         ?string $default = null,
-    ): self
-    {
+    ): self {
         $this->statements[] = new VarcharStatement(
             name: $name,
             size: $length,
@@ -90,8 +88,7 @@ final class CreateTableStatement implements QueryStatement
         string $name,
         bool $nullable = false,
         ?string $default = null,
-    ): self
-    {
+    ): self {
         $this->statements[] = new CharStatement(
             name: $name,
             nullable: $nullable,
@@ -106,8 +103,7 @@ final class CreateTableStatement implements QueryStatement
         bool $unsigned = false,
         bool $nullable = false,
         ?int $default = null,
-    ): self
-    {
+    ): self {
         $this->statements[] = new IntegerStatement(
             name: $name,
             unsigned: $unsigned,
@@ -122,8 +118,7 @@ final class CreateTableStatement implements QueryStatement
         string $name,
         bool $nullable = false,
         ?float $default = null,
-    ): self
-    {
+    ): self {
         $this->statements[] = new FloatStatement(
             name: $name,
             nullable: $nullable,
@@ -137,8 +132,7 @@ final class CreateTableStatement implements QueryStatement
         string $name,
         bool $nullable = false,
         ?string $default = null,
-    ): self
-    {
+    ): self {
         $this->statements[] = new DatetimeStatement(
             name: $name,
             nullable: $nullable,
@@ -152,8 +146,7 @@ final class CreateTableStatement implements QueryStatement
         string $name,
         bool $nullable = false,
         ?string $default = null,
-    ): self
-    {
+    ): self {
         $this->statements[] = new DateStatement(
             name: $name,
             nullable: $nullable,
@@ -167,8 +160,7 @@ final class CreateTableStatement implements QueryStatement
         string $name,
         bool $nullable = false,
         ?bool $default = null,
-    ): self
-    {
+    ): self {
         $this->statements[] = new BooleanStatement(
             name: $name,
             nullable: $nullable,
@@ -182,8 +174,7 @@ final class CreateTableStatement implements QueryStatement
         string $name,
         bool $nullable = false,
         ?string $default = null,
-    ): self
-    {
+    ): self {
         $this->statements[] = new JsonStatement(
             name: $name,
             nullable: $nullable,
@@ -198,8 +189,7 @@ final class CreateTableStatement implements QueryStatement
         array $values,
         bool $nullable = false,
         ?string $default = null,
-    ): self
-    {
+    ): self {
         $this->statements[] = new SetStatement(
             name: $name,
             values: $values,

--- a/src/Tempest/Generation/src/DataObjects/StubFile.php
+++ b/src/Tempest/Generation/src/DataObjects/StubFile.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Tempest\Generation\DataObjects;
 
-use Exception;
-use Nette\InvalidStateException;
-use Tempest\Generation\ClassManipulator;
 use Tempest\Generation\Enums\StubFileType;
+use Tempest\Generation\ClassManipulator;
+use ReflectionException;
+use Nette\InvalidStateException;
+use InvalidArgumentException;
+use Exception;
 
 /**
  * Represents a file that is to be generated.
@@ -32,9 +34,9 @@ final class StubFile
                 filePath: $pathOrClass,
                 type: StubFileType::CLASS_FILE,
             );
-        } catch (InvalidStateException) {
+        } catch (InvalidStateException|ReflectionException) {
             if (! file_exists($pathOrClass)) {
-                throw new Exception(sprintf('The file "%s" does not exist.', $pathOrClass));
+                throw new InvalidArgumentException(sprintf('The file "%s" does not exist.', $pathOrClass));
             }
 
             return new self(

--- a/src/Tempest/Generation/src/DataObjects/StubFile.php
+++ b/src/Tempest/Generation/src/DataObjects/StubFile.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Tempest\Generation\DataObjects;
 
-use Tempest\Generation\Enums\StubFileType;
-use Tempest\Generation\ClassManipulator;
-use ReflectionException;
-use Nette\InvalidStateException;
 use InvalidArgumentException;
-use Exception;
+use Nette\InvalidStateException;
+use ReflectionException;
+use Tempest\Generation\ClassManipulator;
+use Tempest\Generation\Enums\StubFileType;
 
 /**
  * Represents a file that is to be generated.

--- a/tests/Integration/Console/Commands/MakeConfigCommandTest.php
+++ b/tests/Integration/Console/Commands/MakeConfigCommandTest.php
@@ -6,8 +6,17 @@ namespace Tests\Tempest\Integration\Console\Commands;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Tempest\Cache\CacheConfig;
+use Tempest\CommandBus\CommandBusConfig;
+use Tempest\Console\ConsoleConfig;
 use Tempest\Console\Enums\ConfigType;
 use Tempest\Core\ComposerNamespace;
+use Tempest\Database\DatabaseConfig;
+use Tempest\EventBus\EventBusConfig;
+use Tempest\Log\LogConfig;
+use Tempest\View\Renderers\BladeConfig;
+use Tempest\View\Renderers\TwigConfig;
+use Tempest\View\ViewConfig;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 use function Tempest\Support\str;
 
@@ -44,11 +53,11 @@ final class MakeConfigCommandTest extends FrameworkIntegrationTestCase
             ->submit();
 
         $filepath = "App/{$configType->value}.config.php";
-        
+
         $this->installer
             ->assertFileExists($filepath)
             ->assertFileContains($filepath, "use {$expectedConfigClass}")
-            ->assertFileContains($filepath, "return new " . str($expectedConfigClass)->classBasename()->toString());
+            ->assertFileContains($filepath, 'return new ' . str($expectedConfigClass)->classBasename()->toString());
     }
 
     public static function config_type_provider(): array
@@ -56,39 +65,39 @@ final class MakeConfigCommandTest extends FrameworkIntegrationTestCase
         return [
             'database_config' => [
                 'configType' => ConfigType::DATABASE,
-                'expectedConfigClass' => \Tempest\Database\DatabaseConfig::class,
+                'expectedConfigClass' => DatabaseConfig::class,
             ],
             'twig_config' => [
                 'configType' => ConfigType::TWIG,
-                'expectedConfigClass' => \Tempest\View\Renderers\TwigConfig::class,
+                'expectedConfigClass' => TwigConfig::class,
             ],
             'blade_config' => [
                 'configType' => ConfigType::BLADE,
-                'expectedConfigClass' => \Tempest\View\Renderers\BladeConfig::class,
+                'expectedConfigClass' => BladeConfig::class,
             ],
             'view_config' => [
                 'configType' => ConfigType::VIEW,
-                'expectedConfigClass' => \Tempest\View\ViewConfig::class,
+                'expectedConfigClass' => ViewConfig::class,
             ],
             'event_bus_config' => [
                 'configType' => ConfigType::EVENT_BUS,
-                'expectedConfigClass' => \Tempest\EventBus\EventBusConfig::class,
+                'expectedConfigClass' => EventBusConfig::class,
             ],
             'command_bus_config' => [
                 'configType' => ConfigType::COMMAND_BUS,
-                'expectedConfigClass' => \Tempest\CommandBus\CommandBusConfig::class,
+                'expectedConfigClass' => CommandBusConfig::class,
             ],
             'log_config' => [
                 'configType' => ConfigType::LOG,
-                'expectedConfigClass' => \Tempest\Log\LogConfig::class,
+                'expectedConfigClass' => LogConfig::class,
             ],
             'cache_config' => [
                 'configType' => ConfigType::CACHE,
-                'expectedConfigClass' => \Tempest\Cache\CacheConfig::class,
+                'expectedConfigClass' => CacheConfig::class,
             ],
             'console_config' => [
                 'configType' => ConfigType::CONSOLE,
-                'expectedConfigClass' => \Tempest\Console\ConsoleConfig::class,
+                'expectedConfigClass' => ConsoleConfig::class,
             ],
         ];
     }

--- a/tests/Integration/Console/Commands/MakeConfigCommandTest.php
+++ b/tests/Integration/Console/Commands/MakeConfigCommandTest.php
@@ -33,111 +33,63 @@ final class MakeConfigCommandTest extends FrameworkIntegrationTestCase
         parent::tearDown();
     }
 
+    #[DataProvider('config_type_provider')]
     #[Test]
-    public function make_database_config(): void {
+    public function make_config(
+        ConfigType $configType,
+        string $expectedConfigClass,
+    ): void {
         $this->console
-            ->call('make:config ' . ConfigType::DATABASE->value)
+            ->call('make:config ' . $configType->value)
             ->submit();
 
+        $filepath = "App/{$configType->value}.config.php";
+        
         $this->installer
-            ->assertFileExists('App/database.config.php')
-            ->assertFileContains('App/database.config.php', 'use Tempest\Database\DatabaseConfig')
-            ->assertFileContains('App/database.config.php', 'return new DatabaseConfig');
+            ->assertFileExists($filepath)
+            ->assertFileContains($filepath, "use {$expectedConfigClass}")
+            ->assertFileContains($filepath, "return new " . str($expectedConfigClass)->classBasename()->toString());
     }
 
-    #[Test]
-    public function make_twig_config(): void {
-        $this->console
-            ->call('make:config ' . ConfigType::TWIG->value)
-            ->submit();
-
-        $this->installer
-            ->assertFileExists('App/twig.config.php')
-            ->assertFileContains('App/twig.config.php', 'use Tempest\View\Renderers\TwigConfig')
-            ->assertFileContains('App/twig.config.php', 'return new TwigConfig');
-    }
-
-    #[Test]
-    public function make_blade_config(): void {
-        $this->console
-            ->call('make:config ' . ConfigType::BLADE->value)
-            ->submit();
-
-        $this->installer
-            ->assertFileExists('App/blade.config.php')
-            ->assertFileContains('App/blade.config.php', 'use Tempest\View\Renderers\BladeConfig')
-            ->assertFileContains('App/blade.config.php', 'return new BladeConfig');
-    }
-
-    #[Test]
-    public function make_view_config(): void {
-        $this->console
-            ->call('make:config ' . ConfigType::VIEW->value)
-            ->submit();
-
-        $this->installer
-            ->assertFileExists('App/view.config.php')
-            ->assertFileContains('App/view.config.php', 'use Tempest\View\ViewConfig')
-            ->assertFileContains('App/view.config.php', 'return new ViewConfig');
-    }
-
-    #[Test]
-    public function make_event_bus_config(): void {
-        $this->console
-            ->call('make:config ' . ConfigType::EVENT_BUS->value)
-            ->submit();
-
-        $this->installer
-            ->assertFileExists('App/event-bus.config.php')
-            ->assertFileContains('App/event-bus.config.php', 'use Tempest\EventBus\EventBusConfig')
-            ->assertFileContains('App/event-bus.config.php', 'return new EventBusConfig');
-    }
-
-    #[Test]
-    public function make_command_bus_config(): void {
-        $this->console
-            ->call('make:config ' . ConfigType::COMMAND_BUS->value)
-            ->submit();
-
-        $this->installer
-            ->assertFileExists('App/command-bus.config.php')
-            ->assertFileContains('App/command-bus.config.php', 'use Tempest\CommandBus\CommandBusConfig')
-            ->assertFileContains('App/command-bus.config.php', 'return new CommandBusConfig');
-    }
-
-    #[Test]
-    public function make_log_config(): void {
-        $this->console
-            ->call('make:config ' . ConfigType::LOG->value)
-            ->submit();
-
-        $this->installer
-            ->assertFileExists('App/log.config.php')
-            ->assertFileContains('App/log.config.php', 'use Tempest\Log\LogConfig')
-            ->assertFileContains('App/log.config.php', 'return new LogConfig');
-    }
-
-    #[Test]
-    public function make_cache_config(): void {
-        $this->console
-            ->call('make:config ' . ConfigType::CACHE->value)
-            ->submit();
-
-        $this->installer
-            ->assertFileExists('App/cache.config.php')
-            ->assertFileContains('App/cache.config.php', 'use Tempest\Cache\CacheConfig')
-            ->assertFileContains('App/cache.config.php', 'return new CacheConfig');
-    }
-
-    #[Test]
-    public function make_console_config(): void {
-        $this->console
-            ->call('make:config ' . ConfigType::CONSOLE->value)
-            ->submit();
-
-        $this->installer
-            ->assertFileExists('App/console.config.php')
-            ->assertFileContains('App/console.config.php', 'use Tempest\Console\ConsoleConfig')
-            ->assertFileContains('App/console.config.php', 'return new ConsoleConfig');
+    public static function config_type_provider(): array
+    {
+        return [
+            'database_config' => [
+                'configType' => ConfigType::DATABASE,
+                'expectedConfigClass' => 'Tempest\Database\DatabaseConfig',
+            ],
+            'twig_config' => [
+                'configType' => ConfigType::TWIG,
+                'expectedConfigClass' => 'Tempest\View\Renderers\TwigConfig',
+            ],
+            'blade_config' => [
+                'configType' => ConfigType::BLADE,
+                'expectedConfigClass' => 'Tempest\View\Renderers\BladeConfig',
+            ],
+            'view_config' => [
+                'configType' => ConfigType::VIEW,
+                'expectedConfigClass' => 'Tempest\View\ViewConfig',
+            ],
+            'event_bus_config' => [
+                'configType' => ConfigType::EVENT_BUS,
+                'expectedConfigClass' => 'Tempest\EventBus\EventBusConfig',
+            ],
+            'command_bus_config' => [
+                'configType' => ConfigType::COMMAND_BUS,
+                'expectedConfigClass' => 'Tempest\CommandBus\CommandBusConfig',
+            ],
+            'log_config' => [
+                'configType' => ConfigType::LOG,
+                'expectedConfigClass' => 'Tempest\Log\LogConfig',
+            ],
+            'cache_config' => [
+                'configType' => ConfigType::CACHE,
+                'expectedConfigClass' => 'Tempest\Cache\CacheConfig',
+            ],
+            'console_config' => [
+                'configType' => ConfigType::CONSOLE,
+                'expectedConfigClass' => 'Tempest\Console\ConsoleConfig',
+            ],
+        ];
     }
 }

--- a/tests/Integration/Console/Commands/MakeConfigCommandTest.php
+++ b/tests/Integration/Console/Commands/MakeConfigCommandTest.php
@@ -56,39 +56,39 @@ final class MakeConfigCommandTest extends FrameworkIntegrationTestCase
         return [
             'database_config' => [
                 'configType' => ConfigType::DATABASE,
-                'expectedConfigClass' => 'Tempest\Database\DatabaseConfig',
+                'expectedConfigClass' => \Tempest\Database\DatabaseConfig::class,
             ],
             'twig_config' => [
                 'configType' => ConfigType::TWIG,
-                'expectedConfigClass' => 'Tempest\View\Renderers\TwigConfig',
+                'expectedConfigClass' => \Tempest\View\Renderers\TwigConfig::class,
             ],
             'blade_config' => [
                 'configType' => ConfigType::BLADE,
-                'expectedConfigClass' => 'Tempest\View\Renderers\BladeConfig',
+                'expectedConfigClass' => \Tempest\View\Renderers\BladeConfig::class,
             ],
             'view_config' => [
                 'configType' => ConfigType::VIEW,
-                'expectedConfigClass' => 'Tempest\View\ViewConfig',
+                'expectedConfigClass' => \Tempest\View\ViewConfig::class,
             ],
             'event_bus_config' => [
                 'configType' => ConfigType::EVENT_BUS,
-                'expectedConfigClass' => 'Tempest\EventBus\EventBusConfig',
+                'expectedConfigClass' => \Tempest\EventBus\EventBusConfig::class,
             ],
             'command_bus_config' => [
                 'configType' => ConfigType::COMMAND_BUS,
-                'expectedConfigClass' => 'Tempest\CommandBus\CommandBusConfig',
+                'expectedConfigClass' => \Tempest\CommandBus\CommandBusConfig::class,
             ],
             'log_config' => [
                 'configType' => ConfigType::LOG,
-                'expectedConfigClass' => 'Tempest\Log\LogConfig',
+                'expectedConfigClass' => \Tempest\Log\LogConfig::class,
             ],
             'cache_config' => [
                 'configType' => ConfigType::CACHE,
-                'expectedConfigClass' => 'Tempest\Cache\CacheConfig',
+                'expectedConfigClass' => \Tempest\Cache\CacheConfig::class,
             ],
             'console_config' => [
                 'configType' => ConfigType::CONSOLE,
-                'expectedConfigClass' => 'Tempest\Console\ConsoleConfig',
+                'expectedConfigClass' => \Tempest\Console\ConsoleConfig::class,
             ],
         ];
     }

--- a/tests/Integration/Console/Commands/MakeConfigCommandTest.php
+++ b/tests/Integration/Console/Commands/MakeConfigCommandTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Console\Commands;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Console\Enums\ConfigType;
+use Tempest\Core\ComposerNamespace;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+use function Tempest\Support\str;
+
+/**
+ * @internal
+ */
+final class MakeConfigCommandTest extends FrameworkIntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->installer->configure(
+            __DIR__ . '/install',
+            new ComposerNamespace('App\\', __DIR__ . '/install/App'),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->installer->clean();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function make_database_config(): void {
+        $this->console
+            ->call('make:config ' . ConfigType::DATABASE->value)
+            ->submit();
+
+        $this->installer
+            ->assertFileExists('App/database.config.php')
+            ->assertFileContains('App/database.config.php', 'use Tempest\Database\DatabaseConfig')
+            ->assertFileContains('App/database.config.php', 'return new DatabaseConfig');
+    }
+
+    #[Test]
+    public function make_twig_config(): void {
+        $this->console
+            ->call('make:config ' . ConfigType::TWIG->value)
+            ->submit();
+
+        $this->installer
+            ->assertFileExists('App/twig.config.php')
+            ->assertFileContains('App/twig.config.php', 'use Tempest\View\Renderers\TwigConfig')
+            ->assertFileContains('App/twig.config.php', 'return new TwigConfig');
+    }
+
+    #[Test]
+    public function make_blade_config(): void {
+        $this->console
+            ->call('make:config ' . ConfigType::BLADE->value)
+            ->submit();
+
+        $this->installer
+            ->assertFileExists('App/blade.config.php')
+            ->assertFileContains('App/blade.config.php', 'use Tempest\View\Renderers\BladeConfig')
+            ->assertFileContains('App/blade.config.php', 'return new BladeConfig');
+    }
+
+    #[Test]
+    public function make_view_config(): void {
+        $this->console
+            ->call('make:config ' . ConfigType::VIEW->value)
+            ->submit();
+
+        $this->installer
+            ->assertFileExists('App/view.config.php')
+            ->assertFileContains('App/view.config.php', 'use Tempest\View\ViewConfig')
+            ->assertFileContains('App/view.config.php', 'return new ViewConfig');
+    }
+
+    #[Test]
+    public function make_event_bus_config(): void {
+        $this->console
+            ->call('make:config ' . ConfigType::EVENT_BUS->value)
+            ->submit();
+
+        $this->installer
+            ->assertFileExists('App/event-bus.config.php')
+            ->assertFileContains('App/event-bus.config.php', 'use Tempest\EventBus\EventBusConfig')
+            ->assertFileContains('App/event-bus.config.php', 'return new EventBusConfig');
+    }
+
+    #[Test]
+    public function make_command_bus_config(): void {
+        $this->console
+            ->call('make:config ' . ConfigType::COMMAND_BUS->value)
+            ->submit();
+
+        $this->installer
+            ->assertFileExists('App/command-bus.config.php')
+            ->assertFileContains('App/command-bus.config.php', 'use Tempest\CommandBus\CommandBusConfig')
+            ->assertFileContains('App/command-bus.config.php', 'return new CommandBusConfig');
+    }
+
+    #[Test]
+    public function make_log_config(): void {
+        $this->console
+            ->call('make:config ' . ConfigType::LOG->value)
+            ->submit();
+
+        $this->installer
+            ->assertFileExists('App/log.config.php')
+            ->assertFileContains('App/log.config.php', 'use Tempest\Log\LogConfig')
+            ->assertFileContains('App/log.config.php', 'return new LogConfig');
+    }
+
+    #[Test]
+    public function make_cache_config(): void {
+        $this->console
+            ->call('make:config ' . ConfigType::CACHE->value)
+            ->submit();
+
+        $this->installer
+            ->assertFileExists('App/cache.config.php')
+            ->assertFileContains('App/cache.config.php', 'use Tempest\Cache\CacheConfig')
+            ->assertFileContains('App/cache.config.php', 'return new CacheConfig');
+    }
+
+    #[Test]
+    public function make_console_config(): void {
+        $this->console
+            ->call('make:config ' . ConfigType::CONSOLE->value)
+            ->submit();
+
+        $this->installer
+            ->assertFileExists('App/console.config.php')
+            ->assertFileContains('App/console.config.php', 'use Tempest\Console\ConsoleConfig')
+            ->assertFileContains('App/console.config.php', 'return new ConsoleConfig');
+    }
+}

--- a/tests/Integration/Database/Builder/ModelQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/ModelQueryBuilderTest.php
@@ -105,13 +105,13 @@ final class ModelQueryBuilderTest extends FrameworkIntegrationTestCase
         (Book::new(title: 'D'))->save();
 
         $results = [];
-        Book::query()->chunk(function (array $chunk) use (&$results) {
+        Book::query()->chunk(function (array $chunk) use (&$results): void {
             $results = [...$results, ...$chunk];
         }, 2);
         $this->assertCount(4, $results);
 
         $results = [];
-        Book::query()->where('title <> "A"')->chunk(function (array $chunk) use (&$results) {
+        Book::query()->where('title <> "A"')->chunk(function (array $chunk) use (&$results): void {
             $results = [...$results, ...$chunk];
         }, 2);
         $this->assertCount(3, $results);

--- a/tests/Integration/Database/QueryTest.php
+++ b/tests/Integration/Database/QueryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Integration\Database;
 
 use Tempest\Database\Migrations\CreateMigrationsTable;
@@ -8,6 +10,9 @@ use Tests\Tempest\Fixtures\Migrations\CreateAuthorTable;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
+/**
+ * @internal
+ */
 final class QueryTest extends FrameworkIntegrationTestCase
 {
     public function test_with_bindings(): void


### PR DESCRIPTION
This PR add the `make:config` command
This close a TODO on #759 

I have created a config type enum to have a list of supported config type, similar to #804 
So it supports all of these config types : 
- database
- twig
- blade
- view
- event-bus
- command-bus
- log
- cache
- console

I'm not really familiar with all components so please give me feedbacks on related stub files, I have stick as much as possible to the doc 😄 

Notice that I didn't add a support for `AppConfig` it is because the doc seems to be outdated as params are no longer the same as the current codebase and I'm not sure that we can create a custom `AppConfig` or if this is only internal ( have seen a default one which take env variables )
Also checked the `FrameworkInstaller` which don't seems to create a default `AppConfig` too.

Tell me if I forgot any Config type 😄 
