### PR TITLE
ci: prevent coveralls failures from failing tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -106,6 +106,7 @@ jobs:
       - if: matrix.php == '8.4' && matrix.database == 'sqlite' && matrix.os == 'ubuntu-latest' && matrix.stability == 'prefer-stable'
         name: Coveralls
         uses: coverallsapp/github-action@v2
+        continue-on-error: true
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           file: build/reports/clover.xml


### PR DESCRIPTION
Coveralls was on maintenance today, marking tests as failed in CI because the upload job fails. I don't believe CI should fail because of this.