### PR TITLE
feat(support): rename `map_array` to `map_iterable`

### DIFF
--- a/src/Tempest/Support/src/Arr/ManipulatesArray.php
+++ b/src/Tempest/Support/src/Arr/ManipulatesArray.php
@@ -469,7 +469,7 @@ trait ManipulatesArray
      */
     public function map(Closure $map): static
     {
-        return $this->createOrModify(namespace\map_array($this->value, $map));
+        return $this->createOrModify(namespace\map_iterable($this->value, $map));
     }
 
     /**

--- a/src/Tempest/Support/src/Arr/functions.php
+++ b/src/Tempest/Support/src/Arr/functions.php
@@ -679,7 +679,7 @@ namespace Tempest\Support\Arr {
      *
      * @return array<TKey, TMapValue>
      */
-    function map_array(iterable $array, Closure $map): array
+    function map_iterable(iterable $array, Closure $map): array
     {
         $result = [];
 
@@ -1013,7 +1013,7 @@ namespace Tempest\Support\Arr {
      */
     function flat_map(iterable $array, Closure $map, int|float $depth = 1): array
     {
-        return namespace\flatten(namespace\map_array(to_array($array), $map), $depth);
+        return namespace\flatten(namespace\map_iterable(to_array($array), $map), $depth);
     }
 
     /**


### PR DESCRIPTION
`Arr\map` was changed to `Arr\map_array` in https://github.com/tempestphp/tempest-framework/pull/1045 in order to not conflict with `Tempest\map`, which was understandably frustrating when auto-importing with IDEs.

However, the new name feels like a cheap version of the existing `array_map`. Having `array_map` and `map_array` available feels quite awkward.

`map_iterable` as a name makes a clearer distinction with `array_map`.