### PR TITLE
feat(router): introduce response processors

### DIFF
--- a/src/Tempest/Router/src/ErrorResponses/ErrorResponseProcessor.php
+++ b/src/Tempest/Router/src/ErrorResponses/ErrorResponseProcessor.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tempest\Router\ErrorResponses;
+
+use Tempest\Http\Status;
+use Tempest\Router\Response;
+use Tempest\Router\ResponseProcessor;
+use Tempest\View\GenericView;
+use Tempest\View\View;
+
+final class ErrorResponseProcessor implements ResponseProcessor
+{
+    public function process(Response $response): Response
+    {
+        return match ($response->status) {
+            Status::INTERNAL_SERVER_ERROR, Status::NOT_FOUND, Status::FORBIDDEN, Status::UNAUTHORIZED => $response->setBody($this->renderErrorView($response->status)),
+            default => $response,
+        };
+    }
+
+    private function renderErrorView(Status $status): View
+    {
+        return new GenericView(__DIR__ . '/error.view.php', [
+            'css' => $this->getCss(),
+            'status' => $status->value,
+            'title' => $status->description(),
+            'message' => match ($status) {
+                Status::INTERNAL_SERVER_ERROR => 'An unexpected server error occurred',
+                Status::NOT_FOUND => 'This page could not be found',
+                Status::FORBIDDEN => 'You do not have permission to access this page',
+                Status::UNAUTHORIZED => 'You must be authenticated in to access this page',
+                default => $status->description(),
+            },
+        ]);
+    }
+
+    private function getCss(): string
+    {
+        return file_get_contents(__DIR__ . '/style.css');
+    }
+}

--- a/src/Tempest/Router/src/ErrorResponses/error.view.php
+++ b/src/Tempest/Router/src/ErrorResponses/error.view.php
@@ -1,0 +1,14 @@
+<html lang="en">
+<head>
+  <title>{{ $title }}</title>
+  <style>{!! $css !!}</style>
+</head>
+<body>
+  <div class="flex flex-col justify-center items-center bg-[#061324] min-w-screen min-h-screen text-[#a8caf7] antialiased">
+    <div class="px-8 container">
+      <h1 class="font-thin text-8xl">{{ $status }}</h1>
+      <p class="text-xl uppercase">{{ \Tempest\Support\Str\ensure_ends_with($message, '.') }}</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/Tempest/Router/src/ErrorResponses/style.css
+++ b/src/Tempest/Router/src/ErrorResponses/style.css
@@ -1,0 +1,230 @@
+/*! tailwindcss v4.0.17 | MIT License | https://tailwindcss.com */
+@layer theme, base, components, utilities;
+@layer theme {
+  :root, :host {
+    --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    'Noto Color Emoji';
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+    --spacing: 0.25rem;
+    --text-xl: 1.25rem;
+    --text-xl--line-height: calc(1.75 / 1.25);
+    --text-8xl: 6rem;
+    --text-8xl--line-height: 1;
+    --font-weight-thin: 100;
+    --default-font-family: var(--font-sans);
+    --default-mono-font-family: var(--font-mono);
+  }
+}
+@layer base {
+  *, ::after, ::before, ::backdrop, ::file-selector-button {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+  html, :host {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji');
+    font-feature-settings: var(--default-font-feature-settings, normal);
+    font-variation-settings: var(--default-font-variation-settings, normal);
+    -webkit-tap-highlight-color: transparent;
+  }
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+  abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+  a {
+    color: inherit;
+    -webkit-text-decoration: inherit;
+    text-decoration: inherit;
+  }
+  b, strong {
+    font-weight: bolder;
+  }
+  code, kbd, samp, pre {
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace);
+    font-feature-settings: var(--default-mono-font-feature-settings, normal);
+    font-variation-settings: var(--default-mono-font-variation-settings, normal);
+    font-size: 1em;
+  }
+  small {
+    font-size: 80%;
+  }
+  sub, sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  sub {
+    bottom: -0.25em;
+  }
+  sup {
+    top: -0.5em;
+  }
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+  :-moz-focusring {
+    outline: auto;
+  }
+  progress {
+    vertical-align: baseline;
+  }
+  summary {
+    display: list-item;
+  }
+  ol, ul, menu {
+    list-style: none;
+  }
+  img, svg, video, canvas, audio, iframe, embed, object {
+    display: block;
+    vertical-align: middle;
+  }
+  img, video {
+    max-width: 100%;
+    height: auto;
+  }
+  button, input, select, optgroup, textarea, ::file-selector-button {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+  :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+  :where(select:is([multiple], [size])) optgroup option {
+    padding-inline-start: 20px;
+  }
+  ::file-selector-button {
+    margin-inline-end: 4px;
+  }
+  ::placeholder {
+    opacity: 1;
+  }
+  @supports (not (-webkit-appearance: -apple-pay-button)) or (contain-intrinsic-size: 1px) {
+    ::placeholder {
+      color: color-mix(in oklab, currentColor 50%, transparent);
+    }
+  }
+  textarea {
+    resize: vertical;
+  }
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  ::-webkit-date-and-time-value {
+    min-height: 1lh;
+    text-align: inherit;
+  }
+  ::-webkit-datetime-edit {
+    display: inline-flex;
+  }
+  ::-webkit-datetime-edit-fields-wrapper {
+    padding: 0;
+  }
+  ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month-field, ::-webkit-datetime-edit-day-field, ::-webkit-datetime-edit-hour-field, ::-webkit-datetime-edit-minute-field, ::-webkit-datetime-edit-second-field, ::-webkit-datetime-edit-millisecond-field, ::-webkit-datetime-edit-meridiem-field {
+    padding-block: 0;
+  }
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+  button, input:where([type='button'], [type='reset'], [type='submit']), ::file-selector-button {
+    appearance: button;
+  }
+  ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
+    height: auto;
+  }
+  [hidden]:where(:not([hidden='until-found'])) {
+    display: none!important;
+  }
+}
+@layer utilities {
+  .container {
+    width: 100%;
+    @media (width >= 40rem) {
+      max-width: 40rem;
+    }
+    @media (width >= 48rem) {
+      max-width: 48rem;
+    }
+    @media (width >= 64rem) {
+      max-width: 64rem;
+    }
+    @media (width >= 80rem) {
+      max-width: 80rem;
+    }
+    @media (width >= 96rem) {
+      max-width: 96rem;
+    }
+  }
+  .flex {
+    display: flex;
+  }
+  .min-h-screen {
+    min-height: 100vh;
+  }
+  .min-w-screen {
+    min-width: 100vw;
+  }
+  .flex-col {
+    flex-direction: column;
+  }
+  .items-center {
+    align-items: center;
+  }
+  .justify-center {
+    justify-content: center;
+  }
+  .bg-\[\#061324\] {
+    background-color: #061324;
+  }
+  .px-8 {
+    padding-inline: calc(var(--spacing) * 8);
+  }
+  .text-8xl {
+    font-size: var(--text-8xl);
+    line-height: var(--tw-leading, var(--text-8xl--line-height));
+  }
+  .text-xl {
+    font-size: var(--text-xl);
+    line-height: var(--tw-leading, var(--text-xl--line-height));
+  }
+  .font-thin {
+    --tw-font-weight: var(--font-weight-thin);
+    font-weight: var(--font-weight-thin);
+  }
+  .text-\[\#a8caf7\] {
+    color: #a8caf7;
+  }
+  .uppercase {
+    text-transform: uppercase;
+  }
+  .antialiased {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+}
+@property --tw-font-weight {
+  syntax: "*";
+  inherits: false;
+}

--- a/src/Tempest/Router/src/GenericRouter.php
+++ b/src/Tempest/Router/src/GenericRouter.php
@@ -42,6 +42,7 @@ final class GenericRouter implements Router
         private readonly Container $container,
         private readonly RouteMatcher $routeMatcher,
         private readonly AppConfig $appConfig,
+        private readonly RouteConfig $routeConfig,
     ) {}
 
     public function throwExceptions(): self
@@ -52,6 +53,13 @@ final class GenericRouter implements Router
     }
 
     public function dispatch(Request|PsrRequest $request): Response
+    {
+        return $this->processResponse(
+            $this->processRequest($request),
+        );
+    }
+
+    private function processRequest(Request|PsrRequest $request): Response
     {
         if (! ($request instanceof PsrRequest)) {
             $request = map($request)->with(RequestToPsrRequestMapper::class)->do();
@@ -194,6 +202,18 @@ final class GenericRouter implements Router
         }
 
         return $input;
+    }
+
+    private function processResponse(Response $response): Response
+    {
+        foreach ($this->routeConfig->responseProcessors as $responseProcessorClass) {
+            /** @var \Tempest\Response\ResponseProcessor $responseProcessor */
+            $responseProcessor = $this->container->get($responseProcessorClass);
+
+            $response = $responseProcessor->process($response);
+        }
+
+        return $response;
     }
 
     // TODO: could in theory be moved to a dynamic initializer

--- a/src/Tempest/Router/src/IsResponse.php
+++ b/src/Tempest/Router/src/IsResponse.php
@@ -110,4 +110,11 @@ trait IsResponse
 
         return $this;
     }
+
+    public function setBody(View|string|array|Generator|null $body): self
+    {
+        $this->body = $body;
+
+        return $this;
+    }
 }

--- a/src/Tempest/Router/src/Response.php
+++ b/src/Tempest/Router/src/Response.php
@@ -41,4 +41,8 @@ interface Response
     public function addCookie(Cookie $cookie): self;
 
     public function removeCookie(string $key): self;
+
+    public function setStatus(Status $status): self;
+
+    public function setBody(View|string|array|Generator|null $body): self;
 }

--- a/src/Tempest/Router/src/ResponseProcessor.php
+++ b/src/Tempest/Router/src/ResponseProcessor.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Router;
+
+interface ResponseProcessor
+{
+    public function process(Response $response): Response;
+}

--- a/src/Tempest/Router/src/ResponseProcessorDiscovery.php
+++ b/src/Tempest/Router/src/ResponseProcessorDiscovery.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Router;
+
+use Tempest\Discovery\Discovery;
+use Tempest\Discovery\DiscoveryLocation;
+use Tempest\Discovery\IsDiscovery;
+use Tempest\Reflection\ClassReflector;
+
+final class ResponseProcessorDiscovery implements Discovery
+{
+    use IsDiscovery;
+
+    public function __construct(
+        private readonly RouteConfig $routeConfig,
+    ) {}
+
+    public function discover(DiscoveryLocation $location, ClassReflector $class): void
+    {
+        if (! $class->implements(ResponseProcessor::class)) {
+            return;
+        }
+
+        $this->discoveryItems->add($location, [$class->getName()]);
+    }
+
+    public function apply(): void
+    {
+        foreach ($this->discoveryItems as [$className]) {
+            $viewProcessor = new ClassReflector($className);
+
+            $this->routeConfig->addResponseProcessor($viewProcessor->getName());
+        }
+    }
+}

--- a/src/Tempest/Router/src/Responses/ServerError.php
+++ b/src/Tempest/Router/src/Responses/ServerError.php
@@ -14,7 +14,7 @@ final class ServerError implements Response
 {
     use IsResponse;
 
-    public function __construct(View|Generator|string|array|null $body)
+    public function __construct(View|Generator|string|array|null $body = null)
     {
         $this->status = Status::INTERNAL_SERVER_ERROR;
         $this->body = $body;

--- a/src/Tempest/Router/src/RouteConfig.php
+++ b/src/Tempest/Router/src/RouteConfig.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Router;
 
-use Tempest\Router\Routing\Construction\DiscoveredRoute;
-use Tempest\Router\Routing\Matching\MatchingRegex;
+use Tempest\Reflection\ClassReflector;
 
 final class RouteConfig
 {
@@ -16,6 +15,8 @@ final class RouteConfig
         public array $dynamicRoutes = [],
         /** @var array<string, MatchingRegex> */
         public array $matchingRegexes = [],
+        /** @var class-string<\Tempest\Response\ResponseProcessor>[] */
+        public array $responseProcessors = [],
     ) {}
 
     public function apply(RouteConfig $newConfig): void
@@ -23,5 +24,10 @@ final class RouteConfig
         $this->staticRoutes = $newConfig->staticRoutes;
         $this->dynamicRoutes = $newConfig->dynamicRoutes;
         $this->matchingRegexes = $newConfig->matchingRegexes;
+    }
+
+    public function addResponseProcessor(string $responseProcessor): void
+    {
+        $this->responseProcessors[] = $responseProcessor;
     }
 }

--- a/tests/Integration/Route/RouterTest.php
+++ b/tests/Integration/Route/RouterTest.php
@@ -11,8 +11,8 @@ use Tempest\Core\AppConfig;
 use Tempest\Database\Migrations\CreateMigrationsTable;
 use Tempest\Http\Status;
 use Tempest\Router\GenericRouter;
-use Tempest\Router\MatchedRoute;
 use Tempest\Router\Responses\Ok;
+use Tempest\Router\RouteConfig;
 use Tempest\Router\Router;
 use Tests\Tempest\Fixtures\Controllers\ControllerWithEnumBinding;
 use Tests\Tempest\Fixtures\Controllers\EnumForController;
@@ -25,6 +25,7 @@ use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
+use function Tempest\reflect;
 use function Tempest\uri;
 
 /**
@@ -246,5 +247,15 @@ final class RouterTest extends FrameworkIntegrationTestCase
         $this->assertTrue($router->isCurrentUri(ControllerWithEnumBinding::class));
         $this->assertTrue($router->isCurrentUri(ControllerWithEnumBinding::class, input: EnumForController::FOO));
         $this->assertFalse($router->isCurrentUri(ControllerWithEnumBinding::class, input: EnumForController::BAR));
+    }
+
+    public function test_response_processor(): void
+    {
+        $this->container->get(RouteConfig::class)->addResponseProcessor(TestResponseProcessor::class);
+
+        $this->http
+            ->get('/')
+            ->assertHeaderContains('X-Processed', 'true')
+            ->assertOk();
     }
 }

--- a/tests/Integration/Route/TestResponseProcessor.php
+++ b/tests/Integration/Route/TestResponseProcessor.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Tempest\Integration\Route;
+
+use Tempest\Router\Response;
+use Tempest\Router\ResponseProcessor;
+
+final readonly class TestResponseProcessor implements ResponseProcessor
+{
+    public function process(Response $response): Response
+    {
+        return $response->addHeader('X-Processed', 'true');
+    }
+}


### PR DESCRIPTION
Closes https://github.com/tempestphp/tempest-framework/issues/701

This pull request introduces the concept of "response processors", which is the same as view processors but for responses.

This allows intercepting responses right before they are sent. In contrast to HTTP middleware, they will be called if there was an error somewhere in the HTTP layer, since they are last in the router pipeline.

This notably allows for implementing custom error pages in a very simple way:

```php
use function Tempest\view;

final class ErrorStatusResponseProcessor implements ResponseProcessor
{
    public function process(Response $response): Response
    {
        if (! $response->status->isSuccessful()) {
            return $response->setBody(view('./error.view.php', status: $response->status));
        }

        return $response;
    }
}
```

The pull request now includes a built-in error page displayed for HTTP 500, 404, 403, and 401. Other error statuses will keep sending a blank page for now.

![CleanShot 2025-03-26 at 23 25 53](https://github.com/user-attachments/assets/c8821544-a0f9-4191-862c-de7b9581976f)

## Questions

- I think we should not send the built-in error pages if the request doesn't expect JSON responses, but I don't believe we currently have utilities to detect that
- Should we display the built-in error page for more/less statuses?
- I think this makes the current `HttpProductionErrorHandler`'s `showErrorPage` useless?

I'd appreciate criticism about the approach taken here.
