### PR TITLE
feat(container): add `container:show` command

### DIFF
--- a/src/Tempest/Container/src/Commands/ContainerShowCommand.php
+++ b/src/Tempest/Container/src/Commands/ContainerShowCommand.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tempest\Container\Commands;
+
+use Closure;
+use Tempest\Console\Console;
+use Tempest\Console\ConsoleCommand;
+use Tempest\Console\ExitCode;
+use Tempest\Container\Container;
+use Tempest\Container\GenericContainer;
+use Tempest\Reflection\ClassReflector;
+use Tempest\Reflection\FunctionReflector;
+
+use function Tempest\Support\Arr\sort;
+use function Tempest\Support\Arr\sort_keys;
+use function Tempest\Support\str;
+use function Tempest\Support\Str\after_last;
+use function Tempest\Support\Str\before_last;
+use function Tempest\Support\Str\contains;
+
+final class ContainerShowCommand
+{
+    public function __construct(
+        private readonly Container $container,
+        private readonly Console $console,
+    ) {}
+
+    #[ConsoleCommand(description: 'Shows the container bindings')]
+    public function __invoke(): ExitCode
+    {
+        if (! ($this->container instanceof GenericContainer)) {
+            $this->console->error('The registered container instance does not expose its bindings.');
+
+            return ExitCode::ERROR;
+        }
+
+        $this->listBindings(
+            title: 'Initializers',
+            bindings: sort($this->container->getInitializers()),
+            formatKey: fn (string $class): string => $this->formatClassKey($class),
+            formatValue: fn (string $_, string $initializer): string => $this->formatClassValue($initializer),
+            reject: static fn (string $_, string $initializer): bool => contains($initializer, ['\\Stubs', '\\Fixtures']),
+        );
+
+        $this->listBindings(
+            title: 'Dyanmic initializers',
+            bindings: sort($this->container->getDynamicInitializers()),
+            formatKey: fn (int $_, string $class): string => $this->formatClassKey($class),
+            formatValue: static function (int $_, string $class): string {
+                $name = new ClassReflector($class)
+                    ->getMethod('initialize')
+                    ->getReturnType()
+                    ->getName();
+
+                return match ($name) {
+                    'object' => "<style='fg-gray'>object</style>",
+                    default => "<style='fg-blue'>{$name}</style>",
+                };
+            },
+        );
+
+        $this->listBindings('Definitions', sort_keys($this->container->getDefinitions()));
+        $this->listBindings('Singletons', sort_keys($this->container->getSingletons()));
+
+        return ExitCode::SUCCESS;
+    }
+
+    private function listBindings(string $title, array $bindings, ?Closure $formatKey = null, ?Closure $formatValue = null, ?Closure $reject = null): void
+    {
+        if (! $bindings) {
+            return;
+        }
+
+        $reject ??= static fn (): bool => false;
+        $formatKey ??= fn (int|string $key): string => $this->formatClassKey($key);
+        $formatValue ??= fn (int|string $key, mixed $value): string => $this->formatClassValue($value, $key);
+
+        $this->console->header($title);
+
+        foreach ($bindings as $class => $definition) {
+            if ($reject($class, $definition)) {
+                continue;
+            }
+
+            $this->console->keyValue(
+                key: $formatKey($class, $definition),
+                value: $formatValue($class, $definition),
+            );
+        }
+    }
+
+    private function formatClassValue(string|object $class, mixed $key = null): string
+    {
+        if ($class instanceof Closure) {
+            $serialized = str(new FunctionReflector($class)->getName())->afterFirst(':')->stripEnd('}');
+            $declaringClass = $serialized->before('::');
+            $method = $serialized->between('::', '():');
+            $line = $serialized->afterLast(':');
+
+            return sprintf(
+                "<style='fg-blue dim'>%s</style><style='dim'>::</style><style='fg-blue'>%s</style><style='dim'>():</style><style='fg-blue'>%s</style>",
+                $declaringClass,
+                $method,
+                $line,
+            );
+        }
+
+        if (! is_string($class)) {
+            $class = $class::class;
+        }
+
+        if ($key === $class) {
+            return "<style='fg-green dim bold'>SELF</style>";
+        }
+
+        $namespace = before_last($class, '\\');
+        $name = after_last($class, '\\');
+
+        return sprintf("<style='fg-blue dim'>%s\\</style><style='fg-blue'>%s</style>", $namespace, $name);
+    }
+
+    private function formatClassKey(string $class): string
+    {
+        $namespace = before_last($class, '\\');
+        $name = after_last($class, '\\');
+
+        return sprintf("<style='fg-gray'>%s\\</style>%s", $namespace, $name);
+    }
+}

--- a/src/Tempest/Container/src/Commands/ContainerShowCommand.php
+++ b/src/Tempest/Container/src/Commands/ContainerShowCommand.php
@@ -18,11 +18,11 @@ use function Tempest\Support\Str\after_last;
 use function Tempest\Support\Str\before_last;
 use function Tempest\Support\Str\contains;
 
-final class ContainerShowCommand
+final readonly class ContainerShowCommand
 {
     public function __construct(
-        private readonly Container $container,
-        private readonly Console $console,
+        private Container $container,
+        private Console $console,
     ) {}
 
     #[ConsoleCommand(description: 'Shows the container bindings')]

--- a/src/Tempest/Container/src/GenericContainer.php
+++ b/src/Tempest/Container/src/GenericContainer.php
@@ -63,6 +63,11 @@ final class GenericContainer implements Container
         return $this->definitions->getArrayCopy();
     }
 
+    public function getSingletons(): array
+    {
+        return $this->singletons->getArrayCopy();
+    }
+
     public function getInitializers(): array
     {
         return $this->initializers->getArrayCopy();

--- a/tests/Integration/Container/Commands/ContainerShowCommandTest.php
+++ b/tests/Integration/Container/Commands/ContainerShowCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Tempest\Integration\Container\Commands;
+
+use Tempest\Container\Commands\ContainerShowCommand;
+use Tempest\Container\Container;
+use Tempest\Container\GenericContainer;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+final class ContainerShowCommandTest extends FrameworkIntegrationTestCase
+{
+    public function test_command(): void
+    {
+        $this->console
+            ->call(ContainerShowCommand::class)
+            ->assertSee('INITIALIZERS')
+            ->assertSee('SINGLETONS')
+            ->assertSuccess();
+    }
+
+    public function test_with_another_container(): void
+    {
+        $this->container->singleton(
+            Container::class,
+            new class(clone $this->container) implements Container {
+                public function __construct(
+                    private readonly GenericContainer $container,
+                ) {}
+
+                public function register(string $className, callable $definition): self
+                {
+                    $this->container->register($className, $definition);
+
+                    return $this;
+                }
+
+                public function unregister(string $className): self
+                {
+                    $this->container->unregister($className);
+
+                    return $this;
+                }
+
+                public function singleton(string $className, mixed $definition, ?string $tag = null): self
+                {
+                    $this->container->singleton($className, $definition, $tag);
+
+                    return $this;
+                }
+
+                public function config(object $config): self
+                {
+                    $this->container->config($config);
+
+                    return $this;
+                }
+
+                public function get(string $className, ?string $tag = null, mixed ...$params): mixed
+                {
+                    return $this->container->get($className, $tag, ...$params);
+                }
+
+                public function has(string $className, ?string $tag = null): bool
+                {
+                    return $this->container->has($className, $tag);
+                }
+
+                public function invoke(mixed $method, mixed ...$params): mixed
+                {
+                    return $this->container->invoke($method, ...$params);
+                }
+
+                public function addInitializer(mixed $initializerClass): self
+                {
+                    $this->container->addInitializer($initializerClass);
+
+                    return $this;
+                }
+            },
+        );
+
+        $this->console
+            ->call(ContainerShowCommand::class)
+            ->assertSee('The registered container instance does not expose its bindings.')
+            ->assertError();
+    }
+}

--- a/tests/Integration/Container/Commands/ContainerShowCommandTest.php
+++ b/tests/Integration/Container/Commands/ContainerShowCommandTest.php
@@ -24,7 +24,7 @@ final class ContainerShowCommandTest extends FrameworkIntegrationTestCase
             Container::class,
             new class(clone $this->container) implements Container {
                 public function __construct(
-                    private readonly GenericContainer $container,
+                    private readonly Container $container,
                 ) {}
 
                 public function register(string $className, callable $definition): self


### PR DESCRIPTION
This pull request adds a `container:show` console command that lists container definitions, singletons, and initializers. This is useful for debugging, I've needed that several times.

![CleanShot 2025-04-06 at 13 39 41](https://github.com/user-attachments/assets/38d1afc2-53cf-4717-b183-24a0a8696630)
