### PR TITLE
feat(validation): allow `Stringable` objects in `IsString` rule

### DIFF
--- a/src/Tempest/Validation/src/Rules/IsString.php
+++ b/src/Tempest/Validation/src/Rules/IsString.php
@@ -6,6 +6,7 @@ namespace Tempest\Validation\Rules;
 
 use Attribute;
 use Tempest\Validation\Rule;
+use Stringable;
 
 #[Attribute]
 final readonly class IsString implements Rule
@@ -18,6 +19,10 @@ final readonly class IsString implements Rule
     public function isValid(mixed $value): bool
     {
         if ($this->orNull && $value === null) {
+            return true;
+        }
+
+        if ($value instanceof Stringable) {
             return true;
         }
 

--- a/src/Tempest/Validation/src/Rules/IsString.php
+++ b/src/Tempest/Validation/src/Rules/IsString.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tempest\Validation\Rules;
 
 use Attribute;
-use Tempest\Validation\Rule;
 use Stringable;
+use Tempest\Validation\Rule;
 
 #[Attribute]
 final readonly class IsString implements Rule

--- a/src/Tempest/Validation/tests/Rules/IsStringTest.php
+++ b/src/Tempest/Validation/tests/Rules/IsStringTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Validation\Tests\Rules;
+
+use PHPUnit\Framework\TestCase;
+use Stringable;
+use Tempest\Validation\Rules\IsString;
+
+/**
+ * @internal
+ */
+final class IsStringTest extends TestCase
+{
+    public function test_valid_non_nullable_string(): void
+    {
+        $rule = new IsString();
+
+        $this->assertTrue($rule->isValid('test string'));
+        $this->assertFalse($rule->isValid(false));
+        $this->assertFalse($rule->isValid([]));
+        $this->assertSame('Value should be a string', $rule->message());
+    }
+
+    public function test_valid_nullable_string(): void
+    {
+        $rule = new IsString(orNull: true);
+
+        $this->assertTrue($rule->isValid('test string'));
+        $this->assertTrue($rule->isValid(null));
+        $this->assertFalse($rule->isValid(false));
+        $this->assertFalse($rule->isValid([]));
+    }
+
+    public function test_valid_stringable_object(): void
+    {
+        $rule = new IsString();
+
+        $stringable_object = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'stringable object';
+            }
+        };
+
+        $this->assertTrue($rule->isValid($stringable_object));
+    }
+}


### PR DESCRIPTION
### **Changes**  
- Updated `IsString::isValid()` to accept `Stringable` objects.  
- Added a test case in `IsStringTest` to verify `Stringable` support.  

### **Fixes**  
Fixes [[#989](https://github.com/tempestphp/tempest-framework/issues/989)]