### PR TITLE
feat(view): attribute precedence

### DIFF
--- a/src/Tempest/View/src/Elements/IsElement.php
+++ b/src/Tempest/View/src/Elements/IsElement.php
@@ -32,7 +32,23 @@ trait IsElement
             $wrappingAttributes = [];
         }
 
-        return [...$this->attributes, ...$wrappingAttributes];
+        $attributes = [...$this->attributes, ...$wrappingAttributes];
+
+        // Some attributes should always come after others,
+        // so that these expressions have access to the data attributes
+        $attributePrecedence = [
+            ':foreach' => 1,
+            ':if' => 2,
+        ];
+
+        uksort($attributes, function (string $a, string $b) use ($attributePrecedence) {
+            $precedenceA = $attributePrecedence[$a] ?? 0;
+            $precedenceB = $attributePrecedence[$b] ?? 0;
+
+            return $precedenceA <=> $precedenceB;
+        });
+
+        return $attributes;
     }
 
     public function hasAttribute(string $name): bool

--- a/tests/Integration/View/TempestViewRendererTest.php
+++ b/tests/Integration/View/TempestViewRendererTest.php
@@ -575,6 +575,35 @@ final class TempestViewRendererTest extends FrameworkIntegrationTestCase
         );
     }
 
+    public function test_loop_variable_can_be_used_within_the_looped_tag(): void
+    {
+        $html = $this->render(
+            view(
+                <<<'HTML'
+                    <a :foreach="$items as $item" :href="$item->uri">
+                        {{ $item->title }}
+                    </a>
+                HTML,
+            )
+                ->data(items: [
+                    new class {
+                        public string $title = 'Item 1';
+
+                        public string $uri = '/item-1';
+                    },
+                    new class {
+                        public string $title = 'Item 2';
+
+                        public string $uri = '/item-2';
+                    },
+                ]),
+        );
+
+        $this->assertSnippetsMatch(<<<'HTML'
+        <a href="/item-1">Item 1</a><a href="/item-2">Item 2</a>
+        HTML, $html);
+    }
+
     private function assertSnippetsMatch(string $expected, string $actual): void
     {
         $expected = str_replace([PHP_EOL, ' '], '', $expected);

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -791,6 +791,39 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         HTML, $html);
     }
 
+    public function test_loop_variable_can_be_used_within_the_looped_tag(): void
+    {
+        $this->registerViewComponent(
+            'x-some-component-with-loop',
+            <<<'HTML'
+            <a :foreach="$items as $item" :href="$item->uri">
+                {{ $item->title }}
+            </a>
+            HTML,
+        );
+
+        $html = $this->render(
+            view(
+                <<<'HTML'
+                    <x-some-component-with-loop :items="$this->items" />
+                HTML,
+            )->data(items: [
+                new class {
+                    public string $title = 'Item 1';
+                    public string $uri = '/item-1';
+                },
+                new class {
+                    public string $title = 'Item 2';
+                    public string $uri = '/item-2';
+                },
+            ]
+        ));
+
+        $this->assertSnippetsMatch(<<<'HTML'
+        <a href="/item-1">Item 1</a><a href="/item-2">Item 2</a>
+        HTML, $html);
+    }
+
     private function assertSnippetsMatch(string $expected, string $actual): void
     {
         $expected = str_replace([PHP_EOL, ' '], '', $expected);

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -807,17 +807,20 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
                 <<<'HTML'
                     <x-some-component-with-loop :items="$this->items" />
                 HTML,
-            )->data(items: [
-                new class {
-                    public string $title = 'Item 1';
-                    public string $uri = '/item-1';
-                },
-                new class {
-                    public string $title = 'Item 2';
-                    public string $uri = '/item-2';
-                },
-            ]
-        ));
+            )
+                ->data(items: [
+                    new class {
+                        public string $title = 'Item 1';
+
+                        public string $uri = '/item-1';
+                    },
+                    new class {
+                        public string $title = 'Item 2';
+
+                        public string $uri = '/item-2';
+                    },
+                ]),
+        );
 
         $this->assertSnippetsMatch(<<<'HTML'
         <a href="/item-1">Item 1</a><a href="/item-2">Item 2</a>

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -791,42 +791,6 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         HTML, $html);
     }
 
-    public function test_loop_variable_can_be_used_within_the_looped_tag(): void
-    {
-        $this->registerViewComponent(
-            'x-some-component-with-loop',
-            <<<'HTML'
-            <a :foreach="$items as $item" :href="$item->uri">
-                {{ $item->title }}
-            </a>
-            HTML,
-        );
-
-        $html = $this->render(
-            view(
-                <<<'HTML'
-                    <x-some-component-with-loop :items="$this->items" />
-                HTML,
-            )
-                ->data(items: [
-                    new class {
-                        public string $title = 'Item 1';
-
-                        public string $uri = '/item-1';
-                    },
-                    new class {
-                        public string $title = 'Item 2';
-
-                        public string $uri = '/item-2';
-                    },
-                ]),
-        );
-
-        $this->assertSnippetsMatch(<<<'HTML'
-        <a href="/item-1">Item 1</a><a href="/item-2">Item 2</a>
-        HTML, $html);
-    }
-
     private function assertSnippetsMatch(string $expected, string $actual): void
     {
         $expected = str_replace([PHP_EOL, ' '], '', $expected);


### PR DESCRIPTION
When looping in a tag, like `<div :foreach="$iterable as $value"`, `$value` cannot be used within the same tag in an attribute.

Example:

```html
<a :foreach="$links as $link" :href="$link->uri">
    {{ $link->label }}
</a>
```

In the example above, the link tag will be rendered with the label, but the `href` attribute will be missing.

~Alternative solution: allow for using [`<template>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template) for things such as `:foreach` and `:if`, etc. It's better than wrapping things in `div` because `template` doesn't get rendered as a tag itself in the page.~

~Currently, in Tempest, `<template>` and everything in it is not rendered at all.~

_Never mind, Tempest has `<x-template>` 😅_ 


Fixes #1157 