### PR TITLE
feat(database): allow overriding table names through model class attributes

### DIFF
--- a/src/Tempest/Database/src/IsDatabaseModel.php
+++ b/src/Tempest/Database/src/IsDatabaseModel.php
@@ -9,6 +9,7 @@ use Tempest\Database\Builder\TableName;
 use Tempest\Database\Config\DatabaseConfig;
 use Tempest\Database\Exceptions\MissingRelation;
 use Tempest\Database\Exceptions\MissingValue;
+use Tempest\Database\TableName as TableNameAttribute;
 use Tempest\Reflection\ClassReflector;
 use Tempest\Reflection\PropertyReflector;
 
@@ -57,10 +58,14 @@ trait IsDatabaseModel
 
     public static function table(): TableName
     {
-        $name = get(DatabaseConfig::class)
+        $specificName = new ClassReflector(static::class)
+            ->getAttribute(TableNameAttribute::class)
+            ?->name;
+
+        $conventionalName = get(DatabaseConfig::class)
             ->namingStrategy->getName(self::class);
 
-        return new TableName($name);
+        return new TableName($specificName ?? $conventionalName);
     }
 
     public static function new(mixed ...$params): self

--- a/src/Tempest/Database/src/TableName.php
+++ b/src/Tempest/Database/src/TableName.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tempest\Database;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class TableName
+{
+    public function __construct(
+        public string $name,
+    ) {
+    }
+}

--- a/tests/Integration/ORM/IsDatabaseModelTest.php
+++ b/tests/Integration/ORM/IsDatabaseModelTest.php
@@ -42,6 +42,9 @@ use Tests\Tempest\Integration\ORM\Migrations\CreateCasterModelTable;
 use Tests\Tempest\Integration\ORM\Migrations\CreateHasManyChildTable;
 use Tests\Tempest\Integration\ORM\Migrations\CreateHasManyParentTable;
 use Tests\Tempest\Integration\ORM\Migrations\CreateHasManyThroughTable;
+use Tests\Tempest\Integration\ORM\Models\AttributeTableNameModel;
+use Tests\Tempest\Integration\ORM\Models\BaseModel;
+use Tests\Tempest\Integration\ORM\Models\StaticMethodTableNameModel;
 
 /**
  * @internal
@@ -528,5 +531,12 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         $invalid = C::find(name: 'three')->all();
 
         $this->assertCount(0, $invalid);
+    }
+
+    public function test_table_name_overrides(): void
+    {
+        $this->assertEquals('base_models', BaseModel::table()->tableName);
+        $this->assertEquals('custom_attribute_table_name', AttributeTableNameModel::table()->tableName);
+        $this->assertEquals('custom_static_method_table_name', StaticMethodTableNameModel::table()->tableName);
     }
 }

--- a/tests/Integration/ORM/Models/AttributeTableNameModel.php
+++ b/tests/Integration/ORM/Models/AttributeTableNameModel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Tempest\Integration\ORM\Models;
+
+use Tempest\Database\DatabaseModel;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\TableName;
+
+#[TableName('custom_attribute_table_name')]
+final class AttributeTableNameModel implements DatabaseModel
+{
+    use IsDatabaseModel;
+}

--- a/tests/Integration/ORM/Models/BaseModel.php
+++ b/tests/Integration/ORM/Models/BaseModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests\Tempest\Integration\ORM\Models;
+
+use Tempest\Database\DatabaseModel;
+use Tempest\Database\IsDatabaseModel;
+
+final class BaseModel implements DatabaseModel
+{
+    use IsDatabaseModel;
+}

--- a/tests/Integration/ORM/Models/StaticMethodTableNameModel.php
+++ b/tests/Integration/ORM/Models/StaticMethodTableNameModel.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Tempest\Integration\ORM\Models;
+
+use Tempest\Database\Builder\TableName;
+use Tempest\Database\DatabaseModel;
+use Tempest\Database\IsDatabaseModel;
+
+final class StaticMethodTableNameModel implements DatabaseModel
+{
+    use IsDatabaseModel;
+
+    public static function table(): TableName
+    {
+        return new TableName('custom_static_method_table_name');
+    }
+}


### PR DESCRIPTION
This pull request offers the ability to specify table names through attributes:

```php
#[TableName('aircraft')]
final class Aircraft implements DatabaseModel
{
    use IsDatabaseModel;
}
```

This was already possible through overriding the static `table` method, but this way is less verbose and feels more like Tempest.