### PR TITLE
fix(vite): generate absolute asset urls

### DIFF
--- a/src/Tempest/Vite/src/TagsResolver/ManifestTagsResolver.php
+++ b/src/Tempest/Vite/src/TagsResolver/ManifestTagsResolver.php
@@ -14,6 +14,7 @@ use Tempest\Vite\ViteConfig;
 use function Tempest\root_path;
 use function Tempest\Support\arr;
 use function Tempest\Support\str;
+use function Tempest\Support\Str\ensure_starts_with;
 
 final readonly class ManifestTagsResolver implements TagsResolver
 {
@@ -237,7 +238,7 @@ final readonly class ManifestTagsResolver implements TagsResolver
 
     private function getAssetPath(string $path): string
     {
-        return $this->viteConfig->build->buildDirectory . '/' . $path;
+        return ensure_starts_with($this->viteConfig->build->buildDirectory . '/' . $path, prefix: '/');
     }
 
     private function fileToAssetPath(string $file): string

--- a/tests/Integration/Vite/ManifestTagsResolverTest.php
+++ b/tests/Integration/Vite/ManifestTagsResolverTest.php
@@ -30,7 +30,7 @@ final class ManifestTagsResolverTest extends FrameworkIntegrationTestCase
 
         $this->assertSame(
             expected: [
-                '<script type="module" src="build/assets/main-YJD4Cw3J.js"></script>',
+                '<script type="module" src="/build/assets/main-YJD4Cw3J.js"></script>',
             ],
             actual: $resolver->resolveTags(['src/main.ts']),
         );
@@ -46,8 +46,8 @@ final class ManifestTagsResolverTest extends FrameworkIntegrationTestCase
 
         $this->assertSame(
             expected: [
-                '<link rel="stylesheet" href="build/assets/main-DObprJ9K.css" />',
-                '<script type="module" src="build/assets/main-CK61jJwL.js"></script>',
+                '<link rel="stylesheet" href="/build/assets/main-DObprJ9K.css" />',
+                '<script type="module" src="/build/assets/main-CK61jJwL.js"></script>',
             ],
             actual: $resolver->resolveTags(['src/main.ts']),
         );
@@ -73,16 +73,16 @@ final class ManifestTagsResolverTest extends FrameworkIntegrationTestCase
 
         $tags = $resolver->resolveTags(['resources/js/app.js']);
 
-        $this->assertContains('<link rel="modulepreload" href="build/assets/index-BSdK3M0e.js" nonce="123" />', $tags);
-        $this->assertContains('<link rel="stylesheet" href="build/assets/index-B3s1tYeC.css" nonce="123" />', $tags);
-        $this->assertContains('<script type="module" src="build/assets/app-lliD09ip.js" nonce="123"></script>', $tags);
+        $this->assertContains('<link rel="modulepreload" href="/build/assets/index-BSdK3M0e.js" nonce="123" />', $tags);
+        $this->assertContains('<link rel="stylesheet" href="/build/assets/index-B3s1tYeC.css" nonce="123" />', $tags);
+        $this->assertContains('<script type="module" src="/build/assets/app-lliD09ip.js" nonce="123"></script>', $tags);
 
         if ($strategy !== PrefetchStrategy::NONE) {
             $this->assertStringContainsString('nonce="123', $tags[3]);
             $this->assertStringContainsString(
                 needle: <<<JS
-                    [{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/index-B3s1tYeC.css"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/index-BSdK3M0e.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/_plugin-vue_export-helper-DlAUqK2U.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/ApplicationLogo-BhIZH06z.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/GuestLayout-BY3LC-73.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/TextInput-C8CCB_U_.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/PrimaryButton-DuXwr-9M.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/ConfirmPassword-CDwcgU8E.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/ForgotPassword-B0WWE0BO.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/Login-DAFSdGSW.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/Register-CfYQbTlA.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/ResetPassword-BNl7a4X1.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/VerifyEmail-CyukB_SZ.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/AuthenticatedLayout-DfWF52N1.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/Dashboard-DM_LxQy2.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/DeleteUserForm-B1oHFaVP.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/UpdatePasswordForm-CaeWqGla.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/UpdateProfileInformationForm-CJwkYwQQ.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/Edit-CYV2sXpe.js"},{"rel":"prefetch","fetchpriority":"low","href":"build\/assets\/Welcome-D_7l79PQ.js"}]
-                    JS,
+                [{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/index-B3s1tYeC.css"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/index-BSdK3M0e.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/_plugin-vue_export-helper-DlAUqK2U.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/ApplicationLogo-BhIZH06z.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/GuestLayout-BY3LC-73.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/TextInput-C8CCB_U_.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/PrimaryButton-DuXwr-9M.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/ConfirmPassword-CDwcgU8E.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/ForgotPassword-B0WWE0BO.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/Login-DAFSdGSW.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/Register-CfYQbTlA.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/ResetPassword-BNl7a4X1.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/VerifyEmail-CyukB_SZ.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/AuthenticatedLayout-DfWF52N1.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/Dashboard-DM_LxQy2.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/DeleteUserForm-B1oHFaVP.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/UpdatePasswordForm-CaeWqGla.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/UpdateProfileInformationForm-CJwkYwQQ.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/Edit-CYV2sXpe.js"},{"rel":"prefetch","fetchpriority":"low","href":"\/build\/assets\/Welcome-D_7l79PQ.js"}]
+                JS,
                 haystack: $tags[3],
             );
         }

--- a/tests/Integration/Vite/ViteTagsComponentTest.php
+++ b/tests/Integration/Vite/ViteTagsComponentTest.php
@@ -33,19 +33,19 @@ final class ViteTagsComponentTest extends FrameworkIntegrationTestCase
                 ));
 
                 $html = $this->render(<<<'HTML'
-                    <html lang="en">
-                    <head>
-                        <x-vite-tags entrypoint="src/foo.ts" />
-                    </head>
-                    <body>Foo</body>
-                    </html>
-                    HTML);
+                <html lang="en">
+                <head>
+                    <x-vite-tags entrypoint="src/foo.ts" />
+                </head>
+                <body>Foo</body>
+                </html>
+                HTML);
 
                 $this->assertStringEqualsStringIgnoringLineEndings(
                     expected: <<<HTML
-                        <html lang="en"><head><script type="module" src="http://localhost:5173/@vite/client"></script><script type="module" src="http://localhost:5173/src/foo.ts"></script></head><body>Foo
-                        </body></html>
-                        HTML,
+                    <html lang="en"><head><script type="module" src="http://localhost:5173/@vite/client"></script><script type="module" src="http://localhost:5173/src/foo.ts"></script></head><body>Foo
+                    </body></html>
+                    HTML,
                     actual: $html,
                 );
             },
@@ -68,19 +68,19 @@ final class ViteTagsComponentTest extends FrameworkIntegrationTestCase
                 ));
 
                 $html = $this->render(<<<'HTML'
-                    <html lang="en">
-                    <head>
-                        <x-vite-tags :entrypoint="['src/foo.ts', 'src/bar.css']" />
-                    </head>
-                    <body>Foo</body>
-                    </html>
-                    HTML);
+                <html lang="en">
+                <head>
+                    <x-vite-tags :entrypoint="['src/foo.ts', 'src/bar.css']" />
+                </head>
+                <body>Foo</body>
+                </html>
+                HTML);
 
                 $this->assertStringEqualsStringIgnoringLineEndings(
                     expected: <<<HTML
-                        <html lang="en"><head><script type="module" src="http://localhost:5173/@vite/client"></script><script type="module" src="http://localhost:5173/src/foo.ts"></script><link rel="stylesheet" href="http://localhost:5173/src/bar.css" /></head><body>Foo
-                        </body></html>
-                        HTML,
+                    <html lang="en"><head><script type="module" src="http://localhost:5173/@vite/client"></script><script type="module" src="http://localhost:5173/src/foo.ts"></script><link rel="stylesheet" href="http://localhost:5173/src/bar.css" /></head><body>Foo
+                    </body></html>
+                    HTML,
                     actual: $html,
                 );
             },
@@ -103,19 +103,19 @@ final class ViteTagsComponentTest extends FrameworkIntegrationTestCase
                 ));
 
                 $html = $this->render(<<<'HTML'
-                    <html lang="en">
-                    <head>
-                        <x-vite-tags />
-                    </head>
-                    <body>Foo</body>
-                    </html>
-                    HTML);
+                <html lang="en">
+                <head>
+                    <x-vite-tags />
+                </head>
+                <body>Foo</body>
+                </html>
+                HTML);
 
                 $this->assertStringEqualsStringIgnoringLineEndings(
                     expected: <<<HTML
-                        <html lang="en"><head><script type="module" src="http://localhost:5173/@vite/client"></script><script type="module" src="http://localhost:5173/src/foo.ts"></script><link rel="stylesheet" href="http://localhost:5173/src/bar.css" /></head><body>Foo
-                        </body></html>
-                        HTML,
+                    <html lang="en"><head><script type="module" src="http://localhost:5173/@vite/client"></script><script type="module" src="http://localhost:5173/src/foo.ts"></script><link rel="stylesheet" href="http://localhost:5173/src/bar.css" /></head><body>Foo
+                    </body></html>
+                    HTML,
                     actual: $html,
                 );
             },
@@ -139,17 +139,17 @@ final class ViteTagsComponentTest extends FrameworkIntegrationTestCase
                 ));
 
                 $html = $this->render(<<<'HTML'
-                    <html lang="en">
-                    <head>
-                        <x-vite-tags />
-                    </head>
-                    <body></body>
-                    </html>
-                    HTML);
+                <html lang="en">
+                <head>
+                    <x-vite-tags />
+                </head>
+                <body></body>
+                </html>
+                HTML);
 
                 $this->assertStringEqualsStringIgnoringLineEndings(<<<'HTML'
-                    <html lang="en"><head><script type="module" src="build/assets/foo-YJD4Cw3J.js"></script></head><body></body></html>
-                    HTML, $html);
+                <html lang="en"><head><script type="module" src="/build/assets/foo-YJD4Cw3J.js"></script></head><body></body></html>
+                HTML, $html);
             },
             files: [
                 'public/build/manifest.json' => $this->fixture('two-unrelated-entrypoints.json'),
@@ -169,17 +169,17 @@ final class ViteTagsComponentTest extends FrameworkIntegrationTestCase
                 ));
 
                 $html = $this->render(<<<'HTML'
-                    <html lang="en">
-                    <head>
-                        <x-vite-tags entrypoint="src/bar.ts" />
-                    </head>
-                    <body></body>
-                    </html>
-                    HTML);
+                <html lang="en">
+                <head>
+                    <x-vite-tags entrypoint="src/bar.ts" />
+                </head>
+                <body></body>
+                </html>
+                HTML);
 
                 $this->assertStringEqualsStringIgnoringLineEndings(<<<'HTML'
-                    <html lang="en"><head><script type="module" src="build/assets/bar-WlXl03ld.js"></script></head><body></body></html>
-                    HTML, $html);
+                <html lang="en"><head><script type="module" src="/build/assets/bar-WlXl03ld.js"></script></head><body></body></html>
+                HTML, $html);
             },
             files: [
                 'public/build/manifest.json' => $this->fixture('two-unrelated-entrypoints.json'),
@@ -199,17 +199,17 @@ final class ViteTagsComponentTest extends FrameworkIntegrationTestCase
                 ));
 
                 $html = $this->render(<<<'HTML'
-                    <html lang="en">
-                    <head>
-                        <x-vite-tags :entrypoints="['src/bar.ts', 'src/foo.ts']" />
-                    </head>
-                    <body></body>
-                    </html>
-                    HTML);
+                <html lang="en">
+                <head>
+                    <x-vite-tags :entrypoints="['src/bar.ts', 'src/foo.ts']" />
+                </head>
+                <body></body>
+                </html>
+                HTML);
 
                 $this->assertStringEqualsStringIgnoringLineEndings(<<<'HTML'
-                    <html lang="en"><head><script type="module" src="build/assets/bar-WlXl03ld.js"></script><script type="module" src="build/assets/foo-YJD4Cw3J.js"></script></head><body></body></html>
-                    HTML, $html);
+                <html lang="en"><head><script type="module" src="/build/assets/bar-WlXl03ld.js"></script><script type="module" src="/build/assets/foo-YJD4Cw3J.js"></script></head><body></body></html>
+                HTML, $html);
             },
             files: [
                 'public/build/manifest.json' => $this->fixture('two-unrelated-entrypoints.json'),

--- a/tests/Integration/Vite/ViteTest.php
+++ b/tests/Integration/Vite/ViteTest.php
@@ -94,7 +94,7 @@ final class ViteTest extends FrameworkIntegrationTestCase
 
                 $this->assertSame(
                     expected: [
-                        '<script type="module" src="build/assets/main-YJD4Cw3J.js"></script>',
+                        '<script type="module" src="/build/assets/main-YJD4Cw3J.js"></script>',
                     ],
                     actual: $tags,
                 );
@@ -130,8 +130,8 @@ final class ViteTest extends FrameworkIntegrationTestCase
 
                 $this->assertSame(
                     expected: [
-                        '<link rel="stylesheet" href="build/assets/main-DObprJ9K.css" />',
-                        '<script type="module" src="build/assets/main-CK61jJwL.js"></script>',
+                        '<link rel="stylesheet" href="/build/assets/main-DObprJ9K.css" />',
+                        '<script type="module" src="/build/assets/main-CK61jJwL.js"></script>',
                     ],
                     actual: $tags,
                 );
@@ -151,9 +151,9 @@ final class ViteTest extends FrameworkIntegrationTestCase
 
                 $this->assertSame(
                     expected: [
-                        '<link rel="modulepreload" href="build/assets/index-BSdK3M0e.js" />',
-                        '<link rel="stylesheet" href="build/assets/index-B3s1tYeC.css" />',
-                        '<script type="module" src="build/assets/app-lliD09ip.js"></script>',
+                        '<link rel="modulepreload" href="/build/assets/index-BSdK3M0e.js" />',
+                        '<link rel="stylesheet" href="/build/assets/index-B3s1tYeC.css" />',
+                        '<script type="module" src="/build/assets/app-lliD09ip.js"></script>',
                     ],
                     actual: $tags,
                 );
@@ -179,7 +179,7 @@ final class ViteTest extends FrameworkIntegrationTestCase
                 $tags = $vite->getTags(['src/bar.ts']);
 
                 $this->assertSame(
-                    expected: ['<script type="module" src="build/assets/bar-WlXl03ld.js"></script>'],
+                    expected: ['<script type="module" src="/build/assets/bar-WlXl03ld.js"></script>'],
                     actual: $tags,
                 );
             },


### PR DESCRIPTION
This pull request fixes the generation of asset URLs in Vite by making them absolute, relative to the root.

There is no "asset url" option right now, but open to add it in the future when someone first needs it.