### PR TITLE
fix(view): prevent compiling parent elements of minified void tags

### DIFF
--- a/src/Tempest/View/src/Renderers/TempestViewCompiler.php
+++ b/src/Tempest/View/src/Renderers/TempestViewCompiler.php
@@ -109,7 +109,7 @@ final readonly class TempestViewCompiler
         $template = str($template)
             // Convert self-closing and void tags
             ->replaceRegex(
-                regex: '/<(?<element>\w.*?)\/>/',
+                regex: '/<(?<element>\w[^<]*?)\/>/',
                 replace: function (array $match) {
                     $element = str($match['element'])->trim();
 

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -695,4 +695,15 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         <html lang="en"><head></head><body><br><hr></body></html>
         HTML, $html);
     }
+
+    public function test_renders_minified_html_with_void_elements(): void
+    {
+        $html = $this->render(<<<'HTML'
+            <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"/><path d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"/></g></svg>
+        HTML);
+
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'HTML'
+        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewbox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"></path><path d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"></path></g></svg>
+        HTML, $html);
+    }
 }


### PR DESCRIPTION
This pull request fixes an issue where minified HTML that contained void tags would get broken, due to the conversion of self-closing tag selecting the parents tags as well.

To be more specific, here is what the previous regex, `/<(?<element>\w.*?)\/>/`, would select on the following snippet:

**Snippet**
```html
<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"/><path d="M4.012 16.737A2 2 0 0 1 3 15V5c0-1.1.9-2 2-2h10c.75 0 1.158.385 1.5 1"/></g></svg>
```

**Match from regex**
```html
<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"/>
```

However, the intended match was the self-closing `path` element inside:

```html
<path d="M7 9.667A2.667 2.667 0 0 1 9.667 7h8.666A2.667 2.667 0 0 1 21 9.667v8.666A2.667 2.667 0 0 1 18.333 21H9.667A2.667 2.667 0 0 1 7 18.333z"/>
```

The result is that the final HTML would get its `path` outside of the `svg` element.

To fix this, I updated the regex to not catch opening chevrons. This is not a good fix, because parsing HTML is not that simple, but until the next edge case, this will do!