### PR TITLE
feat(support): add `words` and `sentence` methods to string utils

### DIFF
--- a/src/Tempest/Support/src/Str/ManipulatesString.php
+++ b/src/Tempest/Support/src/Str/ManipulatesString.php
@@ -188,6 +188,22 @@ trait ManipulatesString
     }
 
     /**
+     * Converts the current string to a naive sentence case.
+     */
+    public function sentence(): static
+    {
+        return $this->createOrModify(to_sentence_case($this->value));
+    }
+
+    /**
+     * Returns an array of words from the current string.
+     */
+    public function words(): ImmutableArray
+    {
+        return new ImmutableArray(to_words($this->value));
+    }
+
+    /**
      * Transliterates the current string to ASCII. Invalid characters are replaced with their closest counterpart.
      *
      * @param string $language Language of the source string. Defaults to english.

--- a/src/Tempest/Support/tests/Str/ManipulatesStringTest.php
+++ b/src/Tempest/Support/tests/Str/ManipulatesStringTest.php
@@ -700,4 +700,27 @@ b'));
         $this->assertFalse(str('helloü')->isAscii());
         $this->assertFalse(str('بسم الله')->isAscii());
     }
+
+    #[TestWith(['foo bar baz', ['foo', 'bar', 'baz']])]
+    #[TestWith(['foo-bar-baz', ['foo', 'bar', 'baz']])]
+    #[TestWith(['1foo_bar1', ['1foo_bar1']])]
+    #[TestWith(['fooBar', ['fooBar']])]
+    #[TestWith(['Jon Doe', ['Jon', 'Doe']])]
+    #[TestWith(['-Jon Doe', ['Jon', 'Doe']])]
+    #[TestWith(['_Jon_Doe', ['_Jon_Doe']])]
+    public function test_words(string $input, array $output): void
+    {
+        $this->assertEquals($output, str($input)->words()->toArray());
+    }
+
+    #[TestWith(['foo bar baz', 'Foo bar baz'])]
+    #[TestWith(['foo-bar-baz', 'Foo bar baz'])]
+    #[TestWith(['Foo Bar', 'Foo bar'])]
+    #[TestWith(['1foo_bar1', '1foo_bar1'])]
+    #[TestWith(['getting-started', 'Getting started'])]
+    #[TestWith(['Getting Started', 'Getting started'])]
+    public function test_sentence(string $input, string $output): void
+    {
+        $this->assertEquals($output, str($input)->sentence()->toString());
+    }
 }


### PR DESCRIPTION
This pull request adds a `words` and `sentence` method to the string classes.

Both of these are quite hard to get right.
- `words` tries to be accurate here, by counting actual words—tests could be improved, but I think it's a fine start.
- `sentence` is pretty naive and built on top of `words`. It uppercases the first word and lowercase the rest. Actual sentence case is super hard to achieve, and I expect this method to be improved over time, so it's a fine start as well.