### PR TITLE
fix(view): support `<x-component>` in auto-registered components

### DIFF
--- a/src/Tempest/Router/src/Input/InputStream.php
+++ b/src/Tempest/Router/src/Input/InputStream.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tempest\Router\Input;
 
 interface InputStream

--- a/src/Tempest/Router/src/Input/InputStreamInitializer.php
+++ b/src/Tempest/Router/src/Input/InputStreamInitializer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tempest\Router\Input;
 
 use Tempest\Container\Container;

--- a/src/Tempest/Router/src/Input/StdinInputStream.php
+++ b/src/Tempest/Router/src/Input/StdinInputStream.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tempest\Router\Input;
 
 use function Tempest\Support\str;

--- a/src/Tempest/Validation/src/SkipValidation.php
+++ b/src/Tempest/Validation/src/SkipValidation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tempest\Validation;
 
 use Attribute;

--- a/src/Tempest/Validation/tests/Fixtures/ObjectWithObjectProperty.php
+++ b/src/Tempest/Validation/tests/Fixtures/ObjectWithObjectProperty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tempest\Validation\Tests\Fixtures;
 
 final class ObjectWithObjectProperty

--- a/src/Tempest/Validation/tests/Fixtures/ObjectWithSkipValidation.php
+++ b/src/Tempest/Validation/tests/Fixtures/ObjectWithSkipValidation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tempest\Validation\Tests\Fixtures;
 
 use Tempest\Validation\SkipValidation;

--- a/src/Tempest/Validation/tests/Fixtures/ObjectWithStringProperty.php
+++ b/src/Tempest/Validation/tests/Fixtures/ObjectWithStringProperty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tempest\Validation\Tests\Fixtures;
 
 final class ObjectWithStringProperty

--- a/src/Tempest/Validation/tests/Fixtures/ValidateObjectA.php
+++ b/src/Tempest/Validation/tests/Fixtures/ValidateObjectA.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tempest\Validation\Tests\Fixtures;
 
 final class ValidateObjectA

--- a/src/Tempest/Validation/tests/Fixtures/ValidateObjectB.php
+++ b/src/Tempest/Validation/tests/Fixtures/ValidateObjectB.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tempest\Validation\Tests\Fixtures;
 
 use Tempest\Validation\Rules\Length;

--- a/src/Tempest/Validation/tests/Fixtures/ValidateObjectC.php
+++ b/src/Tempest/Validation/tests/Fixtures/ValidateObjectC.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tempest\Validation\Tests\Fixtures;
 
 use Tempest\Validation\Rules\Email;

--- a/src/Tempest/View/src/Elements/ViewComponentElement.php
+++ b/src/Tempest/View/src/Elements/ViewComponentElement.php
@@ -30,7 +30,7 @@ final class ViewComponentElement implements Element
     ) {
         $this->attributes = $attributes;
         $this->dataAttributes = arr($attributes)
-            ->filter(fn ($value, $key) => ! str_starts_with($key, ':'))
+            ->filter(fn ($_, $key) => ! str_starts_with($key, ':'))
             // Attributes are converted to camelCase by default for PHP variable usage, but in the context of data attributes, kebab case is good
             ->mapWithKeys(fn ($value, $key) => yield str($key)->kebab()->toString() => $value)
             ->toArray();

--- a/src/Tempest/View/src/ViewComponentDiscovery.php
+++ b/src/Tempest/View/src/ViewComponentDiscovery.php
@@ -45,7 +45,6 @@ final class ViewComponentDiscovery implements Discovery, DiscoversPath
         }
 
         $fileName = str(pathinfo($path, PATHINFO_FILENAME))->before('.');
-
         $contents = str(file_get_contents($path))->ltrim();
 
         preg_match(
@@ -54,7 +53,7 @@ final class ViewComponentDiscovery implements Discovery, DiscoversPath
             matches: $matches,
         );
 
-        if ($fileName->startsWith('x-')) {
+        if ($fileName->startsWith('x-') && ! isset($matches['name'])) {
             $this->discoveryItems->add($location, [
                 $fileName->toString(),
                 new AnonymousViewComponent(

--- a/src/Tempest/View/src/ViewProcessor.php
+++ b/src/Tempest/View/src/ViewProcessor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tempest\View;
 
 interface ViewProcessor

--- a/src/Tempest/View/src/ViewProcessorDiscovery.php
+++ b/src/Tempest/View/src/ViewProcessorDiscovery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tempest\View;
 
 use Tempest\Discovery\Discovery;

--- a/tests/Integration/View/ViewComponentDiscoveryTest.php
+++ b/tests/Integration/View/ViewComponentDiscoveryTest.php
@@ -30,4 +30,32 @@ final class ViewComponentDiscoveryTest extends FrameworkIntegrationTestCase
             $this->assertStringContainsString('x-input', $duplicateViewComponent->getMessage());
         }
     }
+
+    public function test_auto_registration(): void
+    {
+        $discovery = $this->container->get(ViewComponentDiscovery::class);
+        $discovery->setItems(new DiscoveryItems([]));
+        $discovery->discoverPath(new DiscoveryLocation('', ''), __DIR__ . '/x-auto-registered.view.php');
+        $discovery->apply();
+
+        $html = $this->render(<<<'HTML'
+        <x-auto-registered></x-auto-registered>
+        HTML);
+
+        $this->assertSame('<span>Hello World</span>', $html);
+    }
+
+    public function test_auto_registration_with_x_component(): void
+    {
+        $discovery = $this->container->get(ViewComponentDiscovery::class);
+        $discovery->setItems(new DiscoveryItems([]));
+        $discovery->discoverPath(new DiscoveryLocation('', ''), __DIR__ . '/x-auto-registered-with-declaration.view.php');
+        $discovery->apply();
+
+        $html = $this->render(<<<'HTML'
+        <x-auto-registered-with-declaration></x-auto-registered-with-x-component>
+        HTML);
+
+        $this->assertSame('<span>Hello World</span>', $html);
+    }
 }

--- a/tests/Integration/View/x-auto-registered-with-declaration.view.php
+++ b/tests/Integration/View/x-auto-registered-with-declaration.view.php
@@ -1,0 +1,8 @@
+<?php
+use function Tempest\Support\Str\to_title_case;
+
+?>
+
+<x-component name="x-auto-registered-with-declaration">
+	<span>{{ to_title_case('hello world') }}</span>
+</x-component>

--- a/tests/Integration/View/x-auto-registered.view.php
+++ b/tests/Integration/View/x-auto-registered.view.php
@@ -1,0 +1,5 @@
+<?php
+use function Tempest\Support\Str\to_title_case;
+?>
+
+<span>{{ to_title_case('hello world') }}</span>


### PR DESCRIPTION
Closes #1017

This pull request adds backwards compatibility to components that use `<x-component>` to declare themselves.