### PR TITLE
feat(vite): disable tag resolution in tests by default

### DIFF
--- a/src/Tempest/Framework/Testing/IntegrationTest.php
+++ b/src/Tempest/Framework/Testing/IntegrationTest.php
@@ -56,7 +56,9 @@ abstract class IntegrationTest extends TestCase
         $this->console = $this->container->get(ConsoleTester::class);
         $this->http = $this->container->get(HttpRouterTester::class);
         $this->installer = $this->container->get(InstallerTester::class);
+
         $this->vite = $this->container->get(ViteTester::class);
+        $this->vite->preventTagResolution();
 
         $request = new GenericRequest(Method::GET, '/', []);
         $this->container->singleton(Request::class, fn () => $request);


### PR DESCRIPTION
The current default behavior during tests is to try to look for a manifest file to generate Vite tags with, which is generally a bad idea because this file is not supposed to exists.

This pull request fixes that by disabling tag resolution by default, so tests can pass without a manifest error being triggered.