### PR TITLE
feat(database): add a `findBy` method to models

### DIFF
--- a/src/Tempest/Database/src/DatabaseModel.php
+++ b/src/Tempest/Database/src/DatabaseModel.php
@@ -28,6 +28,8 @@ interface DatabaseModel
 
     public static function find(Id $id, array $relations = []): ?self;
 
+    public static function findBy(mixed ...$conditions): ModelQueryBuilder;
+
     public function save(): self;
 
     public function getId(): Id;

--- a/src/Tempest/Database/src/IsDatabaseModel.php
+++ b/src/Tempest/Database/src/IsDatabaseModel.php
@@ -91,6 +91,15 @@ trait IsDatabaseModel
             ->find($id);
     }
 
+    public static function findBy(mixed ...$conditions): ModelQueryBuilder
+    {
+        $query = self::query();
+        
+        array_walk($conditions, fn($value, $column) => $query->whereField($column, $value));
+
+        return $query;
+    }
+
     public function load(string ...$relations): self
     {
         $new = self::find($this->getId(), $relations);


### PR DESCRIPTION
This is inspired by Rails a bit where I can fetch models with simple equality conditions like
```ruby
Book.where(out_of_print: true)
```

and using PHP named arguments and this PR I can now do the same like this:
```php
Book::findBy(out_of_print: true)->all();
```

as opposed to
```php
Book::query()->where('out_of_print = 1')->all();
```

In my use case I'll probably do a name or slug lookup for a single record with a unique constraint like:
```php
Source::findBy(name: '...')->first();
```

The `findBy` method returns a `ModelQueryBuilder` so loading relations and doing anything more complicated than simple equality conditions still works:
```php
Book::findBy(out_of_print: true)->where('year > :year', year: 2000)->with('author')->all();
```