### PR TITLE
feat(http): fix http header casing on retrieval

### DIFF
--- a/src/Tempest/Router/src/IsRequest.php
+++ b/src/Tempest/Router/src/IsRequest.php
@@ -25,7 +25,7 @@ trait IsRequest
     private(set) array $body = [];
 
     #[SkipValidation]
-    private(set) array $headers = [];
+    private(set) RequestHeaders $headers;
 
     #[SkipValidation]
     private(set) string $path;
@@ -52,7 +52,7 @@ trait IsRequest
         $this->method = $method;
         $this->uri = $uri;
         $this->body = $body;
-        $this->headers = $headers;
+        $this->headers = RequestHeaders::normalizeFromArray($headers);
         $this->files = $files;
 
         $this->path ??= $this->resolvePath();

--- a/src/Tempest/Router/src/Mappers/PsrRequestToGenericRequestMapper.php
+++ b/src/Tempest/Router/src/Mappers/PsrRequestToGenericRequestMapper.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\UploadedFileInterface;
 use Tempest\Http\Method;
 use Tempest\Mapper\Mapper;
 use Tempest\Router\GenericRequest;
+use Tempest\Router\RequestHeaders;
 use Tempest\Router\Upload;
 
 use function Tempest\map;
@@ -50,7 +51,7 @@ final readonly class PsrRequestToGenericRequestMapper implements Mapper
             'method' => Method::from($from->getMethod()),
             'uri' => (string) $from->getUri(),
             'body' => $data,
-            'headers' => $headersAsString,
+            'headers' => RequestHeaders::normalizeFromArray($headersAsString),
             'path' => $from->getUri()->getPath(),
             'query' => $query,
             'files' => $uploads,

--- a/src/Tempest/Router/src/Mappers/RequestToPsrRequestMapper.php
+++ b/src/Tempest/Router/src/Mappers/RequestToPsrRequestMapper.php
@@ -23,7 +23,7 @@ final readonly class RequestToPsrRequestMapper implements Mapper
             uploadedFiles: $from->files,
             uri: $from->uri,
             method: $from->method->value,
-            headers: $from->headers,
+            headers: $from->headers->toArray(),
             cookieParams: $from->cookies,
             queryParams: $from->query,
             parsedBody: $from->body,

--- a/src/Tempest/Router/src/Request.php
+++ b/src/Tempest/Router/src/Request.php
@@ -21,7 +21,7 @@ interface Request
         get;
     }
 
-    public array $headers {
+    public RequestHeaders $headers {
         get;
     }
 

--- a/src/Tempest/Router/src/RequestHeaders.php
+++ b/src/Tempest/Router/src/RequestHeaders.php
@@ -18,7 +18,7 @@ final readonly class RequestHeaders implements ArrayAccess, IteratorAggregate
     public static function normalizeFromArray(array $headers): self
     {
         $normalized = array_combine(
-            array_map('strtolower', array_keys($headers)),
+            array_map(strtolower(...), array_keys($headers)),
             array_values($headers),
         );
         return new self($normalized);

--- a/src/Tempest/Router/src/RequestHeaders.php
+++ b/src/Tempest/Router/src/RequestHeaders.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Router;
+
+use ArrayAccess;
+use ArrayIterator;
+use IteratorAggregate;
+use LogicException;
+use Traversable;
+
+final readonly class RequestHeaders implements ArrayAccess, IteratorAggregate
+{
+    /**
+     * @param array<string, string> $headers
+     */
+    public static function normalizeFromArray(array $headers): self
+    {
+        $normalized = array_combine(
+            array_map('strtolower', array_keys($headers)),
+            array_values($headers),
+        );
+        return new self($normalized);
+    }
+
+    /** @param array<string, string> $headers */
+    private function __construct(
+        private array $headers = [],
+    ) {
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        $offset = strtolower($offset);
+
+        return isset($this->headers[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): string
+    {
+        return $this->get((string) $offset);
+    }
+
+    public function get(string $name): string
+    {
+        return $this->headers[strtolower($name)];
+    }
+
+    public function getHeader(string $name): Header
+    {
+        return new Header(strtolower($name), [$this->get($name)]);
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new LogicException('Unable to alter request headers.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new LogicException('Unable to alter request headers.');
+    }
+
+    public function toArray(): array
+    {
+        return $this->headers;
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->headers);
+    }
+}

--- a/src/Tempest/Router/tests/GenericRequestTest.php
+++ b/src/Tempest/Router/tests/GenericRequestTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Tests;
+
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use Tempest\Http\Method;
+use Tempest\Router\GenericRequest;
+use Tempest\Router\Header;
+use Tempest\Router\RequestHeaders;
+
+final class GenericRequestTest extends TestCase
+{
+    public function test_normalizes_header_access(): void
+    {
+        $upperCaseValue = 'UpperCase';
+        $lowerCaseValue = 'LowerCase';
+
+        $request = new GenericRequest(
+            method: Method::GET,
+            uri: '/',
+            headers: [
+                'UPPERCASE' => $upperCaseValue,
+                'lowercase' => $lowerCaseValue,
+            ],
+        );
+
+        $this->assertSame($upperCaseValue, $request->headers['uppercase']);
+        $this->assertSame($upperCaseValue, $request->headers['UPPerCasE']);
+        $this->assertSame($lowerCaseValue, $request->headers['lowercase']);
+
+        $this->assertSame($upperCaseValue, $request->headers->get('UpperCase'));
+        $this->assertEquals(
+            new Header('uppercase', [$upperCaseValue]),
+            $request->headers->getHeader('UpperCase'),
+        );
+    }
+
+    public function test_throws_on_set(): void
+    {
+        $headers = new GenericRequest(
+            method: Method::GET,
+            uri: '/',
+        )->headers;
+
+        $this->expectException(LogicException::class);
+        $headers['x'] = 'yes';
+    }
+
+    public function test_throws_on_unset(): void
+    {
+        $headers = new GenericRequest(
+            method: Method::GET,
+            uri: '/',
+            headers: [
+                'x' => 'yes',
+            ],
+        )->headers;
+
+        $this->expectException(LogicException::class);
+        unset($headers['x']);
+    }
+}


### PR DESCRIPTION
# What

Fixes #1006 .

- Ensures all headers keys are lowercased when constructing the request and when retrieving the values from the headers

# How to test

1. Have a controller with this method
```
    #[Get('/headers')]
    public function headers(Request $request): Response {
        return new Ok([
            'host' => $request->headers['host'] ?? null,
            'Host' => $request->headers['Host'] ?? null,
        ]);
    }
```
2. Call the method and see as a result `{"host":"localhost:8000","Host":"localhost:8000"}`. 

# Notes

1. I did not yet do any work on the cookie retrieval. I will do that in a later PR. The reason being, the cookies in a request are accessed through the container instead of passing them through (like any other array). I think I might rework that in one go.
