### PR TITLE
fix(mapper): properly serialize nullable properties in objects

### DIFF
--- a/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
+++ b/src/Tempest/Mapper/src/Mappers/ObjectToArrayMapper.php
@@ -45,7 +45,7 @@ final readonly class ObjectToArrayMapper implements Mapper
     {
         $propertyValue = $property->getValue($object);
 
-        if (($serializer = $this->serializerFactory->forProperty($property)) !== null) {
+        if ($propertyValue !== null && ($serializer = $this->serializerFactory->forProperty($property)) !== null) {
             return $serializer->serialize($propertyValue);
         }
 

--- a/tests/Integration/Mapper/Fixtures/ObjectWithNullableProperties.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithNullableProperties.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+use DateTimeImmutable;
+use Tempest\Mapper\Strict;
+
+#[Strict]
+final class ObjectWithNullableProperties
+{
+    public function __construct(
+        public string $a,
+        public float $b,
+        public ?DateTimeImmutable $c,
+    ) {}
+}

--- a/tests/Integration/Mapper/Mappers/ObjectToArrayMapperTestCase.php
+++ b/tests/Integration/Mapper/Mappers/ObjectToArrayMapperTestCase.php
@@ -7,10 +7,12 @@ namespace Tests\Tempest\Integration\Mapper\Mappers;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectA;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithJsonSerialize;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithNullableProperties;
 
 use function Tempest\map;
 
 /**
+ *
  * @internal
  */
 final class ObjectToArrayMapperTestCase extends FrameworkIntegrationTestCase
@@ -27,5 +29,20 @@ final class ObjectToArrayMapperTestCase extends FrameworkIntegrationTestCase
         $array = map(new ObjectWithJsonSerialize('a', 'b'))->toArray();
 
         $this->assertSame(['c' => 'a', 'd' => 'b'], $array);
+    }
+
+    public function test_object_with_nullable_properties_to_array(): void
+    {
+        $object = new ObjectWithNullableProperties(a: 'a', b: 3.1416, c: null);
+        $array = map($object)->toArray();
+
+        $this->assertSame(
+            [
+                'a' => 'a',
+                'b' => '3.1416',
+                'c' => null,
+            ],
+            $array,
+        );
     }
 }


### PR DESCRIPTION
Fixes #1077 

### Description

The **ObjectToArrayMapper** does not take into account if a property is null when trying to retrieve a Serializer for it. If a property has a null value, the mappers should map that directly instead of trying to obtain the serializer for its type, otherwise a `CannotSerializeValue` exception is thrown when the property is perfectly mappable (from null to null). This is already the behaviour observed in **ModelToQueryMapper**.

### Proposed solution

In **ObjectToArrayMapper**, line **48**:

```php
$propertyValue = $property->getValue($object);

if ($propertyValue !== null && ($serializer = $this->serializerFactory->forProperty($property)) !== null) {
    return $serializer->serialize($propertyValue);
}

return $propertyValue;
```

### Steps to reproduce

Create a class with a nullable property:

```php
use DateTimeImmutable;
use Tempest\Mapper\Strict;

#[Strict]
final class ObjectWithNullableProperties
{
    public function __construct(
        public string $a,
        public float $b,
        public ?DateTimeImmutable $c,
    ) {}
}
```

Instantiate it with a null value in the nullable property and map it to an array:

```php
$object = new ObjectWithNullableProperties(a: 'a', b: 3.1416, c: null);
$array = map($object)->toArray();
```

You would expect this array:

```php
[
    'a' => 'a',
    'b' => '3.1416',
    'c' => null,
]
```

But a `CannotSerializeValue` exception is thrown instead.