### PR TITLE
fix(support): non-dev bun dependencies installation

### DIFF
--- a/src/Tempest/Support/src/JavaScript/DependencyInstaller.php
+++ b/src/Tempest/Support/src/JavaScript/DependencyInstaller.php
@@ -58,11 +58,17 @@ final readonly class DependencyInstaller
      */
     private function getInstallProcess(PackageManager $packageManager, string $cwd, string|array $dependencies, bool $dev = false): Process
     {
-        return new Process([
-            $packageManager->getBinaryName(),
-            $packageManager->getInstallCommand(),
-            $dev ? '-D' : '',
-            ...wrap($dependencies),
-        ], $cwd);
+        return new Process(
+            array_filter(
+                [
+                    $packageManager->getBinaryName(),
+                    $packageManager->getInstallCommand(),
+                    $dev ? '-D' : null,
+                    ...wrap($dependencies),
+                ],
+                fn (?string $arg): bool => $arg !== null,
+            ),
+            $cwd,
+        );
     }
 }

--- a/tests/Integration/Support/DependencyInstallerTest.php
+++ b/tests/Integration/Support/DependencyInstallerTest.php
@@ -58,6 +58,22 @@ final class DependencyInstallerTest extends FrameworkIntegrationTestCase
         });
     }
 
+    #[TestWith(['bun.lock'])]
+    #[TestWith(['package-lock.json'])]
+    public function test_can_install_non_dev_dependencies(string $lockfile): void
+    {
+        $this->callInTemporaryDirectory(function (string $directory) use ($lockfile): void {
+            file_put_contents("{$directory}/package.json", data: '{}');
+            file_put_contents("{$directory}/{$lockfile}", data: null);
+
+            $installer = $this->container->get(DependencyInstaller::class);
+            $installer->silentlyInstallDependencies($directory, 'vite-plugin-tempest', dev: false);
+
+            $this->assertTrue(is_dir($directory . '/node_modules'), message: 'Dependencies were not installed.');
+            $this->assertNotNull(json_decode(file_get_contents($directory . '/package.json'), associative: true)['dependencies']['vite-plugin-tempest']);
+        });
+    }
+
     private function callInTemporaryDirectory(Closure $callback): void
     {
         $directory = __DIR__ . '/Fixtures/tmp';


### PR DESCRIPTION
Not sure why, but the empty `""` string in the command breaks installing non-dev dependencies when using bun.