### PR TITLE
feat(event-bus): add event bus testing utilities

### DIFF
--- a/src/Tempest/EventBus/src/Testing/EventBusTester.php
+++ b/src/Tempest/EventBus/src/Testing/EventBusTester.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tempest\EventBus\Testing;
+
+use BackedEnum;
+use Closure;
+use PHPUnit\Framework\Assert;
+use Tempest\Container\Container;
+use Tempest\EventBus\EventBus;
+use Tempest\EventBus\EventBusConfig;
+use UnitEnum;
+
+final class EventBusTester
+{
+    private FakeEventBus $fakeEventBus;
+
+    public function __construct(
+        private readonly Container $container,
+    ) {}
+
+    public function fake(): self
+    {
+        $this->fakeEventBus = new FakeEventBus($this->container->get(EventBusConfig::class));
+        $this->container->singleton(EventBus::class, $this->fakeEventBus);
+
+        return $this;
+    }
+
+    public function assertDispatched(string|object $event, ?Closure $callback = null, ?int $count = null): self
+    {
+        $this->assertFaked();
+
+        Assert::assertNotNull(
+            actual: $dispatches = $this->findDispatches($event),
+            message: 'The event was not dispatched.',
+        );
+
+        if ($count !== null) {
+            Assert::assertCount($count, $dispatches, 'The number of dispatches does not match.');
+        }
+
+        if ($callback !== null) {
+            foreach ($dispatches as $dispatch) {
+                Assert::assertNotFalse($callback($dispatch), 'The callback failed.');
+            }
+        }
+
+        return $this;
+    }
+
+    public function assertNotDispatched(string|object $event): self
+    {
+        $this->assertFaked();
+
+        Assert::assertEmpty($this->findDispatches($event), 'The event was dispatched.');
+
+        return $this;
+    }
+
+    public function assertListeningTo(string $event, ?int $count = null): self
+    {
+        $this->assertFaked();
+
+        Assert::assertNotEmpty(
+            actual: $handlers = $this->findHandlersFor($event),
+            message: 'The event is not being listened to.',
+        );
+
+        if ($count !== null) {
+            Assert::assertSame($count, count($handlers), 'The number of handlers does not match.');
+        }
+
+        return $this;
+    }
+
+    private function findDispatches(string|object $event): array
+    {
+        return array_filter($this->fakeEventBus->dispatched, function (string|object $dispatched) use ($event) {
+            if ($dispatched === $event) {
+                return true;
+            }
+
+            if (class_exists($event) && $dispatched instanceof $event) {
+                return true;
+            }
+
+            return false;
+        });
+    }
+
+    /** @return array<\Tempest\EventBus\CallableEventHandler> */
+    private function findHandlersFor(string|object $event): array
+    {
+        $eventName = match (true) {
+            $event instanceof BackedEnum => $event->value,
+            $event instanceof UnitEnum => $event->name,
+            is_string($event) => $event,
+            default => $event::class,
+        };
+
+        return $this->fakeEventBus->eventBusConfig->handlers[$eventName] ?? [];
+    }
+
+    private function assertFaked(): self
+    {
+        Assert::assertTrue(isset($this->fakeEventBus), 'No fake event bus has been set.');
+
+        return $this;
+    }
+}

--- a/src/Tempest/EventBus/src/Testing/FakeEventBus.php
+++ b/src/Tempest/EventBus/src/Testing/FakeEventBus.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tempest\EventBus\Testing;
+
+use Closure;
+use Tempest\EventBus\EventBus;
+use Tempest\EventBus\EventBusConfig;
+
+final class FakeEventBus implements EventBus
+{
+    public array $dispatched = [];
+
+    public function __construct(
+        public EventBusConfig $eventBusConfig,
+    ) {}
+
+    public function listen(string|object $event, Closure $handler): void
+    {
+        $this->eventBusConfig->addClosureHandler($event, $handler);
+    }
+
+    public function dispatch(string|object $event): void
+    {
+        $this->dispatched[] = $event;
+    }
+}

--- a/src/Tempest/Framework/Testing/IntegrationTest.php
+++ b/src/Tempest/Framework/Testing/IntegrationTest.php
@@ -14,6 +14,7 @@ use Tempest\Core\AppConfig;
 use Tempest\Core\FrameworkKernel;
 use Tempest\Core\Kernel;
 use Tempest\Database\Migrations\MigrationManager;
+use Tempest\EventBus\Testing\EventBusTester;
 use Tempest\Framework\Testing\Http\HttpRouterTester;
 use Tempest\Http\Method;
 use Tempest\Router\GenericRequest;
@@ -42,6 +43,8 @@ abstract class IntegrationTest extends TestCase
 
     protected ViteTester $vite;
 
+    protected EventBusTester $eventBus;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -62,6 +65,8 @@ abstract class IntegrationTest extends TestCase
 
         $this->vite = $this->container->get(ViteTester::class);
         $this->vite->preventTagResolution();
+
+        $this->eventBus = $this->container->get(EventBusTester::class);
 
         $request = new GenericRequest(Method::GET, '/', []);
         $this->container->singleton(Request::class, fn () => $request);

--- a/tests/Integration/EventBus/EventBusTesterTest.php
+++ b/tests/Integration/EventBus/EventBusTesterTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\EventBus;
+
+use LogicException;
+use PHPUnit\Framework\ExpectationFailedException;
+use Tempest\EventBus\EventBus;
+use Tempest\EventBus\Testing\FakeEventBus;
+use Tests\Tempest\Integration\EventBus\Fixtures\FakeEvent;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+/**
+ * @internal
+ */
+final class EventBusTesterTest extends FrameworkIntegrationTestCase
+{
+    public function test_fake(): void
+    {
+        $this->eventBus->fake();
+
+        $this->assertInstanceOf(FakeEventBus::class, $this->container->get(EventBus::class));
+    }
+
+    public function test_assertion_on_real_event_bus(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('No fake event bus has been set');
+
+        $this->eventBus->assertDispatched('event-bus-fake-event');
+    }
+
+    public function test_assert_dispatched(): void
+    {
+        $this->eventBus->fake();
+
+        $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
+        $this->eventBus->assertDispatched('event-bus-fake-event');
+
+        $this->container->get(EventBus::class)->dispatch(new FakeEvent('foo'));
+        $this->eventBus->assertDispatched(FakeEvent::class);
+    }
+
+    public function test_assert_dispatched_with_callback(): void
+    {
+        $this->eventBus->fake();
+
+        $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
+        $this->eventBus->assertDispatched('event-bus-fake-event', function (string $event) {
+            return $event === 'event-bus-fake-event';
+        });
+
+        $this->container->get(EventBus::class)->dispatch(new FakeEvent('foo'));
+        $this->eventBus->assertDispatched(FakeEvent::class, function (FakeEvent $event) {
+            return $event->value === 'foo';
+        });
+    }
+
+    public function test_assert_dispatched_with_count(): void
+    {
+        $this->eventBus->fake();
+
+        $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
+        $this->eventBus->assertDispatched('event-bus-fake-event', count: 1);
+
+        $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
+        $this->eventBus->assertDispatched('event-bus-fake-event', count: 2);
+
+        $this->container->get(EventBus::class)->dispatch(new FakeEvent('foo'));
+        $this->eventBus->assertDispatched(FakeEvent::class, count: 1);
+
+        $this->container->get(EventBus::class)->dispatch(new FakeEvent('foo'));
+        $this->eventBus->assertDispatched(FakeEvent::class, count: 2);
+
+        $this->container->get(EventBus::class)->dispatch(new FakeEvent('baz'));
+        $this->eventBus->assertDispatched(FakeEvent::class, count: 3);
+    }
+
+    public function test_assert_dispatched_with_count_failure(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The number of dispatches does not match');
+
+        $this->eventBus->fake();
+
+        $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
+        $this->eventBus->assertDispatched('event-bus-fake-event', count: 2);
+    }
+
+    public function test_assert_dispatched_with_callback_failure(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The callback failed');
+
+        $this->eventBus->fake();
+
+        $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
+        $this->eventBus->assertDispatched('event-bus-fake-event', function (string $event) {
+            return $event !== 'event-bus-fake-event';
+        });
+    }
+
+    public function test_assert_dispatched_object_with_callback_failure(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The callback failed');
+
+        $this->eventBus->fake();
+
+        $this->container->get(EventBus::class)->dispatch(new FakeEvent('foo'));
+        $this->eventBus->assertDispatched(FakeEvent::class, function (FakeEvent $event) {
+            return $event->value === 'foobar';
+        });
+    }
+
+    public function test_assert_not_dispatched(): void
+    {
+        $this->eventBus->fake();
+
+        $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
+        $this->eventBus->assertNotDispatched('this-was-not-dispatched');
+    }
+
+    public function test_assert_not_dispatched_failure(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The event was dispatched');
+
+        $this->eventBus->fake();
+
+        $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
+        $this->eventBus->assertNotDispatched('event-bus-fake-event');
+    }
+
+    public function test_assert_not_dispatched_object_failure(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The event was dispatched');
+
+        $this->eventBus->fake();
+
+        $this->container->get(EventBus::class)->dispatch(new FakeEvent('foo'));
+        $this->eventBus->assertNotDispatched(FakeEvent::class);
+    }
+
+    public function test_assert_listening_to(): void
+    {
+        $this->eventBus->fake();
+
+        $this->container->get(EventBus::class)->listen(FakeEvent::class, function (FakeEvent $_): never {
+            throw new LogicException('This should not be called');
+        });
+
+        $this->eventBus->assertListeningTo(FakeEvent::class);
+        $this->eventBus->assertListeningTo(FakeEvent::class);
+    }
+
+    public function test_assert_listening_to_count(): void
+    {
+        $this->eventBus->fake();
+
+        $this->container->get(EventBus::class)->listen(FakeEvent::class, function (FakeEvent $_): never {
+            throw new LogicException('This should not be called');
+        });
+
+        $this->eventBus->assertListeningTo(FakeEvent::class, count: 1);
+
+        $this->container->get(EventBus::class)->listen(FakeEvent::class, function (FakeEvent $_): never {
+            throw new LogicException('This should not be called');
+        });
+
+        $this->eventBus->assertListeningTo(FakeEvent::class, count: 2);
+    }
+
+    public function test_assert_listening_to_failure(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The event is not being listened to');
+
+        $this->eventBus->fake();
+
+        $this->eventBus->assertListeningTo(FakeEvent::class);
+    }
+
+    public function test_assert_listening_to_count_failure(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The number of handlers does not match');
+
+        $this->eventBus->fake();
+
+        $this->container->get(EventBus::class)->listen(FakeEvent::class, function (FakeEvent $_): never {
+            throw new LogicException('This should not be called');
+        });
+
+        $this->eventBus->assertListeningTo(FakeEvent::class, count: 2);
+    }
+}

--- a/tests/Integration/EventBus/EventBusTesterTest.php
+++ b/tests/Integration/EventBus/EventBusTesterTest.php
@@ -18,7 +18,7 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
 {
     public function test_fake(): void
     {
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->assertInstanceOf(FakeEventBus::class, $this->container->get(EventBus::class));
     }
@@ -26,14 +26,14 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
     public function test_assertion_on_real_event_bus(): void
     {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('No fake event bus has been set');
+        $this->expectExceptionMessage('Asserting against the event bus require the `preventEventHandling()` method to be called first.');
 
         $this->eventBus->assertDispatched('event-bus-fake-event');
     }
 
     public function test_assert_dispatched(): void
     {
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
         $this->eventBus->assertDispatched('event-bus-fake-event');
@@ -44,7 +44,7 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
 
     public function test_assert_dispatched_with_callback(): void
     {
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
         $this->eventBus->assertDispatched('event-bus-fake-event', function (string $event) {
@@ -59,7 +59,7 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
 
     public function test_assert_dispatched_with_count(): void
     {
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
         $this->eventBus->assertDispatched('event-bus-fake-event', count: 1);
@@ -82,7 +82,7 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('The number of dispatches does not match');
 
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
         $this->eventBus->assertDispatched('event-bus-fake-event', count: 2);
@@ -93,7 +93,7 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('The callback failed');
 
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
         $this->eventBus->assertDispatched('event-bus-fake-event', function (string $event) {
@@ -106,7 +106,7 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('The callback failed');
 
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->container->get(EventBus::class)->dispatch(new FakeEvent('foo'));
         $this->eventBus->assertDispatched(FakeEvent::class, function (FakeEvent $event) {
@@ -116,7 +116,7 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
 
     public function test_assert_not_dispatched(): void
     {
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
         $this->eventBus->assertNotDispatched('this-was-not-dispatched');
@@ -127,7 +127,7 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('The event was dispatched');
 
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
         $this->eventBus->assertNotDispatched('event-bus-fake-event');
@@ -138,7 +138,7 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('The event was dispatched');
 
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->container->get(EventBus::class)->dispatch(new FakeEvent('foo'));
         $this->eventBus->assertNotDispatched(FakeEvent::class);
@@ -146,7 +146,7 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
 
     public function test_assert_listening_to(): void
     {
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->container->get(EventBus::class)->listen(FakeEvent::class, function (FakeEvent $_): never {
             throw new LogicException('This should not be called');
@@ -158,7 +158,7 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
 
     public function test_assert_listening_to_count(): void
     {
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->container->get(EventBus::class)->listen(FakeEvent::class, function (FakeEvent $_): never {
             throw new LogicException('This should not be called');
@@ -178,7 +178,7 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('The event is not being listened to');
 
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->eventBus->assertListeningTo(FakeEvent::class);
     }
@@ -188,7 +188,7 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('The number of handlers does not match');
 
-        $this->eventBus->fake();
+        $this->eventBus->preventEventHandling();
 
         $this->container->get(EventBus::class)->listen(FakeEvent::class, function (FakeEvent $_): never {
             throw new LogicException('This should not be called');

--- a/tests/Integration/EventBus/Fixtures/FakeEvent.php
+++ b/tests/Integration/EventBus/Fixtures/FakeEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Tempest\Integration\EventBus\Fixtures;
+
+final readonly class FakeEvent
+{
+    public function __construct(
+        public string $value,
+    ) {}
+}


### PR DESCRIPTION
This pull request adds a new `EventBusTester` class, with an associated property in `IntegrationTest`. It allows faking the event bus, preventing handlers from being called, and enabling assertions on dispatches and listeners.

```php
$this->eventBus->fake(); // register `FakeEventBus` as a singleton for `EventBus`

$this->eventBus->assertDispatched('my-event');
$this->eventBus->assertDispatched(MyEvent::class);
$this->eventBus->assertDispatched(new MyEvent());

$this->eventBus->assertNotDispatched('my-event');
$this->eventBus->assertListeningTo('my-event');
```

`assertDispatched` has optional `count` and `callback` arguments, the former asserting a specific number of dispatches, and the later accepting a callback that should return `false` if some conditions don't match.

I'll add documentation once this is merged