### PR TITLE
feat(console): add `make:generator-command` command

### DIFF
--- a/src/Tempest/Console/src/Commands/MakeGeneratorCommandCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeGeneratorCommandCommand.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Tempest\Console\Commands;
 
-use function Tempest\Support\str;
-use Tempest\Generation\DataObjects\StubFile;
-use Tempest\Core\PublishesFiles;
-use Tempest\Console\Stubs\GeneratorCommandStub;
-use Tempest\Console\ConsoleCommand;
 use Tempest\Console\ConsoleArgument;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Console\Stubs\GeneratorCommandStub;
+use Tempest\Core\PublishesFiles;
+use Tempest\Generation\DataObjects\StubFile;
+
+use function Tempest\Support\str;
 
 final class MakeGeneratorCommandCommand
 {

--- a/src/Tempest/Console/src/Commands/MakeGeneratorCommandCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeGeneratorCommandCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Commands;
+
+use function Tempest\Support\str;
+use Tempest\Generation\DataObjects\StubFile;
+use Tempest\Core\PublishesFiles;
+use Tempest\Console\Stubs\GeneratorCommandStub;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Console\ConsoleArgument;
+
+final class MakeGeneratorCommandCommand
+{
+    use PublishesFiles;
+
+    #[ConsoleCommand(
+        name: 'make:generator-command',
+        description: 'Creates a new generator command class',
+        aliases: ['generator-command:make', 'generator-command:create', 'create:generator-command'],
+    )]
+    public function __invoke(
+        #[ConsoleArgument(description: 'The name of the generator command class to create')]
+        string $className,
+    ): void {
+        $suggestedPath = $this->getSuggestedPath($className);
+        $targetPath = $this->promptTargetPath($suggestedPath);
+        $shouldOverride = $this->askForOverride($targetPath);
+
+        $this->stubFileGenerator->generateClassFile(
+            stubFile: StubFile::from(GeneratorCommandStub::class),
+            targetPath: $targetPath,
+            shouldOverride: $shouldOverride,
+            replacements: [
+                'dummy-command-slug' => str($className)->kebab()->toString(),
+            ],
+        );
+
+        $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
+    }
+}

--- a/src/Tempest/Console/src/Stubs/GeneratorCommandStub.php
+++ b/src/Tempest/Console/src/Stubs/GeneratorCommandStub.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tempest\Console\Stubs;
 
-use Tempest\Generation\DataObjects\StubFile;
-use Tempest\Core\PublishesFiles;
-use Tempest\Console\ConsoleCommand;
 use Tempest\Console\ConsoleArgument;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Core\PublishesFiles;
+use Tempest\Generation\DataObjects\StubFile;
 
 final class GeneratorCommandStub
 {

--- a/src/Tempest/Console/src/Stubs/GeneratorCommandStub.php
+++ b/src/Tempest/Console/src/Stubs/GeneratorCommandStub.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Stubs;
+
+use Tempest\Generation\DataObjects\StubFile;
+use Tempest\Core\PublishesFiles;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Console\ConsoleArgument;
+
+final class GeneratorCommandStub
+{
+    use PublishesFiles;
+
+    #[ConsoleCommand(name: 'dummy-command-slug')]
+    public function __invoke(
+        #[ConsoleArgument(description: 'The name of the class to create')]
+        string $className,
+    ): void {
+        $suggestedPath = $this->getSuggestedPath($className);
+        $targetPath = $this->promptTargetPath($suggestedPath);
+        $shouldOverride = $this->askForOverride($targetPath);
+
+        $this->stubFileGenerator->generateClassFile(
+            stubFile: StubFile::from('MyStubClass::class'),
+            targetPath: $targetPath,
+            shouldOverride: $shouldOverride,
+        );
+
+        $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
+    }
+}

--- a/tests/Integration/Console/Commands/MakeGeneratorCommandCommandTest.php
+++ b/tests/Integration/Console/Commands/MakeGeneratorCommandCommandTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Console\Commands;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Cache\CacheConfig;
+use Tempest\CommandBus\CommandBusConfig;
+use Tempest\Console\ConsoleConfig;
+use Tempest\Console\Enums\ConfigType;
+use Tempest\Core\ComposerNamespace;
+use Tempest\Database\Config\MysqlConfig;
+use Tempest\EventBus\EventBusConfig;
+use Tempest\Log\LogConfig;
+use Tempest\View\Renderers\BladeConfig;
+use Tempest\View\Renderers\TwigConfig;
+use Tempest\View\ViewConfig;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\get;
+use function Tempest\Support\str;
+
+/**
+ * @internal
+ */
+final class MakeGeneratorCommandCommandTest extends FrameworkIntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->installer->configure(
+            __DIR__ . '/install',
+            new ComposerNamespace('App\\', __DIR__ . '/install/App'),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->installer->clean();
+
+        parent::tearDown();
+    }
+
+    #[DataProvider('command_input_provider')]
+    #[Test]
+    public function make_command(
+        string $commandArgs,
+        string $expectedPath,
+        string $expectedNamespace,
+    ): void {
+        $this->console
+            ->call("make:generator-command {$commandArgs}")
+            ->submit();
+
+        $this->installer
+            ->assertFileExists($expectedPath)
+            ->assertFileContains($expectedPath, 'namespace ' . $expectedNamespace . ';');
+    }
+
+    public static function command_input_provider(): array
+    {
+        return [
+            'make_with_defaults' => [
+                'commandArgs' => 'MyCommand',
+                'expectedPath' => 'App/MyCommand.php',
+                'expectedNamespace' => 'App',
+            ],
+            'make_with_other_namespace' => [
+                'commandArgs' => 'Commands\\MyCommand',
+                'expectedPath' => 'App/Commands/MyCommand.php',
+                'expectedNamespace' => 'App\\Commands',
+            ],
+            'make_with_input_path' => [
+                'commandArgs' => 'Commands/MyCommand',
+                'expectedPath' => 'App/Commands/MyCommand.php',
+                'expectedNamespace' => 'App\\Commands',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR checks a TODO on #759 

It adds a command to make other generator commands
The main difference with a classic command is that it use the `PublishesFiles` trait  
The main method also have a "classic" skeleton of what I usually use to make internal make commands, this must be seen as a faster starter to make a generator-command