### PR TITLE
feat(database): add a `Virtual` attribute to exclude model properties from query builder

### DIFF
--- a/src/Tempest/Database/src/Builder/ModelQueryBuilder.php
+++ b/src/Tempest/Database/src/Builder/ModelQueryBuilder.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Tempest\Database\Builder;
 
 use Closure;
-use Tempest\Database\DatabaseModel;
 use Tempest\Database\Id;
-use Tempest\Database\Query;
 use function Tempest\map;
+use Tempest\Database\Query;
+use function Tempest\reflect;
+use Tempest\Database\Virtual;
+use Tempest\Database\DatabaseModel;
 
 /**
  * @template TModelClass of DatabaseModel
@@ -164,6 +166,8 @@ final class ModelQueryBuilder
         $relations = $this->getRelations($modelDefinition);
 
         $fields = $modelDefinition->getFieldNames();
+
+        $fields = array_filter($fields, fn(FieldName $field) => !(reflect($this->modelClass, $field->fieldName)->hasAttribute(Virtual::class)));
 
         foreach ($relations as $relation) {
             $fields = [...$fields, ...$relation->getFieldNames()];

--- a/src/Tempest/Database/src/Virtual.php
+++ b/src/Tempest/Database/src/Virtual.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final readonly class Virtual
+{
+}

--- a/tests/Fixtures/Models/AWithVirtual.php
+++ b/tests/Fixtures/Models/AWithVirtual.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Models;
+
+use Tempest\Database\Virtual;
+use Tempest\Database\DatabaseModel;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\Builder\TableName;
+
+final class AWithVirtual implements DatabaseModel
+{
+    use IsDatabaseModel;
+
+    #[Virtual]
+    public int $fake {
+        get => $this->id->id * -1;
+    }
+
+    public function __construct(
+        public B $b,
+    ) {
+    }
+
+    public static function table(): TableName
+    {
+        return new TableName('a');
+    }
+}


### PR DESCRIPTION
Fixes #962

Example use-case where I have a JSON `config` column and I just want a handy readonly accessor for values in it:
```php
<?php

namespace App\Models;

use Tempest\Database\Virtual;
use Tempest\Database\DatabaseModel;
use Tempest\Database\IsDatabaseModel;

final class MyModel implements DatabaseModel
{
	use IsDatabaseModel;

	#[Virtual]
	public string $url
	{
		get => $this->config['url'] ?? '';
	}

	public function __construct(
		public string $name,
		public ?array $config,
	)
	{ }
}
```

^ in this case I mark the `$url` property with `Virtual` so that `ModelQueryBuilder` doesn't include it in the SELECT clause of queries against this model