### PR TITLE
feat(console): add `make:discovery` command

### DIFF
--- a/src/Tempest/Discovery/src/Commands/MakeDiscoveryCommand.php
+++ b/src/Tempest/Discovery/src/Commands/MakeDiscoveryCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Discovery\Commands;
+
+use Tempest\Generation\DataObjects\StubFile;
+use Tempest\Discovery\Stubs\DiscoveryStub;
+use Tempest\Core\PublishesFiles;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Console\ConsoleArgument;
+
+final class MakeDiscoveryCommand
+{
+    use PublishesFiles;
+
+    #[ConsoleCommand(
+        name: 'make:discovery',
+        description: 'Creates a new discovery class',
+        aliases: ['discovery:make', 'discovery:create', 'create:discovery'],
+    )]
+    public function __invoke(
+        #[ConsoleArgument(description: 'The name of the discovery class to create')]
+        string $className,
+    ): void {
+        $suggestedPath = $this->getSuggestedPath($className);
+        $targetPath = $this->promptTargetPath($suggestedPath);
+        $shouldOverride = $this->askForOverride($targetPath);
+
+        $this->stubFileGenerator->generateClassFile(
+            stubFile: StubFile::from(DiscoveryStub::class),
+            targetPath: $targetPath,
+            shouldOverride: $shouldOverride,
+        );
+
+        $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
+    }
+}

--- a/src/Tempest/Discovery/src/Commands/MakeDiscoveryCommand.php
+++ b/src/Tempest/Discovery/src/Commands/MakeDiscoveryCommand.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Tempest\Discovery\Commands;
 
-use Tempest\Generation\DataObjects\StubFile;
-use Tempest\Discovery\Stubs\DiscoveryStub;
-use Tempest\Core\PublishesFiles;
-use Tempest\Console\ConsoleCommand;
 use Tempest\Console\ConsoleArgument;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Core\PublishesFiles;
+use Tempest\Discovery\Stubs\DiscoveryStub;
+use Tempest\Generation\DataObjects\StubFile;
 
 final class MakeDiscoveryCommand
 {

--- a/src/Tempest/Discovery/src/Stubs/DiscoveryStub.php
+++ b/src/Tempest/Discovery/src/Stubs/DiscoveryStub.php
@@ -6,8 +6,8 @@ namespace Tempest\Discovery\Stubs;
 
 use Tempest\Discovery\Discovery;
 use Tempest\Discovery\DiscoveryLocation;
-use Tempest\Reflection\ClassReflector;
 use Tempest\Discovery\IsDiscovery;
+use Tempest\Reflection\ClassReflector;
 
 final class DiscoveryStub implements Discovery
 {
@@ -18,10 +18,10 @@ final class DiscoveryStub implements Discovery
         if (! $class->implements('MyClass::class')) {
             return;
         }
-        
+
         $this->discoveryItems->add($location, $class);
     }
-    
+
     public function apply(): void
     {
         foreach ($this->discoveryItems as $class) {

--- a/src/Tempest/Discovery/src/Stubs/DiscoveryStub.php
+++ b/src/Tempest/Discovery/src/Stubs/DiscoveryStub.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Discovery\Stubs;
+
+use Tempest\Discovery\Discovery;
+use Tempest\Discovery\DiscoveryLocation;
+use Tempest\Reflection\ClassReflector;
+use Tempest\Discovery\IsDiscovery;
+
+final class DiscoveryStub implements Discovery
+{
+    use IsDiscovery;
+
+    public function discover(DiscoveryLocation $location, ClassReflector $class): void
+    {
+        if (! $class->implements('MyClass::class')) {
+            return;
+        }
+        
+        $this->discoveryItems->add($location, $class);
+    }
+    
+    public function apply(): void
+    {
+        foreach ($this->discoveryItems as $class) {
+            // Do something with the discovered class
+        }
+    }
+}

--- a/tests/Integration/Discovery/Commands/MakeDiscoveryCommandTest.php
+++ b/tests/Integration/Discovery/Commands/MakeDiscoveryCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Tempest\Integration\Database\Commands;
+namespace Tests\Tempest\Integration\Discovery\Commands;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Integration/Discovery/Commands/MakeDiscoveryCommandTest.php
+++ b/tests/Integration/Discovery/Commands/MakeDiscoveryCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Database\Commands;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Core\ComposerNamespace;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+/**
+ * @internal
+ */
+class MakeDiscoveryCommandTest extends FrameworkIntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->installer->configure(
+            __DIR__ . '/install',
+            new ComposerNamespace('App\\', __DIR__ . '/install/App'),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->installer->clean();
+
+        parent::tearDown();
+    }
+
+    #[DataProvider('command_input_provider')]
+    #[Test]
+    public function make_command(
+        string $commandArgs,
+        string $expectedPath,
+        string $expectedNamespace,
+    ): void {
+        $this->console
+            ->call("make:discovery {$commandArgs}")
+            ->submit();
+
+        $this->installer
+            ->assertFileExists($expectedPath)
+            ->assertFileContains($expectedPath, 'namespace ' . $expectedNamespace . ';')
+            ->assertFileExists($expectedPath, 'implements Discovery')
+            ->assertFileContains($expectedPath, 'public function discover');
+    }
+
+    public static function command_input_provider(): array
+    {
+        return [
+            'make_with_defaults' => [
+                'commandArgs' => 'CustomDiscovery',
+                'expectedPath' => 'App/CustomDiscovery.php',
+                'expectedNamespace' => 'App',
+            ],
+            'make_with_other_namespace' => [
+                'commandArgs' => 'CustomDiscoveries\\CustomDiscovery',
+                'expectedPath' => 'App/CustomDiscoveries/CustomDiscovery.php',
+                'expectedNamespace' => 'App\\CustomDiscoveries',
+            ],
+            'make_with_input_path' => [
+                'commandArgs' => 'CustomDiscoveries/CustomDiscovery',
+                'expectedPath' => 'App/CustomDiscoveries/CustomDiscovery.php',
+                'expectedNamespace' => 'App\\CustomDiscoveries',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR checks a TODO on #759 

It adds a command to make a custom discovery  
I kept it simple as the raw file discovery is probably a 1% use case and well-documented  

I think it deserve its own command even if it's like other concepts only an interface + trait, but the stub helps to build faster the discover/apply methods without checking the docs