### PR TITLE
feat(database): Add migration hash checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ final class MigrateUpCommand
         description: 'Run all new migrations',
         middleware: [ForceMiddleware::class, CautionMiddleware::class],
     )]
-    public function __invoke(): void
-    {
-        $this->migrationManager->up();
+    public function __invoke(
+        #[ConsoleArgument(description: '')]
+        bool $allowChanges = false,
+    ): void {
+        $this->migrationManager->up($allowChanges);
 
         $this->console->success("Everything migrated");
     }

--- a/src/Tempest/Database/src/Migrations/CreateMigrationsTable.php
+++ b/src/Tempest/Database/src/Migrations/CreateMigrationsTable.php
@@ -18,7 +18,8 @@ final class CreateMigrationsTable implements DatabaseMigration
     {
         return new CreateTableStatement(Model::table()->tableName)
             ->primary()
-            ->text('name');
+            ->text('name')
+            ->varchar('hash', 64);
     }
 
     public function down(): QueryStatement

--- a/src/Tempest/Database/src/Migrations/Migration.php
+++ b/src/Tempest/Database/src/Migrations/Migration.php
@@ -12,4 +12,6 @@ final class Migration implements DatabaseModel
     use IsDatabaseModel;
 
     public string $name;
+
+    public string $hash;
 }

--- a/src/Tempest/Database/src/Migrations/MigrationException.php
+++ b/src/Tempest/Database/src/Migrations/MigrationException.php
@@ -12,4 +12,9 @@ final class MigrationException extends Exception
     {
         return new self('Migrations table does not exist. Nothing to roll back.');
     }
+
+    public static function hashMismatch(): self
+    {
+        return new self('Migration hash mismatch.');
+    }
 }

--- a/src/Tempest/Database/src/Migrations/MigrationManager.php
+++ b/src/Tempest/Database/src/Migrations/MigrationManager.php
@@ -10,8 +10,10 @@ use Tempest\Database\Config\DatabaseConfig;
 use Tempest\Database\Config\DatabaseDialect;
 use Tempest\Database\Database;
 use Tempest\Database\DatabaseMigration as MigrationInterface;
+use Tempest\Database\DatabaseMigration;
 use Tempest\Database\Exceptions\QueryException;
 use Tempest\Database\Query;
+use Tempest\Database\QueryStatement;
 use Tempest\Database\QueryStatements\DropTableStatement;
 use Tempest\Database\QueryStatements\SetForeignKeyChecksStatement;
 use Tempest\Database\QueryStatements\ShowTablesStatement;
@@ -29,7 +31,7 @@ final readonly class MigrationManager
     ) {
     }
 
-    public function up(): void
+    public function up(bool $allowChanges): void
     {
         try {
             $existingMigrations = Migration::all();
@@ -39,13 +41,17 @@ final readonly class MigrationManager
             $existingMigrations = Migration::all();
         }
 
-        $existingMigrations = array_map(
-            static fn (Migration $migration) => $migration->name,
-            $existingMigrations,
-        );
-
         foreach ($this->migrations as $migration) {
-            if (in_array($migration->name, $existingMigrations, strict: true)) {
+            $existingMigration = array_find(
+                $existingMigrations,
+                static fn (Migration $existingMigration) => $existingMigration->name === $migration->name,
+            );
+
+            if ($existingMigration !== null) {
+                if (! $allowChanges) {
+                    $this->verifyMigrationHash($migration, $existingMigration);
+                }
+
                 continue;
             }
 
@@ -126,6 +132,7 @@ final readonly class MigrationManager
 
             Migration::create(
                 name: $migration->name,
+                hash: $this->getMigrationHash($migration),
             );
         } catch (PDOException $pdoException) {
             event(new MigrationFailed($migration->name, $pdoException));
@@ -198,5 +205,40 @@ final readonly class MigrationManager
             },
             new ShowTablesStatement()->fetch($dialect),
         );
+    }
+
+    private function getMigrationHash(DatabaseMigration $migration): string
+    {
+        $minifiedDownSql = $this->getMinifiedSqlFromStatement($migration->down());
+        $minifiedUpSql = $this->getMinifiedSqlFromStatement($migration->up());
+
+        return hash('sha256', $minifiedDownSql . $minifiedUpSql);
+    }
+
+    private function getMinifiedSqlFromStatement(?QueryStatement $statement): string
+    {
+        if ($statement === null) {
+            return '';
+        }
+
+        $query = new Query($statement->compile($this->databaseConfig->dialect));
+
+        // Remove comments
+        $sql = preg_replace('/--.*$/m', '', $query->getSql()); // Remove SQL single-line comments
+        $sql = preg_replace('/\/\*[\s\S]*?\*\//', '', $sql); // Remove block comments
+
+        // Remove blank lines and excessive spaces
+        $sql = preg_replace('/\s+/', ' ', trim($sql));
+
+        return $sql;
+    }
+
+    private function verifyMigrationHash(DatabaseMigration $migration, Migration $existingMigration): void
+    {
+        $hash = $this->getMigrationHash($migration);
+
+        if ($hash !== $existingMigration->hash) {
+            event(new MigrationFailed($migration->name, MigrationException::hashMismatch()));
+        }
     }
 }

--- a/src/Tempest/Framework/Commands/MigrateUpCommand.php
+++ b/src/Tempest/Framework/Commands/MigrateUpCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Framework\Commands;
 
 use Tempest\Console\Console;
+use Tempest\Console\ConsoleArgument;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Middleware\CautionMiddleware;
 use Tempest\Console\Middleware\ForceMiddleware;
@@ -29,9 +30,11 @@ final class MigrateUpCommand
         description: 'Runs all new migrations',
         middleware: [ForceMiddleware::class, CautionMiddleware::class],
     )]
-    public function __invoke(): void
-    {
-        $this->migrationManager->up();
+    public function __invoke(
+        #[ConsoleArgument(description: '')]
+        bool $allowChanges = false,
+    ): void {
+        $this->migrationManager->up($allowChanges);
 
         $this->console
             ->success(sprintf('Migrated %s migrations', $this->count));

--- a/tests/Integration/Database/MigrationManagerTest.php
+++ b/tests/Integration/Database/MigrationManagerTest.php
@@ -17,13 +17,13 @@ final class MigrationManagerTest extends FrameworkIntegrationTestCase
     {
         $migrationManager = $this->container->get(MigrationManager::class);
 
-        $migrationManager->up();
+        $migrationManager->up(allowChanges: false);
 
         $migrations = Migration::all();
         $this->assertNotEmpty($migrations);
         $oldCount = count($migrations);
 
-        $migrationManager->up();
+        $migrationManager->up(allowChanges: false);
 
         $migrations = Migration::all();
         $this->assertNotEmpty($migrations);


### PR DESCRIPTION
This PR adds Hash-checking to database migrations - preventing migration files from being tempered with.

WIP - will update PR description later.