### PR TITLE
feat(mapper): add `MapFrom` and `MapTo` attributes

### DIFF
--- a/src/Tempest/Mapper/src/Attributes/MapFrom.php
+++ b/src/Tempest/Mapper/src/Attributes/MapFrom.php
@@ -7,6 +7,6 @@ namespace Tempest\Mapper\Attributes;
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class MapFrom {
     public function __construct(
-        public readonly string $from
+        public readonly string $key
     ) {}
 }

--- a/src/Tempest/Mapper/src/Attributes/MapFrom.php
+++ b/src/Tempest/Mapper/src/Attributes/MapFrom.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Tempest\Mapper\Attributes;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class MapFrom {
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class MapFrom
+{
     public function __construct(
-        public readonly string $key
-    ) {}
+        public readonly string $key,
+    ) {
+    }
 }

--- a/src/Tempest/Mapper/src/Attributes/MapFrom.php
+++ b/src/Tempest/Mapper/src/Attributes/MapFrom.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Mapper\Attributes;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+final class MapFrom {
+    public function __construct(
+        public readonly string $from
+    ) {}
+}

--- a/src/Tempest/Mapper/src/Attributes/MapFrom.php
+++ b/src/Tempest/Mapper/src/Attributes/MapFrom.php
@@ -7,10 +7,10 @@ namespace Tempest\Mapper\Attributes;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class MapFrom
+final readonly class MapFrom
 {
     public function __construct(
-        public readonly string $key,
+        public string $name,
     ) {
     }
 }

--- a/src/Tempest/Mapper/src/Attributes/MapTo.php
+++ b/src/Tempest/Mapper/src/Attributes/MapTo.php
@@ -7,10 +7,10 @@ namespace Tempest\Mapper\Attributes;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
-final class MapTo
+final readonly class MapTo
 {
     public function __construct(
-        public readonly string $key,
+        public string $name,
     ) {
     }
 }

--- a/src/Tempest/Mapper/src/Attributes/MapTo.php
+++ b/src/Tempest/Mapper/src/Attributes/MapTo.php
@@ -7,6 +7,6 @@ namespace Tempest\Mapper\Attributes;
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class MapTo {
     public function __construct(
-        public readonly string $to
+        public readonly string $key
     ) {}
 }

--- a/src/Tempest/Mapper/src/Attributes/MapTo.php
+++ b/src/Tempest/Mapper/src/Attributes/MapTo.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Tempest\Mapper\Attributes;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class MapTo {
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class MapTo
+{
     public function __construct(
-        public readonly string $key
-    ) {}
+        public readonly string $key,
+    ) {
+    }
 }

--- a/src/Tempest/Mapper/src/Attributes/MapTo.php
+++ b/src/Tempest/Mapper/src/Attributes/MapTo.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Mapper\Attributes;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+final class MapTo {
+    public function __construct(
+        public readonly string $to
+    ) {}
+}

--- a/src/Tempest/Mapper/src/Mappers/ArrayToObjectMapper.php
+++ b/src/Tempest/Mapper/src/Mappers/ArrayToObjectMapper.php
@@ -121,7 +121,7 @@ final readonly class ArrayToObjectMapper implements Mapper
         $mapFrom = $property->getAttribute(MapFrom::class);
         
         if ( ! is_null( $mapFrom ) ) {
-            return $mapFrom->from;
+            return $mapFrom->key;
         }
 
         return $property->getName();

--- a/src/Tempest/Mapper/src/Mappers/ArrayToObjectMapper.php
+++ b/src/Tempest/Mapper/src/Mappers/ArrayToObjectMapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Mapper\Mappers;
 
+use Tempest\Mapper\Attributes\MapFrom;
 use Tempest\Mapper\Casters\CasterFactory;
 use Tempest\Mapper\Exceptions\MissingValuesException;
 use Tempest\Mapper\Mapper;
@@ -56,7 +57,7 @@ final readonly class ArrayToObjectMapper implements Mapper
                 continue;
             }
 
-            $propertyName = $property->getName();
+            $propertyName = $this->resolvePropertyName($property);
 
             if (! array_key_exists($propertyName, $from)) {
                 $isStrictProperty = $isStrictClass || $property->hasAttribute(Strict::class);
@@ -114,6 +115,16 @@ final readonly class ArrayToObjectMapper implements Mapper
         $this->validate($object);
 
         return $object;
+    }
+
+    private function resolvePropertyName( PropertyReflector $property ): string {
+        $mapFrom = $property->getAttribute(MapFrom::class);
+        
+        if ( ! is_null( $mapFrom ) ) {
+            return $mapFrom->from;
+        }
+
+        return $property->getName();
     }
 
     private function resolveObject(mixed $objectOrClass): object

--- a/src/Tempest/Mapper/src/Mappers/ArrayToObjectMapper.php
+++ b/src/Tempest/Mapper/src/Mappers/ArrayToObjectMapper.php
@@ -122,7 +122,7 @@ final readonly class ArrayToObjectMapper implements Mapper
     {
         $mapFrom = $property->getAttribute(MapFrom::class);
 
-        if (! is_null($mapFrom)) {
+        if ($mapFrom !== null) {
             return $mapFrom->name;
         }
 

--- a/src/Tempest/Mapper/src/Mappers/ArrayToObjectMapper.php
+++ b/src/Tempest/Mapper/src/Mappers/ArrayToObjectMapper.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tempest\Mapper\Mappers;
 
-use Tempest\Mapper\Casters\ArrayCaster;
 use Tempest\Mapper\Attributes\MapFrom;
+use Tempest\Mapper\Casters\ArrayCaster;
 use Tempest\Mapper\Casters\CasterFactory;
 use Tempest\Mapper\Exceptions\MissingValuesException;
 use Tempest\Mapper\Mapper;
@@ -118,10 +118,11 @@ final readonly class ArrayToObjectMapper implements Mapper
         return $object;
     }
 
-    private function resolvePropertyName( PropertyReflector $property ): string {
+    private function resolvePropertyName(PropertyReflector $property): string
+    {
         $mapFrom = $property->getAttribute(MapFrom::class);
-        
-        if ( ! is_null( $mapFrom ) ) {
+
+        if (! is_null($mapFrom)) {
             return $mapFrom->key;
         }
 

--- a/src/Tempest/Mapper/src/Mappers/ArrayToObjectMapper.php
+++ b/src/Tempest/Mapper/src/Mappers/ArrayToObjectMapper.php
@@ -123,7 +123,7 @@ final readonly class ArrayToObjectMapper implements Mapper
         $mapFrom = $property->getAttribute(MapFrom::class);
 
         if (! is_null($mapFrom)) {
-            return $mapFrom->key;
+            return $mapFrom->name;
         }
 
         return $property->getName();

--- a/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
+++ b/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
@@ -73,7 +73,7 @@ final readonly class ObjectToArrayMapper implements Mapper
         $property_mapto_attribute = $property->getAttribute(MapToAttribute::class);
 
         if (! is_null($property_mapto_attribute)) {
-            $property_name = $property_mapto_attribute->key;
+            $property_name = $property_mapto_attribute->name;
         }
 
         return $property_name;

--- a/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
+++ b/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 namespace Tempest\Mapper\Mappers;
 
 use JsonSerializable;
+use Tempest\Mapper\Attributes\MapTo as MapToAttribute;
 use Tempest\Mapper\Mapper;
 use Tempest\Mapper\MapTo;
+use Tempest\Reflection\ClassReflector;
+use Tempest\Reflection\PropertyReflector;
+
+use function Tempest\Support\arr;
 
 final readonly class ObjectToArrayMapper implements Mapper
 {
@@ -17,10 +22,58 @@ final readonly class ObjectToArrayMapper implements Mapper
 
     public function map(mixed $from, mixed $to): array
     {
-        if ($from instanceof JsonSerializable) {
+        $properties       = $this->resolveProperties($from);
+        $mappedProperties = [];
+
+        foreach ( $properties as $property_name => $property_value ) {
+            try {
+                $property       = PropertyReflector::fromParts(class: $from, name: $property_name);
+                $property_name  = $this->resolvePropertyName($property);
+                $property_value = $property_value;
+
+                // @TODO May be removed if we want to handle private/protected properties
+                if ( ! $property->isPublic() ) {
+                    continue;
+                }
+
+                $mappedProperties[ $property_name ] = $property_value;
+            } catch (\ReflectionException) {
+                continue;
+            }
+        }
+
+        return $mappedProperties;        
+    }
+
+    /**
+     * @return array<string, mixed> The properties name and value
+     */
+    private function resolveProperties( object $from ): array {
+        if ( $from instanceof JsonSerializable ) {
             return $from->jsonSerialize();
         }
 
-        return (array) $from;
+        try {
+            $class      = new ClassReflector($from);
+            $properties = $class->getProperties();
+            $properties = iterator_to_array($properties);
+
+            return arr($properties)
+                ->mapWithKeys(fn(PropertyReflector $property) => yield $property->getName() => $property->getValue($from))
+                ->toArray();
+        } catch ( \ReflectionException) {
+            return [];
+        }
+    }
+    
+    private function resolvePropertyName( PropertyReflector $property ): string {
+        $property_name            = $property->getName();
+        $property_mapto_attribute = $property->getAttribute(MapToAttribute::class);
+
+        if ( ! is_null( $property_mapto_attribute ) ) {
+            $property_name = $property_mapto_attribute->to;
+        }
+
+        return $property_name;
     }
 }

--- a/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
+++ b/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
@@ -28,9 +28,10 @@ final readonly class ObjectToArrayMapper implements Mapper
         foreach ($properties as $propertyName => $propertyValue) {
             try {
                 $property = PropertyReflector::fromParts(class: $from, name: $propertyName);
+
                 $propertyName = $this->resolvePropertyName($property);
 
-                $mappedProperties[ $propertyName ] = $propertyValue;
+                $mappedProperties[$propertyName] = $propertyValue;
             } catch (ReflectionException) {
                 continue;
             }

--- a/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
+++ b/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Tempest\Mapper\Mappers;
 
 use JsonSerializable;
+use ReflectionException;
 use Tempest\Mapper\Attributes\MapTo as MapToAttribute;
 use Tempest\Mapper\Mapper;
 use Tempest\Mapper\MapTo;
 use Tempest\Reflection\ClassReflector;
 use Tempest\Reflection\PropertyReflector;
-
 use function Tempest\Support\arr;
 
 final readonly class ObjectToArrayMapper implements Mapper
@@ -22,55 +22,57 @@ final readonly class ObjectToArrayMapper implements Mapper
 
     public function map(mixed $from, mixed $to): array
     {
-        $properties       = $this->resolveProperties($from);
+        $properties = $this->resolveProperties($from);
         $mappedProperties = [];
 
-        foreach ( $properties as $property_name => $property_value ) {
+        foreach ($properties as $property_name => $property_value) {
             try {
-                $property       = PropertyReflector::fromParts(class: $from, name: $property_name);
-                $property_name  = $this->resolvePropertyName($property);
+                $property = PropertyReflector::fromParts(class: $from, name: $property_name);
+                $property_name = $this->resolvePropertyName($property);
                 $property_value = $property_value;
 
                 // @TODO May be removed if we want to handle private/protected properties
-                if ( ! $property->isPublic() ) {
+                if (! $property->isPublic()) {
                     continue;
                 }
 
                 $mappedProperties[ $property_name ] = $property_value;
-            } catch (\ReflectionException) {
+            } catch (ReflectionException) {
                 continue;
             }
         }
 
-        return $mappedProperties;        
+        return $mappedProperties;
     }
 
     /**
      * @return array<string, mixed> The properties name and value
      */
-    private function resolveProperties( object $from ): array {
-        if ( $from instanceof JsonSerializable ) {
+    private function resolveProperties(object $from): array
+    {
+        if ($from instanceof JsonSerializable) {
             return $from->jsonSerialize();
         }
 
         try {
-            $class      = new ClassReflector($from);
+            $class = new ClassReflector($from);
             $properties = $class->getProperties();
             $properties = iterator_to_array($properties);
 
             return arr($properties)
-                ->mapWithKeys(fn(PropertyReflector $property) => yield $property->getName() => $property->getValue($from))
+                ->mapWithKeys(fn (PropertyReflector $property) => yield $property->getName() => $property->getValue($from))
                 ->toArray();
-        } catch ( \ReflectionException) {
+        } catch (ReflectionException) {
             return [];
         }
     }
-    
-    private function resolvePropertyName( PropertyReflector $property ): string {
-        $property_name            = $property->getName();
+
+    private function resolvePropertyName(PropertyReflector $property): string
+    {
+        $property_name = $property->getName();
         $property_mapto_attribute = $property->getAttribute(MapToAttribute::class);
 
-        if ( ! is_null( $property_mapto_attribute ) ) {
+        if (! is_null($property_mapto_attribute)) {
             $property_name = $property_mapto_attribute->key;
         }
 

--- a/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
+++ b/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
@@ -71,7 +71,7 @@ final readonly class ObjectToArrayMapper implements Mapper
         $property_mapto_attribute = $property->getAttribute(MapToAttribute::class);
 
         if ( ! is_null( $property_mapto_attribute ) ) {
-            $property_name = $property_mapto_attribute->to;
+            $property_name = $property_mapto_attribute->key;
         }
 
         return $property_name;

--- a/src/Tempest/Reflection/src/PropertyReflector.php
+++ b/src/Tempest/Reflection/src/PropertyReflector.php
@@ -71,15 +71,18 @@ final readonly class PropertyReflector implements Reflector
         return $this->getType()->isNullable();
     }
 
-    public function isPrivate(): bool {
+    public function isPrivate(): bool
+    {
         return $this->reflectionProperty->isPrivate();
     }
 
-    public function isProtected(): bool {
+    public function isProtected(): bool
+    {
         return $this->reflectionProperty->isProtected();
     }
 
-    public function isPublic(): bool {
+    public function isPublic(): bool
+    {
         return $this->reflectionProperty->isPublic();
     }
 

--- a/src/Tempest/Reflection/src/PropertyReflector.php
+++ b/src/Tempest/Reflection/src/PropertyReflector.php
@@ -71,6 +71,18 @@ final readonly class PropertyReflector implements Reflector
         return $this->getType()->isNullable();
     }
 
+    public function isPrivate(): bool {
+        return $this->reflectionProperty->isPrivate();
+    }
+
+    public function isProtected(): bool {
+        return $this->reflectionProperty->isProtected();
+    }
+
+    public function isPublic(): bool {
+        return $this->reflectionProperty->isPublic();
+    }
+
     public function getIterableType(): ?TypeReflector
     {
         $doc = $this->reflectionProperty->getDocComment();

--- a/tests/Integration/Mapper/Fixtures/ObjectWithMapFromAttribute.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithMapFromAttribute.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+use Tempest\Mapper\Attributes\MapFrom;
+
+final class ObjectWithMapFromAttribute
+{
+    public function __construct(
+        #[MapFrom('name')]
+        public readonly string $fullName
+    ) {}
+}

--- a/tests/Integration/Mapper/Fixtures/ObjectWithMapFromAttribute.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithMapFromAttribute.php
@@ -10,6 +10,7 @@ final class ObjectWithMapFromAttribute
 {
     public function __construct(
         #[MapFrom('name')]
-        public readonly string $fullName
-    ) {}
+        public readonly string $fullName,
+    ) {
+    }
 }

--- a/tests/Integration/Mapper/Fixtures/ObjectWithMapToAttribute.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithMapToAttribute.php
@@ -11,7 +11,5 @@ final class ObjectWithMapToAttribute
     public function __construct(
         #[MapTo('name')]
         public readonly string $fullName,
-        protected string $email,
-        private string $password,
     ) {}
 }

--- a/tests/Integration/Mapper/Fixtures/ObjectWithMapToAttribute.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithMapToAttribute.php
@@ -11,5 +11,6 @@ final class ObjectWithMapToAttribute
     public function __construct(
         #[MapTo('name')]
         public readonly string $fullName,
-    ) {}
+    ) {
+    }
 }

--- a/tests/Integration/Mapper/Fixtures/ObjectWithMapToAttribute.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithMapToAttribute.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+use Tempest\Mapper\Attributes\MapTo;
+
+final class ObjectWithMapToAttribute
+{
+    public function __construct(
+        #[MapTo('name')]
+        public readonly string $fullName,
+        protected string $email,
+        private string $password,
+    ) {}
+}

--- a/tests/Integration/Mapper/Fixtures/ObjectWithMapToCollisions.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithMapToCollisions.php
@@ -11,10 +11,9 @@ final class ObjectWithMapToCollisions
     public function __construct(
         #[MapTo('name')]
         public readonly string $first_name,
-
         #[MapTo('full_name')]
         public readonly string $name,
-
-        public readonly string $last_name
-    ) {}
+        public readonly string $last_name,
+    ) {
+    }
 }

--- a/tests/Integration/Mapper/Fixtures/ObjectWithMapToCollisions.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithMapToCollisions.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+use Tempest\Mapper\Attributes\MapTo;
+
+final class ObjectWithMapToCollisions
+{
+    public function __construct(
+        #[MapTo('name')]
+        public readonly string $first_name,
+
+        #[MapTo('full_name')]
+        public readonly string $name,
+
+        public readonly string $last_name
+    ) {}
+}

--- a/tests/Integration/Mapper/Fixtures/ObjectWithMapToCollisionsJsonSerializable.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithMapToCollisionsJsonSerializable.php
@@ -4,21 +4,22 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Mapper\Fixtures;
 
+use JsonSerializable;
 use Tempest\Mapper\Attributes\MapTo;
 
-final class ObjectWithMapToCollisionsJsonSerializable implements \JsonSerializable
+final class ObjectWithMapToCollisionsJsonSerializable implements JsonSerializable
 {
     public function __construct(
         #[MapTo('name')]
         public readonly string $first_name,
-
         #[MapTo('full_name')]
         public readonly string $name,
+        public readonly string $last_name,
+    ) {
+    }
 
-        public readonly string $last_name
-    ) {}
-
-    public function jsonSerialize(): mixed {
+    public function jsonSerialize(): mixed
+    {
         return [
             'first_name' => $this->first_name,
             'name' => $this->name,

--- a/tests/Integration/Mapper/Fixtures/ObjectWithMapToCollisionsJsonSerializable.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithMapToCollisionsJsonSerializable.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+use Tempest\Mapper\Attributes\MapTo;
+
+final class ObjectWithMapToCollisionsJsonSerializable implements \JsonSerializable
+{
+    public function __construct(
+        #[MapTo('name')]
+        public readonly string $first_name,
+
+        #[MapTo('full_name')]
+        public readonly string $name,
+
+        public readonly string $last_name
+    ) {}
+
+    public function jsonSerialize(): mixed {
+        return [
+            'first_name' => $this->first_name,
+            'name' => $this->name,
+        ];
+    }
+}

--- a/tests/Integration/Mapper/Fixtures/ObjectWithMappedVariousPropertyScope.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithMappedVariousPropertyScope.php
@@ -15,5 +15,6 @@ final class ObjectWithMappedVariousPropertyScope
         protected string $protectedProp,
         #[MapTo('public')]
         public string $publicProp,
-    ) {}
+    ) {
+    }
 }

--- a/tests/Integration/Mapper/Fixtures/ObjectWithMappedVariousPropertyScope.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithMappedVariousPropertyScope.php
@@ -9,7 +9,7 @@ use Tempest\Mapper\Attributes\MapTo;
 final class ObjectWithMappedVariousPropertyScope
 {
     public function __construct(
-        #[MapTo('private')]
+        #[MapTo('private')] // @phpstan-ignore-line property.onlyWritten
         private string $privateProp,
         #[MapTo('protected')]
         protected string $protectedProp,

--- a/tests/Integration/Mapper/Fixtures/ObjectWithMappedVariousPropertyScope.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithMappedVariousPropertyScope.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+use Tempest\Mapper\Attributes\MapTo;
+
+final class ObjectWithMappedVariousPropertyScope
+{
+    public function __construct(
+        #[MapTo('private')]
+        private string $privateProp,
+        #[MapTo('protected')]
+        protected string $protectedProp,
+        #[MapTo('public')]
+        public string $publicProp,
+    ) {}
+}

--- a/tests/Integration/Mapper/MapperTest.php
+++ b/tests/Integration/Mapper/MapperTest.php
@@ -7,7 +7,6 @@ namespace Tests\Tempest\Integration\Mapper;
 use Tempest\Mapper\Exceptions\MissingValuesException;
 use Tempest\Mapper\MapTo;
 use Tempest\Validation\Exceptions\ValidationException;
-use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMapFromAttribute;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -16,13 +15,13 @@ use Tests\Tempest\Integration\Mapper\Fixtures\ObjectFactoryWithValidation;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithBoolProp;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithFloatProp;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithIntProp;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMapFromAttribute;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMappedVariousPropertyScope;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMapToAttribute;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMapToCollisions;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMapToCollisionsJsonSerializable;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithStrictOnClass;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithStrictProperty;
-use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMappedVariousPropertyScope;
-
 use function Tempest\make;
 use function Tempest\map;
 
@@ -180,41 +179,45 @@ final class MapperTest extends FrameworkIntegrationTestCase
         $this->assertFalse($object->prop);
     }
 
-    public function test_map_from_attribute(): void {
+    public function test_map_from_attribute(): void
+    {
         $object = map([
-            'name' => 'Guillaume'
+            'name' => 'Guillaume',
         ])->to(ObjectWithMapFromAttribute::class);
 
         $this->assertSame('Guillaume', $object->fullName);
     }
 
-    public function test_map_to_attribute(): void {
+    public function test_map_to_attribute(): void
+    {
         $array = map(new ObjectWithMapToAttribute(
-            fullName: 'Guillaume'
+            fullName: 'Guillaume',
         ))->to(MapTo::ARRAY);
 
         $this->assertSame(['name' => 'Guillaume'], $array);
     }
 
-    public function test_map_to_handle_name_collisions(): void {
+    public function test_map_to_handle_name_collisions(): void
+    {
         $array = map(new ObjectWithMapToCollisions(
             first_name: 'my first name',
             name: 'my name',
-            last_name: 'my last name'
+            last_name: 'my last name',
         ))->to(MapTo::ARRAY);
 
         $this->assertSame([
             'name' => 'my first name',
             'full_name' => 'my name',
-            'last_name' => 'my last name'
+            'last_name' => 'my last name',
         ], $array);
     }
 
-    public function test_map_to_handle_name_collisions_with_json_serializable(): void {
+    public function test_map_to_handle_name_collisions_with_json_serializable(): void
+    {
         $array = map(new ObjectWithMapToCollisionsJsonSerializable(
             first_name: 'my first name',
             name: 'my name',
-            last_name: 'my last name'
+            last_name: 'my last name',
         ))->to(MapTo::ARRAY);
 
         $this->assertSame([
@@ -223,7 +226,8 @@ final class MapperTest extends FrameworkIntegrationTestCase
         ], $array);
     }
 
-    public function test_map_to_handle_various_property_visibility(): void {
+    public function test_map_to_handle_various_property_visibility(): void
+    {
         $array = map(new ObjectWithMappedVariousPropertyScope(
             publicProp: 'public',
             protectedProp: 'protected',

--- a/tests/Integration/Mapper/MapperTest.php
+++ b/tests/Integration/Mapper/MapperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Tempest\Integration\Mapper;
 
 use Tempest\Mapper\Exceptions\MissingValuesException;
+use Tempest\Mapper\MapTo;
 use Tempest\Validation\Exceptions\ValidationException;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMapFromAttribute;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
@@ -15,8 +16,13 @@ use Tests\Tempest\Integration\Mapper\Fixtures\ObjectFactoryWithValidation;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithBoolProp;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithFloatProp;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithIntProp;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMapToAttribute;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMapToCollisions;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMapToCollisionsJsonSerializable;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithStrictOnClass;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithStrictProperty;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMappedVariousPropertyScope;
+
 use function Tempest\make;
 use function Tempest\map;
 
@@ -180,5 +186,52 @@ final class MapperTest extends FrameworkIntegrationTestCase
         ])->to(ObjectWithMapFromAttribute::class);
 
         $this->assertSame('Guillaume', $object->fullName);
+    }
+
+    public function test_map_to_attribute(): void {
+        $array = map(new ObjectWithMapToAttribute(
+            fullName: 'Guillaume'
+        ))->to(MapTo::ARRAY);
+
+        $this->assertSame(['name' => 'Guillaume'], $array);
+    }
+
+    public function test_map_to_handle_name_collisions(): void {
+        $array = map(new ObjectWithMapToCollisions(
+            first_name: 'my first name',
+            name: 'my name',
+            last_name: 'my last name'
+        ))->to(MapTo::ARRAY);
+
+        $this->assertSame([
+            'name' => 'my first name',
+            'full_name' => 'my name',
+            'last_name' => 'my last name'
+        ], $array);
+    }
+
+    public function test_map_to_handle_name_collisions_with_json_serializable(): void {
+        $array = map(new ObjectWithMapToCollisionsJsonSerializable(
+            first_name: 'my first name',
+            name: 'my name',
+            last_name: 'my last name'
+        ))->to(MapTo::ARRAY);
+
+        $this->assertSame([
+            'name' => 'my first name',
+            'full_name' => 'my name',
+        ], $array);
+    }
+
+    public function test_map_to_handle_various_property_visibility(): void {
+        $array = map(new ObjectWithMappedVariousPropertyScope(
+            publicProp: 'public',
+            protectedProp: 'protected',
+            privateProp: 'private',
+        ))->to(MapTo::ARRAY);
+
+        $this->assertSame([
+            'public' => 'public',
+        ], $array);
     }
 }

--- a/tests/Integration/Mapper/MapperTest.php
+++ b/tests/Integration/Mapper/MapperTest.php
@@ -229,9 +229,9 @@ final class MapperTest extends FrameworkIntegrationTestCase
     public function test_map_to_handle_various_property_visibility(): void
     {
         $array = map(new ObjectWithMappedVariousPropertyScope(
-            publicProp: 'public',
-            protectedProp: 'protected',
             privateProp: 'private',
+            protectedProp: 'protected',
+            publicProp: 'public',
         ))->to(MapTo::ARRAY);
 
         $this->assertSame([

--- a/tests/Integration/Mapper/MapperTest.php
+++ b/tests/Integration/Mapper/MapperTest.php
@@ -6,6 +6,7 @@ namespace Tests\Tempest\Integration\Mapper;
 
 use Tempest\Mapper\Exceptions\MissingValuesException;
 use Tempest\Validation\Exceptions\ValidationException;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMapFromAttribute;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -171,5 +172,13 @@ final class MapperTest extends FrameworkIntegrationTestCase
         $object = map(['prop' => ''])->to(ObjectWithBoolProp::class);
 
         $this->assertFalse($object->prop);
+    }
+
+    public function test_map_from_attribute(): void {
+        $object = map([
+            'name' => 'Guillaume'
+        ])->to(ObjectWithMapFromAttribute::class);
+
+        $this->assertSame('Guillaume', $object->fullName);
     }
 }


### PR DESCRIPTION
This closes #877 
It adds both Attributes. I have a couple of notes here

I don't know if my tests are properly located, maybe they should go in specific `MapperTestCase` class ?

( for `MapTo` )
Due to a weird native array cast for private/protected properties, For now I only keep public properties  
So they're collected from the `ClassReflector` instead of the native array cast ( `jsonSerialize()` remains a priority )  
https://www.php.net/manual/en/language.types.array.php#language.types.array.casting  
I don't really know how we want to deal with private/protected properties then  

I mainly work on `ObjectToArrayMapper` and `ArrayToObjectMapper`  
It seems like the json versions uses those internally so I think I've covered all "object" things

Now, in technical aspect, I've used the reflection component to resolve names and values and the way I design it should allow us to improve the mapping with more additional stuff ( such as custom Transformers on properties for example )  
But maybe I have missed something, as I don't find where the "native" ones are used