### PR TITLE
feat(console): add option to use terminal width to render key/values

### DIFF
--- a/src/Tempest/Console/src/Console.php
+++ b/src/Tempest/Console/src/Console.php
@@ -71,7 +71,7 @@ interface Console
 
     public function success(string $contents, ?string $title = null): self;
 
-    public function keyValue(string $key, ?string $value = null): self;
+    public function keyValue(string $key, ?string $value = null, bool $useAvailableWidth = false): self;
 
     public function instructions(array|string $lines): self;
 

--- a/src/Tempest/Console/src/GenericConsole.php
+++ b/src/Tempest/Console/src/GenericConsole.php
@@ -186,9 +186,9 @@ final class GenericConsole implements Console
         return $clone;
     }
 
-    public function keyValue(string $key, ?string $value = null): self
+    public function keyValue(string $key, ?string $value = null, bool $useAvailableWidth = false): self
     {
-        $this->writeln(new KeyValueRenderer()->render($key, $value));
+        $this->writeln(new KeyValueRenderer()->render($key, $value, $useAvailableWidth));
 
         return $this;
     }

--- a/src/Tempest/Router/src/Commands/RoutesCommand.php
+++ b/src/Tempest/Router/src/Commands/RoutesCommand.php
@@ -68,11 +68,19 @@ final readonly class RoutesCommand
                 key: str($route->method->value)
                     ->alignRight(width: 8)
                     ->wrap("<style='fg-{$color}'>", '</style>')
-                    ->append(' ', $route->uri)
+                    ->append(' ', $this->formatRouteUri($route->uri))
                     ->toString(),
                 value: $this->formatRouteHandler($route->handler),
+                useAvailableWidth: true,
             );
         }
+    }
+
+    private function formatRouteUri(string $uri): string
+    {
+        return str($uri)
+            ->replaceRegex('/{.*?}/', '<style="fg-blue">$0</style>')
+            ->toString();
     }
 
     private function formatRouteHandler(MethodReflector $handler): string

--- a/tests/Integration/Console/Renderers/KeyValueRendererTest.php
+++ b/tests/Integration/Console/Renderers/KeyValueRendererTest.php
@@ -26,8 +26,11 @@ final class KeyValueRendererTest extends FrameworkIntegrationTestCase
     public function test_render_total_width_smaller_than_text(): void
     {
         $renderer = new KeyValueRenderer();
-        $rendered = $renderer->render('Some long text', 'Some long text', maximumWidth: 0);
+        $rendered = $renderer->render('Some long text', str_repeat('a', KeyValueRenderer::MAX_WIDTH));
 
-        $this->assertSame('Some long text <style="fg-gray dim">...</style> Some long text', $rendered);
+        $this->assertSame(
+            'Some long text <style="fg-gray dim">...</style> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            $rendered,
+        );
     }
 }


### PR DESCRIPTION
This pull request updates the `Console#keyValue` method to allow using the available terminal width instead of the predefined 125 characters length.

The `routes:list` command has also been updated to use this option, since the space is needed.