### PR TITLE
ci: enforce all linter rules to be respected

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require-dev": {
         "aidan-casey/mock-client": "dev-master",
-        "carthage-software/mago": "0.22.0",
+        "carthage-software/mago": "0.22.2",
         "guzzlehttp/psr7": "^2.6.1",
         "illuminate/view": "~11.7.0",
         "mikey179/vfsstream": "^2.0@dev",
@@ -179,7 +179,7 @@
         "phpunit": "vendor/bin/phpunit --display-warnings --display-skipped --display-deprecations --display-errors --display-notices",
         "coverage": "vendor/bin/phpunit --coverage-html build/reports/html --coverage-clover build/reports/clover.xml",
         "mago:fmt": "vendor/bin/mago fmt && vendor/bin/mago lint --fix --potentially-unsafe --fmt",
-        "mago:lint": "vendor/bin/mago lint",
+        "mago:lint": "vendor/bin/mago lint --minimum-level=note",
         "phpstan": "vendor/bin/phpstan analyse src tests --memory-limit=1G",
         "rector": "vendor/bin/rector process --no-ansi",
         "merge": "php -d\"error_reporting = E_ALL & ~E_DEPRECATED\" vendor/bin/monorepo-builder merge",


### PR DESCRIPTION
Previously, only error-level feedback from Mago were enforced in CI. Thanks to the latest version of Mago, we now require all rules to be respected.