### PR TITLE
Add missing DoNotDiscover attribute to Console stubs

### DIFF
--- a/src/Tempest/Console/src/Commands/MakeCommandCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeCommandCommand.php
@@ -8,6 +8,7 @@ use Tempest\Console\ConsoleArgument;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Stubs\CommandStub;
 use Tempest\Core\PublishesFiles;
+use Tempest\Generation\ClassManipulator;
 use Tempest\Generation\DataObjects\StubFile;
 
 use function Tempest\Support\str;
@@ -35,6 +36,9 @@ final class MakeCommandCommand
             shouldOverride: $shouldOverride,
             replacements: [
                 'dummy-command-slug' => str($className)->kebab()->toString(),
+            ],
+            manipulations: [
+                fn(ClassManipulator $manipulator) => $manipulator->removeClassAttribute('DoNotDiscover')
             ],
         );
 

--- a/src/Tempest/Console/src/Commands/MakeGeneratorCommandCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeGeneratorCommandCommand.php
@@ -8,6 +8,7 @@ use Tempest\Console\ConsoleArgument;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Stubs\GeneratorCommandStub;
 use Tempest\Core\PublishesFiles;
+use Tempest\Generation\ClassManipulator;
 use Tempest\Generation\DataObjects\StubFile;
 
 use function Tempest\Support\str;
@@ -35,6 +36,9 @@ final class MakeGeneratorCommandCommand
             shouldOverride: $shouldOverride,
             replacements: [
                 'dummy-command-slug' => str($className)->kebab()->toString(),
+            ],
+            manipulations: [
+                fn(ClassManipulator $manipulator) => $manipulator->removeClassAttribute('DoNotDiscover')
             ],
         );
 

--- a/src/Tempest/Console/src/ConsoleConfig.php
+++ b/src/Tempest/Console/src/ConsoleConfig.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace Tempest\Console;
 
-use Tempest\Console\Middleware\ConsoleExceptionMiddleware;
-use Tempest\Console\Middleware\HelpMiddleware;
-use Tempest\Console\Middleware\InvalidCommandMiddleware;
-use Tempest\Console\Middleware\OverviewMiddleware;
-use Tempest\Console\Middleware\ResolveOrRescueMiddleware;
 use Tempest\Core\Middleware;
 use Tempest\Reflection\MethodReflector;
 
@@ -21,7 +16,7 @@ final class ConsoleConfig
         public array $commands = [],
         public ?string $logPath = null,
 
-        /** @var Middleware<\Tempest\Console\ConsoleMiddleware> */
+        /** @var Middleware<ConsoleMiddleware> */
         public Middleware $middleware = new Middleware(),
     ) {}
 

--- a/src/Tempest/Console/src/Stubs/CommandStub.php
+++ b/src/Tempest/Console/src/Stubs/CommandStub.php
@@ -6,7 +6,9 @@ namespace Tempest\Console\Stubs;
 
 use Tempest\Console\Console;
 use Tempest\Console\ConsoleCommand;
+use Tempest\Discovery\DoNotDiscover;
 
+#[DoNotDiscover]
 final class CommandStub
 {
     public function __construct(

--- a/src/Tempest/Console/src/Stubs/GeneratorCommandStub.php
+++ b/src/Tempest/Console/src/Stubs/GeneratorCommandStub.php
@@ -7,8 +7,10 @@ namespace Tempest\Console\Stubs;
 use Tempest\Console\ConsoleArgument;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Core\PublishesFiles;
+use Tempest\Discovery\DoNotDiscover;
 use Tempest\Generation\DataObjects\StubFile;
 
+#[DoNotDiscover]
 final class GeneratorCommandStub
 {
     use PublishesFiles;

--- a/tests/Integration/Console/Commands/MakeCommandCommandTest.php
+++ b/tests/Integration/Console/Commands/MakeCommandCommandTest.php
@@ -44,7 +44,8 @@ final class MakeCommandCommandTest extends FrameworkIntegrationTestCase
 
         $this->installer
             ->assertFileExists($expectedPath)
-            ->assertFileContains($expectedPath, 'namespace ' . $expectedNamespace . ';');
+            ->assertFileContains($expectedPath, 'namespace ' . $expectedNamespace . ';')
+            ->assertFileNotContains($expectedPath, '#[DoNotDiscover]');
     }
 
     public static function command_input_provider(): array

--- a/tests/Integration/Console/Commands/MakeGeneratorCommandCommandTest.php
+++ b/tests/Integration/Console/Commands/MakeGeneratorCommandCommandTest.php
@@ -44,7 +44,8 @@ final class MakeGeneratorCommandCommandTest extends FrameworkIntegrationTestCase
 
         $this->installer
             ->assertFileExists($expectedPath)
-            ->assertFileContains($expectedPath, 'namespace ' . $expectedNamespace . ';');
+            ->assertFileContains($expectedPath, 'namespace ' . $expectedNamespace . ';')
+            ->assertFileNotContains($expectedPath, '#[DoNotDiscover]');
     }
 
     public static function command_input_provider(): array


### PR DESCRIPTION
Fixes #1134.

1. Adds the `DoNotDiscover` attribute to Console stubs
2. Updates the Console `make:` commands to remove the attribute when generating the class
3. Updates the integration tests to reflect the expected behavior

