### PR TITLE
feat(vite): add Tailwind CSS option to the installer

### DIFF
--- a/src/Tempest/Core/src/Commands/InstallCommand.php
+++ b/src/Tempest/Core/src/Commands/InstallCommand.php
@@ -35,7 +35,7 @@ final readonly class InstallCommand
             return;
         }
 
-        if (! $this->confirm("Running the <em>{$installer->name}</em> installer, continue?")) {
+        if (! $this->confirm("Running the <em>{$installer->name}</em> installer, continue?", default: true)) {
             $this->error('Aborted.');
 
             return;

--- a/src/Tempest/Vite/src/Installer/Tailwind/main.css
+++ b/src/Tempest/Vite/src/Installer/Tailwind/main.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/src/Tempest/Vite/src/Installer/Tailwind/main.ts
+++ b/src/Tempest/Vite/src/Installer/Tailwind/main.ts
@@ -1,0 +1,3 @@
+import './main.css'
+
+console.log('🌊')

--- a/src/Tempest/Vite/src/Installer/Tailwind/vite.config.ts
+++ b/src/Tempest/Vite/src/Installer/Tailwind/vite.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from 'vite'
 import tempest from 'vite-plugin-tempest'
+import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
 	plugins: [
+		tailwindcss(),
 		tempest(),
 	],
 })


### PR DESCRIPTION
This pull request adds the ability to install Tailwind CSS when using the `vite` installer. By default, a question will be asked to the user, but the `--tailwind` flag bypasses the prompt.

https://github.com/user-attachments/assets/b01d4ae6-7c83-490e-9075-cc1f4989d7e1

The Tailwind CSS installation uses the Vite implementation, installing both `tailwindcss` and `@tailwindcss/vite`.

Closes https://github.com/tempestphp/tempest-framework/issues/917