### PR TITLE
feat(view): add icon component

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ DISCOVERY_CACHE=false
 # Enable or disable config cache
 CONFIG_CACHE=false
 
+# Enable or disable icon cache
+ICON_CACHE=true
+
 # Enable or disable view cache
 VIEW_CACHE=false
 

--- a/src/Tempest/Cache/src/CacheConfig.php
+++ b/src/Tempest/Cache/src/CacheConfig.php
@@ -36,7 +36,7 @@ final class CacheConfig
         ?bool $enable = null,
     ) {
         $this->enable = $enable ?? env('CACHE');
-        $this->iconCache = (bool) env('ICON_CACHE', false);
+        $this->iconCache = (bool) env('ICON_CACHE', true);
         $this->projectCache = (bool) env('PROJECT_CACHE', false);
         $this->viewCache = (bool) env('VIEW_CACHE', false);
         $this->discoveryCache = $this->resolveDiscoveryCacheStrategy();

--- a/src/Tempest/Cache/src/CacheConfig.php
+++ b/src/Tempest/Cache/src/CacheConfig.php
@@ -17,6 +17,8 @@ final class CacheConfig
 
     public ?bool $enable;
 
+    public bool $iconCache = false;
+
     public bool $projectCache = false;
 
     public bool $viewCache = false;
@@ -34,6 +36,7 @@ final class CacheConfig
         ?bool $enable = null,
     ) {
         $this->enable = $enable ?? env('CACHE');
+        $this->iconCache = (bool) env('ICON_CACHE', false);
         $this->projectCache = (bool) env('PROJECT_CACHE', false);
         $this->viewCache = (bool) env('VIEW_CACHE', false);
         $this->discoveryCache = $this->resolveDiscoveryCacheStrategy();

--- a/src/Tempest/Cache/src/IconCache.php
+++ b/src/Tempest/Cache/src/IconCache.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Cache;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+
+final class IconCache implements Cache
+{
+    use IsCache;
+
+    private CacheItemPoolInterface $pool;
+
+    public function __construct(
+        private readonly CacheConfig $cacheConfig,
+    ) {
+        $this->pool = new FilesystemAdapter(
+            directory: $this->cacheConfig->directory . '/icons',
+        );
+    }
+
+    protected function getCachePool(): CacheItemPoolInterface
+    {
+        return $this->pool;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->cacheConfig->enable ?? $this->cacheConfig->iconCache;
+    }
+}

--- a/src/Tempest/Console/src/Testing/ConsoleTester.php
+++ b/src/Tempest/Console/src/Testing/ConsoleTester.php
@@ -182,6 +182,24 @@ final class ConsoleTester
         return $this->assertContains($text);
     }
 
+    public function assertSeeCount(string $text, int $expectedCount): self
+    {
+        $actualCount = substr_count($this->output->asUnformattedString(), $text);
+
+        Assert::assertSame(
+            $expectedCount,
+            $actualCount,
+            sprintf(
+                'Failed to assert that console output counted: %s exactly %d times. These lines were printed: %s',
+                $text,
+                $expectedCount,
+                PHP_EOL . PHP_EOL . $this->output->asUnformattedString() . PHP_EOL,
+            ),
+        );
+
+        return $this;
+    }
+
     public function assertNotSee(string $text): self
     {
         return $this->assertDoesNotContain($text);

--- a/src/Tempest/View/src/Components/Icon.php
+++ b/src/Tempest/View/src/Components/Icon.php
@@ -74,9 +74,7 @@ final readonly class Icon implements ViewComponent
             return $this->cache->resolve(
                 key: "iconify-{$prefix}-{$name}",
                 cache: fn () => $this->download($prefix, $name),
-                expiresAt: new DateTimeImmutable()->add(
-                    new DateInterval('PT1H'),
-                ),
+                expiresAt: null,
             );
         } catch (Exception) {
             return null;

--- a/src/Tempest/View/src/Components/Icon.php
+++ b/src/Tempest/View/src/Components/Icon.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\View\Components;
+
+use DateInterval;
+use DateTimeImmutable;
+use Exception;
+use Tempest\Cache\Cache;
+use Tempest\HttpClient\HttpClient;
+use Tempest\Support\Str\ImmutableString;
+use Tempest\View\Elements\ViewComponentElement;
+use Tempest\View\ViewComponent;
+
+final readonly class Icon implements ViewComponent
+{
+    public function __construct(
+        private Cache $cache,
+        private HttpClient $http,
+    ) {
+    }
+
+    public static function getName(): string
+    {
+        return 'x-icon';
+    }
+
+    public function compile(ViewComponentElement $element): string
+    {
+        $name = $element->getAttribute('name');
+        $class = $element->getAttribute('class');
+
+        $svg = $this->render($name);
+
+        return new ImmutableString($svg)
+            ->replace(
+                search: '<svg ',
+                replace: "<svg class=\"{$class}\" ",
+            )
+            ->toString();
+    }
+
+    /**
+     * Downloads the icon's SVG file from the Iconify API
+     */
+    private function download(string $prefix, string $name): ?string
+    {
+        try {
+            return $this->http->get("https://api.iconify.design/{$prefix}/{$name}.svg")->body;
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    /**
+     * Renders an icon
+     *
+     * This method is responsible for rendering the icon. If the icon is not
+     * in the cache, it will download it on the fly and cache it for future
+     * use. If the icon is already in the cache, it will be served from there.
+     */
+    private function render(string $name): ?string
+    {
+        try {
+            $parts = explode(':', $name, 2);
+
+            if (count($parts) !== 2) {
+                return null;
+            }
+
+            [$prefix, $name] = $parts;
+
+            return $this->cache->resolve(
+                key: "iconify-{$prefix}-{$name}",
+                cache: fn () => $this->download($prefix, $name),
+                expiresAt: new DateTimeImmutable()->add(
+                    new DateInterval('PT1H'),
+                ),
+            );
+        } catch (Exception) {
+            return null;
+        }
+    }
+}

--- a/src/Tempest/View/src/Components/Icon.php
+++ b/src/Tempest/View/src/Components/Icon.php
@@ -34,9 +34,9 @@ final readonly class Icon implements ViewComponent
         $svg = $this->render($name);
 
         if (! $svg) {
-            return $this->config->environment->isLocal() ?
-                '<!-- unknown-icon: ' . $name . ' -->' :
-                '';
+            return $this->config->environment->isLocal()
+                ? ('<!-- unknown-icon: ' . $name . ' -->')
+                : '';
         }
 
         return match ($class) {

--- a/src/Tempest/View/src/Components/Icon.php
+++ b/src/Tempest/View/src/Components/Icon.php
@@ -6,6 +6,7 @@ namespace Tempest\View\Components;
 
 use Exception;
 use Tempest\Cache\IconCache;
+use Tempest\Core\AppConfig;
 use Tempest\HttpClient\HttpClient;
 use Tempest\Support\Str\ImmutableString;
 use Tempest\View\Elements\ViewComponentElement;
@@ -14,6 +15,7 @@ use Tempest\View\ViewComponent;
 final readonly class Icon implements ViewComponent
 {
     public function __construct(
+        private AppConfig $config,
         private IconCache $cache,
         private HttpClient $http,
     ) {
@@ -32,7 +34,9 @@ final readonly class Icon implements ViewComponent
         $svg = $this->render($name);
 
         if (! $svg) {
-            return '';
+            return $this->config->environment->isLocal() ?
+                '<!-- unknown-icon: ' . $name . ' -->' :
+                '';
         }
 
         return match ($class) {

--- a/src/Tempest/View/src/Components/Icon.php
+++ b/src/Tempest/View/src/Components/Icon.php
@@ -7,6 +7,7 @@ namespace Tempest\View\Components;
 use Exception;
 use Tempest\Cache\IconCache;
 use Tempest\Core\AppConfig;
+use Tempest\Http\Status;
 use Tempest\HttpClient\HttpClient;
 use Tempest\Support\Str\ImmutableString;
 use Tempest\View\Elements\ViewComponentElement;
@@ -51,7 +52,13 @@ final readonly class Icon implements ViewComponent
     private function download(string $prefix, string $name): ?string
     {
         try {
-            return $this->http->get("https://api.iconify.design/{$prefix}/{$name}.svg")->body;
+            $response = $this->http->get("https://api.iconify.design/{$prefix}/{$name}.svg");
+
+            if ($response->status !== Status::OK) {
+                return null;
+            }
+
+            return $response->body;
         } catch (Exception) {
             return null;
         }

--- a/src/Tempest/View/src/Components/Icon.php
+++ b/src/Tempest/View/src/Components/Icon.php
@@ -83,6 +83,9 @@ final readonly class Icon implements ViewComponent
         }
     }
 
+    /**
+     * Forwards the user-provided class attribute to the SVG element
+     */
     private function injectClass(string $svg, string $class): string
     {
         return new ImmutableString($svg)

--- a/src/Tempest/View/src/Components/Icon.php
+++ b/src/Tempest/View/src/Components/Icon.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Tempest\View\Components;
 
-use DateInterval;
-use DateTimeImmutable;
 use Exception;
 use Tempest\Cache\IconCache;
 use Tempest\HttpClient\HttpClient;

--- a/src/Tempest/View/src/Components/Icon.php
+++ b/src/Tempest/View/src/Components/Icon.php
@@ -7,7 +7,7 @@ namespace Tempest\View\Components;
 use DateInterval;
 use DateTimeImmutable;
 use Exception;
-use Tempest\Cache\Cache;
+use Tempest\Cache\IconCache;
 use Tempest\HttpClient\HttpClient;
 use Tempest\Support\Str\ImmutableString;
 use Tempest\View\Elements\ViewComponentElement;
@@ -16,7 +16,7 @@ use Tempest\View\ViewComponent;
 final readonly class Icon implements ViewComponent
 {
     public function __construct(
-        private Cache $cache,
+        private IconCache $cache,
         private HttpClient $http,
     ) {
     }

--- a/src/Tempest/View/src/Components/Icon.php
+++ b/src/Tempest/View/src/Components/Icon.php
@@ -33,12 +33,14 @@ final readonly class Icon implements ViewComponent
 
         $svg = $this->render($name);
 
-        $svg =  match($class) {
+        if (! $svg) {
+            return '';
+        }
+
+        return match ($class) {
             null => $svg,
             default => $this->injectClass($svg, $class),
         };
-        
-        return $svg;
     }
 
     /**

--- a/src/Tempest/View/src/Components/Icon.php
+++ b/src/Tempest/View/src/Components/Icon.php
@@ -33,12 +33,12 @@ final readonly class Icon implements ViewComponent
 
         $svg = $this->render($name);
 
-        return new ImmutableString($svg)
-            ->replace(
-                search: '<svg ',
-                replace: "<svg class=\"{$class}\" ",
-            )
-            ->toString();
+        $svg =  match($class) {
+            null => $svg,
+            default => $this->injectClass($svg, $class),
+        };
+        
+        return $svg;
     }
 
     /**
@@ -79,5 +79,15 @@ final readonly class Icon implements ViewComponent
         } catch (Exception) {
             return null;
         }
+    }
+
+    private function injectClass(string $svg, string $class): string
+    {
+        return new ImmutableString($svg)
+            ->replace(
+                search: '<svg ',
+                replace: "<svg class=\"{$class}\" ",
+            )
+            ->toString();
     }
 }

--- a/src/Tempest/View/src/Config/icon.config.php
+++ b/src/Tempest/View/src/Config/icon.config.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+use Tempest\View\IconConfig;
+
+return new IconConfig();

--- a/src/Tempest/View/src/IconConfig.php
+++ b/src/Tempest/View/src/IconConfig.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\View;
+
+final class IconConfig
+{
+    public function __construct(
+        /**
+         * The number of seconds to cache the icon SVG files.
+         *
+         * If null, the icons will be cached indefinitely.
+         *
+         * @var int|null
+         */
+        public ?int $cacheDuration = null,
+
+        /**
+         * URL of the Iconify API.
+         *
+         * This allows you to switch to a local or self-hosted Iconify API.
+         *
+         * @var string
+         */
+        public string $iconifyApiUrl = 'https://api.iconify.design',
+    ) {
+    }
+}

--- a/tests/Integration/Cache/CacheClearCommandTest.php
+++ b/tests/Integration/Cache/CacheClearCommandTest.php
@@ -17,9 +17,10 @@ final class CacheClearCommandTest extends FrameworkIntegrationTestCase
     {
         $this->console
             ->call('cache:clear')
+            ->print()
             ->assertSee(ProjectCache::class)
             ->submit('0')
             ->submit('yes')
-            ->assertSee('CLEARED');
+           ->assertSeeCount('CLEARED', 1);
     }
 }

--- a/tests/Integration/Cache/CacheClearCommandTest.php
+++ b/tests/Integration/Cache/CacheClearCommandTest.php
@@ -20,7 +20,6 @@ final class CacheClearCommandTest extends FrameworkIntegrationTestCase
             ->assertSee(ProjectCache::class)
             ->submit('0')
             ->submit('yes')
-            ->assertSee(ProjectCache::class)
-            ->assertNotSee(ViewCache::class);
+            ->assertSee('CLEARED');
     }
 }

--- a/tests/Integration/View/IconComponentTest.php
+++ b/tests/Integration/View/IconComponentTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\View;
+
+use Tempest\Cache\IconCache;
+use Tempest\Core\AppConfig;
+use Tempest\Core\ConfigCache;
+use Tempest\Core\Environment;
+use Tempest\Http\Status;
+use Tempest\HttpClient\HttpClient;
+use Tempest\Router\GenericResponse;
+use Tempest\View\IconConfig;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+final class IconComponentTest extends FrameworkIntegrationTestCase
+{
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container->get(IconCache::class)->clear();
+        $this->container->get(ConfigCache::class)->clear();
+    }
+
+    public function test_it_renders_an_icon(): void
+    {
+        $mockHttpClient = $this->createMock(HttpClient::class);
+            $mockHttpClient
+                ->expects($this->once())
+                ->method('get')
+                ->with('https://api.iconify.design/ph/eye.svg')
+                ->willReturn(new GenericResponse(status: Status::OK, body: '<svg></svg>'));
+
+        $this->container->register(HttpClient::class, fn() => $mockHttpClient);
+
+        $this->assertSame(
+            '<svg></svg>',
+            $this->render(
+                '<x-icon name="ph:eye" />',
+            ),
+        );
+    }
+
+    public function test_it_downloads_the_icon_from_a_custom_api(): void
+    {
+        $mockHttpClient = $this->createMock(HttpClient::class);
+            $mockHttpClient
+                ->expects($this->exactly(1))
+                ->method('get')
+                ->with('https://api.iconify.test/ph/eye.svg')
+                ->willReturn(new GenericResponse(status: Status::OK, body: '<svg></svg>'));
+
+        $this->container->register(HttpClient::class, fn() => $mockHttpClient);
+        
+        $this->container->singleton(
+            IconConfig::class, 
+            fn () => new IconConfig(iconifyApiUrl: 'https://api.iconify.test')
+        );
+       
+        $this->assertSame(
+            '<svg></svg>',
+            $this->render(
+                '<x-icon name="ph:eye" />',
+            ),
+        );
+    }
+
+    public function test_it_caches_icons_on_the_first_render(): void
+    {
+        $mockHttpClient = $this->createMock(HttpClient::class);
+            $mockHttpClient
+                ->expects($this->once())
+                ->method('get')
+                ->with('https://api.iconify.design/ph/eye.svg')
+                ->willReturn(new GenericResponse(status: Status::OK, body: '<svg></svg>'));
+
+        $this->container->register(HttpClient::class, fn() => $mockHttpClient);
+
+        $this->render('<x-icon name="ph:eye" />');
+
+        $iconCache = $this->container->get(IconCache::class);
+        $cachedIcon = $iconCache?->get('iconify-ph-eye');
+
+        $this->assertNotNull($cachedIcon);
+        $this->assertSame('<svg></svg>', $cachedIcon);
+    }
+
+    public function test_it_renders_an_icon_from_cache(): void
+    {
+        $mockHttpClient = $this->createMock(HttpClient::class);
+        $mockHttpClient
+            ->expects($this->exactly(1))
+            ->method('get')
+            ->with('https://api.iconify.design/ph/eye.svg')
+            ->willReturn(new GenericResponse(status: Status::OK, body: '<svg></svg>'));
+
+        $this->container->register(HttpClient::class, fn() => $mockHttpClient);
+
+        // Trigger first render, which should cache the icon
+        $this->render('<x-icon name="ph:eye" />');
+
+        $this->assertSame(
+            '<svg></svg>',
+            $this->render('<x-icon name="ph:eye" />'),
+        );
+    }
+
+    public function test_it_renders_a_debug_comment_in_local_env_when_icon_does_not_exist(): void
+    {
+        $mockHttpClient = $this->createMock(HttpClient::class);
+        $mockHttpClient
+            ->expects($this->once())
+            ->method('get')
+            ->with('https://api.iconify.design/ph/eye.svg')
+            ->willReturn(new GenericResponse(status: Status::NOT_FOUND, body: ''));
+
+        $this->container->register(HttpClient::class, fn() => $mockHttpClient);
+        $this->container->singleton(AppConfig::class, fn () => new AppConfig(environment: Environment::LOCAL));
+        
+        $this->assertSame(
+            '<!-- unknown-icon: ph:eye -->',
+            $this->render('<x-icon name="ph:eye" />'),
+        );
+    }
+
+    public function test_it_renders_an_empty_string__in_non_local_env_when_icon_does_not_exist(): void
+    {
+        $mockHttpClient = $this->createMock(HttpClient::class);
+        $mockHttpClient
+            ->expects($this->once())
+            ->method('get')
+            ->with('https://api.iconify.design/ph/eye.svg')
+            ->willReturn(new GenericResponse(status: Status::NOT_FOUND, body: ''));
+
+        $this->container->register(HttpClient::class, fn() => $mockHttpClient);
+        $this->container->singleton(AppConfig::class, fn () => new AppConfig(environment: Environment::PRODUCTION));
+
+        $this->assertSame(
+            '',
+            $this->render('<x-icon name="ph:eye" />'),
+        );
+    }
+
+    public function test_it_forwards_the_class_attribute(): void
+    {
+        $mockHttpClient = $this->createMock(HttpClient::class);
+        $mockHttpClient
+            ->expects($this->exactly(1))
+            ->method('get')
+            ->with('https://api.iconify.design/ph/eye.svg')
+            ->willReturn(new GenericResponse(status: Status::OK, body: '<svg></svg>'));
+
+        $this->container->register(HttpClient::class, fn() => $mockHttpClient);
+
+        $this->assertSame(
+            '<svg class="size-5"></svg>',
+            $this->render(
+                '<x-icon name="ph:eye" class="size-5" />',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a new `x-icon` component.

### Usage

```html
<x-icon name="ph:eye" class="size-5 text-zinc-500" />
```

### How it works

On first render, the icon is downloaded from Iconify, and cached indefinitely. On subsequent renders, the icon is pulled from the cache instead of the Iconify API.

### API

The component accepts the following props:

- `name`: The name of the component, in the format `{prefix}:{name}`
- `class`: The class attribute to set on the underlying `svg` HTML element

### Areas of improvement

- [x] Configurable cache duration
- [x] Configurable Iconify API url
- [ ] Default icon prefix

### Documentation

This PR doesn't include documentation for the component, but I plan to send an other PR to address it.

Closes #1002 