### PR TITLE
refactor(support): improve regular expression utilities

### DIFF
--- a/src/Tempest/Support/src/Str/ManipulatesString.php
+++ b/src/Tempest/Support/src/Str/ManipulatesString.php
@@ -577,20 +577,27 @@ trait ManipulatesString
      *
      * ### Example
      * ```php
-     * str('10-abc')->match('/(?<id>\d+-)/'); // ['id' => '10']
+     * str('10-abc')->match('/(?<id>\d+-)/', match: 'id'); // 10
      * ```
+     *
+     * @param non-empty-string $pattern The regular expression to match on
+     * @param string|int $match The group number or name to retrieve
+     * @param mixed $default The default value to return if no match is found
+     * @param 0|256|512|768 $flags
      */
-    public function match(string $regex): array
+    public function match(string $pattern, array|Stringable|int|string $match = 1, mixed $default = null, int $flags = 0, int $offset = 0): null|int|string|array
     {
-        return Regex\get_first_match($this->value, $regex);
+        return Regex\get_match($this->value, $pattern, $match, $default, $flags, $offset);
     }
 
     /**
      * Gets all portions of the instance that match the given regular expression.
+     *
+     * @param non-empty-string $pattern The regular expression to match on
      */
-    public function matchAll(string $regex, int $flags = 0, int $offset = 0): array
+    public function matchAll(Stringable|string $pattern, array|Stringable|int|string $matches = 0, int $offset = 0): ImmutableArray
     {
-        return Regex\get_all_matches($this->value, $regex, $flags, $offset);
+        return new ImmutableArray(Regex\get_all_matches($this->value, $pattern, $matches, $offset));
     }
 
     /**

--- a/src/Tempest/Support/tests/Str/ManipulatesStringTest.php
+++ b/src/Tempest/Support/tests/Str/ManipulatesStringTest.php
@@ -298,7 +298,7 @@ final class ManipulatesStringTest extends TestCase
 
     public function test_match(): void
     {
-        $match = str('10-abc')->match('/(?<id>\d+-)/')['id'];
+        $match = str('10-abc')->match('/(?<id>\d+-)/', match: 'id');
 
         $this->assertSame('10-', $match);
     }
@@ -321,110 +321,32 @@ final class ManipulatesStringTest extends TestCase
 
     public function test_match_all(): void
     {
-        // Test for Simple Pattern
-        $regex = '/Hello/';
-        $matches = str('Hello world, Hello universe')->matchAll($regex);
-        $expected = [['Hello', 'Hello']];
-        $this->assertSame($expected, $matches);
+        $this->assertSame([
+            ['Hello'],
+            ['Hello'],
+        ], str('Hello world, Hello universe')->matchAll('/Hello/')->toArray());
 
-        // Test for Named Capture Groups
-        $regex = '/(?<adjective>quick|lazy) (?<noun>brown|dog)/';
-        $matches = str('The quick brown fox, then the lazy dog')->matchAll($regex);
-        $expectedAdjectives = [
-            [
-                'quick brown',
-                'lazy dog',
-            ],
-            'adjective' => [
-                'quick',
-                'lazy',
-            ],
-            1 => [
-                'quick',
-                'lazy',
-            ],
-            'noun' => [
-                'brown',
-                'dog',
-            ],
-            2 => [
-                'brown',
-                'dog',
-            ],
-        ];
-
-        $this->assertSame($expectedAdjectives, $matches);
-
-        // Test for No Matches
-        $regex = '/cat/';
-        $matches = str('The quick brown fox, then the lazy dog')->matchAll($regex);
-        $expected = [];
-        $this->assertSame($expected, $matches);
-
-        // Test for Mixed Captures
-        $regex = '/(?<adjective>quick|lazy) (?<noun>brown|dog) (?<action>jumps|eats)?/';
-        $matches = str('The quick brown fox, then the lazy dog eats')->matchAll($regex);
-        $expected = [
-            [
-                'quick brown ',
-                'lazy dog eats',
-            ],
-            'adjective' => [
-                'quick',
-                'lazy',
-            ],
-            [
-                'quick',
-                'lazy',
-            ],
-            'noun' => [
-                'brown',
-                'dog',
-            ],
-            [
-                'brown',
-                'dog',
-            ],
-            'action' => [
-                '',
-                'eats',
-            ],
-            [
-                '',
-                'eats',
-            ],
-        ];
-        $this->assertSame($expected, $matches);
-
-        // Test flags
-        $regex = '/(foo)(bar)/';
-        $matches = str('foobarbaz')->matchAll($regex, PREG_OFFSET_CAPTURE);
-        $expected = [
+        $this->assertSame(
             [
                 [
-                    'foobar',
-                    0,
+                    'match' => "<href='https://bsky.app'>Bluesky</href>",
+                    'quote' => "'",
+                    'href' => 'https://bsky.app',
                 ],
-            ],
-            [
                 [
-                    'foo',
-                    0,
+                    'match' => "<href='https://x.com.com'>X</href>",
+                    'quote' => "'",
+                    'href' => 'https://x.com.com',
                 ],
             ],
-            [
-                [
-                    'bar',
-                    3,
-                ],
-            ],
-        ];
-        $this->assertSame($expected, $matches);
-
-        $regex = '/^def/';
-        $matches = str('abcdef')->matchAll(regex: $regex, offset: 3);
-        $expected = [];
-        $this->assertSame($expected, $matches);
+            str("<href='https://bsky.app'>Bluesky</href><href='https://x.com.com'>X</href>")
+                ->matchAll('/(?<match>\<href=(?<quote>[\"\'])(?<href>.+?)\k<quote>\>(?:(?!\<href).)*?\<\/href\>)/g', matches: [
+                    'match',
+                    'quote',
+                    'href',
+                ])
+                ->toArray(),
+        );
     }
 
     public function test_explode(): void

--- a/src/Tempest/View/src/Elements/PhpForeachElement.php
+++ b/src/Tempest/View/src/Elements/PhpForeachElement.php
@@ -54,7 +54,7 @@ final class PhpForeachElement implements Element, WrapsElement
         );
 
         if ($this->else !== null) {
-            $collectionName = str($foreachAttribute)->match('/^(?<match>.*)\s+as/')['match'];
+            $collectionName = str($foreachAttribute)->match('/^(?<match>.*)\s+as/', 'match');
 
             $this->else->consumeAttribute(':forelse');
 

--- a/src/Tempest/View/src/Renderers/TempestViewCompiler.php
+++ b/src/Tempest/View/src/Renderers/TempestViewCompiler.php
@@ -129,7 +129,7 @@ final readonly class TempestViewCompiler
         // Find head nodes, these are parsed separately so that we skip HTML's head-parsing rules
         $headNodes = [];
 
-        $headTemplate = $template->match('/<head>((.|\n)*?)<\/head>/')[1] ?? null;
+        $headTemplate = $template->match('/<head>((.|\n)*?)<\/head>/');
 
         if ($headTemplate) {
             $headNodes = HTMLDocument::createFromString(


### PR DESCRIPTION
This pull request improves our regular expression utilities.

When they were first added, it was mostly to improve the error handling of `preg_` functions. This iteration offers a better API than simple wrappers.

The most common use for `preg_match` is to return a specific group, named or not. This is what `get_match` does:

```php
Regex\get_match('10-abc', '/(?<id>\d+)-.*/'); // 10 (first match by default)
Regex\get_match('10-abc', '/(?<id>\d+)-.*/', match: 'id'); // 10
Regex\get_match('abc', '/(?<id>\d+)-.*/', match: 'id', default: 1); // 1
```

Next, `get_all_matches` is almost the same as `preg_match_all`, but it always uses `PREG_SET_ORDER` for better grouping, and filters out keys not specified in `matches`.

```php
Regex\get_all_matches(
    subject: "<href='https://bsky.app'>Bluesky</href>",
    pattern: '/(?<match>\<href=(?<quote>[\"\'])(?<href>.+?)\k<quote>\>(?:(?!\<href).)*?\<\/href\>)/',
    matches: [
        'match',
        'quote',
        'href',
    ]
);
```