### PR TITLE
feat(database): add `raw` to `CreateTableStatement`

### DIFF
--- a/src/Tempest/Database/src/QueryStatements/CreateTableStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/CreateTableStatement.php
@@ -220,6 +220,13 @@ final class CreateTableStatement implements QueryStatement
         return $this;
     }
 
+    public function raw(string $statement): self
+    {
+        $this->statements[] = new RawStatement($statement);
+
+        return $this;
+    }
+
     public function compile(DatabaseDialect $dialect): string
     {
         $createTable = sprintf(


### PR DESCRIPTION
Something small I encountered while working on a hobby project.

I wanted to add a timestamp column, but don't have the time to create a proper statement specific class for it.

So I thought this might be a nice little nugget.