### PR TITLE
refactor(console): improve console output consistency

### DIFF
--- a/src/Tempest/Console/src/Actions/ExecuteConsoleCommand.php
+++ b/src/Tempest/Console/src/Actions/ExecuteConsoleCommand.php
@@ -41,6 +41,16 @@ final readonly class ExecuteConsoleCommand
         ));
     }
 
+    public function withoutArgumentBag(): self
+    {
+        $bag = new ConsoleArgumentBag([
+            $this->argumentBag->getBinaryPath(),
+            $this->argumentBag->getCommandName(),
+        ]);
+
+        return new self($this->container, $this->consoleConfig, $bag, $this->resolveConsoleCommand);
+    }
+
     private function getCallable(array $commandMiddleware): ConsoleMiddlewareCallable
     {
         $callable = new ConsoleMiddlewareCallable(function (Invocation $invocation) {

--- a/src/Tempest/Console/src/Actions/ExecuteConsoleCommand.php
+++ b/src/Tempest/Console/src/Actions/ExecuteConsoleCommand.php
@@ -14,6 +14,8 @@ use Tempest\Console\Input\ConsoleArgumentBag;
 use Tempest\Container\Container;
 use Throwable;
 
+use function Tempest\Support\Arr\wrap;
+
 final readonly class ExecuteConsoleCommand
 {
     public function __construct(
@@ -77,9 +79,10 @@ final readonly class ExecuteConsoleCommand
     }
 
     /** @return array{string,array} */
-    private function resolveCommandAndArguments(string|array $command, array $arguments = []): array
+    private function resolveCommandAndArguments(string|array $command, string|array $arguments = []): array
     {
         $commandName = $command;
+        $arguments = wrap($arguments);
 
         if (is_array($command)) {
             $commandName = $command[0] ?? '';

--- a/src/Tempest/Console/src/Commands/MakeCommandCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeCommandCommand.php
@@ -38,6 +38,7 @@ final class MakeCommandCommand
             ],
         );
 
+        $this->console->writeln();
         $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
     }
 }

--- a/src/Tempest/Console/src/Commands/MakeCommandCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeCommandCommand.php
@@ -39,6 +39,6 @@ final class MakeCommandCommand
         );
 
         $this->console->writeln();
-        $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
+        $this->console->success(sprintf('File successfully created at <file="%s"/>.', $targetPath));
     }
 }

--- a/src/Tempest/Console/src/Commands/MakeGeneratorCommandCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeGeneratorCommandCommand.php
@@ -39,6 +39,6 @@ final class MakeGeneratorCommandCommand
         );
 
         $this->console->writeln();
-        $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
+        $this->console->success(sprintf('File successfully created at <file="%s"/>.', $targetPath));
     }
 }

--- a/src/Tempest/Console/src/Commands/MakeGeneratorCommandCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeGeneratorCommandCommand.php
@@ -38,6 +38,7 @@ final class MakeGeneratorCommandCommand
             ],
         );
 
+        $this->console->writeln();
         $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
     }
 }

--- a/src/Tempest/Console/src/Commands/MakeMiddlewareCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeMiddlewareCommand.php
@@ -41,6 +41,7 @@ final class MakeMiddlewareCommand
             shouldOverride: $shouldOverride,
         );
 
+        $this->console->writeln();
         $this->console->success(sprintf('Middleware successfully created at <file="%s"/>.', $targetPath));
     }
 

--- a/src/Tempest/Console/src/Components/InteractiveComponentRenderer.php
+++ b/src/Tempest/Console/src/Components/InteractiveComponentRenderer.php
@@ -226,15 +226,7 @@ final class InteractiveComponentRenderer
      */
     private function validate(mixed $value, array $validation): ?Rule
     {
-        $validator = new Validator();
-
-        try {
-            $validator->validateValue($value, $validation);
-        } catch (InvalidValueException $invalidValueException) {
-            return $invalidValueException->failingRules[0];
-        }
-
-        return null;
+        return new Validator()->validateValue($value, $validation)[0] ?? null;
     }
 
     public function isComponentSupported(Console $console, InteractiveConsoleComponent $component): bool

--- a/src/Tempest/Console/src/Components/Renderers/MessageRenderer.php
+++ b/src/Tempest/Console/src/Components/Renderers/MessageRenderer.php
@@ -23,7 +23,6 @@ final readonly class MessageRenderer
             ->implode("\n");
 
         return str()
-            ->append("\n")
             ->append("<style='fg-{$this->color} bold'>{$title}</style> <style='dim fg-{$this->color}'>//</style>")
             ->append("<style='fg-{$this->color}'>{$lines}</style>")
             ->toString();

--- a/src/Tempest/Console/src/Components/Renderers/RendersInput.php
+++ b/src/Tempest/Console/src/Components/Renderers/RendersInput.php
@@ -17,6 +17,8 @@ trait RendersInput
 
     public const int MARGIN_TOP = 1;
 
+    public const int MARGIN_BOTTOM = 0;
+
     private ImmutableString $frame;
 
     private Terminal $terminal;
@@ -54,10 +56,10 @@ trait RendersInput
     private function finishRender(): string
     {
         if ($this->state->isFinished() && $this->frame->endsWith("\n")) {
-            $this->frame = $this->frame->replaceEnd("\n", '');
+            $this->frame = $this->frame->stripEnd("\n");
         }
 
-        return $this->frame->toString();
+        return $this->frame->append(str_repeat("\n", self::MARGIN_BOTTOM))->toString();
     }
 
     private function truncate(?string $string = null, int $maxLineOffset = 0): string

--- a/src/Tempest/Console/src/Components/Renderers/TextInputRenderer.php
+++ b/src/Tempest/Console/src/Components/Renderers/TextInputRenderer.php
@@ -8,6 +8,7 @@ use Tempest\Console\Components\ComponentState;
 use Tempest\Console\Components\TextBuffer;
 use Tempest\Console\Point;
 use Tempest\Console\Terminal\Terminal;
+use Tempest\Support\Str\ImmutableString;
 
 use function Tempest\Support\str;
 
@@ -42,7 +43,8 @@ final class TextInputRenderer
         $lines = str($buffer->text ?: ($placeholder ?: ''))
             ->explode("\n")
             ->flatMap(fn (string $line) => str($line)->chunk($this->maxLineCharacters)->toArray())
-            ->map(static fn (string $line) => str($line)->replaceEnd("\n", ' '));
+            ->map(static fn (string $line) => str($line)->replaceEnd("\n", ' '))
+            ->filter(fn (ImmutableString $line) => $line->isNotEmpty());
 
         // calculates scroll offset based on cursor position
         $this->scrollOffset = $this->calculateScrollOffset($lines, $this->maximumLines, $buffer->getRelativeCursorPosition($this->maxLineCharacters)->y);
@@ -51,7 +53,7 @@ final class TextInputRenderer
         $displayLines = $lines->slice($this->scrollOffset, $this->state->isFinished() ? 1 : $this->maximumLines);
 
         // if there is nothing to display after the component is done, show "no input"
-        if ($this->state->isFinished() && $lines->count() === 0) {
+        if ($this->state->isFinished() && $lines->isEmpty()) {
             $this->line($this->style('italic dim', 'No input.'))->newLine();
         }
 

--- a/src/Tempest/Console/src/Exceptions/ConsoleErrorHandler.php
+++ b/src/Tempest/Console/src/Exceptions/ConsoleErrorHandler.php
@@ -15,6 +15,8 @@ use Tempest\Highlight\Escape;
 use Tempest\Highlight\Highlighter;
 use Throwable;
 
+use function Tempest\Support\str;
+
 final readonly class ConsoleErrorHandler implements ErrorHandler
 {
     public function __construct(
@@ -36,9 +38,9 @@ final readonly class ConsoleErrorHandler implements ErrorHandler
                 condition: $throwable->getMessage(),
                 callback: fn (Console $console) => $console->error($throwable->getMessage()),
             )
-            ->writeln($this->getSnippet($throwable->getFile(), $throwable->getLine()))
             ->writeln()
-            ->writeln('<u>' . $throwable->getFile() . ':' . $throwable->getLine() . '</u>')
+            ->writeln('In ' . $this->formatFileWithLine($throwable->getFile() . ':' . $throwable->getLine()))
+            ->writeln($this->getSnippet($throwable->getFile(), $throwable->getLine()))
             ->writeln();
 
         if ($this->argumentBag->get('-v') !== null) {
@@ -48,12 +50,11 @@ final readonly class ConsoleErrorHandler implements ErrorHandler
 
             $this->console->writeln();
         } else {
-            $firstLine = $throwable->getTrace()[0];
-
             $this->console
-                ->writeln('<style="fg-blue bold">#0</style> ' . $this->formatTrace($firstLine))
+                ->writeln('<style="fg-blue bold">#0</style> ' . $this->formatTrace($throwable->getTrace()[0]))
+                ->writeln('<style="fg-blue bold">#1</style> ' . $this->formatTrace($throwable->getTrace()[1]))
                 ->writeln()
-                ->writeln('<em>-v</em> show more')
+                ->writeln('   <style="dim">Run with -v to show more.</style>')
                 ->writeln();
         }
 
@@ -75,10 +76,13 @@ final readonly class ConsoleErrorHandler implements ErrorHandler
     private function getSnippet(string $file, int $lineNumber): string
     {
         $highlighter = $this->highlighter->withGutter();
-        $code = Escape::terminal($highlighter->parse(file_get_contents($file), 'php'));
+        $code = Escape::terminal($highlighter->parse(file_get_contents($file), language: 'php'));
         $lines = explode(PHP_EOL, $code);
 
-        $lines[$lineNumber - 1] = $lines[$lineNumber - 1] . ' <style="fg-red"><</style>';
+        $lines[$lineNumber - 1] = str($lines[$lineNumber - 1])
+            ->replaceRegex('/^\d+/', fn (array $match) => "<style='fg-red'>{$match[0]}</style>")
+            ->append('  <style="fg-red"><<<</style>')
+            ->toString();
 
         $excerptSize = 5;
         $start = max(0, ($lineNumber - $excerptSize) - 2);
@@ -87,16 +91,30 @@ final readonly class ConsoleErrorHandler implements ErrorHandler
         return PHP_EOL . implode(PHP_EOL, $lines);
     }
 
-    private function formatTrace(mixed $trace): string
+    private function formatFileWithLine(string $file): string
+    {
+        [$file, $line] = explode(':', $file);
+        $directory = dirname($file);
+        $filename = basename($file);
+
+        return sprintf('<style="fg-gray">%s/</style>%s<style="dim">:</style>%s', $directory, $filename, $line);
+    }
+
+    private function formatTrace(array $trace): string
     {
         if (isset($trace['file'])) {
-            return '<u>' . $trace['file'] . ':' . $trace['line'] . '</u>';
+            return $this->formatFileWithLine($trace['file'] . ':' . $trace['line']);
         }
 
         if (isset($trace['class'])) {
-            return $trace['class'] . $trace['type'] . $trace['function'];
+            return sprintf(
+                "%s<style='dim'>%s</style>%s<style='dim'>()</style>",
+                $trace['class'],
+                $trace['type'],
+                $trace['function'],
+            );
         }
 
-        return $trace['function'] . '()';
+        return sprintf("%s<style='dim'>()</style>", $trace['function']);
     }
 }

--- a/src/Tempest/Console/src/Exceptions/InterruptException.php
+++ b/src/Tempest/Console/src/Exceptions/InterruptException.php
@@ -10,6 +10,7 @@ final class InterruptException extends ConsoleException
 {
     public function render(Console $console): void
     {
+        $console->writeln();
         $console->error('Interrupted by user.');
     }
 }

--- a/src/Tempest/Console/src/Exceptions/InvalidCommandException.php
+++ b/src/Tempest/Console/src/Exceptions/InvalidCommandException.php
@@ -20,17 +20,19 @@ final class InvalidCommandException extends ConsoleException
 
     public function render(Console $console): void
     {
-        $console->error('Invalid command usage:');
-
-        (new RenderConsoleCommand($console))($this->consoleCommand);
-
         $missingArguments = implode(', ', array_map(
             fn (ConsoleArgumentDefinition $argumentDefinition) => $argumentDefinition->name,
             $this->invalidArguments,
         ));
 
         if ($missingArguments) {
-            $console->writeln("Missing arguments: {$missingArguments}");
+            $console->writeln();
+            $console->error("Missing arguments: {$missingArguments}");
+        } else {
+            $console->writeln();
+            $console->error('Invalid command usage.');
         }
+
+        $console->info('Run again with --help for more information.');
     }
 }

--- a/src/Tempest/Console/src/Exceptions/InvalidEnumArgument.php
+++ b/src/Tempest/Console/src/Exceptions/InvalidEnumArgument.php
@@ -35,6 +35,8 @@ final class InvalidEnumArgument extends ConsoleException
             callback: fn (BackedEnum $case) => $case->value,
             array: $this->argumentType::cases(),
         );
+
+        $console->writeln();
         $console->error("Invalid argument {$value} for `{$this->argumentName}` argument, valid values are: " . implode(', ', $cases));
     }
 }

--- a/src/Tempest/Console/src/Exceptions/UnsupportedComponent.php
+++ b/src/Tempest/Console/src/Exceptions/UnsupportedComponent.php
@@ -18,6 +18,7 @@ final class UnsupportedComponent extends ConsoleException
 
     public function render(Console $console): void
     {
+        $console->writeln();
         $console->error($this->message);
     }
 }

--- a/src/Tempest/Console/src/GenericConsole.php
+++ b/src/Tempest/Console/src/GenericConsole.php
@@ -239,7 +239,7 @@ final class GenericConsole implements Console
                 placeholder: $placeholder,
                 hint: $hint,
                 multiline: $multiline,
-            ));
+            ), $validation);
         }
 
         if ($multiple) {
@@ -247,7 +247,7 @@ final class GenericConsole implements Console
                 label: $question,
                 options: $options,
                 default: wrap($default),
-            ));
+            ), $validation);
         }
 
         $component = new SingleChoiceComponent(

--- a/src/Tempest/Console/src/GenericConsole.php
+++ b/src/Tempest/Console/src/GenericConsole.php
@@ -56,7 +56,7 @@ final class GenericConsole implements Console
 
     public function call(string|array $command, string|array $arguments = []): ExitCode|int
     {
-        return ($this->executeConsoleCommand)($command, $arguments);
+        return $this->executeConsoleCommand->withoutArgumentBag()($command, $arguments);
     }
 
     public function setComponentRenderer(InteractiveComponentRenderer $componentRenderer): self

--- a/src/Tempest/Console/src/Input/ConsoleArgumentBag.php
+++ b/src/Tempest/Console/src/Input/ConsoleArgumentBag.php
@@ -131,6 +131,14 @@ final class ConsoleArgumentBag
 
     public function add(ConsoleInputArgument $argument): self
     {
+        foreach ($this->arguments as $existing) {
+            if ($existing->name && $existing->name === $argument->name) {
+                $existing->value = $argument->value;
+
+                return $this;
+            }
+        }
+
         $this->arguments[] = $argument;
 
         return $this;

--- a/src/Tempest/Console/src/Input/ConsoleArgumentBag.php
+++ b/src/Tempest/Console/src/Input/ConsoleArgumentBag.php
@@ -148,11 +148,10 @@ final class ConsoleArgumentBag
     {
         // Handle arguments manually passed as an associative array first.
         if (is_associative($arguments) && ! is_int(array_key_first($arguments))) {
-            $i = 0;
             foreach ($arguments as $key => $value) {
                 $this->add(new ConsoleInputArgument(
-                    name: $key,
-                    position: $i++,
+                    name: is_int($key) ? null : $key,
+                    position: is_int($key) ? $key : null,
                     value: $value,
                 ));
             }

--- a/src/Tempest/Console/src/Input/ConsoleArgumentBag.php
+++ b/src/Tempest/Console/src/Input/ConsoleArgumentBag.php
@@ -6,6 +6,8 @@ namespace Tempest\Console\Input;
 
 use Tempest\Console\Exceptions\InvalidEnumArgument;
 
+use function Tempest\Support\Arr\is_associative;
+
 final class ConsoleArgumentBag
 {
     /** @var ConsoleInputArgument[] */
@@ -136,6 +138,21 @@ final class ConsoleArgumentBag
 
     public function addMany(array $arguments): self
     {
+        // Handle arguments manually passed as an associative array first.
+        if (is_associative($arguments) && ! is_int(array_key_first($arguments))) {
+            $i = 0;
+            foreach ($arguments as $key => $value) {
+                $this->add(new ConsoleInputArgument(
+                    name: $key,
+                    position: $i++,
+                    value: $value,
+                ));
+            }
+
+            return $this;
+        }
+
+        // Otherwise, $arguments is an array of flags or positional argument.
         foreach ($arguments as $argument) {
             if (str_starts_with($argument, '-') && ! str_starts_with($argument, '--')) {
                 $flags = str_split($argument);
@@ -150,9 +167,7 @@ final class ConsoleArgumentBag
         $position = count($this->arguments);
 
         foreach (array_values($arguments) as $index => $argument) {
-            $this->add(
-                ConsoleInputArgument::fromString($argument, $position + $index),
-            );
+            $this->add(ConsoleInputArgument::fromString($argument, $position + $index));
         }
 
         return $this;

--- a/src/Tempest/Console/src/Input/ConsoleArgumentBag.php
+++ b/src/Tempest/Console/src/Input/ConsoleArgumentBag.php
@@ -131,14 +131,6 @@ final class ConsoleArgumentBag
 
     public function add(ConsoleInputArgument $argument): self
     {
-        foreach ($this->arguments as $existing) {
-            if ($existing->name && $existing->name === $argument->name) {
-                $existing->value = $argument->value;
-
-                return $this;
-            }
-        }
-
         $this->arguments[] = $argument;
 
         return $this;

--- a/src/Tempest/Console/src/Middleware/InvalidCommandMiddleware.php
+++ b/src/Tempest/Console/src/Middleware/InvalidCommandMiddleware.php
@@ -43,6 +43,10 @@ final readonly class InvalidCommandMiddleware implements ConsoleMiddleware
             subheader: $invocation->consoleCommand->description,
         );
 
+        if (! $this->console->supportsPrompting()) {
+            throw $exception;
+        }
+
         foreach ($exception->invalidArguments as $argument) {
             $isEnum = is_a($argument->type, BackedEnum::class, allow_string: true);
             $name = str($argument->name)->snake(' ')->upperFirst()->toString();

--- a/src/Tempest/Console/src/Middleware/InvalidCommandMiddleware.php
+++ b/src/Tempest/Console/src/Middleware/InvalidCommandMiddleware.php
@@ -45,23 +45,34 @@ final readonly class InvalidCommandMiddleware implements ConsoleMiddleware
 
         foreach ($exception->invalidArguments as $argument) {
             $isEnum = is_a($argument->type, BackedEnum::class, allow_string: true);
+            $name = str($argument->name)->snake(' ')->upperFirst()->toString();
 
-            $value = $this->console->ask(
-                question: str($argument->name)->snake(' ')->upperFirst()->toString(),
-                options: $isEnum ? $argument->type::cases() : null,
-                default: $argument->default,
-                hint: $argument->help ?? $argument->description,
-                validation: array_filter([
-                    $isEnum
-                        ? new Enum($argument->type)
-                        : new NotEmpty(),
-                    match ($argument->type) {
-                        'bool' => new IsBoolean(),
-                        'int' => new Numeric(),
+            if ($argument->type === 'bool') {
+                $value = $this->console->confirm(
+                    question: $name,
+                    default: $argument->default ?? false,
+                );
+            } else {
+                $value = $this->console->ask(
+                    question: $name,
+                    default: $argument->default,
+                    hint: $argument->help ?? $argument->description,
+                    options: match (true) {
+                        $isEnum => $argument->type::cases(),
                         default => null,
                     },
-                ]),
-            );
+                    validation: array_filter([
+                        $isEnum
+                            ? new Enum($argument->type)
+                            : new NotEmpty(),
+                        match ($argument->type) {
+                            'bool' => new IsBoolean(),
+                            'int' => new Numeric(),
+                            default => null,
+                        },
+                    ]),
+                );
+            }
 
             $invocation->argumentBag->add(new ConsoleInputArgument(
                 name: $argument->name,

--- a/src/Tempest/Console/src/Middleware/InvalidCommandMiddleware.php
+++ b/src/Tempest/Console/src/Middleware/InvalidCommandMiddleware.php
@@ -56,7 +56,7 @@ final readonly class InvalidCommandMiddleware implements ConsoleMiddleware
                 $value = $this->console->ask(
                     question: $name,
                     default: $argument->default,
-                    hint: $argument->help ?? $argument->description,
+                    hint: $argument->help ?: $argument->description,
                     options: match (true) {
                         $isEnum => $argument->type::cases(),
                         default => null,

--- a/src/Tempest/Console/src/Stubs/GeneratorCommandStub.php
+++ b/src/Tempest/Console/src/Stubs/GeneratorCommandStub.php
@@ -28,6 +28,7 @@ final class GeneratorCommandStub
             shouldOverride: $shouldOverride,
         );
 
+        $this->console->writeln();
         $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
     }
 }

--- a/src/Tempest/Console/src/Stubs/GeneratorCommandStub.php
+++ b/src/Tempest/Console/src/Stubs/GeneratorCommandStub.php
@@ -29,6 +29,6 @@ final class GeneratorCommandStub
         );
 
         $this->console->writeln();
-        $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
+        $this->console->success(sprintf('File successfully created at <file="%s"/>.', $targetPath));
     }
 }

--- a/src/Tempest/Container/src/Commands/MakeInitializerCommand.php
+++ b/src/Tempest/Container/src/Commands/MakeInitializerCommand.php
@@ -46,6 +46,7 @@ final class MakeInitializerCommand
             ],
         );
 
+        $this->console->writeln();
         $this->console->success(sprintf('Initializer successfully created at "%s".', $targetPath));
     }
 }

--- a/src/Tempest/Core/src/PublishesFiles.php
+++ b/src/Tempest/Core/src/PublishesFiles.php
@@ -24,11 +24,13 @@ use Throwable;
 
 use function strlen;
 use function Tempest\root_path;
+use function Tempest\src_path;
 use function Tempest\Support\Namespace\to_base_class_name;
 use function Tempest\Support\path;
 use function Tempest\Support\Path\to_absolute_path;
 use function Tempest\Support\Path\to_relative_path;
 use function Tempest\Support\str;
+use function Tempest\Support\Str\class_basename;
 
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
@@ -149,17 +151,14 @@ trait PublishesFiles
     {
         // Separate input path and classname
         $inputClassName = to_base_class_name($className);
-        $inputPath = path($className)->stripEnd($inputClassName);
+        $inputPath = path($className)->stripEnd(class_basename($className));
         $className = str($inputClassName)
             ->pascal()
             ->finish($classSuffix ?? '')
             ->toString();
 
         // Prepare the suggested path from the project namespace
-        return str(to_absolute_path($this->composer->mainNamespace->path, $pathPrefix ?? '', $inputPath))
-            ->finish('/')
-            ->append($className . '.php')
-            ->toString();
+        return src_path($pathPrefix ?? '', $inputPath, $className . '.php');
     }
 
     /**
@@ -171,11 +170,13 @@ trait PublishesFiles
     {
         $className = to_base_class_name($suggestedPath);
 
-        return $this->console->ask(
+        $targetPath = $this->console->ask(
             question: sprintf('Where do you want to save the file <em>%s</em>?', $className),
-            default: $suggestedPath,
+            default: to_relative_path(root_path(), $suggestedPath),
             validation: [new NotEmpty(), new EndsWith('.php')],
         );
+
+        return to_absolute_path(root_path(), $targetPath);
     }
 
     /**

--- a/src/Tempest/Core/src/PublishesFiles.php
+++ b/src/Tempest/Core/src/PublishesFiles.php
@@ -24,11 +24,12 @@ use Throwable;
 
 use function strlen;
 use function Tempest\root_path;
+use function Tempest\src_path;
 use function Tempest\Support\Namespace\to_base_class_name;
 use function Tempest\Support\path;
-use function Tempest\Support\Path\to_absolute_path;
 use function Tempest\Support\Path\to_relative_path;
 use function Tempest\Support\str;
+use function Tempest\Support\Str\class_basename;
 
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
@@ -149,17 +150,14 @@ trait PublishesFiles
     {
         // Separate input path and classname
         $inputClassName = to_base_class_name($className);
-        $inputPath = path($className)->stripEnd($inputClassName);
+        $inputPath = path($className)->stripEnd(class_basename($className));
         $className = str($inputClassName)
             ->pascal()
             ->finish($classSuffix ?? '')
             ->toString();
 
         // Prepare the suggested path from the project namespace
-        return str(to_absolute_path($this->composer->mainNamespace->path, $pathPrefix ?? '', $inputPath))
-            ->finish('/')
-            ->append($className . '.php')
-            ->toString();
+        return to_relative_path(root_path(), src_path($pathPrefix ?? '', $inputPath, $className . '.php'));
     }
 
     /**

--- a/src/Tempest/Core/src/PublishesFiles.php
+++ b/src/Tempest/Core/src/PublishesFiles.php
@@ -24,12 +24,11 @@ use Throwable;
 
 use function strlen;
 use function Tempest\root_path;
-use function Tempest\src_path;
 use function Tempest\Support\Namespace\to_base_class_name;
 use function Tempest\Support\path;
+use function Tempest\Support\Path\to_absolute_path;
 use function Tempest\Support\Path\to_relative_path;
 use function Tempest\Support\str;
-use function Tempest\Support\Str\class_basename;
 
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
@@ -150,14 +149,17 @@ trait PublishesFiles
     {
         // Separate input path and classname
         $inputClassName = to_base_class_name($className);
-        $inputPath = path($className)->stripEnd(class_basename($className));
+        $inputPath = path($className)->stripEnd($inputClassName);
         $className = str($inputClassName)
             ->pascal()
             ->finish($classSuffix ?? '')
             ->toString();
 
         // Prepare the suggested path from the project namespace
-        return to_relative_path(root_path(), src_path($pathPrefix ?? '', $inputPath, $className . '.php'));
+        return str(to_absolute_path($this->composer->mainNamespace->path, $pathPrefix ?? '', $inputPath))
+            ->finish('/')
+            ->append($className . '.php')
+            ->toString();
     }
 
     /**

--- a/src/Tempest/Database/src/Commands/MakeModelCommand.php
+++ b/src/Tempest/Database/src/Commands/MakeModelCommand.php
@@ -33,6 +33,7 @@ final class MakeModelCommand
             shouldOverride: $shouldOverride,
         );
 
+        $this->console->writeln();
         $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
     }
 }

--- a/src/Tempest/Database/src/Commands/MakeModelCommand.php
+++ b/src/Tempest/Database/src/Commands/MakeModelCommand.php
@@ -34,6 +34,6 @@ final class MakeModelCommand
         );
 
         $this->console->writeln();
-        $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
+        $this->console->success(sprintf('File successfully created at <file="%s"/>.', $targetPath));
     }
 }

--- a/src/Tempest/Database/src/Migrations/MigrationException.php
+++ b/src/Tempest/Database/src/Migrations/MigrationException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Tempest\Database\Migrations;
 
-use Exception;
-
 interface MigrationException
 {
 }

--- a/src/Tempest/Database/src/Migrations/MigrationHashMismatchException.php
+++ b/src/Tempest/Database/src/Migrations/MigrationHashMismatchException.php
@@ -8,9 +8,8 @@ use Exception;
 
 final class MigrationHashMismatchException extends Exception implements MigrationException
 {
-    public function __construct(
-        string $message = 'Migration file has been tampered with.',
-    ) {
+    public function __construct(string $message = 'Migration file has been tampered with.')
+    {
         parent::__construct($message);
     }
 }

--- a/src/Tempest/Database/src/Migrations/MissingMigrationFileException.php
+++ b/src/Tempest/Database/src/Migrations/MissingMigrationFileException.php
@@ -8,9 +8,8 @@ use Exception;
 
 final class MissingMigrationFileException extends Exception implements MigrationException
 {
-    public function __construct(
-        string $message = 'Migration file is missing.',
-    ) {
+    public function __construct(string $message = 'Migration file is missing.')
+    {
         parent::__construct($message);
     }
 }

--- a/src/Tempest/Discovery/src/Commands/MakeDiscoveryCommand.php
+++ b/src/Tempest/Discovery/src/Commands/MakeDiscoveryCommand.php
@@ -33,6 +33,7 @@ final class MakeDiscoveryCommand
             shouldOverride: $shouldOverride,
         );
 
+        $this->console->writeln();
         $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
     }
 }

--- a/src/Tempest/Discovery/src/Commands/MakeDiscoveryCommand.php
+++ b/src/Tempest/Discovery/src/Commands/MakeDiscoveryCommand.php
@@ -34,6 +34,6 @@ final class MakeDiscoveryCommand
         );
 
         $this->console->writeln();
-        $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
+        $this->console->success(sprintf('File successfully created at <file="%s"/>.', $targetPath));
     }
 }

--- a/src/Tempest/Framework/Commands/MigrateFreshCommand.php
+++ b/src/Tempest/Framework/Commands/MigrateFreshCommand.php
@@ -50,7 +50,7 @@ final class MigrateFreshCommand
             $this->console->info('There is no migration to drop.');
         }
 
-        return $this->console->call(MigrateUpCommand::class, ['fresh' => false]);
+        return $this->console->call(MigrateUpCommand::class, ['fresh' => false, 'validate' => false]);
     }
 
     #[EventHandler]

--- a/src/Tempest/Framework/Commands/MigrateFreshCommand.php
+++ b/src/Tempest/Framework/Commands/MigrateFreshCommand.php
@@ -43,24 +43,24 @@ final class MigrateFreshCommand
             }
         }
 
-        $this->console->info('Dropping tables…');
-
+        $this->console->header('Dropping tables');
         $this->migrationManager->dropAll();
 
-        $this->console
-            ->success(sprintf('Dropped %s tables', $this->count))
-            ->writeln();
+        if ($this->count === 0) {
+            $this->console->info('There is no migration to drop.');
+        }
 
-        $this->console->info('Migrate up…');
-
-        return $this->console->call(MigrateUpCommand::class);
+        return $this->console->call(MigrateUpCommand::class, ['fresh' => false]);
     }
 
     #[EventHandler]
     public function onTableDropped(TableDropped $event): void
     {
-        $this->console->writeln("- Dropped {$event->name}");
         $this->count += 1;
+        $this->console->keyValue(
+            key: "<style='fg-gray'>{$event->name}</style>",
+            value: "<style='fg-green'>DROPPED</style>",
+        );
     }
 
     #[EventHandler]

--- a/src/Tempest/Framework/Commands/MigrateRehashCommand.php
+++ b/src/Tempest/Framework/Commands/MigrateRehashCommand.php
@@ -26,9 +26,8 @@ final readonly class MigrateRehashCommand
     )]
     public function __invoke(): void
     {
+        $this->console->header('Hashing migrations');
         $this->migrationManager->rehashAll();
-
-        $this->console
-            ->success('Rehashed all migrations');
+        $this->console->success('Migrations have been re-hashed.');
     }
 }

--- a/src/Tempest/Framework/Commands/MigrateUpCommand.php
+++ b/src/Tempest/Framework/Commands/MigrateUpCommand.php
@@ -28,6 +28,7 @@ final class MigrateUpCommand
     #[ConsoleCommand(
         name: 'migrate:up',
         description: 'Runs all new migrations',
+        aliases: ['migrate'],
         middleware: [ForceMiddleware::class, CautionMiddleware::class],
     )]
     public function __invoke(

--- a/src/Tempest/Framework/Commands/MigrateUpCommand.php
+++ b/src/Tempest/Framework/Commands/MigrateUpCommand.php
@@ -34,6 +34,8 @@ final class MigrateUpCommand
     public function __invoke(
         #[ConsoleArgument(description: 'Validates the integrity of existing migration files by checking if they have been tampered with.')]
         bool $validate = true,
+        #[ConsoleArgument(description: 'Drops all tables and rerun migrations from scratch.')]
+        bool $fresh = false,
     ): ExitCode {
         if ($validate) {
             $validationSuccess = $this->console->call(MigrateValidateCommand::class);
@@ -43,10 +45,16 @@ final class MigrateUpCommand
             }
         }
 
+        if ($fresh) {
+            return $this->console->call(MigrateFreshCommand::class, ['validate' => false]);
+        }
+
+        $this->console->header('Migrating');
         $this->migrationManager->up();
 
-        $this->console
-            ->success(sprintf('Migrated %s migrations', $this->count));
+        if ($this->count === 0) {
+            $this->console->info('There is no new migration to run.');
+        }
 
         return ExitCode::SUCCESS;
     }
@@ -54,7 +62,10 @@ final class MigrateUpCommand
     #[EventHandler]
     public function onMigrationMigrated(MigrationMigrated $event): void
     {
-        $this->console->writeln("- {$event->name}");
         $this->count += 1;
+        $this->console->keyValue(
+            key: "<style='fg-gray'>{$event->name}</style>",
+            value: "<style='fg-green'>MIGRATED</style>",
+        );
     }
 }

--- a/src/Tempest/Framework/Commands/MigrateUpCommand.php
+++ b/src/Tempest/Framework/Commands/MigrateUpCommand.php
@@ -8,12 +8,15 @@ use Tempest\Console\Console;
 use Tempest\Console\ConsoleArgument;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\ExitCode;
+use Tempest\Console\Input\ConsoleArgumentBag;
 use Tempest\Console\Middleware\CautionMiddleware;
 use Tempest\Console\Middleware\ForceMiddleware;
 use Tempest\Container\Singleton;
 use Tempest\Database\Migrations\MigrationManager;
 use Tempest\Database\Migrations\MigrationMigrated;
 use Tempest\EventBus\EventHandler;
+
+use function Tempest\get;
 
 #[Singleton]
 final class MigrateUpCommand
@@ -46,7 +49,7 @@ final class MigrateUpCommand
         }
 
         if ($fresh) {
-            return $this->console->call(MigrateFreshCommand::class, ['validate' => false]);
+            return $this->console->call(MigrateFreshCommand::class, ['validate' => false, 'fresh' => false]);
         }
 
         $this->console->header('Migrating');

--- a/src/Tempest/Generation/src/Exceptions/FileGenerationFailedException.php
+++ b/src/Tempest/Generation/src/Exceptions/FileGenerationFailedException.php
@@ -11,6 +11,7 @@ final class FileGenerationFailedException extends ConsoleException
 {
     public function render(Console $console): void
     {
+        $console->writeln();
         $console->error($this->getMessage());
     }
 }

--- a/src/Tempest/Router/src/Commands/MakeControllerCommand.php
+++ b/src/Tempest/Router/src/Commands/MakeControllerCommand.php
@@ -41,6 +41,7 @@ final class MakeControllerCommand
             ],
         );
 
+        $this->console->writeln();
         $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
     }
 }

--- a/src/Tempest/Router/src/Commands/MakeControllerCommand.php
+++ b/src/Tempest/Router/src/Commands/MakeControllerCommand.php
@@ -42,6 +42,6 @@ final class MakeControllerCommand
         );
 
         $this->console->writeln();
-        $this->console->success(sprintf('File successfully created at <em>%s</em>.', $targetPath));
+        $this->console->success(sprintf('File successfully created at <file="%s"/>.', $targetPath));
     }
 }

--- a/src/Tempest/Router/src/Commands/MakeRequestCommand.php
+++ b/src/Tempest/Router/src/Commands/MakeRequestCommand.php
@@ -35,6 +35,7 @@ final class MakeRequestCommand
             shouldOverride: $shouldOverride,
         );
 
+        $this->console->writeln();
         $this->console->success(sprintf('Request successfully created at "%s".', $targetPath));
     }
 }

--- a/src/Tempest/Router/src/Commands/MakeResponseCommand.php
+++ b/src/Tempest/Router/src/Commands/MakeResponseCommand.php
@@ -35,6 +35,7 @@ final class MakeResponseCommand
             shouldOverride: $shouldOverride,
         );
 
+        $this->console->writeln();
         $this->console->success(sprintf('Response successfully created at "%s".', $targetPath));
     }
 }

--- a/src/Tempest/Validation/src/Validator.php
+++ b/src/Tempest/Validation/src/Validator.php
@@ -142,7 +142,7 @@ final readonly class Validator
             default => [true, ''],
         };
 
-        return new readonly class($isValid, $message) implements Rule {
+        return new class($isValid, $message) implements Rule {
             public function __construct(
                 private bool $isValid,
                 private string $message,

--- a/tests/Integration/Core/PublishesFilesTest.php
+++ b/tests/Integration/Core/PublishesFilesTest.php
@@ -11,7 +11,7 @@ use Tempest\Support\Namespace\Psr4Namespace;
 use Tests\Tempest\Fixtures\Core\PublishesFilesConcreteClass;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-use function Tempest\Support\path;
+use function Tempest\Support\Path\normalize;
 
 /**
  * @internal
@@ -45,10 +45,9 @@ final class PublishesFilesTest extends FrameworkIntegrationTestCase
     ): void {
         $composer = $this->container->get(Composer::class);
         $concreteClass = $this->container->get(PublishesFilesConcreteClass::class);
-        $appPath = str_replace('\\', '/', $composer->mainNamespace->path); // Normalize windows path
 
         $this->assertSame(
-            expected: path($appPath, $expected)->toString(),
+            expected: normalize($composer->mainNamespace->path, $expected),
             actual: $concreteClass->getSuggestedPath(
                 className: $className,
                 pathPrefix: $pathPrefix,

--- a/tests/Integration/Framework/Commands/MigrateDownCommandTest.php
+++ b/tests/Integration/Framework/Commands/MigrateDownCommandTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Framework\Commands;
 
-use Tempest\Database\Migrations\MigrationException;
 use Tempest\Database\Migrations\TableNotFoundException;
+use Tempest\Framework\Commands\MigrateDownCommand;
+use Tempest\Framework\Commands\MigrateUpCommand;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 /**
@@ -16,11 +17,11 @@ final class MigrateDownCommandTest extends FrameworkIntegrationTestCase
     public function test_migrate_rollback_command(): void
     {
         $this->console
-            ->call('migrate:up --force')
+            ->call(MigrateUpCommand::class, ['force' => true])
             ->assertContains('create_migrations_table');
 
         $this->console
-            ->call('migrate:down --force')
+            ->call(MigrateDownCommand::class, ['force' => true])
             ->assertContains('create_migrations_table')
             ->assertContains('Rolled back');
     }
@@ -28,7 +29,7 @@ final class MigrateDownCommandTest extends FrameworkIntegrationTestCase
     public function test_errors_when_no_migrations_to_rollback(): void
     {
         $this->console
-            ->call('migrate:down')
+            ->call(MigrateDownCommand::class)
             ->assertContains(new TableNotFoundException()->getMessage());
     }
 }

--- a/tests/Integration/Framework/Commands/MigrateFreshCommandTest.php
+++ b/tests/Integration/Framework/Commands/MigrateFreshCommandTest.php
@@ -7,6 +7,8 @@ namespace Tests\Tempest\Integration\Framework\Commands;
 use PHPUnit\Framework\Assert;
 use Tempest\Console\ExitCode;
 use Tempest\Database\Migrations\Migration;
+use Tempest\Framework\Commands\MigrateFreshCommand;
+use Tempest\Framework\Commands\MigrateUpCommand;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 /**
@@ -17,14 +19,15 @@ final class MigrateFreshCommandTest extends FrameworkIntegrationTestCase
     public function test_migrate_fresh_command(): void
     {
         $this->console
-            ->call('migrate:up')
+            ->call(MigrateUpCommand::class)
             ->assertContains('create_migrations_table')
-            ->assertContains('Migrated')
+            ->assertContains('MIGRATED')
             ->assertSuccess();
 
         $this->console
-            ->call('migrate:fresh')
-            ->assertContains('Dropped ')
+            ->call(MigrateFreshCommand::class)
+            ->assertContains('DROPPING')
+            ->assertNotSee('There is no migration to drop')
             ->assertSuccess();
 
         Assert::assertNotEmpty(Migration::all());
@@ -33,7 +36,7 @@ final class MigrateFreshCommandTest extends FrameworkIntegrationTestCase
     public function test_migrate_fresh_command_inserts_new_records(): void
     {
         $this->console
-            ->call('migrate:fresh')
+            ->call(MigrateFreshCommand::class)
             ->assertContains('create_migrations_table');
 
         Assert::assertNotEmpty(Migration::all());
@@ -42,7 +45,7 @@ final class MigrateFreshCommandTest extends FrameworkIntegrationTestCase
     public function test_migrate_fresh_command_fails_with_validate_when_migrations_are_tampered_with(): void
     {
         $this->console
-            ->call('migrate:fresh')
+            ->call(MigrateFreshCommand::class)
             ->assertContains('Migration files are valid')
             ->assertExitCode(ExitCode::SUCCESS);
 
@@ -53,14 +56,14 @@ final class MigrateFreshCommandTest extends FrameworkIntegrationTestCase
         }
 
         $this->console
-            ->call('migrate:fresh')
+            ->call(MigrateFreshCommand::class)
             ->assertExitCode(ExitCode::INVALID);
     }
 
     public function test_migrate_fresh_command_skips_validation_and_runs_if_specified(): void
     {
         $this->console
-            ->call('migrate:fresh')
+            ->call(MigrateFreshCommand::class)
             ->assertContains('Migration files are valid')
             ->assertExitCode(ExitCode::SUCCESS);
 

--- a/tests/Integration/Framework/Commands/MigrateRehashCommandTest.php
+++ b/tests/Integration/Framework/Commands/MigrateRehashCommandTest.php
@@ -7,6 +7,8 @@ namespace Tests\Tempest\Integration\Framework\Commands;
 use PHPUnit\Framework\Assert;
 use Tempest\Console\ExitCode;
 use Tempest\Database\Migrations\Migration;
+use Tempest\Framework\Commands\MigrateFreshCommand;
+use Tempest\Framework\Commands\MigrateRehashCommand;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 /**
@@ -16,23 +18,20 @@ final class MigrateRehashCommandTest extends FrameworkIntegrationTestCase
 {
     public function test_migrate_rehash_rehashes_all_existing_migrations(): void
     {
-        $this->console
-            ->call('migrate:fresh --force');
+        $this->console->call(MigrateFreshCommand::class, ['force' => true]);
 
-        $migrations = Migration::all();
-        foreach ($migrations as $migration) {
+        foreach (Migration::all() as $migration) {
             $migration->hash = 'invalid-hash';
             $migration->save();
         }
 
         $this->console
-            ->call('migrate:rehash')
-            ->assertContains('Rehashed all migrations')
+            ->call(MigrateRehashCommand::class)
+            ->assertContains('Migrations have been re-hashed')
             ->assertExitCode(ExitCode::SUCCESS);
 
-        $migrations = Migration::all();
-        foreach ($migrations as $migration) {
-            Assert::assertNotSame('invalid-hash', $migration->hash);
+        foreach (Migration::all() as $migration) {
+            $this->assertNotSame('invalid-hash', $migration->hash);
         }
     }
 }

--- a/tests/Integration/Framework/Commands/MigrateUpCommandTest.php
+++ b/tests/Integration/Framework/Commands/MigrateUpCommandTest.php
@@ -7,6 +7,7 @@ namespace Tests\Tempest\Integration\Framework\Commands;
 use PHPUnit\Framework\Assert;
 use Tempest\Console\ExitCode;
 use Tempest\Database\Migrations\Migration;
+use Tempest\Framework\Commands\MigrateUpCommand;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 /**
@@ -17,9 +18,9 @@ final class MigrateUpCommandTest extends FrameworkIntegrationTestCase
     public function test_migrate_command(): void
     {
         $this->console
-            ->call('migrate:up')
+            ->call(MigrateUpCommand::class)
             ->assertContains('create_migrations_table')
-            ->assertContains('Migrated');
+            ->assertContains('MIGRATED');
 
         Assert::assertNotEmpty(Migration::all());
     }
@@ -27,7 +28,7 @@ final class MigrateUpCommandTest extends FrameworkIntegrationTestCase
     public function test_migrate_command_inserts_new_records(): void
     {
         $this->console
-            ->call('migrate:up')
+            ->call(MigrateUpCommand::class)
             ->assertContains('create_migrations_table');
 
         Assert::assertNotEmpty(Migration::all());
@@ -36,7 +37,7 @@ final class MigrateUpCommandTest extends FrameworkIntegrationTestCase
     public function test_migrate_command_validates_migrations(): void
     {
         $this->console
-            ->call('migrate:up')
+            ->call(MigrateUpCommand::class)
             ->assertContains('Migration files are valid')
             ->assertExitCode(ExitCode::SUCCESS);
 
@@ -46,30 +47,28 @@ final class MigrateUpCommandTest extends FrameworkIntegrationTestCase
     public function test_migrate_up_command_fails_when_migrations_are_tampered_with(): void
     {
         $this->console
-            ->call('migrate:up')
+            ->call(MigrateUpCommand::class)
             ->assertContains('Migration files are valid')
             ->assertExitCode(ExitCode::SUCCESS);
 
-        $migrations = Migration::all();
-        foreach ($migrations as $migration) {
+        foreach (Migration::all() as $migration) {
             $migration->hash = 'invalid-hash';
             $migration->save();
         }
 
         $this->console
-            ->call('migrate:up')
+            ->call(MigrateUpCommand::class)
             ->assertExitCode(ExitCode::INVALID);
     }
 
     public function test_migrate_up_command_skips_validation_and_runs_if_specified(): void
     {
         $this->console
-            ->call('migrate:up')
+            ->call(MigrateUpCommand::class)
             ->assertContains('Migration files are valid')
             ->assertExitCode(ExitCode::SUCCESS);
 
-        $migrations = Migration::all();
-        foreach ($migrations as $migration) {
+        foreach (Migration::all() as $migration) {
             $migration->hash = 'invalid-hash';
             $migration->save();
         }

--- a/tests/Integration/Framework/Commands/MigrateValidateCommandTest.php
+++ b/tests/Integration/Framework/Commands/MigrateValidateCommandTest.php
@@ -6,6 +6,8 @@ namespace Tests\Tempest\Integration\Framework\Commands;
 
 use Tempest\Console\ExitCode;
 use Tempest\Database\Migrations\Migration;
+use Tempest\Framework\Commands\MigrateFreshCommand;
+use Tempest\Framework\Commands\MigrateValidateCommand;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 /**
@@ -16,44 +18,38 @@ final class MigrateValidateCommandTest extends FrameworkIntegrationTestCase
     public function test_migration_validate_command_verifies_valid_migrations(): void
     {
         $this->console
-            ->call('migrate:validate')
+            ->call(MigrateValidateCommand::class)
             ->assertContains('Migration files are valid');
     }
 
     public function test_migration_validate_command_fails_when_migrations_are_tampered_with(): void
     {
-        $this->console
-            ->call('migrate:fresh --force');
+        $this->console->call(MigrateFreshCommand::class, ['force' => true]);
 
-        $migrations = Migration::all();
-
-        foreach ($migrations as $migration) {
+        foreach (Migration::all() as $migration) {
             $migration->hash = 'invalid-hash';
             $migration->save();
         }
 
         $this->console
-            ->call('migrate:validate')
-            ->assertContains('Migration file has been tampered with')
+            ->call(MigrateValidateCommand::class)
+            ->assertContains('HASH MISMATCH')
             ->assertExitCode(ExitCode::ERROR);
     }
 
     public function test_migration_validate_command_fails_when_migration_file_is_missing(): void
     {
-        $this->console
-            ->call('migrate:fresh --force');
+        $this->console->call(MigrateFreshCommand::class, ['force' => true]);
 
-        /**
-         * Creating a Migration Record to simulate a missing migration file.
-         */
+        // Creating a migration record to simulate a missing migration file.
         Migration::create(
             name: 'create_missing_migration_file',
             hash: 'hash',
         );
 
         $this->console
-            ->call('migrate:validate')
-            ->assertContains('Migration file is missing')
+            ->call(MigrateValidateCommand::class)
+            ->assertContains('MISSING FILE')
             ->assertExitCode(ExitCode::ERROR);
     }
 }


### PR DESCRIPTION
As a follow-up to https://github.com/tempestphp/tempest-framework/pull/1100, this pull request is another pass at console output consistency. It consists of minor fixes, as well as the following changes:

## Fixed a bug with `$console->call`

Tempest has a singleton `ConsoleArgumentBag` that initially stores the `argv` arguments. When the CLI is booted, this is what determines which command to run. However, this argument bag is still used for subsequent `$console->call` runs, resulting in arguments being mixed up.

This is fixed by adding a `withoutArgumentBag` to `ExecuteConsoleCommand`.

```php
public function call(string|array $command, string|array $arguments = []): ExitCode|int
{
    return $this->executeConsoleCommand->withoutArgumentBag()($command, $arguments);
}
```

&nbsp;

## Migration output refresh

The migrations console message didn't use a header or key/value lines, so I added them.

Additionally, I aliased `migrate:up` to `migrate` for those like me who have some Laravel muscle memory. Similarly, I added the `--fresh` flag to `migrate:up`, so we can run `migrate --fresh` as an alias of `migrate:fresh`.

**Before**

![CleanShot 2025-03-30 at 13 42 30](https://github.com/user-attachments/assets/664d9584-890e-4e2f-adba-daa59bb441c4)

![CleanShot 2025-03-30 at 13 42 51](https://github.com/user-attachments/assets/cf1ce9da-8a58-499d-8079-e8c888942863)

**After**

![CleanShot 2025-03-30 at 13 43 46](https://github.com/user-attachments/assets/1cc53e22-64c1-4e57-aeba-3f03cc81b821)

![CleanShot 2025-03-30 at 13 44 05](https://github.com/user-attachments/assets/b2a13147-d003-4249-93fa-2e05e2124b53)


&nbsp;


## Clean up of console errors

I slightly updated the rendering of console errors. The error line is easier to spot thanks to a red line number as well as three `<<<` instead of one `<`.

The exact file and line where the error appeared is the first thing displayed below the actual error message. Lastly, the file and lines are colored to highlight the important parts.

**Before**

![CleanShot 2025-03-30 at 13 40 14](https://github.com/user-attachments/assets/1a0647be-2dea-41b6-ae91-87ecbf6b4428)

**After**

![CleanShot 2025-03-30 at 13 40 28](https://github.com/user-attachments/assets/875316de-8d8b-4a5b-b41e-d47adcd76be1)

&nbsp;

## Removal of top margin in console messages

In the last console refresh, I added a top margin above `error`, `success` and `info` console messages. This was nice to automatically separate them from the input components, but it also had a major drawback—that it was not possible to have two lines without spacing.

I removed this margin, helping fix the output of console errors above, as well as other parts of the console. The drawback is that some console commands, like the `make` ones, have to manually draw a new line before their output.

**Before**

![CleanShot 2025-03-30 at 13 54 09](https://github.com/user-attachments/assets/3da647df-b8a6-4e8b-866a-d890184bd6d8)

**After**

![CleanShot 2025-03-30 at 13 54 43](https://github.com/user-attachments/assets/60ff9082-9302-4d0b-a6e6-92710c104ba0)
