### PR TITLE
test(view): added test that includes self-closing html tag (#982)

### DIFF
--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -574,4 +574,15 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         </body></html>
         HTML, $html);
     }
+
+    public function test_self_closing_tag(): void
+    {
+        $html = $this->render(<<<'HTML'
+        <html lang="en"><body>Hello<br/>there</body></html>
+        HTML);
+
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'HTML'
+        <html lang="en"><body>Hello<br/>there</body></html>
+        HTML, $html);
+    }
 }


### PR DESCRIPTION
Adding self closing tags in a tempest view gets expanded by `Dom\HTMLDocument`.  Specifically by `$dom->saveHtml()`

This PR adds a failing test to test this.

e.g. source:

```php
<html lang="en"><body>Hello<br/>there</body></html>
```

becomes:

```php
<html lang="en"><body>Hello<br></br>there</body></html>
```
