### PR TITLE
fix(view): prevent `$var` from being `null`ed after passing to component

### DIFF
--- a/src/Tempest/View/src/Elements/PhpDataElement.php
+++ b/src/Tempest/View/src/Elements/PhpDataElement.php
@@ -26,14 +26,16 @@ final class PhpDataElement implements Element, WrapsElement
 
     public function compile(): string
     {
-        $variableName = str($this->name)->ltrim(':')->camel()->toString();
+        $localVariableName = str($this->name)->ltrim(':')->camel()->toString();
         $isExpression = str_starts_with($this->name, ':');
         $value = $this->value ?? '';
 
         // We'll declare the variable in PHP right before the actual element
         $variableDeclaration = sprintf(
-            '$%s ??= %s ?? null;',
-            $variableName,
+            '$_%sIsLocal = isset($%s) === false; $%s ??= %s ?? null;',
+            $localVariableName,
+            $localVariableName,
+            $localVariableName,
             $isExpression
                 ? ($value ?: 'null')
                 : var_export($value, true), // @mago-expect best-practices/no-debug-symbols
@@ -42,8 +44,9 @@ final class PhpDataElement implements Element, WrapsElement
         // And we'll remove it right after the element, this way we've created a "local scope"
         // where the variable is only available to that specific element.
         $variableRemoval = sprintf(
-            'unset($%s);',
-            $variableName,
+            'if ($_%sIsLocal) { unset($%s); }',
+            $localVariableName,
+            $localVariableName,
         );
 
         // Support for boolean attributes. When an expression attribute has a falsy value, it won't be rendered at all.

--- a/tests/Integration/View/TempestViewRendererDataPassingTest.php
+++ b/tests/Integration/View/TempestViewRendererDataPassingTest.php
@@ -371,4 +371,23 @@ final class TempestViewRendererDataPassingTest extends FrameworkIntegrationTestC
 
         $this->assertStringContainsString(' href="hi"', $html);
     }
+
+    public function test_global_variables_are_kept(): void
+    {
+        $this->registerViewComponent('x-test', <<<'HTML'
+        <div>{{ $item }}</div>
+        HTML);
+
+        $html = $this->render(<<<'HTML'
+        <x-test :item="$item"></x-test>
+        <x-test :item="$item"></x-test>
+        <x-test :item="$item"></x-test>
+        HTML, item: 'foo');
+
+        $this->assertSnippetsMatch(<<<'HTML'
+        <div>foo</div>
+        <div>foo</div>
+        <div>foo</div>
+        HTML, $html);
+    }
 }

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -652,20 +652,6 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         HTML, $html);
     }
 
-    public function test_attribute_precedence(): void
-    {
-        $this->markTestSkipped('TODO');
-
-        // Order should be: upperB > upperA > innerB > innerA
-        //        $this->registerViewComponent('x-test', <<<'HTML'
-        //        <div data-foo="innerA" :data-foo="'innerB'"></div>
-        //        HTML);
-        //        $html = $this->render(<<<'HTML'
-        //        <x-test data-foo="upperA" :data-foo="'upperB'"></x-test>
-        //        HTML);
-        //        $this->assertStringEqualsStringIgnoringLineEndings('<div data-foo="upperB"></div>', $html);
-    }
-
     public function test_does_not_duplicate_br(): void
     {
         $this->registerViewComponent('x-html-base', <<<'HTML'
@@ -788,55 +774,6 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
                     </tr>
                 </tbody>
             </table>
-        HTML, $html);
-    }
-
-    public function test_same_variable_can_be_passed_to_multiple_components(): void
-    {
-        $this->registerViewComponent(
-            'x-my-aside',
-            '<aside><x-template :foreach="$items as $item"><a href="$item[\'id\']">{{$item[\'label\']}}</a></x-template></aside>',
-        );
-
-        $this->registerViewComponent(
-            'x-my-main',
-            '<main><x-template :foreach="$items as $item"><div>{{$item$item[\'label\']}}</div></x-template></main>',
-        );
-
-        $this->registerViewComponent(
-            'x-my-footer',
-            '<footer><x-template :foreach="$items as $item"><p>{{$item[\'label\']}}</p></x-template></footer>',
-        );
-
-        $html = $this->render(
-            view(
-                <<<'HTML'
-                <x-my-aside :items="$items" />
-                <x-my-main :items="$items" />
-                <x-my-footer :items="$items" />
-                HTML,
-            )
-                ->data(
-                    items: [
-                        ['id' => '1', 'label' => 'Item 1'],
-                        ['id' => '2', 'label' => 'Item 2'],
-                    ],
-                ),
-        );
-
-        $this->assertSnippetsMatch(<<<HTML
-            <aside>
-                <a href="1">Item 1</a>
-                <a href="2">Item 2</a>
-            </aside>
-            <main>
-                <div>Item 1</div>
-                <div>Item 2</div>
-            </main>
-            <footer>
-                <p>Item 1</p>
-                <p>Item 2</p>
-            </footer>
         HTML, $html);
     }
 

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -795,17 +795,17 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
     {
         $this->registerViewComponent(
             'x-my-aside',
-            '<aside><x-template :foreach="$items as $item"><a href="$item[\'id\']">{{$item[\'label\']}}</a></x-template></aside>'
+            '<aside><x-template :foreach="$items as $item"><a href="$item[\'id\']">{{$item[\'label\']}}</a></x-template></aside>',
         );
 
         $this->registerViewComponent(
             'x-my-main',
-            '<main><x-template :foreach="$items as $item"><div>{{$item$item[\'label\']}}</div></x-template></main>'
+            '<main><x-template :foreach="$items as $item"><div>{{$item$item[\'label\']}}</div></x-template></main>',
         );
 
         $this->registerViewComponent(
             'x-my-footer',
-            '<footer><x-template :foreach="$items as $item"><p>{{$item[\'label\']}}</p></x-template></footer>'
+            '<footer><x-template :foreach="$items as $item"><p>{{$item[\'label\']}}</p></x-template></footer>',
         );
 
         $html = $this->render(
@@ -815,12 +815,13 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
                 <x-my-main :items="$items" />
                 <x-my-footer :items="$items" />
                 HTML,
-            )->data(
-                items: [
-                    ['id' => '1', 'label' => 'Item 1'],
-                    ['id' => '2', 'label' => 'Item 2'],
-                ],
             )
+                ->data(
+                    items: [
+                        ['id' => '1', 'label' => 'Item 1'],
+                        ['id' => '2', 'label' => 'Item 2'],
+                    ],
+                ),
         );
 
         $this->assertSnippetsMatch(<<<HTML

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -791,6 +791,54 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         HTML, $html);
     }
 
+    public function test_same_variable_can_be_passed_to_multiple_components(): void
+    {
+        $this->registerViewComponent(
+            'x-my-aside',
+            '<aside><x-template :foreach="$items as $item"><a href="$item[\'id\']">{{$item[\'label\']}}</a></x-template></aside>'
+        );
+
+        $this->registerViewComponent(
+            'x-my-main',
+            '<main><x-template :foreach="$items as $item"><div>{{$item$item[\'label\']}}</div></x-template></main>'
+        );
+
+        $this->registerViewComponent(
+            'x-my-footer',
+            '<footer><x-template :foreach="$items as $item"><p>{{$item[\'label\']}}</p></x-template></footer>'
+        );
+
+        $html = $this->render(
+            view(
+                <<<'HTML'
+                <x-my-aside :items="$items" />
+                <x-my-main :items="$items" />
+                <x-my-footer :items="$items" />
+                HTML,
+            )->data(
+                items: [
+                    ['id' => '1', 'label' => 'Item 1'],
+                    ['id' => '2', 'label' => 'Item 2'],
+                ],
+            )
+        );
+
+        $this->assertSnippetsMatch(<<<HTML
+            <aside>
+                <a href="1">Item 1</a>
+                <a href="2">Item 2</a>
+            </aside>
+            <main>
+                <div>Item 1</div>
+                <div>Item 2</div>
+            </main>
+            <footer>
+                <p>Item 1</p>
+                <p>Item 2</p>
+            </footer>
+        HTML, $html);
+    }
+
     private function assertSnippetsMatch(string $expected, string $actual): void
     {
         $expected = str_replace([PHP_EOL, ' '], '', $expected);


### PR DESCRIPTION
When you have a view (or a component) that has the variable `$items` in it, you can only pass it to one component - after that, the variable is `null`'ed.

Here's an example:

```html
<!-- some.view.php -->

{!! json_encode($items) !!} <!-- This outputs `[{"id":"1","label":"Item 1"},{"id":"2","label":"Item 2"}]` -->
<x-my-aside :items="$items" />
{!! json_encode($items) !!} <!-- This is now `null` -->
```

Because of that, this becomes impossible to do:

```html
<x-my-aside :items="$items" />
<x-my-main :items="$items" />
<x-my-footer :items="$items" />
```