### PR TITLE
fix(validation): prevent type errors in rules using `preg_match`

### DIFF
--- a/src/Tempest/Validation/src/Rules/Alpha.php
+++ b/src/Tempest/Validation/src/Rules/Alpha.php
@@ -12,6 +12,10 @@ final readonly class Alpha implements Rule
 {
     public function isValid(mixed $value): bool
     {
+        if (! is_string($value)) {
+            return false;
+        }
+
         return boolval(preg_match('/^[A-Za-z]+$/', $value));
     }
 

--- a/src/Tempest/Validation/src/Rules/AlphaNumeric.php
+++ b/src/Tempest/Validation/src/Rules/AlphaNumeric.php
@@ -12,6 +12,10 @@ final readonly class AlphaNumeric implements Rule
 {
     public function isValid(mixed $value): bool
     {
+        if (! is_string($value)) {
+            return false;
+        }
+
         return boolval(preg_match('/^[A-Za-z0-9]+$/', $value));
     }
 

--- a/src/Tempest/Validation/src/Rules/Numeric.php
+++ b/src/Tempest/Validation/src/Rules/Numeric.php
@@ -12,6 +12,10 @@ final readonly class Numeric implements Rule
 {
     public function isValid(mixed $value): bool
     {
+        if (! is_string($value)) {
+            return false;
+        }
+
         return boolval(preg_match('/^[0-9]+$/', $value));
     }
 

--- a/src/Tempest/Validation/src/Rules/RegEx.php
+++ b/src/Tempest/Validation/src/Rules/RegEx.php
@@ -17,6 +17,10 @@ final readonly class RegEx implements Rule
 
     public function isValid(mixed $value): bool
     {
+        if (! is_string($value)) {
+            return false;
+        }
+
         return preg_match($this->pattern, $value) === 1;
     }
 

--- a/src/Tempest/Validation/src/Rules/Time.php
+++ b/src/Tempest/Validation/src/Rules/Time.php
@@ -17,6 +17,10 @@ final readonly class Time implements Rule
 
     public function isValid(mixed $value): bool
     {
+        if (! is_string($value)) {
+            return false;
+        }
+
         if ($this->twentyFourHour) {
             return preg_match('/^([0-1][0-9]|2[0-3]):?[0-5][0-9]$|^(([0-1]?[0-9]|2[0-3]):[0-5][0-9])$/', $value) === 1;
         }

--- a/src/Tempest/Validation/src/Rules/Ulid.php
+++ b/src/Tempest/Validation/src/Rules/Ulid.php
@@ -12,6 +12,10 @@ final readonly class Ulid implements Rule
 {
     public function isValid(mixed $value): bool
     {
+        if (! is_string($value)) {
+            return false;
+        }
+
         return preg_match('/^[0-9A-HJKMNP-TV-Z]{26}$/i', $value) === 1;
     }
 

--- a/src/Tempest/Validation/src/Rules/Uuid.php
+++ b/src/Tempest/Validation/src/Rules/Uuid.php
@@ -12,6 +12,10 @@ final readonly class Uuid implements Rule
 {
     public function isValid(mixed $value): bool
     {
+        if (! is_string($value)) {
+            return false;
+        }
+
         return boolval(preg_match('/^[a-f\d]{8}(-[a-f\d]{4}){4}[a-f\d]{8}$/i', $value));
     }
 

--- a/src/Tempest/Validation/tests/Rules/AlphaNumericTest.php
+++ b/src/Tempest/Validation/tests/Rules/AlphaNumericTest.php
@@ -20,5 +20,6 @@ final class AlphaNumericTest extends TestCase
         $this->assertFalse($rule->isValid('string_123'));
         $this->assertTrue($rule->isValid('string123'));
         $this->assertTrue($rule->isValid('STRING123'));
+        $this->assertFalse($rule->isValid([])); // Should return false, not a TypeError from preg_match
     }
 }

--- a/src/Tempest/Validation/tests/Rules/AlphaTest.php
+++ b/src/Tempest/Validation/tests/Rules/AlphaTest.php
@@ -20,5 +20,6 @@ final class AlphaTest extends TestCase
         $this->assertFalse($rule->isValid('string123'));
         $this->assertTrue($rule->isValid('string'));
         $this->assertTrue($rule->isValid('STRING'));
+        $this->assertFalse($rule->isValid([])); // Should return false, not a TypeError from preg_match
     }
 }

--- a/src/Tempest/Validation/tests/Rules/RegexTest.php
+++ b/src/Tempest/Validation/tests/Rules/RegexTest.php
@@ -28,4 +28,15 @@ final class RegexTest extends TestCase
         $this->assertTrue($rule->isValid('AB'));
         $this->assertTrue($rule->isValid('Ab'));
     }
+
+    public function test_non_imvalid_types(): void
+    {
+        $rule = new RegEx('/^[0-9]+$/');
+
+        // Invalid types should return false, not a TypeError.
+        $this->assertFalse($rule->isValid(false));
+        $this->assertFalse($rule->isValid([]));
+        $this->assertFalse($rule->isValid(new \stdClass()));
+        $this->assertFalse($rule->isValid(null));
+    }
 }

--- a/src/Tempest/Validation/tests/Rules/TimeTest.php
+++ b/src/Tempest/Validation/tests/Rules/TimeTest.php
@@ -34,6 +34,8 @@ final class TimeTest extends TestCase
         $this->assertTrue($rule->isValid('01:00 P.M.'));
         $this->assertTrue($rule->isValid('01:00 PM'));
         $this->assertTrue($rule->isValid('01:59 a.m.'));
+
+        $this->assertFalse($rule->isValid([])); // Should return false, not a TypeError from preg_match
     }
 
     public function test_military_time(): void
@@ -80,5 +82,14 @@ final class TimeTest extends TestCase
         $this->assertTrue($rule->isValid('2200'));
         $this->assertTrue($rule->isValid('2300'));
         $this->assertTrue($rule->isValid('2340'));
+    }
+
+    public function test_non_string_pregmatch_subject(): void
+    {
+        $rule = new Time(twentyFourHour: true);
+
+        $this->assertFalse($rule->isValid([]));
+        $this->assertFalse($rule->isValid(new \stdClass()));
+        $this->assertFalse($rule->isValid(null));
     }
 }

--- a/src/Tempest/Validation/tests/Rules/UlidTest.php
+++ b/src/Tempest/Validation/tests/Rules/UlidTest.php
@@ -23,5 +23,6 @@ final class UlidTest extends TestCase
         $this->assertFalse($rule->isValid('01FV8CE8P3XVZTVK0S6F05Z5ZU')); // contains invalid character
         $this->assertFalse($rule->isValid('01FV8CE8P3XVZTVK0S6F05')); // too short
         $this->assertFalse($rule->isValid('01FV8CE8P3XVZTVK0S6F05Z5ZAAAAA')); // too long
+        $this->assertFalse($rule->isValid([])); // Should return false, not a TypeError from preg_match
     }
 }

--- a/src/Tempest/Validation/tests/Rules/UuidTest.php
+++ b/src/Tempest/Validation/tests/Rules/UuidTest.php
@@ -19,6 +19,7 @@ final class UuidTest extends TestCase
         $this->assertSame('Value should contain a valid UUID', $rule->message());
 
         $this->assertFalse($rule->isValid('string_123'));
+        $this->assertFalse($rule->isValid([])); // Should return false, not a TypeError from preg_match
 
         // UUID v1
         $this->assertTrue($rule->isValid('CB2F46B4-D0C6-11EE-A506-0242AC120002'));


### PR DESCRIPTION
**Summary:**
This PR adds a check to ensure the value passed to `preg_match` is a string in various validation rules, preventing a `TypeError` when non-string values (e.g., arrays, booleans, or objects) are provided.

**Changes:**
- Added type checks for string values in the **Alpha**, **AlphaNumeric**, **Numeric**, **RegEx**, **Time**, **Ulid**, and **Uuid** validation rules.
- Updated tests to ensure invalid types return `false` instead of causing a `TypeError`.

**Purpose:**
To prevent errors when non-string values are passed to `preg_match` and improve the stability of the validation rules.