### PR TITLE
fix(vite): fall back to global entrypoints if supplied ones are empty

### DIFF
--- a/src/Tempest/Vite/src/Vite.php
+++ b/src/Tempest/Vite/src/Vite.php
@@ -47,7 +47,9 @@ final class Vite
      */
     public function getTags(?array $entrypoints = null): array
     {
-        return $this->getTagsResolver()->resolveTags($entrypoints ?? $this->viteConfig->build->entrypoints);
+        return $this->getTagsResolver()->resolveTags(
+            array_filter($entrypoints ?: []) ?: array_filter($this->viteConfig->build->entrypoints ?: []),
+        );
     }
 
     /**


### PR DESCRIPTION
When using `vite_tags()` in templates, the argument will be `null` by default. I think that's a bug in the views implementation, but I took the opportunity to fix `getTags` to handle that situation anyway.