### PR TITLE
feat(database): add explicit relation attributes

### DIFF
--- a/src/Tempest/Database/src/BelongsTo.php
+++ b/src/Tempest/Database/src/BelongsTo.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final readonly class BelongsTo
+{
+    public function __construct(public string $localPropertyName, public string $inversePropertyName = 'id')
+    {
+    }
+}

--- a/src/Tempest/Database/src/Builder/Relations/HasManyRelation.php
+++ b/src/Tempest/Database/src/Builder/Relations/HasManyRelation.php
@@ -6,24 +6,27 @@ namespace Tempest\Database\Builder\Relations;
 
 use Tempest\Database\Builder\FieldName;
 use Tempest\Database\Builder\TableName;
+use Tempest\Database\Exceptions\InvalidRelation;
+use Tempest\Database\HasMany;
 use Tempest\Reflection\ClassReflector;
 use Tempest\Reflection\PropertyReflector;
 
 final readonly class HasManyRelation implements Relation
 {
-    private ClassReflector $relationModelClass;
+    private function __construct(
+        private ClassReflector $relationModelClass,
+        private FieldName $localField,
+        private FieldName $joinField,
+    ) {
+    }
 
-    private FieldName $localField;
-
-    private FieldName $joinField;
-
-    public function __construct(PropertyReflector $property, string $alias)
+    public static function fromInference(PropertyReflector $property, string $alias): self
     {
-        $this->relationModelClass = $property->getIterableType()->asClass();
+        $relationModelClass = self::getRelationModelClass($property);
 
         $inverseProperty = null;
 
-        foreach ($this->relationModelClass->getPublicProperties() as $potentialInverseProperty) {
+        foreach ($relationModelClass->getPublicProperties() as $potentialInverseProperty) {
             if ($potentialInverseProperty->getType()->equals($property->getClass()->getType())) {
                 $inverseProperty = $potentialInverseProperty;
 
@@ -31,11 +34,45 @@ final readonly class HasManyRelation implements Relation
             }
         }
 
-        $localTable = TableName::for($property->getClass(), $alias);
-        $this->localField = new FieldName($localTable, 'id');
+        if ($inverseProperty === null) {
+            throw InvalidRelation::inversePropertyNotFound(
+                $property->getClass()->getName(),
+                $property->getName(),
+                $relationModelClass->getName(),
+            );
+        }
 
-        $joinTable = TableName::for($this->relationModelClass, "{$alias}.{$property->getName()}[]");
-        $this->joinField = new FieldName($joinTable, $inverseProperty->getName() . '_id');
+        $localTable = TableName::for($property->getClass(), $alias);
+        $localField = new FieldName($localTable, 'id');
+
+        $joinTable = TableName::for($relationModelClass, "{$alias}.{$property->getName()}[]");
+        $joinField = new FieldName($joinTable, $inverseProperty->getName() . '_id');
+
+        return new self($relationModelClass, $localField, $joinField);
+    }
+
+    public static function getRelationModelClass(
+        PropertyReflector $property,
+        HasMany|null $relation = null,
+    ): ClassReflector {
+        if ($relation !== null && $relation->inverseClassName !== null) {
+            return new ClassReflector($relation->inverseClassName);
+        }
+
+        return $property->getIterableType()->asClass();
+    }
+
+    public static function fromAttribute(HasMany $relation, PropertyReflector $property, string $alias): self
+    {
+        $relationModelClass = self::getRelationModelClass($property, $relation);
+
+        $localTable = TableName::for($property->getClass(), $alias);
+        $localField = new FieldName($localTable, $relation->localPropertyName);
+
+        $joinTable = TableName::for($relationModelClass, "{$alias}.{$property->getName()}[]");
+        $joinField = new FieldName($joinTable, $relation->inversePropertyName);
+
+        return new self($relationModelClass, $localField, $joinField);
     }
 
     public function getStatement(): string

--- a/src/Tempest/Database/src/HasMany.php
+++ b/src/Tempest/Database/src/HasMany.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final readonly class HasMany
+{
+    /** @param null|class-string $inverseClassName */
+    public function __construct(
+        public string $inversePropertyName,
+        public ?string $inverseClassName = null,
+        public string $localPropertyName = 'id',
+    ) {
+    }
+}

--- a/src/Tempest/Database/tests/Relations/BelongsToRelationTest.php
+++ b/src/Tempest/Database/tests/Relations/BelongsToRelationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Tests\Relations;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Database\Builder\ModelDefinition;
+use Tempest\Database\Tests\Relations\Fixtures\BelongsToParentModel;
+
+/**
+ * @internal
+ */
+final class BelongsToRelationTest extends TestCase
+{
+    public function test_inferred_belongs_to_relation(): void
+    {
+        $definition = new ModelDefinition(BelongsToParentModel::class);
+        $inferredRelation = $definition->getRelations('relatedModel');
+
+        $this->assertCount(1, $inferredRelation);
+        $this->assertSame('belongs_to_parent_model.relatedModel', $inferredRelation[0]->getRelationName());
+        $this->assertEquals(
+            'LEFT JOIN `belongs_to_related` AS `belongs_to_parent_model.relatedModel`' .
+            ' ON `belongs_to_parent_model`.`relatedModel_id` = `belongs_to_parent_model.relatedModel`.`id`',
+            $inferredRelation[0]->getStatement(),
+        );
+    }
+
+    public function test_attribute_with_default_belongs_to_relation(): void
+    {
+        $definition = new ModelDefinition(BelongsToParentModel::class);
+        $namedRelation = $definition->getRelations('otherRelatedModel');
+
+        $this->assertCount(1, $namedRelation);
+
+        $this->assertSame('belongs_to_parent_model.otherRelatedModel', $namedRelation[0]->getRelationName());
+        $this->assertEquals(
+            'LEFT JOIN `belongs_to_related` AS `belongs_to_parent_model.otherRelatedModel`' .
+            ' ON `belongs_to_parent_model`.`other_id` = `belongs_to_parent_model.otherRelatedModel`.`id`',
+            $namedRelation[0]->getStatement(),
+        );
+    }
+
+    public function test_attribute_belongs_to_relation(): void
+    {
+        $definition = new ModelDefinition(BelongsToParentModel::class);
+        $doublyNamedRelation = $definition->getRelations('stillOtherRelatedModel');
+
+        $this->assertCount(1, $doublyNamedRelation);
+
+        $this->assertSame('belongs_to_parent_model.stillOtherRelatedModel', $doublyNamedRelation[0]->getRelationName());
+        $this->assertEquals(
+            'LEFT JOIN `belongs_to_related` AS `belongs_to_parent_model.stillOtherRelatedModel`' .
+            ' ON `belongs_to_parent_model`.`other_id` = `belongs_to_parent_model.stillOtherRelatedModel`.`other_id`',
+            $doublyNamedRelation[0]->getStatement(),
+        );
+    }
+}

--- a/src/Tempest/Database/tests/Relations/Fixtures/BelongsToParentModel.php
+++ b/src/Tempest/Database/tests/Relations/Fixtures/BelongsToParentModel.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Tests\Relations\Fixtures;
+
+use Tempest\Database\BelongsTo;
+use Tempest\Database\Builder\TableName;
+use Tempest\Database\DatabaseModel;
+use Tempest\Database\IsDatabaseModel;
+
+final class BelongsToParentModel implements DatabaseModel
+{
+    use IsDatabaseModel;
+
+    public static function table(): TableName
+    {
+        return new TableName('belongs_to_parent_model');
+    }
+
+    public BelongsToRelatedModel $relatedModel;
+
+    #[BelongsTo('other_id')]
+    public BelongsToRelatedModel $otherRelatedModel;
+
+    #[BelongsTo('other_id', 'other_id')]
+    public BelongsToRelatedModel $stillOtherRelatedModel;
+}

--- a/src/Tempest/Database/tests/Relations/Fixtures/BelongsToRelatedModel.php
+++ b/src/Tempest/Database/tests/Relations/Fixtures/BelongsToRelatedModel.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Tests\Relations\Fixtures;
+
+use Tempest\Database\Builder\TableName;
+use Tempest\Database\DatabaseModel;
+use Tempest\Database\HasMany;
+use Tempest\Database\IsDatabaseModel;
+
+final class BelongsToRelatedModel implements DatabaseModel
+{
+    use IsDatabaseModel;
+
+    /** @var \Tempest\Database\Tests\Relations\Fixtures\BelongsToParentModel[] */
+    public array $inferred = [];
+
+    #[HasMany('other_id')]
+    /** @var \Tempest\Database\Tests\Relations\Fixtures\BelongsToParentModel[] */
+    public array $attribute = [];
+
+    #[HasMany('other_id', BelongsToParentModel::class, 'other_id')]
+    public array $full = [];
+
+    /** @var \Tempest\Database\Tests\Relations\Fixtures\HasOneParentModel[] */
+    public array $invalid = [];
+
+    public static function table(): TableName
+    {
+        return new TableName('belongs_to_related');
+    }
+}

--- a/src/Tempest/Database/tests/Relations/HasManyRelationTest.php
+++ b/src/Tempest/Database/tests/Relations/HasManyRelationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Tests\Relations;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Database\Builder\ModelDefinition;
+use Tempest\Database\Exceptions\InvalidRelation;
+use Tempest\Database\Tests\Relations\Fixtures\BelongsToRelatedModel;
+
+/**
+ * @internal
+ */
+final class HasManyRelationTest extends TestCase
+{
+    public function test_cannot_find_inverse(): void
+    {
+        $definition = new ModelDefinition(BelongsToRelatedModel::class);
+
+        $this->expectException(InvalidRelation::class);
+        $definition->getRelations('invalid');
+    }
+
+    public function test_inferred_has_many_relation(): void
+    {
+        $definition = new ModelDefinition(BelongsToRelatedModel::class);
+        $inferredRelation = $definition->getRelations('inferred');
+
+        $this->assertCount(1, $inferredRelation);
+        $this->assertSame('belongs_to_related.inferred[]', $inferredRelation[0]->getRelationName());
+        $this->assertEquals(
+            'LEFT JOIN `belongs_to_parent_model` AS `belongs_to_related.inferred[]`' .
+            ' ON `belongs_to_related`.`id` = `belongs_to_related.inferred[]`.`relatedModel_id`',
+            $inferredRelation[0]->getStatement(),
+        );
+    }
+
+    public function test_attribute_with_defaults_has_many_relation(): void
+    {
+        $definition = new ModelDefinition(BelongsToRelatedModel::class);
+        $relation = $definition->getRelations('attribute');
+
+        $this->assertCount(1, $relation);
+        $this->assertSame('belongs_to_related.attribute[]', $relation[0]->getRelationName());
+        $this->assertEquals(
+            'LEFT JOIN `belongs_to_parent_model` AS `belongs_to_related.attribute[]`' .
+            ' ON `belongs_to_related`.`id` = `belongs_to_related.attribute[]`.`other_id`',
+            $relation[0]->getStatement(),
+        );
+    }
+
+    public function test_fully_filled_attribute_has_many_relation(): void
+    {
+        $definition = new ModelDefinition(BelongsToRelatedModel::class);
+        $relation = $definition->getRelations('full');
+
+        $this->assertCount(1, $relation);
+        $this->assertSame('belongs_to_related.full[]', $relation[0]->getRelationName());
+        $this->assertEquals(
+            'LEFT JOIN `belongs_to_parent_model` AS `belongs_to_related.full[]`' .
+            ' ON `belongs_to_related`.`other_id` = `belongs_to_related.full[]`.`other_id`',
+            $relation[0]->getStatement(),
+        );
+    }
+}


### PR DESCRIPTION
# What

Fixes https://github.com/tempestphp/tempest-framework/issues/756

- Adds explicit relation attributes for HasMany and BelongsTo
- Add tests for both explicit and implicit relation definitions

# Outstanding questions

- I implemented it by "database" reference. So you supply the inverse and local database field names. Is this what we want? Or is it preferred to supply the inverse property name and infer the sql name from that?

# After merge

- If / when approved I will create an PR for the docs repo. 