### PR TITLE
feat(database): store default sqlite database in internal storage

### DIFF
--- a/src/Tempest/Database/src/Config/database.config.php
+++ b/src/Tempest/Database/src/Config/database.config.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Tempest\Database\Config\SQLiteConfig;
 
+use function Tempest\internal_storage_path;
+
 return new SQLiteConfig(
-    path: __DIR__ . '/../database.sqlite',
+    path: internal_storage_path('database.sqlite'),
 );


### PR DESCRIPTION
This pull request updates the location of the default SQLite database to put it in the internal storage, instead of being nested into the vendor directory.