### PR TITLE
feat(console): add `editor:metadata` command

### DIFF
--- a/src/Tempest/Console/src/Commands/EditorMetadataCommand.php
+++ b/src/Tempest/Console/src/Commands/EditorMetadataCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Commands;
+
+use Tempest\Console\Console;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Console\HasConsole;
+use Tempest\Core\Kernel;
+
+final readonly class EditorMetadataCommand
+{
+    use HasConsole;
+
+    public function __construct(
+        private Console $console,
+        private Kernel $kernel,
+    ) {
+    }
+
+    #[ConsoleCommand(
+        name: 'editor:metadata',
+        description: 'Returns metadata for integration with text editors.',
+        hidden: true,
+    )]
+    public function __invoke(): void
+    {
+        $this->console->write(
+            contents: json_encode($this->collectMetadata(), JSON_PRETTY_PRINT),
+        );
+    }
+
+    /**
+     * Collects metadata about the framework and the application
+     */
+    private function collectMetadata(): array
+    {
+        return ['framework' => $this->getFrameworkMetadata()];
+    }
+
+    /**
+     * Retrieves the metadata of the framework.
+     *
+     * @return array<string, mixed>
+     */
+    private function getFrameworkMetadata(): array
+    {
+        return [
+            'name' => 'Tempest',
+            'version' => $this->kernel::VERSION,
+        ];
+    }
+}


### PR DESCRIPTION
### Summary

This PR adds a new _hidden_ `editor:metadata` command to the framework.

### Description

The goal of the `editor:metadata` command is to expose metadata about the framework and the host application to text editors such as VS Code, allowing for a richer development experience.

In this initial PR, we break the ground by providing a simple `framework` field that exposes the name of the framework, and its version. In the future, the metadata will contain information such as configuration values, discovery locations, component names, etc.

### Exchange format

Metadata is exchanged in the form of a JSON payload directly emitted on stdout.

```shell
~/Code/tempest/framework php tempest editor:metadata
{
    "framework": {
        "name": "Tempest",
        "version": "1.0.0-alpha.5"
    }
}%
```