### PR TITLE
refactor(core): rename `DoNotDiscover` to `SkipDiscovery`

### DIFF
--- a/src/Tempest/Auth/src/Install/CreatePermissionsTable.php
+++ b/src/Tempest/Auth/src/Install/CreatePermissionsTable.php
@@ -7,9 +7,9 @@ namespace Tempest\Auth\Install;
 use Tempest\Database\DatabaseMigration;
 use Tempest\Database\QueryStatements\CreateTableStatement;
 use Tempest\Database\QueryStatements\DropTableStatement;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final class CreatePermissionsTable implements DatabaseMigration
 {
     private(set) string $name = '0000-00-01_create_permissions_table';

--- a/src/Tempest/Auth/src/Install/CreateUserPermissionsTable.php
+++ b/src/Tempest/Auth/src/Install/CreateUserPermissionsTable.php
@@ -7,9 +7,9 @@ namespace Tempest\Auth\Install;
 use Tempest\Database\DatabaseMigration;
 use Tempest\Database\QueryStatements\CreateTableStatement;
 use Tempest\Database\QueryStatements\DropTableStatement;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final class CreateUserPermissionsTable implements DatabaseMigration
 {
     private(set) string $name = '0000-00-02_create_user_permissions_table';

--- a/src/Tempest/Auth/src/Install/CreateUsersTable.php
+++ b/src/Tempest/Auth/src/Install/CreateUsersTable.php
@@ -7,9 +7,9 @@ namespace Tempest\Auth\Install;
 use Tempest\Database\DatabaseMigration;
 use Tempest\Database\QueryStatements\CreateTableStatement;
 use Tempest\Database\QueryStatements\DropTableStatement;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final class CreateUsersTable implements DatabaseMigration
 {
     private(set) string $name = '0000-00-00_create_users_table';

--- a/src/Tempest/Console/src/Commands/MakeCommandCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeCommandCommand.php
@@ -8,7 +8,7 @@ use Tempest\Console\ConsoleArgument;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Stubs\CommandStub;
 use Tempest\Core\PublishesFiles;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\Generation\ClassManipulator;
 use Tempest\Generation\DataObjects\StubFile;
 
@@ -39,7 +39,7 @@ final class MakeCommandCommand
                 'dummy-command-slug' => str($className)->kebab()->toString(),
             ],
             manipulations: [
-                fn (ClassManipulator $class) => $class->removeClassAttribute(DoNotDiscover::class),
+                fn (ClassManipulator $class) => $class->removeClassAttribute(SkipDiscovery::class),
             ],
         );
 

--- a/src/Tempest/Console/src/Commands/MakeGeneratorCommandCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeGeneratorCommandCommand.php
@@ -8,7 +8,7 @@ use Tempest\Console\ConsoleArgument;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Stubs\GeneratorCommandStub;
 use Tempest\Core\PublishesFiles;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\Generation\ClassManipulator;
 use Tempest\Generation\DataObjects\StubFile;
 
@@ -39,7 +39,7 @@ final class MakeGeneratorCommandCommand
                 'dummy-command-slug' => str($className)->kebab()->toString(),
             ],
             manipulations: [
-                fn (ClassManipulator $class) => $class->removeClassAttribute(DoNotDiscover::class),
+                fn (ClassManipulator $class) => $class->removeClassAttribute(SkipDiscovery::class),
             ],
         );
 

--- a/src/Tempest/Console/src/Commands/MakeMiddlewareCommand.php
+++ b/src/Tempest/Console/src/Commands/MakeMiddlewareCommand.php
@@ -13,7 +13,7 @@ use Tempest\Console\Stubs\ConsoleMiddlewareStub;
 use Tempest\Console\Stubs\EventBusMiddlewareStub;
 use Tempest\Console\Stubs\HttpMiddlewareStub;
 use Tempest\Core\PublishesFiles;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\Generation\ClassManipulator;
 use Tempest\Generation\DataObjects\StubFile;
 
@@ -42,7 +42,7 @@ final class MakeMiddlewareCommand
             targetPath: $targetPath,
             shouldOverride: $shouldOverride,
             manipulations: [
-                fn (ClassManipulator $class) => $class->removeClassAttribute(DoNotDiscover::class),
+                fn (ClassManipulator $class) => $class->removeClassAttribute(SkipDiscovery::class),
             ],
         );
 

--- a/src/Tempest/Console/src/Middleware/CautionMiddleware.php
+++ b/src/Tempest/Console/src/Middleware/CautionMiddleware.php
@@ -10,9 +10,9 @@ use Tempest\Console\ConsoleMiddlewareCallable;
 use Tempest\Console\ExitCode;
 use Tempest\Console\Initializers\Invocation;
 use Tempest\Core\AppConfig;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final readonly class CautionMiddleware implements ConsoleMiddleware
 {
     public function __construct(

--- a/src/Tempest/Console/src/Middleware/ForceMiddleware.php
+++ b/src/Tempest/Console/src/Middleware/ForceMiddleware.php
@@ -10,9 +10,9 @@ use Tempest\Console\ConsoleMiddlewareCallable;
 use Tempest\Console\ExitCode;
 use Tempest\Console\GenericConsole;
 use Tempest\Console\Initializers\Invocation;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final readonly class ForceMiddleware implements ConsoleMiddleware
 {
     public function __construct(

--- a/src/Tempest/Console/src/Stubs/CommandBusMiddlewareStub.php
+++ b/src/Tempest/Console/src/Stubs/CommandBusMiddlewareStub.php
@@ -7,9 +7,9 @@ namespace Tempest\Console\Stubs;
 use Tempest\CommandBus\CommandBusMiddleware;
 use Tempest\CommandBus\CommandBusMiddlewareCallable;
 use Tempest\Core\Priority;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 #[Priority(Priority::NORMAL)]
 final class CommandBusMiddlewareStub implements CommandBusMiddleware
 {

--- a/src/Tempest/Console/src/Stubs/CommandStub.php
+++ b/src/Tempest/Console/src/Stubs/CommandStub.php
@@ -6,9 +6,9 @@ namespace Tempest\Console\Stubs;
 
 use Tempest\Console\Console;
 use Tempest\Console\ConsoleCommand;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final class CommandStub
 {
     public function __construct(

--- a/src/Tempest/Console/src/Stubs/ConsoleMiddlewareStub.php
+++ b/src/Tempest/Console/src/Stubs/ConsoleMiddlewareStub.php
@@ -10,9 +10,9 @@ use Tempest\Console\ExitCode;
 use Tempest\Console\HasConsole;
 use Tempest\Console\Initializers\Invocation;
 use Tempest\Core\Priority;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 #[Priority(Priority::NORMAL)]
 final class ConsoleMiddlewareStub implements ConsoleMiddleware
 {

--- a/src/Tempest/Console/src/Stubs/EventBusMiddlewareStub.php
+++ b/src/Tempest/Console/src/Stubs/EventBusMiddlewareStub.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Tempest\Console\Stubs;
 
 use Tempest\Core\Priority;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\EventBus\EventBusMiddleware;
 use Tempest\EventBus\EventBusMiddlewareCallable;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 #[Priority(Priority::NORMAL)]
 final class EventBusMiddlewareStub implements EventBusMiddleware
 {

--- a/src/Tempest/Console/src/Stubs/GeneratorCommandStub.php
+++ b/src/Tempest/Console/src/Stubs/GeneratorCommandStub.php
@@ -7,11 +7,11 @@ namespace Tempest\Console\Stubs;
 use Tempest\Console\ConsoleArgument;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Core\PublishesFiles;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\Generation\ClassManipulator;
 use Tempest\Generation\DataObjects\StubFile;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final class GeneratorCommandStub
 {
     use PublishesFiles;
@@ -30,7 +30,7 @@ final class GeneratorCommandStub
             targetPath: $targetPath,
             shouldOverride: $shouldOverride,
             manipulations: [
-                fn (ClassManipulator $class) => $class->removeClassAttribute(DoNotDiscover::class),
+                fn (ClassManipulator $class) => $class->removeClassAttribute(SkipDiscovery::class),
             ],
         );
 

--- a/src/Tempest/Console/src/Stubs/HttpMiddlewareStub.php
+++ b/src/Tempest/Console/src/Stubs/HttpMiddlewareStub.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Tempest\Console\Stubs;
 
 use Tempest\Core\Priority;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\Router\HttpMiddleware;
 use Tempest\Router\HttpMiddlewareCallable;
 use Tempest\Router\Request;
 use Tempest\Router\Response;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 #[Priority(Priority::NORMAL)]
 final class HttpMiddlewareStub implements HttpMiddleware
 {

--- a/src/Tempest/Container/src/Commands/MakeInitializerCommand.php
+++ b/src/Tempest/Container/src/Commands/MakeInitializerCommand.php
@@ -9,7 +9,7 @@ use Tempest\Console\ConsoleCommand;
 use Tempest\Container\Singleton;
 use Tempest\Container\Stubs\InitializerStub;
 use Tempest\Core\PublishesFiles;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\Generation\ClassManipulator;
 use Tempest\Generation\DataObjects\StubFile;
 
@@ -38,7 +38,7 @@ final class MakeInitializerCommand
             shouldOverride: $shouldOverride,
             manipulations: [
                 function (ClassManipulator $stubClass) use ($isSingleton) {
-                    $stubClass->removeClassAttribute(DoNotDiscover::class);
+                    $stubClass->removeClassAttribute(SkipDiscovery::class);
 
                     if ($isSingleton) {
                         $stubClass->addMethodAttribute('initialize', Singleton::class);

--- a/src/Tempest/Container/src/Stubs/InitializerStub.php
+++ b/src/Tempest/Container/src/Stubs/InitializerStub.php
@@ -6,9 +6,9 @@ namespace Tempest\Container\Stubs;
 
 use Tempest\Container\Container;
 use Tempest\Container\Initializer;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final class InitializerStub implements Initializer
 {
     public function initialize(Container $container): mixed

--- a/src/Tempest/Core/src/Kernel/LoadDiscoveryClasses.php
+++ b/src/Tempest/Core/src/Kernel/LoadDiscoveryClasses.php
@@ -17,7 +17,7 @@ use Tempest\Discovery\DiscoversPath;
 use Tempest\Discovery\Discovery;
 use Tempest\Discovery\DiscoveryItems;
 use Tempest\Discovery\DiscoveryLocation;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\Reflection\ClassReflector;
 use Throwable;
 
@@ -161,11 +161,11 @@ final class LoadDiscoveryClasses
     }
 
     /**
-     * Check whether discovery for a specific class should be skipped based on the #[DoNotDiscover] attribute
+     * Check whether discovery for a specific class should be skipped based on the #[SkipDiscovery] attribute
      */
     private function shouldSkipDiscoveryForClass(Discovery $discovery, ClassReflector $input): bool
     {
-        $attribute = $input->getAttribute(DoNotDiscover::class);
+        $attribute = $input->getAttribute(SkipDiscovery::class);
 
         if ($attribute === null) {
             return false;

--- a/src/Tempest/Core/src/PublishesFiles.php
+++ b/src/Tempest/Core/src/PublishesFiles.php
@@ -9,7 +9,7 @@ use Exception;
 use Tempest\Console\Exceptions\ConsoleException;
 use Tempest\Console\HasConsole;
 use Tempest\Container\Inject;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\Generation\ClassManipulator;
 use Tempest\Generation\DataObjects\StubFile;
 use Tempest\Generation\Enums\StubFileType;
@@ -83,7 +83,7 @@ trait PublishesFiles
                     targetPath: $destination,
                     shouldOverride: true,
                     manipulations: [
-                        fn (ClassManipulator $class) => $class->removeClassAttribute(DoNotDiscover::class),
+                        fn (ClassManipulator $class) => $class->removeClassAttribute(SkipDiscovery::class),
                     ],
                 );
 

--- a/src/Tempest/Database/src/Commands/MakeMigrationCommand.php
+++ b/src/Tempest/Database/src/Commands/MakeMigrationCommand.php
@@ -10,7 +10,7 @@ use Tempest\Console\ConsoleCommand;
 use Tempest\Core\PublishesFiles;
 use Tempest\Database\Enums\MigrationType;
 use Tempest\Database\Stubs\MigrationStub;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\Generation\ClassManipulator;
 use Tempest\Generation\DataObjects\StubFile;
 use Tempest\Generation\Exceptions\FileGenerationAbortedException;
@@ -116,7 +116,7 @@ final class MakeMigrationCommand
                 'dummy-table-name' => str($fileName)->snake()->toString(),
             ],
             manipulations: [
-                fn (ClassManipulator $class) => $class->removeClassAttribute(DoNotDiscover::class),
+                fn (ClassManipulator $class) => $class->removeClassAttribute(SkipDiscovery::class),
             ],
         );
 

--- a/src/Tempest/Database/src/Stubs/MigrationStub.php
+++ b/src/Tempest/Database/src/Stubs/MigrationStub.php
@@ -8,9 +8,9 @@ use Tempest\Database\DatabaseMigration;
 use Tempest\Database\QueryStatement;
 use Tempest\Database\QueryStatements\CreateTableStatement;
 use Tempest\Database\QueryStatements\DropTableStatement;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final class MigrationStub implements DatabaseMigration
 {
     public string $name = 'dummy-date_dummy-table-name';

--- a/src/Tempest/Discovery/src/Commands/MakeDiscoveryCommand.php
+++ b/src/Tempest/Discovery/src/Commands/MakeDiscoveryCommand.php
@@ -7,7 +7,7 @@ namespace Tempest\Discovery\Commands;
 use Tempest\Console\ConsoleArgument;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Core\PublishesFiles;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\Discovery\Stubs\DiscoveryStub;
 use Tempest\Generation\ClassManipulator;
 use Tempest\Generation\DataObjects\StubFile;
@@ -34,7 +34,7 @@ final class MakeDiscoveryCommand
             targetPath: $targetPath,
             shouldOverride: $shouldOverride,
             manipulations: [
-                fn (ClassManipulator $class) => $class->removeClassAttribute(DoNotDiscover::class),
+                fn (ClassManipulator $class) => $class->removeClassAttribute(SkipDiscovery::class),
             ],
         );
 

--- a/src/Tempest/Discovery/src/SkipDiscovery.php
+++ b/src/Tempest/Discovery/src/SkipDiscovery.php
@@ -6,8 +6,11 @@ namespace Tempest\Discovery;
 
 use Attribute;
 
+/**
+ * Instruct Tempest to not discover this class.
+ */
 #[Attribute(Attribute::TARGET_CLASS)]
-final readonly class DoNotDiscover
+final readonly class SkipDiscovery
 {
     public function __construct(
         /**

--- a/src/Tempest/Discovery/src/Stubs/DiscoveryStub.php
+++ b/src/Tempest/Discovery/src/Stubs/DiscoveryStub.php
@@ -6,11 +6,11 @@ namespace Tempest\Discovery\Stubs;
 
 use Tempest\Discovery\Discovery;
 use Tempest\Discovery\DiscoveryLocation;
-use Tempest\Discovery\DoNotDiscover;
 use Tempest\Discovery\IsDiscovery;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\Reflection\ClassReflector;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final class DiscoveryStub implements Discovery
 {
     use IsDiscovery;

--- a/tests/Fixtures/Controllers/TestGlobalMiddleware.php
+++ b/tests/Fixtures/Controllers/TestGlobalMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Fixtures\Controllers;
 
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\Router\HttpMiddleware;
 use Tempest\Router\HttpMiddlewareCallable;
 use Tempest\Router\Request;
 use Tempest\Router\Response;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final readonly class TestGlobalMiddleware implements HttpMiddleware
 {
     public function __invoke(Request $request, HttpMiddlewareCallable $next): Response

--- a/tests/Fixtures/Controllers/TestMiddleware.php
+++ b/tests/Fixtures/Controllers/TestMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Fixtures\Controllers;
 
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 use Tempest\Router\HttpMiddleware;
 use Tempest\Router\HttpMiddlewareCallable;
 use Tempest\Router\Request;
 use Tempest\Router\Response;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final readonly class TestMiddleware implements HttpMiddleware
 {
     public function __construct(

--- a/tests/Fixtures/Discovery/HiddenDatabaseMigration.php
+++ b/tests/Fixtures/Discovery/HiddenDatabaseMigration.php
@@ -6,9 +6,9 @@ namespace Tests\Tempest\Fixtures\Discovery;
 
 use Tempest\Database\DatabaseMigration;
 use Tempest\Database\QueryStatement;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final class HiddenDatabaseMigration implements DatabaseMigration
 {
     private(set) string $name = 'hidden-migration';

--- a/tests/Fixtures/Discovery/HiddenMigratableDatabaseMigration.php
+++ b/tests/Fixtures/Discovery/HiddenMigratableDatabaseMigration.php
@@ -7,9 +7,9 @@ namespace Tests\Tempest\Fixtures\Discovery;
 use Tempest\Database\DatabaseMigration;
 use Tempest\Database\MigrationDiscovery;
 use Tempest\Database\QueryStatement;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover(except: [MigrationDiscovery::class])]
+#[SkipDiscovery(except: [MigrationDiscovery::class])]
 final class HiddenMigratableDatabaseMigration implements DatabaseMigration
 {
     private(set) string $name = 'hidden-migratable-migration';

--- a/tests/Fixtures/TestInstallerClass.php
+++ b/tests/Fixtures/TestInstallerClass.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Fixtures;
 
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final readonly class TestInstallerClass
 {
 }

--- a/tests/Integration/Auth/AuthInstallerTest.php
+++ b/tests/Integration/Auth/AuthInstallerTest.php
@@ -49,7 +49,7 @@ final class AuthInstallerTest extends FrameworkIntegrationTestCase
             $this->installer
                 ->assertFileExists($path)
                 ->assertFileContains($path, 'namespace App\Auth;')
-                ->assertFileNotContains($path, 'DoNotDiscover');
+                ->assertFileNotContains($path, 'SkipDiscovery');
         }
 
         $this->installer->assertFileContains(

--- a/tests/Integration/Console/Commands/MakeCommandCommandTest.php
+++ b/tests/Integration/Console/Commands/MakeCommandCommandTest.php
@@ -44,7 +44,7 @@ final class MakeCommandCommandTest extends FrameworkIntegrationTestCase
 
         $this->installer
             ->assertFileExists($expectedPath)
-            ->assertFileNotContains($expectedPath, 'DoNotDiscover')
+            ->assertFileNotContains($expectedPath, 'SkipDiscovery')
             ->assertFileContains($expectedPath, 'namespace ' . $expectedNamespace . ';');
     }
 

--- a/tests/Integration/Console/Commands/MakeMiddlewareCommandTest.php
+++ b/tests/Integration/Console/Commands/MakeMiddlewareCommandTest.php
@@ -47,7 +47,7 @@ final class MakeMiddlewareCommandTest extends FrameworkIntegrationTestCase
 
         $this->installer
             ->assertFileExists($expectedPath)
-            ->assertFileNotContains($expectedPath, 'DoNotDiscover')
+            ->assertFileNotContains($expectedPath, 'SkipDiscovery')
             ->assertFileContains($expectedPath, 'namespace ' . $expectedNamespace . ';');
     }
 

--- a/tests/Integration/Console/Fixtures/SpecificMiddleware.php
+++ b/tests/Integration/Console/Fixtures/SpecificMiddleware.php
@@ -9,9 +9,9 @@ use Tempest\Console\ConsoleMiddleware;
 use Tempest\Console\ConsoleMiddlewareCallable;
 use Tempest\Console\ExitCode;
 use Tempest\Console\Initializers\Invocation;
-use Tempest\Discovery\DoNotDiscover;
+use Tempest\Discovery\SkipDiscovery;
 
-#[DoNotDiscover]
+#[SkipDiscovery]
 final readonly class SpecificMiddleware implements ConsoleMiddleware
 {
     public function __construct(

--- a/tests/Integration/Container/Commands/MakeInitializerCommandTest.php
+++ b/tests/Integration/Container/Commands/MakeInitializerCommandTest.php
@@ -44,7 +44,7 @@ class MakeInitializerCommandTest extends FrameworkIntegrationTestCase
 
         $this->installer
             ->assertFileExists($expectedPath)
-            ->assertFileNotContains($expectedPath, 'DoNotDiscover')
+            ->assertFileNotContains($expectedPath, 'SkipDiscovery')
             ->assertFileContains($expectedPath, 'namespace ' . $expectedNamespace . ';')
             ->assertFileExists($expectedPath, 'implements Initializer')
             ->assertFileContains($expectedPath, 'public function initialize');

--- a/tests/Integration/Core/InstallCommandTest.php
+++ b/tests/Integration/Core/InstallCommandTest.php
@@ -42,7 +42,7 @@ final class InstallCommandTest extends FrameworkIntegrationTestCase
             )
             ->assertFileNotContains(
                 path: 'App/Foo/Bar/TestInstallerClass.php',
-                search: 'DoNotDiscover',
+                search: 'SkipDiscovery',
             )
             ->assertFileContains(
                 path: 'App/Foo/Bar/TestInstallerClass.php',

--- a/tests/Integration/Database/Commands/MakeMigrationCommandTest.php
+++ b/tests/Integration/Database/Commands/MakeMigrationCommandTest.php
@@ -44,7 +44,7 @@ final class MakeMigrationCommandTest extends FrameworkIntegrationTestCase
 
         $this->installer
             ->assertFileExists($expectedPath)
-            ->assertFileNotContains($expectedPath, 'DoNotDiscover')
+            ->assertFileNotContains($expectedPath, 'SkipDiscovery')
             ->assertFileContains($expectedPath, 'namespace ' . $expectedNamespace . ';');
     }
 

--- a/tests/Integration/Discovery/Commands/MakeDiscoveryCommandTest.php
+++ b/tests/Integration/Discovery/Commands/MakeDiscoveryCommandTest.php
@@ -44,7 +44,7 @@ class MakeDiscoveryCommandTest extends FrameworkIntegrationTestCase
 
         $this->installer
             ->assertFileExists($expectedPath)
-            ->assertFileNotContains($expectedPath, 'DoNotDiscover')
+            ->assertFileNotContains($expectedPath, 'SkipDiscovery')
             ->assertFileContains($expectedPath, 'namespace ' . $expectedNamespace . ';')
             ->assertFileExists($expectedPath, 'implements Discovery')
             ->assertFileContains($expectedPath, 'public function discover');


### PR DESCRIPTION
This is a consistency change, that attribute was the only one with that kind of naming.