### PR TITLE
feat(router): support returning `string` and `array` from controllers

### DIFF
--- a/src/Tempest/Router/src/GenericRouter.php
+++ b/src/Tempest/Router/src/GenericRouter.php
@@ -187,9 +187,9 @@ final class GenericRouter implements Router
         return $currentUri === $candidateUri;
     }
 
-    private function createResponse(Response|View $input): Response
+    private function createResponse(string|array|Response|View $input): Response
     {
-        if ($input instanceof View) {
+        if ($input instanceof View || is_array($input) || is_string($input)) {
             return new Ok($input);
         }
 


### PR DESCRIPTION
This pull request allows returning string and arrays directly from controllers. Both the `ResponseSender` and `Response` classes already supported it already, but not the router's `createResponse`, so this PR changes that.

```php
#[Get('/')]
public function __invoke(): string
{
    return 'hello world'; // no longer throws!
}
```