### PR TITLE
feat(view): cache Blade and Twig templates in internal storage

### DIFF
--- a/src/Tempest/View/src/Renderers/BladeInitializer.php
+++ b/src/Tempest/View/src/Renderers/BladeInitializer.php
@@ -10,6 +10,8 @@ use Tempest\Container\DynamicInitializer;
 use Tempest\Container\Singleton;
 use Tempest\Reflection\ClassReflector;
 
+use function Tempest\internal_storage_path;
+
 final readonly class BladeInitializer implements DynamicInitializer
 {
     public function canInitialize(ClassReflector $class): bool
@@ -28,7 +30,7 @@ final readonly class BladeInitializer implements DynamicInitializer
 
         return new Blade(
             viewPaths: $bladeConfig->viewPaths,
-            cachePath: $bladeConfig->cachePath,
+            cachePath: internal_storage_path($bladeConfig->cachePath ?? 'cache/blade'),
         );
     }
 }

--- a/src/Tempest/View/src/Renderers/TwigConfig.php
+++ b/src/Tempest/View/src/Renderers/TwigConfig.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tempest\View\Renderers;
 
+use function Tempest\internal_storage_path;
+
 final readonly class TwigConfig
 {
     /**
@@ -11,7 +13,7 @@ final readonly class TwigConfig
      */
     public function __construct(
         public array $viewPaths = [],
-        public ?string $cachePath = null,
+        public null|false|string $cachePath = null,
         public bool $debug = false,
         public string $charset = 'utf-8',
         public bool $strictVariables = false,
@@ -28,7 +30,7 @@ final readonly class TwigConfig
             'charset' => $this->charset,
             'strict_variables' => $this->strictVariables,
             'autoescape' => $this->autoescape,
-            'cache' => $this->cachePath ?: false,
+            'cache' => $this->cachePath === false ? false : internal_storage_path($this->cachePath ?? 'cache/twig'),
             'auto_reload' => $this->autoReload,
             'optimizations' => $this->optimizations,
         ];

--- a/tests/Integration/View/BladeViewRendererTest.php
+++ b/tests/Integration/View/BladeViewRendererTest.php
@@ -9,6 +9,7 @@ use Tempest\View\Renderers\BladeViewRenderer;
 use Tempest\View\ViewConfig;
 use Tempest\View\ViewRenderer;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
 use function Tempest\view;
 
 /**
@@ -24,7 +25,7 @@ final class BladeViewRendererTest extends FrameworkIntegrationTestCase
 
         $this->container->config(new BladeConfig(
             viewPaths: [__DIR__ . '/blade'],
-            cachePath: __DIR__ . '/../../../../.cache/tempest/blade/cache',
+            cachePath: 'blade-cache',
         ));
 
         $renderer = $this->container->get(ViewRenderer::class);
@@ -32,10 +33,9 @@ final class BladeViewRendererTest extends FrameworkIntegrationTestCase
         $html = $renderer->render(view('index'));
 
         $this->assertSame(<<<HTML
-            <html>
-            Hi
-            </html>
-            HTML
-            , $html);
+        <html>
+        Hi
+        </html>
+        HTML, $html);
     }
 }

--- a/tests/Integration/View/TwigViewRendererTest.php
+++ b/tests/Integration/View/TwigViewRendererTest.php
@@ -9,6 +9,7 @@ use Tempest\View\Renderers\TwigViewRenderer;
 use Tempest\View\ViewConfig;
 use Tempest\View\ViewRenderer;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
 use function Tempest\view;
 
 /**
@@ -24,7 +25,7 @@ final class TwigViewRendererTest extends FrameworkIntegrationTestCase
 
         $this->container->config(new TwigConfig(
             viewPaths: [__DIR__ . '/twig'],
-            cachePath: __DIR__ . '/../../../.cache/tempest/twig/cache',
+            cachePath: 'twig-cache',
         ));
 
         $renderer = $this->container->get(ViewRenderer::class);
@@ -32,10 +33,9 @@ final class TwigViewRendererTest extends FrameworkIntegrationTestCase
         $html = $renderer->render(view('index.twig', ...['foo' => 'bar']));
 
         $this->assertStringEqualsStringIgnoringLineEndings(<<<HTML
-            <html>
-            <span>bar</span>
-            </html>
-            HTML
-            , $html);
+        <html>
+        <span>bar</span>
+        </html>
+        HTML, $html);
     }
 }


### PR DESCRIPTION
This pull requests updates the default Twig and Blade configurations so that the cache paths are relative to Tempest's internal storage, avoiding the need for userland to make a choice as to where to store these caches.