### PR TITLE
feat(support): support array parameters in string manipulations

### DIFF
--- a/src/Tempest/Support/src/Str/ManipulatesString.php
+++ b/src/Tempest/Support/src/Str/ManipulatesString.php
@@ -224,7 +224,7 @@ trait ManipulatesString
     /**
      * Replaces consecutive instances of a given character with a single character.
      */
-    public function deduplicate(Stringable|string|ArrayAccess|array $characters = ' '): static
+    public function deduplicate(Stringable|string|iterable $characters = ' '): static
     {
         return $this->createOrModify(deduplicate($this->value, $characters));
     }
@@ -280,7 +280,7 @@ trait ManipulatesString
     /**
      * Replaces the first occurrence of `$search` with `$replace`.
      */
-    public function replaceFirst(Stringable|string $search, Stringable|string $replace): static
+    public function replaceFirst(array|Stringable|string $search, Stringable|string $replace): static
     {
         return $this->createOrModify(replace_first($this->value, $search, $replace));
     }
@@ -288,7 +288,7 @@ trait ManipulatesString
     /**
      * Replaces the last occurrence of `$search` with `$replace`.
      */
-    public function replaceLast(Stringable|string $search, Stringable|string $replace): static
+    public function replaceLast(array|Stringable|string $search, Stringable|string $replace): static
     {
         return $this->createOrModify(replace_last($this->value, $search, $replace));
     }
@@ -296,7 +296,7 @@ trait ManipulatesString
     /**
      * Replaces `$search` with `$replace` if `$search` is at the end of the instance.
      */
-    public function replaceEnd(Stringable|string $search, Stringable|string $replace): static
+    public function replaceEnd(array|Stringable|string $search, Stringable|string $replace): static
     {
         return $this->createOrModify(replace_end($this->value, $search, $replace));
     }
@@ -304,7 +304,7 @@ trait ManipulatesString
     /**
      * Replaces `$search` with `$replace` if `$search` is at the start of the instance.
      */
-    public function replaceStart(Stringable|string $search, Stringable|string $replace): static
+    public function replaceStart(array|Stringable|string $search, Stringable|string $replace): static
     {
         return $this->createOrModify(replace_start($this->value, $search, $replace));
     }
@@ -312,7 +312,7 @@ trait ManipulatesString
     /**
      * Strips the specified `$prefix` from the start of the string.
      */
-    public function stripStart(Stringable|string $prefix): static
+    public function stripStart(array|Stringable|string $prefix): static
     {
         return $this->createOrModify(strip_start($this->value, $prefix));
     }
@@ -320,7 +320,7 @@ trait ManipulatesString
     /**
      * Strips the specified `$suffix` from the end of the string.
      */
-    public function stripEnd(Stringable|string $suffix): static
+    public function stripEnd(array|Stringable|string $suffix): static
     {
         return $this->createOrModify(strip_end($this->value, $suffix));
     }
@@ -615,9 +615,9 @@ trait ManipulatesString
      * str('Lorem ipsum')->contains('something else'); // false
      * ```
      */
-    public function contains(string|Stringable $needle): bool
+    public function contains(Stringable|string|array $needle): bool
     {
-        return contains($this->value, (string) $needle);
+        return contains($this->value, $needle);
     }
 
     /**

--- a/src/Tempest/Support/tests/Str/ManipulatesStringTest.php
+++ b/src/Tempest/Support/tests/Str/ManipulatesStringTest.php
@@ -247,6 +247,10 @@ final class ManipulatesStringTest extends TestCase
         $this->assertTrue(str('foobar foobar')->replaceLast('', 'yyy')->equals('foobar foobar'));
         $this->assertTrue(str('Malmö Jönköping')->replaceLast('ö', 'xxx')->equals('Malmö Jönkxxxping'));
         $this->assertTrue(str('Malmö Jönköping')->replaceLast('', 'yyy')->equals('Malmö Jönköping'));
+
+        $this->assertEquals('foobar foobar', str('foobar foobar')->replaceLast([], 'baz')->toString());
+        $this->assertEquals('foobar bazbar', str('foobar foobar')->replaceLast(['foo', 'bar'], 'baz')->toString());
+        $this->assertEquals('foobar foobaz', str('foobar foobar')->replaceLast(['bar', 'foo'], 'baz')->toString());
     }
 
     public function test_replace_first(): void
@@ -258,6 +262,9 @@ final class ManipulatesStringTest extends TestCase
         $this->assertTrue(str('foobar foobar')->replaceFirst('', 'yyy')->equals('foobar foobar'));
         $this->assertTrue(str('Jönköping Malmö')->replaceFirst('ö', 'xxx')->equals('Jxxxnköping Malmö'));
         $this->assertTrue(str('Jönköping Malmö')->replaceFirst('', 'yyy')->equals('Jönköping Malmö'));
+
+        $this->assertTrue(str('foobar foobar')->replaceFirst([], 'baz')->equals('foobar foobar'));
+        $this->assertTrue(str('foobar foobar')->replaceFirst(['foobar', 'foo'], 'baz')->equals('baz foobar'));
     }
 
     public function test_replace_end(): void
@@ -270,6 +277,9 @@ final class ManipulatesStringTest extends TestCase
         $this->assertTrue(str('fooxxx foobar')->replaceEnd('xxx', 'yyy')->equals('fooxxx foobar'));
         $this->assertTrue(str('Malmö Jönköping')->replaceEnd('ö', 'xxx')->equals('Malmö Jönköping'));
         $this->assertTrue(str('Malmö Jönköping')->replaceEnd('öping', 'yyy')->equals('Malmö Jönkyyy'));
+
+        $this->assertEquals('foobar foo', str('foobar foo')->replaceEnd([], 'baz')->toString());
+        $this->assertEquals('foobar baz', str('foobar foo')->replaceEnd(['bar', 'foo'], 'baz')->toString());
     }
 
     public function test_append(): void
@@ -602,6 +612,8 @@ b'));
     {
         $this->assertTrue(str('foo')->contains('fo'));
         $this->assertFalse(str('foo')->contains('bar'));
+        $this->assertTrue(str('foo')->contains(['bar', 'foo']));
+        $this->assertFalse(str('foo')->contains([]));
     }
 
     public function test_levenshtein(): void
@@ -722,5 +734,25 @@ b'));
     public function test_sentence(string $input, string $output): void
     {
         $this->assertEquals($output, str($input)->sentence()->toString());
+    }
+
+    #[TestWith(['http://tempestphp.com', 'http://', 'tempestphp.com'])]
+    #[TestWith(['http://tempestphp.com', ['http://', 'https://'], 'tempestphp.com'])]
+    #[TestWith(['http://tempestphp.com', '', 'http://tempestphp.com'])]
+    #[TestWith(['http://tempestphp.com', [], 'http://tempestphp.com'])]
+    #[TestWith(['http://tempestphp.com', '://', 'http://tempestphp.com'])]
+    #[TestWith(['http://tempestphp.com', ['http', 'http://'], '://tempestphp.com'])]
+    public function test_strip_start(string $input, string|array $strip, string $output): void
+    {
+        $this->assertEquals($output, str($input)->stripStart($strip)->toString());
+    }
+
+    #[TestWith(['foo_bar', '_bar', 'foo'])]
+    #[TestWith(['foo.bar/', '/', 'foo.bar'])]
+    #[TestWith(['foo.bar/', ['/', 'bar/'], 'foo.bar'])]
+    #[TestWith(['foo.bar/', ['bar/', '/'], 'foo.'])]
+    public function test_strip_end(string $input, string|array $strip, string $output): void
+    {
+        $this->assertEquals($output, str($input)->stripEnd($strip)->toString());
     }
 }


### PR DESCRIPTION
This pull request slightly improves the quality of life of string manipulation methods by allowing arrays as parameters in some of them.

```php
str('Jon Doe')->contains(['Jon', 'Billy']);
```