### PR TITLE
fix(discovery): pass real paths to discovery classes

### DIFF
--- a/src/Tempest/Core/src/Kernel/LoadDiscoveryClasses.php
+++ b/src/Tempest/Core/src/Kernel/LoadDiscoveryClasses.php
@@ -139,7 +139,7 @@ final class LoadDiscoveryClasses
                     }
                 } elseif ($discovery instanceof DiscoversPath) {
                     // If the input is NOT a class, AND the discovery class can discover paths, we'll call `discoverPath`
-                    $discovery->discoverPath($location, $input);
+                    $discovery->discoverPath($location, realpath($input));
                 }
             }
         }


### PR DESCRIPTION
Apparently, `RecursiveDirectoryIterator` does not yield canonical paths. This pull request ensures that `discoverPath` gets the actual canonical path to the file.

This shouldn't break anything, but I would like you to double-check @brendt before merging