### PR TITLE
refactor(validation): use lite version of `libphonenumber-for-php`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "ext-readline": "*",
         "ext-simplexml": "*",
         "filp/whoops": "^2.15",
-        "giggsey/libphonenumber-for-php": "^8.13.40",
         "guzzlehttp/guzzle": "^7.8",
         "laminas/laminas-diactoros": "^3.3",
         "monolog/monolog": "^3.7.0",
@@ -35,7 +34,8 @@
         "symfony/var-exporter": "^7.1",
         "tempest/highlight": "^2.11.2",
         "vlucas/phpdotenv": "^5.6",
-        "voku/portable-ascii": "^2.0.3"
+        "voku/portable-ascii": "^2.0.3",
+        "giggsey/libphonenumber-for-php-lite": "^9.0"
     },
     "require-dev": {
         "aidan-casey/mock-client": "dev-master",

--- a/src/Tempest/Validation/composer.json
+++ b/src/Tempest/Validation/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.4",
         "egulias/email-validator": "^4.0.2",
-        "giggsey/libphonenumber-for-php": "^8.13.40",
+        "giggsey/libphonenumber-for-php-lite": "^9.0",
         "tempest/reflection": "dev-main",
         "tempest/support": "dev-main",
         "tempest/highlight": "^2.11.2"


### PR DESCRIPTION
Use https://github.com/giggsey/libphonenumber-for-php-lite instead of full version as the framework is only using it for validation.

Thanks to @natanaelsinisalo for bringing it up.