### PR TITLE
refactor(database): rename `TableName` to `Table`

### DIFF
--- a/src/Tempest/Database/src/Builder/ModelDefinition.php
+++ b/src/Tempest/Database/src/Builder/ModelDefinition.php
@@ -13,7 +13,7 @@ use Tempest\Database\Config\DatabaseConfig;
 use Tempest\Database\Eager;
 use Tempest\Database\HasMany;
 use Tempest\Database\HasOne;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 use Tempest\Reflection\ClassReflector;
 use Tempest\Support\Arr\ImmutableArray;
 
@@ -118,7 +118,7 @@ final readonly class ModelDefinition
     public function getTableDefinition(): TableDefinition
     {
         $specificName = $this->modelClass
-            ->getAttribute(TableName::class)
+            ->getAttribute(Table::class)
             ?->name;
 
         $conventionalName = get(DatabaseConfig::class)

--- a/src/Tempest/Database/src/Builder/ModelInspector.php
+++ b/src/Tempest/Database/src/Builder/ModelInspector.php
@@ -4,7 +4,7 @@ namespace Tempest\Database\Builder;
 
 use ReflectionException;
 use Tempest\Database\Config\DatabaseConfig;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 use Tempest\Reflection\ClassReflector;
 
 use function Tempest\get;
@@ -39,7 +39,7 @@ final class ModelInspector
         }
 
         $specificName = $this->modelClass
-            ->getAttribute(TableName::class)
+            ->getAttribute(Table::class)
             ?->name;
 
         $conventionalName = get(DatabaseConfig::class)

--- a/src/Tempest/Database/src/Table.php
+++ b/src/Tempest/Database/src/Table.php
@@ -5,9 +5,9 @@ namespace Tempest\Database;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_CLASS)]
-final class TableName
+final class Table
 {
     public function __construct(
-        public string $name,
+        public ?string $name = null,
     ) {}
 }

--- a/tests/Fixtures/Models/A.php
+++ b/tests/Fixtures/Models/A.php
@@ -7,7 +7,7 @@ namespace Tests\Tempest\Fixtures\Models;
 use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\IsDatabaseModel;
 
-#[\Tempest\Database\TableName('a')]
+#[\Tempest\Database\Table('a')]
 final class A
 {
     use IsDatabaseModel;

--- a/tests/Fixtures/Models/AWithEager.php
+++ b/tests/Fixtures/Models/AWithEager.php
@@ -8,7 +8,7 @@ use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\Eager;
 use Tempest\Database\IsDatabaseModel;
 
-#[\Tempest\Database\TableName('a')]
+#[\Tempest\Database\Table('a')]
 final class AWithEager
 {
     use IsDatabaseModel;

--- a/tests/Fixtures/Models/AWithLazy.php
+++ b/tests/Fixtures/Models/AWithLazy.php
@@ -8,7 +8,7 @@ use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\IsDatabaseModel;
 use Tempest\Database\Lazy;
 
-#[\Tempest\Database\TableName('a')]
+#[\Tempest\Database\Table('a')]
 final class AWithLazy
 {
     use IsDatabaseModel;

--- a/tests/Fixtures/Models/AWithValue.php
+++ b/tests/Fixtures/Models/AWithValue.php
@@ -6,9 +6,9 @@ namespace Tests\Tempest\Fixtures\Models;
 
 use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('a')]
+#[Table('a')]
 final class AWithValue
 {
     use IsDatabaseModel;

--- a/tests/Fixtures/Models/AWithVirtual.php
+++ b/tests/Fixtures/Models/AWithVirtual.php
@@ -6,10 +6,10 @@ namespace Tests\Tempest\Fixtures\Models;
 
 use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 use Tempest\Database\Virtual;
 
-#[TableName('a')]
+#[Table('a')]
 final class AWithVirtual
 {
     use IsDatabaseModel;

--- a/tests/Fixtures/Models/B.php
+++ b/tests/Fixtures/Models/B.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Fixtures\Models;
 
-use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('b')]
+#[Table('b')]
 final class B
 {
     use IsDatabaseModel;

--- a/tests/Fixtures/Models/BWithEager.php
+++ b/tests/Fixtures/Models/BWithEager.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Fixtures\Models;
 
-use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\Eager;
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('b')]
+#[Table('b')]
 final class BWithEager
 {
     use IsDatabaseModel;

--- a/tests/Fixtures/Models/C.php
+++ b/tests/Fixtures/Models/C.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Fixtures\Models;
 
-use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('c')]
+#[Table('c')]
 final class C
 {
     use IsDatabaseModel;

--- a/tests/Integration/Database/Relations/Fixtures/BelongsToParentModel.php
+++ b/tests/Integration/Database/Relations/Fixtures/BelongsToParentModel.php
@@ -6,9 +6,9 @@ namespace Tests\Tempest\Integration\Database\Relations\Fixtures;
 
 use Tempest\Database\BelongsTo;
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('belongs_to_parent_model')]
+#[Table('belongs_to_parent_model')]
 final class BelongsToParentModel
 {
     use IsDatabaseModel;

--- a/tests/Integration/Database/Relations/Fixtures/BelongsToRelatedModel.php
+++ b/tests/Integration/Database/Relations/Fixtures/BelongsToRelatedModel.php
@@ -6,9 +6,9 @@ namespace Tests\Tempest\Integration\Database\Relations\Fixtures;
 
 use Tempest\Database\HasMany;
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('belongs_to_related')]
+#[Table('belongs_to_related')]
 final class BelongsToRelatedModel
 {
     use IsDatabaseModel;

--- a/tests/Integration/Database/Relations/Fixtures/HasOneInvalidRelatedModel.php
+++ b/tests/Integration/Database/Relations/Fixtures/HasOneInvalidRelatedModel.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tests\Tempest\Integration\Database\Relations\Fixtures;
 
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('has_one_invalid_related')]
+#[Table('has_one_invalid_related')]
 final class HasOneInvalidRelatedModel
 {
     use IsDatabaseModel;

--- a/tests/Integration/Database/Relations/Fixtures/HasOneParentModel.php
+++ b/tests/Integration/Database/Relations/Fixtures/HasOneParentModel.php
@@ -6,9 +6,9 @@ namespace Tests\Tempest\Integration\Database\Relations\Fixtures;
 
 use Tempest\Database\HasOne;
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('has_one_parent_model')]
+#[Table('has_one_parent_model')]
 final class HasOneParentModel
 {
     use IsDatabaseModel;

--- a/tests/Integration/Database/Relations/Fixtures/HasOneRelatedModel.php
+++ b/tests/Integration/Database/Relations/Fixtures/HasOneRelatedModel.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tests\Tempest\Integration\Database\Relations\Fixtures;
 
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('has_one_related')]
+#[Table('has_one_related')]
 final class HasOneRelatedModel
 {
     use IsDatabaseModel;

--- a/tests/Integration/ORM/Models/AttributeTableNameModel.php
+++ b/tests/Integration/ORM/Models/AttributeTableNameModel.php
@@ -3,9 +3,9 @@
 namespace Tests\Tempest\Integration\ORM\Models;
 
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('custom_attribute_table_name')]
+#[Table('custom_attribute_table_name')]
 final class AttributeTableNameModel
 {
     use IsDatabaseModel;

--- a/tests/Integration/ORM/Models/ChildModel.php
+++ b/tests/Integration/ORM/Models/ChildModel.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\ORM\Models;
 
-use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\HasOne;
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('child')]
+#[Table('child')]
 final class ChildModel
 {
     use IsDatabaseModel;

--- a/tests/Integration/ORM/Models/ParentModel.php
+++ b/tests/Integration/ORM/Models/ParentModel.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\ORM\Models;
 
-use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('parent')]
+#[Table('parent')]
 final class ParentModel
 {
     use IsDatabaseModel;

--- a/tests/Integration/ORM/Models/StaticMethodTableNameModel.php
+++ b/tests/Integration/ORM/Models/StaticMethodTableNameModel.php
@@ -2,11 +2,10 @@
 
 namespace Tests\Tempest\Integration\ORM\Models;
 
-use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('custom_static_method_table_name')]
+#[Table('custom_static_method_table_name')]
 final class StaticMethodTableNameModel
 {
     use IsDatabaseModel;

--- a/tests/Integration/ORM/Models/ThroughModel.php
+++ b/tests/Integration/ORM/Models/ThroughModel.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\ORM\Models;
 
-use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\TableName;
+use Tempest\Database\Table;
 
-#[TableName('through')]
+#[Table('through')]
 final class ThroughModel
 {
     use IsDatabaseModel;


### PR DESCRIPTION
The idea behind this is to give the `Table` attribute more flexibility - in case more things need to be added to it in the future.

A good example I can think of right now is `schema` - a concept very commonly used in SQL Server, for example.

Having one attribute per table thing can become terrible real quick.
For example, this:
```php
#[Table(name: 'tweets', schema: 'blogging')]
class Post
{
}
```

is a lot better than this:
```php
#[TableName('tweets')]
#[TableSchema('blogging')]
class Post
{
}
```