### PR TITLE
feat(support): add `basename` to string utils

### DIFF
--- a/src/Tempest/Support/src/Str/ManipulatesString.php
+++ b/src/Tempest/Support/src/Str/ManipulatesString.php
@@ -218,6 +218,14 @@ trait ManipulatesString
     }
 
     /**
+     * Keeps only the base name of the instance.
+     */
+    public function basename(string $suffix = ''): static
+    {
+        return $this->createOrModify(basename($this->value, $suffix));
+    }
+
+    /**
      * Keeps only the base name of the instance, assuming the instance is a class name.
      */
     public function classBasename(): static

--- a/src/Tempest/Support/tests/Str/ManipulatesStringTest.php
+++ b/src/Tempest/Support/tests/Str/ManipulatesStringTest.php
@@ -648,4 +648,19 @@ b'));
         $this->assertSame($string, $result);
         $this->assertEquals('foo', $log);
     }
+
+    public function test_class_basename(): void
+    {
+        $this->assertSame('ImmutableString', str(ImmutableString::class)->classBasename()->toString());
+        $this->assertSame('ImmutableString', str('ImmutableString')->classBasename()->toString());
+        $this->assertSame('', str()->classBasename()->toString());
+    }
+
+    public function test_basename(): void
+    {
+        $this->assertSame('file.txt', str('path/to/file.txt')->basename()->toString());
+        $this->assertSame('file.txt', str('file.txt')->basename()->toString());
+        $this->assertSame('file', str('file.txt')->basename('.txt')->toString());
+        $this->assertSame('', str()->basename()->toString());
+    }
 }


### PR DESCRIPTION
This pull request adds `basename` support to string utils:

```php
str('path/to/file.txt')->basename()->toString() // file.txt
```