### PR TITLE
feat(support): add `mapFirstTo` and `mapLastTo` to array utils

### DIFF
--- a/src/Tempest/Mapper/src/Mappers/StringToStringableMapper.php
+++ b/src/Tempest/Mapper/src/Mappers/StringToStringableMapper.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Mapper\Mappers;
+
+use Stringable;
+use Tempest\Mapper\Mapper;
+
+final readonly class StringToStringableMapper implements Mapper
+{
+    public function canMap(mixed $from, mixed $to): bool
+    {
+        if (! is_a($to, Stringable::class, allow_string: true)) {
+            return false;
+        }
+
+        return $from instanceof Stringable || is_string($from);
+    }
+
+    public function map(mixed $from, mixed $to): Stringable
+    {
+        return new $to($from);
+    }
+}

--- a/src/Tempest/Support/src/Arr/ManipulatesArray.php
+++ b/src/Tempest/Support/src/Arr/ManipulatesArray.php
@@ -357,10 +357,6 @@ trait ManipulatesArray
     /**
      * Returns the item at the given index in the specified array.
      *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
      *
      * @return TValue
      */

--- a/src/Tempest/Support/src/Arr/ManipulatesArray.php
+++ b/src/Tempest/Support/src/Arr/ManipulatesArray.php
@@ -355,6 +355,21 @@ trait ManipulatesArray
     }
 
     /**
+     * Returns the item at the given index in the specified array.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param iterable<TKey,TValue> $array
+     *
+     * @return TValue
+     */
+    public function at(int $index, mixed $default = null): mixed
+    {
+        return namespace\at($this->value, $index, $default);
+    }
+
+    /**
      * Returns an instance of the array without the last value.
      *
      * @param mixed $value The popped value will be stored in this variable

--- a/src/Tempest/Support/src/Arr/ManipulatesArray.php
+++ b/src/Tempest/Support/src/Arr/ManipulatesArray.php
@@ -607,6 +607,34 @@ trait ManipulatesArray
     }
 
     /**
+     * Maps the first item of the instance to the given object.
+     *
+     * @see \Tempest\map()
+     *
+     * @template T
+     * @param class-string<T> $to
+     * @return T
+     */
+    public function mapFirstTo(string $to): mixed
+    {
+        return \Tempest\map($this->first())->to($to);
+    }
+
+    /**
+     * Maps the last item of the instance to the given object.
+     *
+     * @see \Tempest\map()
+     *
+     * @template T
+     * @param class-string<T> $to
+     * @return T
+     */
+    public function mapLastTo(string $to): mixed
+    {
+        return \Tempest\map($this->last())->to($to);
+    }
+
+    /**
      * Returns a new instance of this array sorted by its values.
      *
      * @param bool $desc Sorts in descending order if `true`; defaults to `false` (ascending).

--- a/src/Tempest/Support/src/Arr/functions.php
+++ b/src/Tempest/Support/src/Arr/functions.php
@@ -508,6 +508,28 @@ namespace Tempest\Support\Arr {
     }
 
     /**
+     * Returns the item at the given index in the specified array.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param iterable<TKey,TValue> $array
+     *
+     * @return TValue
+     */
+    function at(iterable $array, int $index, mixed $default = null): mixed
+    {
+        $array = to_array($array);
+
+        if ($index < 0) {
+            $index = abs($index) - 1;
+            $array = namespace\reverse($array);
+        }
+
+        return namespace\get_by_key(array_values($array), key: $index, default: $default);
+    }
+
+    /**
      * Returns the last item in the array that matches the given `$filter`.
      * If `$filter` is `null`, returns the last item.
      *

--- a/src/Tempest/Support/tests/Arr/ManipulatesArrayTest.php
+++ b/src/Tempest/Support/tests/Arr/ManipulatesArrayTest.php
@@ -1763,4 +1763,20 @@ final class ManipulatesArrayTest extends TestCase
                 ->equals($array->groupBy(fn ($item) => $item['brand'])),
         );
     }
+
+    #[TestWith([['foo', 'bar', 'baz'], 0, 'foo'])]
+    #[TestWith([['foo', 'bar', 'baz'], 1, 'bar'])]
+    #[TestWith([['foo', 'bar', 'baz'], 2, 'baz'])]
+    #[TestWith([['foo', 'bar', 'baz'], 3, null])]
+    #[TestWith([['foo', 'bar', 'baz'], -1, 'baz'])]
+    #[TestWith([['foo', 'bar', 'baz'], -2, 'bar'])]
+    #[TestWith([['foo', 'bar', 'baz'], -3, 'foo'])]
+    #[TestWith([['foo', 'bar', 'baz'], -4, null])]
+    #[TestWith([[], 0, null])]
+    #[TestWith([[], 1, null])]
+    #[TestWith([[], 1, 'quux', 'quux'])]
+    public function test_at(array $input, int $index, mixed $expected, mixed $default = null): void
+    {
+        $this->assertSame($expected, arr($input)->at($index, $default));
+    }
 }

--- a/tests/Integration/Support/ArrayTest.php
+++ b/tests/Integration/Support/ArrayTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Tests\Tempest\Integration\Support;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use Tempest\Support\Str\ImmutableString;
+use Tempest\Support\Str\MutableString;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 use Tests\Tempest\Integration\Support\Fixtures\TestObject;
+
 use function Tempest\Support\arr;
 
 /**
@@ -19,6 +22,43 @@ final class ArrayTest extends FrameworkIntegrationTestCase
         $array = arr([['name' => 'test']])->mapTo(TestObject::class);
 
         $this->assertInstanceOf(TestObject::class, $array[0]);
+    }
+
+    public function test_map_first_to(): void
+    {
+        $array = arr([
+            'foo',
+            'bar',
+        ]);
+
+        $this->assertInstanceOf(ImmutableString::class, $array->mapFirstTo(ImmutableString::class));
+        $this->assertInstanceOf(MutableString::class, $array->mapFirstTo(MutableString::class));
+        $this->assertEquals('foo', $array->mapFirstTo(MutableString::class));
+
+        $array = arr([
+            ['name' => 'test'],
+        ]);
+
+        $this->assertInstanceOf(TestObject::class, $array->mapFirstTo(TestObject::class));
+    }
+
+    public function test_map_last_to(): void
+    {
+        $array = arr([
+            'foo',
+            'bar',
+        ]);
+
+        $this->assertInstanceOf(ImmutableString::class, $array->mapLastTo(ImmutableString::class));
+        $this->assertInstanceOf(MutableString::class, $array->mapLastTo(MutableString::class));
+        $this->assertEquals('bar', $array->mapLastTo(MutableString::class));
+
+        $array = arr([
+            ['name' => 'jon'],
+            ['name' => 'doe'],
+        ]);
+
+        $this->assertInstanceOf(TestObject::class, $array->mapLastTo(TestObject::class));
     }
 
     #[DataProvider('provide_sort_cases')]
@@ -38,7 +78,10 @@ final class ArrayTest extends FrameworkIntegrationTestCase
             'Reverse order' => [[5, 4, 3, 2, 1], [1, 2, 3, 4, 5]],
             'Negative numbers' => [[-1, -3, -2, 0], [-3, -2, -1, 0]],
             'Mixed positive and negative' => [[3, -1, 4, 1, -5, 9], [-5, -1, 1, 3, 4, 9]],
-            'Strings' => [['apple', 'orange', 'banana'], ['apple', 'banana', 'orange']],
+            'Strings' => [
+                ['apple', 'orange', 'banana'],
+                ['apple', 'banana', 'orange'],
+            ],
             'Large array' => [range(1000, 1, -1), range(1, 1000)],
         ];
     }


### PR DESCRIPTION
This pull request adds support for using the mapper on the first or last element of an array:

```php
arr(glob(__DIR__ . "/content/{$version->value}/{$category}/*.md"))
  ->map(fn (string $path) => before_first(basename($path), '.'))
  ->sort()
  ->mapFirstTo(ImmutableString::class)
  ->title();
```