### PR TITLE
fix(view): `:` is replaced by `-` and `@` is removed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "ext-readline": "*",
         "ext-simplexml": "*",
         "filp/whoops": "^2.15",
+        "giggsey/libphonenumber-for-php-lite": "^9.0",
         "guzzlehttp/guzzle": "^7.8",
         "laminas/laminas-diactoros": "^3.3",
         "monolog/monolog": "^3.7.0",
@@ -34,8 +35,7 @@
         "symfony/var-exporter": "^7.1",
         "tempest/highlight": "^2.11.2",
         "vlucas/phpdotenv": "^5.6",
-        "voku/portable-ascii": "^2.0.3",
-        "giggsey/libphonenumber-for-php-lite": "^9.0"
+        "voku/portable-ascii": "^2.0.3"
     },
     "require-dev": {
         "aidan-casey/mock-client": "dev-master",

--- a/src/Tempest/View/src/Elements/ElementFactory.php
+++ b/src/Tempest/View/src/Elements/ElementFactory.php
@@ -66,22 +66,7 @@ final class ElementFactory
             return new RawElement(tag: null, content: $token->compile());
         }
 
-        $attributes = [];
-
-        foreach ($token->htmlAttributes as $name => $value) {
-            $name = str($name)
-                ->trim()
-                ->before('=')
-                ->camel()
-                ->toString();
-
-            $value = str($value)
-                ->afterFirst('"')
-                ->beforeLast('"')
-                ->toString();
-
-            $attributes[$name] = $value;
-        }
+        $attributes = $token->htmlAttributes;
 
         foreach ($token->phpAttributes as $index => $content) {
             $attributes[] = new PhpAttribute((string) $index, $content);

--- a/src/Tempest/View/src/Elements/GenericElement.php
+++ b/src/Tempest/View/src/Elements/GenericElement.php
@@ -38,14 +38,6 @@ final class GenericElement implements Element
         $attributes = [];
 
         foreach ($this->getAttributes() as $name => $value) {
-            $name = str($name);
-
-            if ($name->startsWith(':')) {
-                $name = ':' . $name->kebab()->toString();
-            } else {
-                $name = $name->kebab()->toString();
-            }
-
             if ($value) {
                 $attributes[] = $name . '="' . $value . '"';
             } else {

--- a/src/Tempest/View/src/Elements/PhpDataElement.php
+++ b/src/Tempest/View/src/Elements/PhpDataElement.php
@@ -54,7 +54,7 @@ final class PhpDataElement implements Element, WrapsElement
             $attributeName = ltrim($this->name, ':');
 
             $coreElement
-                ->addRawAttribute(new RawConditionalAttribute($attributeName, $coreElement->getAttribute($this->name))->compile())
+                ->addRawAttribute(new RawConditionalAttribute($attributeName, $coreElement->getAttribute($attributeName))->compile())
                 ->unsetAttribute($attributeName);
         }
 

--- a/src/Tempest/View/src/Elements/PhpDataElement.php
+++ b/src/Tempest/View/src/Elements/PhpDataElement.php
@@ -56,7 +56,7 @@ final class PhpDataElement implements Element, WrapsElement
             $coreElement
                 ->addRawAttribute(new RawConditionalAttribute(
                     name: $attributeName,
-                    value: $coreElement->getAttribute($attributeName)
+                    value: $coreElement->getAttribute($attributeName),
                 )->compile())
                 ->unsetAttribute($attributeName);
         }

--- a/src/Tempest/View/src/Elements/PhpDataElement.php
+++ b/src/Tempest/View/src/Elements/PhpDataElement.php
@@ -51,9 +51,11 @@ final class PhpDataElement implements Element, WrapsElement
         $coreElement = $this->unwrap(GenericElement::class);
 
         if ($isExpression && $coreElement) {
+            $attributeName = ltrim($this->name, ':');
+
             $coreElement
-                ->addRawAttribute(new RawConditionalAttribute(ltrim($this->name, ':'), $coreElement->getAttribute($this->name))->compile())
-                ->unsetAttribute(ltrim($this->name, ':'));
+                ->addRawAttribute(new RawConditionalAttribute($attributeName, $coreElement->getAttribute($this->name))->compile())
+                ->unsetAttribute($attributeName);
         }
 
         return sprintf(

--- a/src/Tempest/View/src/Elements/PhpDataElement.php
+++ b/src/Tempest/View/src/Elements/PhpDataElement.php
@@ -54,7 +54,10 @@ final class PhpDataElement implements Element, WrapsElement
             $attributeName = ltrim($this->name, ':');
 
             $coreElement
-                ->addRawAttribute(new RawConditionalAttribute($attributeName, $coreElement->getAttribute($attributeName))->compile())
+                ->addRawAttribute(new RawConditionalAttribute(
+                    name: $attributeName,
+                    value: $coreElement->getAttribute($attributeName)
+                )->compile())
                 ->unsetAttribute($attributeName);
         }
 

--- a/tests/Integration/View/TempestViewRendererTest.php
+++ b/tests/Integration/View/TempestViewRendererTest.php
@@ -547,6 +547,34 @@ final class TempestViewRendererTest extends FrameworkIntegrationTestCase
         $this->assertStringEqualsStringIgnoringLineEndings('<div>test</div>', $html);
     }
 
+    public function test_with_at_symbol_in_html_tag(): void
+    {
+        $rendered = $this->render(
+            view('<button @click="foo">test</button>'),
+        );
+
+        $this->assertStringEqualsStringIgnoringLineEndings(
+            <<<HTML
+            <button @click="foo">test</button>
+            HTML,
+            $rendered,
+        );
+    }
+
+    public function test_with_colon_symbol_in_html_tag(): void
+    {
+        $rendered = $this->render(
+            view('<button x-on:click="foo">test</button>'),
+        );
+
+        $this->assertStringEqualsStringIgnoringLineEndings(
+            <<<HTML
+            <button x-on:click="foo">test</button>
+            HTML,
+            $rendered,
+        );
+    }
+
     private function assertSnippetsMatch(string $expected, string $actual): void
     {
         $expected = str_replace([PHP_EOL, ' '], '', $expected);

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -703,6 +703,34 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         HTML, $html);
     }
 
+    public function test_with_at_symbol_in_html_tag(): void
+    {
+        $rendered = $this->render(
+            view('<button @click="foo">test</button>'),
+        );
+
+        $this->assertStringEqualsStringIgnoringLineEndings(
+            <<<HTML
+            <button @click="foo">test</button>
+            HTML,
+            $rendered,
+        );
+    }
+
+    public function test_with_colon_symbol_in_html_tag(): void
+    {
+        $rendered = $this->render(
+            view('<button x-on:click="foo">test</button>'),
+        );
+
+        $this->assertStringEqualsStringIgnoringLineEndings(
+            <<<HTML
+            <button x-on:click="foo">test</button>
+            HTML,
+            $rendered,
+        );
+    }
+
     private function assertSnippetsMatch(string $expected, string $actual): void
     {
         $expected = str_replace([PHP_EOL, ' '], '', $expected);

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -703,34 +703,6 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         HTML, $html);
     }
 
-    public function test_with_at_symbol_in_html_tag(): void
-    {
-        $rendered = $this->render(
-            view('<button @click="foo">test</button>'),
-        );
-
-        $this->assertStringEqualsStringIgnoringLineEndings(
-            <<<HTML
-            <button @click="foo">test</button>
-            HTML,
-            $rendered,
-        );
-    }
-
-    public function test_with_colon_symbol_in_html_tag(): void
-    {
-        $rendered = $this->render(
-            view('<button x-on:click="foo">test</button>'),
-        );
-
-        $this->assertStringEqualsStringIgnoringLineEndings(
-            <<<HTML
-            <button x-on:click="foo">test</button>
-            HTML,
-            $rendered,
-        );
-    }
-
     private function assertSnippetsMatch(string $expected, string $actual): void
     {
         $expected = str_replace([PHP_EOL, ' '], '', $expected);


### PR DESCRIPTION
>[!WARNING]
>**This PR does NOT contain the fix - just the failing tests**

Currently, if you have `@` or `:` in an HTML component, the render removes the `@` and replaces the `:` with `-`. Examples:

```html
<button @click="alert('Hello World!')">

<!-- Gets rendered as: -->
<button click="alert('Hello World!')">
```

```html
<button x-on:click="alert('Hello World!')">

<!-- Gets rendered as: -->
<button x-on-click="alert('Hello World!')">
```

This breaks libraries such as alpine, htmx, etc.

Fixes #1126