### PR TITLE
fix(view): render falsy and truthy data attributes

### DIFF
--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -6,6 +6,7 @@ namespace Tests\Tempest\Integration\View;
 
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use Tempest\Core\AppConfig;
 use Tempest\Core\Environment;
 use Tempest\Router\Session\Session;
@@ -17,6 +18,7 @@ use Tempest\View\ViewCache;
 use Tests\Tempest\Fixtures\Views\Chapter;
 use Tests\Tempest\Fixtures\Views\DocsView;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
 use function Tempest\view;
 
 /**
@@ -46,8 +48,8 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
             expected: '<div foo="hello" bar="barValue"></div>',
             actual: $this->render(view(
                 <<<'HTML'
-                    <x-my :foo="$this->input" bar="barValue"></x-my>
-                    HTML,
+                <x-my :foo="$this->input" bar="barValue"></x-my>
+                HTML,
             )->data(input: 'hello')),
         );
     }
@@ -63,19 +65,18 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
     public function test_view_can_access_dynamic_slots(): void
     {
         $this->registerViewComponent('x-test', <<<'HTML'
-            <div :foreach="$slots as $slot">
-                <div>{{ $slot->name }}</div>
-                <div>{{ $slot->attributes['language'] }}</div>
-                <div>{{ $slot->language }}</div>
-                <div>{!! $slot->content !!}</div>
-            </div>
-            HTML,
-        );
+        <div :foreach="$slots as $slot">
+            <div>{{ $slot->name }}</div>
+            <div>{{ $slot->attributes['language'] }}</div>
+            <div>{{ $slot->language }}</div>
+            <div>{!! $slot->content !!}</div>
+        </div>
+        HTML);
 
         $html = $this->render(<<<'HTML_WRAP'
         <x-test>
-            <x-slot name="slot-php" language="PHP">PHP Body</x-slot>    
-            <x-slot name="slot-html" language="HTML">HTML Body</x-slot>    
+            <x-slot name="slot-php" language="PHP">PHP Body</x-slot>
+            <x-slot name="slot-html" language="HTML">HTML Body</x-slot>
         </x-test>
         HTML_WRAP);
 
@@ -88,16 +89,15 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
     public function test_dynamic_slots_are_cleaned_up(): void
     {
         $this->registerViewComponent('x-test', <<<'HTML'
-            <div :foreach="$slots as $slot">
-                <div>{{ $slot->name }}</div>
-            </div>
-            <x-slot />
-            HTML,
-        );
+        <div :foreach="$slots as $slot">
+            <div>{{ $slot->name }}</div>
+        </div>
+        <x-slot />
+        HTML);
 
         $html = $this->render(<<<'HTML'
         <x-test>
-            <x-slot name="a"></x-slot>    
+            <x-slot name="a"></x-slot>
             <x-slot name="b"></x-slot>
             <div :if="isset($slots)">internal slots still here</div>
             <div :else>internal slots are cleared</div>
@@ -114,19 +114,17 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
     public function test_slots_with_nested_view_components(): void
     {
         $this->registerViewComponent('x-a', <<<'HTML'
-            <x-slot />
-            <div :foreach="$slots as $slot">
-                <div>A{{ $slot->name }}</div>
-            </div>
-            HTML,
-        );
+        <x-slot />
+        <div :foreach="$slots as $slot">
+            <div>A{{ $slot->name }}</div>
+        </div>
+        HTML);
 
         $this->registerViewComponent('x-b', <<<'HTML'
-            <div :foreach="$slots as $slot">
-                <div>B{{ $slot->name }}</div>
-            </div>
-            HTML,
-        );
+        <div :foreach="$slots as $slot">
+            <div>B{{ $slot->name }}</div>
+        </div>
+        HTML);
 
         $html = $this->render(<<<'HTML'
         <x-a>
@@ -153,22 +151,22 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
 
         $this->render('', slots: []);
     }
-    
+
     public function test_nested_components(): void
     {
         $this->assertStringEqualsStringIgnoringLineEndings(
             expected: <<<'HTML'
-                <form action="#" method="post"><div><div><label for="a">a</label><input type="number" name="a" id="a" value></input></div></div><div><label for="b">b</label><input type="text" name="b" id="b" value></input></div></form>
-                HTML,
+            <form action="#" method="post"><div><div><label for="a">a</label><input type="number" name="a" id="a" value></input></div></div><div><label for="b">b</label><input type="text" name="b" id="b" value></input></div></form>
+            HTML,
             actual: $this->render(view(
                 <<<'HTML'
-                    <x-form action="#">
-                        <div>
-                            <x-input name="a" label="a" type="number"></x-input>
-                        </div>
-                        <x-input name="b" label="b" type="text" />
-                    </x-form>
-                    HTML,
+                <x-form action="#">
+                    <div>
+                        <x-input name="a" label="a" type="number"></x-input>
+                    </div>
+                    <x-input name="b" label="b" type="text" />
+                </x-form>
+                HTML,
             )),
         );
     }
@@ -178,11 +176,11 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         $html = $this->render('<x-view-component-with-another-one-included-a/>');
 
         $this->assertStringContainsStringIgnoringLineEndings(<<<'HTML'
-            hi
+        hi
 
-                
-            <div class="slot-b"><div class="slot-a"></div></div>
-            HTML, $html);
+
+        <div class="slot-b"><div class="slot-a"></div></div>
+        HTML, $html);
     }
 
     public function test_component_with_anther_component_included_with_slot(): void
@@ -190,13 +188,13 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         $html = $this->render('<x-view-component-with-another-one-included-a>test</x-view-component-with-another-one-included-a>');
 
         $this->assertStringEqualsStringIgnoringLineEndings(<<<'HTML'
-            hi
+        hi
 
-                
-            <div class="slot-b"><div class="slot-a">
-                        test
-                    </div></div>
-            HTML, $html);
+
+        <div class="slot-b"><div class="slot-a">
+                    test
+                </div></div>
+        HTML, $html);
     }
 
     public function test_view_component_with_injected_view(): void
@@ -218,8 +216,8 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
 
         $html = $this->render(view(
             <<<'HTML'
-                <x-input name="name" label="a" type="number" />
-                HTML,
+            <x-input name="name" label="a" type="number" />
+            HTML,
         ));
 
         $this->assertStringContainsString('value="original name"', $html);
@@ -261,8 +259,8 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
     {
         $this->assertSame(
             <<<HTML
-                <div class="anonymous">hi</div>
-                HTML,
+            <div class="anonymous">hi</div>
+            HTML,
             $this->render(view('<x-my-a>hi</x-my-a>')),
         );
     }
@@ -285,8 +283,8 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
 
         $this->assertStringEqualsStringIgnoringLineEndings(
             <<<HTML
-                <div>test</div>
-                HTML,
+            <div>test</div>
+            HTML,
             $rendered,
         );
     }
@@ -299,8 +297,8 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
 
         $this->assertStringEqualsStringIgnoringLineEndings(
             <<<HTML
-                <div>test</div>
-                HTML,
+            <div>test</div>
+            HTML,
             $rendered,
         );
     }
@@ -309,15 +307,14 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
     {
         $rendered = $this->render(
             view(<<<HTML
-                <x-with-variable :variable="strtoupper('test')"></x-with-variable>
-                HTML,
-            ),
+            <x-with-variable :variable="strtoupper('test')"></x-with-variable>
+            HTML),
         );
 
         $this->assertStringEqualsStringIgnoringLineEndings(
             <<<HTML
-                <div>TEST</div>
-                HTML,
+            <div>TEST</div>
+            HTML,
             $rendered,
         );
     }
@@ -345,8 +342,8 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         $rendered = $this->render(
             view(
                 <<<'HTML'
-                    <x-with-variable :foreach="$this->variables as $variable" :variable="$variable"></x-with-variable>
-                    HTML,
+                <x-with-variable :foreach="$this->variables as $variable" :variable="$variable"></x-with-variable>
+                HTML,
             )->data(
                 variables: ['a', 'b', 'c'],
             ),
@@ -373,8 +370,8 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         $html = $this->render(view(__DIR__ . '/../../Fixtures/Views/view-component-attribute-without-this-b.view.php'));
 
         $this->assertSame(<<<HTML
-            fromString
-            HTML, $html);
+        fromString
+        HTML, $html);
     }
 
     public function test_view_component_slots_without_self_closing_tags(): void
@@ -382,19 +379,19 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         $html = $this->render(view(__DIR__ . '/../../Fixtures/Views/view-component-with-non-self-closing-slot-b.view.php'));
 
         $this->assertStringEqualsStringIgnoringLineEndings(<<<HTML
-            A: other slot
-                B: other slot
-                C: other slot
+        A: other slot
+            B: other slot
+            C: other slot
 
-                A: 
-                main slot
-                
-                B: 
-                main slot
-                
-                C: 
-                main slot
-            HTML, $html);
+            A:
+            main slot
+
+            B:
+            main slot
+
+            C:
+            main slot
+        HTML, $html);
     }
 
     public function test_view_component_with_camelcase_attribute(): void
@@ -413,12 +410,15 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
 
     public function test_template_component(): void
     {
-        $html = $this->render(<<<'HTML'
-            <x-template :foreach="$items as $item">
-                <div>item {{ $item }}</div>
-                <div>boo</div>
-            </x-template>
-        HTML, items: ['a', 'b', 'c']);
+        $html = $this->render(
+            <<<'HTML'
+                <x-template :foreach="$items as $item">
+                    <div>item {{ $item }}</div>
+                    <div>boo</div>
+                </x-template>
+            HTML,
+            items: ['a', 'b', 'c'],
+        );
 
         $this->assertStringEqualsStringIgnoringLineEndings(<<<'HTML'
         <div>item a</div><div>boo</div>
@@ -456,7 +456,7 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
             '<div foo="fooValue" bar="barValue">body</div>',
         ];
     }
-    
+
     public function test_full_html_document_as_component(): void
     {
         $this->registerViewComponent('x-layout', <<<'HTML'
@@ -480,7 +480,7 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         $this->assertStringContainsString('Hello World', $html);
         $this->assertStringContainsString('</body></html>', $html);
     }
-    
+
     public function test_empty_slots_are_commented_out(): void
     {
         $this->registerViewComponent('x-layout', <<<'HTML'
@@ -625,5 +625,36 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         $html = $this->render('<x-file-component></x-file-component>');
 
         $this->assertSame('<div>hi!</div>', $html);
+    }
+
+    #[TestWith([true])]
+    #[TestWith(['true'])]
+    #[TestWith(['1'])]
+    #[TestWith(['0'])]
+    #[TestWith([1])]
+    public function test_truthy_bool_attribute(mixed $value): void
+    {
+        $html = $this->render(<<<HTML
+        <div :data-active="{$value}"></div>
+        HTML);
+
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'HTML'
+        <div data-active></div>
+        HTML, $html);
+    }
+
+    #[TestWith([false])]
+    #[TestWith([null])]
+    #[TestWith(['false'])]
+    #[TestWith([0])]
+    public function test_falsy_bool_attribute(mixed $value): void
+    {
+        $html = $this->render(<<<HTML
+        <div :data-active="{$value}"></div>
+        HTML);
+
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'HTML'
+        <div></div>
+        HTML, $html);
     }
 }


### PR DESCRIPTION
Another day, another Tempest View improvement in sight!

This pull request adds failing tests for rendering truthy and falsy attributes in an expected way:

```html
<div :data-active="true"></div>
<!-- Should render: <div data-active></div> -->
```

```html
<div :data-active="false"></div>
<!-- Should render: <div></div> -->
```