### PR TITLE
feat(view): add `view:clear` command

### DIFF
--- a/src/Tempest/View/src/Commands/ClearViewCacheCommand.php
+++ b/src/Tempest/View/src/Commands/ClearViewCacheCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\View\Commands;
+
+use Tempest\Cache\CouldNotClearCache;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Console\HasConsole;
+use Tempest\Container\Container;
+use Tempest\View\ViewCache;
+
+final readonly class ClearViewCacheCommand
+{
+    use HasConsole;
+
+    public function __construct(
+        private Container $container,
+    ) {
+    }
+
+    #[ConsoleCommand(name: 'view:clear', description: 'Clears the view cache')]
+    public function __invoke(): void
+    {
+        $this->console->header('Clearing the view cache');
+
+        try {
+            $this->container->get(ViewCache::class)->clear();
+            $value = "<style='bold fg-green'>CLEARED</style>";
+        } catch (CouldNotClearCache) {
+            $value = "<style='bold fg-red'>FAILEd</style>";
+        }
+
+        $this->console->keyValue(key: ViewCache::class, value: $value);
+    }
+}


### PR DESCRIPTION
This pull request adds a `view:clear` command that clears the view cache. This is an alternative to using `cache:clear` and manually selecting the view cache.

Closes https://github.com/tempestphp/tempest-framework/issues/1065