### PR TITLE
chore(linter): exclude cache directories

### DIFF
--- a/mago.toml
+++ b/mago.toml
@@ -6,6 +6,7 @@ includes = ["vendor"]
 excludes = [
   "./vendor/symfony/cache/Traits/ValueWrapper.php",
   "./vendor/composer",
+  "**/.cache"
 ]
 
 [format]


### PR DESCRIPTION
When running things (`composer qa`) locally I got failures in the lint due to cache files. Dunno if this is the best way to do this but it seems to work.