### PR TITLE
fix(view): improved attribute precedence

### DIFF
--- a/src/Tempest/View/src/Elements/IsElement.php
+++ b/src/Tempest/View/src/Elements/IsElement.php
@@ -34,21 +34,16 @@ trait IsElement
 
         $attributes = [...$this->attributes, ...$wrappingAttributes];
 
-        // Some attributes should always come after others,
-        // so that these expressions have access to the data attributes
-        $attributePrecedence = [
-            ':foreach' => 1,
-            ':if' => 2,
-        ];
+        $tailingAttributes = [];
 
-        uksort($attributes, function (string $a, string $b) use ($attributePrecedence) {
-            $precedenceA = $attributePrecedence[$a] ?? 0;
-            $precedenceB = $attributePrecedence[$b] ?? 0;
+        foreach ($attributes as $name => $value) {
+            if ($name === ':foreach' || $name === ':if') {
+                unset($attributes[$name]);
+                $tailingAttributes[$name] = $value;
+            }
+        }
 
-            return $precedenceA <=> $precedenceB;
-        });
-
-        return $attributes;
+        return [...$attributes, ...$tailingAttributes];
     }
 
     public function hasAttribute(string $name): bool

--- a/src/Tempest/View/src/Elements/IsElement.php
+++ b/src/Tempest/View/src/Elements/IsElement.php
@@ -43,7 +43,7 @@ trait IsElement
             }
         }
 
-        return [...$attributes, ...$tailingAttributes];
+        return [...$attributes, ...array_reverse($tailingAttributes)];
     }
 
     public function hasAttribute(string $name): bool

--- a/src/Tempest/View/src/Elements/IsElement.php
+++ b/src/Tempest/View/src/Elements/IsElement.php
@@ -43,6 +43,7 @@ trait IsElement
             }
         }
 
+        // Tailing attributes are reversed because they need to be applied in reverse order
         return [...$attributes, ...array_reverse($tailingAttributes)];
     }
 

--- a/tests/Integration/View/TempestViewRendererCombinedExpressionsTest.php
+++ b/tests/Integration/View/TempestViewRendererCombinedExpressionsTest.php
@@ -76,7 +76,7 @@ final class TempestViewRendererCombinedExpressionsTest extends FrameworkIntegrat
     public function test_foreach_with_if_and_forelse_expression(): void
     {
         $view = <<<'HTML'
-        <div :foreach="$items as $item" :if="$label ?? null">
+        <div :if="$label ?? null" :foreach="$items as $item">
             {{ $label }} {{ $item }}
         </div>
         <span :forelse>

--- a/tests/Integration/View/TempestViewRendererTest.php
+++ b/tests/Integration/View/TempestViewRendererTest.php
@@ -604,7 +604,7 @@ final class TempestViewRendererTest extends FrameworkIntegrationTestCase
         HTML, $html);
     }
 
-    public function test_if_and_foreach_precedence()
+    public function test_if_and_foreach_precedence(): void
     {
         $html = $this->render(
             <<<'HTML'

--- a/tests/Integration/View/TempestViewRendererTest.php
+++ b/tests/Integration/View/TempestViewRendererTest.php
@@ -606,90 +606,97 @@ final class TempestViewRendererTest extends FrameworkIntegrationTestCase
 
     public function test_if_and_foreach_precedence()
     {
-        $html = $this->render(<<<'HTML'
-        <div :foreach="$items as $item" :if="$item->show">{{ $item->name }}</div>    
-        HTML,
+        $html = $this->render(
+            <<<'HTML'
+            <div :foreach="$items as $item" :if="$item->show">{{ $item->name }}</div>    
+            HTML,
             items: [
-                (object)['name' => 'A', 'show' => true],
-                (object)['name' => 'B', 'show' => false],
-                (object)['name' => 'C', 'show' => true],
+                (object) ['name' => 'A', 'show' => true],
+                (object) ['name' => 'B', 'show' => false],
+                (object) ['name' => 'C', 'show' => true],
             ],
         );
 
         $this->assertSnippetsMatch('<div>A</div><div>C</div>', $html);
 
-        $html = $this->render(<<<'HTML'
-        <div :foreach="$items as $item" :if="$show">{{ $item->name }}</div>    
-        HTML,
+        $html = $this->render(
+            <<<'HTML'
+            <div :foreach="$items as $item" :if="$show">{{ $item->name }}</div>    
+            HTML,
             show: true,
             items: [
-                (object)['name' => 'A', 'show' => true],
-                (object)['name' => 'B', 'show' => false],
-                (object)['name' => 'C', 'show' => true],
+                (object) ['name' => 'A', 'show' => true],
+                (object) ['name' => 'B', 'show' => false],
+                (object) ['name' => 'C', 'show' => true],
             ],
         );
 
         $this->assertSnippetsMatch('<div>A</div><div>B</div><div>C</div>', $html);
 
-        $html = $this->render(<<<'HTML'
-        <div :if="$show" :foreach="$items as $item">{{ $item->name }}</div>    
-        HTML,
+        $html = $this->render(
+            <<<'HTML'
+            <div :if="$show" :foreach="$items as $item">{{ $item->name }}</div>    
+            HTML,
             show: true,
             items: [
-                (object)['name' => 'A', 'show' => true],
-                (object)['name' => 'B', 'show' => false],
-                (object)['name' => 'C', 'show' => true],
+                (object) ['name' => 'A', 'show' => true],
+                (object) ['name' => 'B', 'show' => false],
+                (object) ['name' => 'C', 'show' => true],
             ],
         );
 
         $this->assertSnippetsMatch('<div>A</div><div>B</div><div>C</div>', $html);
 
-        $html = $this->render(<<<'HTML'
-        <div :foreach="$items as $item" :if="$show">{{ $item->name }}</div>    
-        HTML,
+        $html = $this->render(
+            <<<'HTML'
+            <div :foreach="$items as $item" :if="$show">{{ $item->name }}</div>    
+            HTML,
             show: false,
             items: [
-                (object)['name' => 'A', 'show' => true],
-                (object)['name' => 'B', 'show' => false],
-                (object)['name' => 'C', 'show' => true],
+                (object) ['name' => 'A', 'show' => true],
+                (object) ['name' => 'B', 'show' => false],
+                (object) ['name' => 'C', 'show' => true],
             ],
         );
 
         $this->assertSnippetsMatch('', $html);
 
-        $html = $this->render(<<<'HTML'
-        <div :if="$show" :foreach="$items as $item">{{ $item->name }}</div>    
-        HTML,
+        $html = $this->render(
+            <<<'HTML'
+            <div :if="$show" :foreach="$items as $item">{{ $item->name }}</div>    
+            HTML,
             show: false,
             items: [
-                (object)['name' => 'A', 'show' => true],
-                (object)['name' => 'B', 'show' => false],
-                (object)['name' => 'C', 'show' => true],
+                (object) ['name' => 'A', 'show' => true],
+                (object) ['name' => 'B', 'show' => false],
+                (object) ['name' => 'C', 'show' => true],
             ],
         );
 
         $this->assertSnippetsMatch('', $html);
 
-        $html = $this->render(<<<'HTML'
-        <div :if="$item->show" :foreach="$items as $item">{{ $item->name }}</div>    
-        HTML,
-            item: (object)['show' => true],
+        $html = $this->render(
+            <<<'HTML'
+            <div :if="$item->show" :foreach="$items as $item">{{ $item->name }}</div>    
+            HTML,
+            item: (object) ['show' => true],
             items: [
-                (object)['name' => 'A', 'show' => true],
-                (object)['name' => 'B', 'show' => false],
-                (object)['name' => 'C', 'show' => true],
+                (object) ['name' => 'A', 'show' => true],
+                (object) ['name' => 'B', 'show' => false],
+                (object) ['name' => 'C', 'show' => true],
             ],
         );
 
         $this->assertSnippetsMatch('<div>A</div><div>B</div><div>C</div>', $html);
 
-        $html = $this->render(<<<'HTML'
-        <div :if="$item->show ?? null" :foreach="$items as $item">{{ $item->name }}</div>    
-        HTML,
+        $html = $this->render(
+            <<<'HTML'
+            <div :if="$item->show ?? null" :foreach="$items as $item">{{ $item->name }}</div>    
+            HTML,
             items: [
-                (object)['name' => 'A', 'show' => true],
-                (object)['name' => 'B', 'show' => false],
-                (object)['name' => 'C', 'show' => true],
+                (object) ['name' => 'A', 'show' => true],
+                (object) ['name' => 'B', 'show' => false],
+                (object) ['name' => 'C', 'show' => true],
             ],
         );
 

--- a/tests/Integration/View/TempestViewRendererTest.php
+++ b/tests/Integration/View/TempestViewRendererTest.php
@@ -604,6 +604,98 @@ final class TempestViewRendererTest extends FrameworkIntegrationTestCase
         HTML, $html);
     }
 
+    public function test_if_and_foreach_precedence()
+    {
+        $html = $this->render(<<<'HTML'
+        <div :foreach="$items as $item" :if="$item->show">{{ $item->name }}</div>    
+        HTML,
+            items: [
+                (object)['name' => 'A', 'show' => true],
+                (object)['name' => 'B', 'show' => false],
+                (object)['name' => 'C', 'show' => true],
+            ],
+        );
+
+        $this->assertSnippetsMatch('<div>A</div><div>C</div>', $html);
+
+        $html = $this->render(<<<'HTML'
+        <div :foreach="$items as $item" :if="$show">{{ $item->name }}</div>    
+        HTML,
+            show: true,
+            items: [
+                (object)['name' => 'A', 'show' => true],
+                (object)['name' => 'B', 'show' => false],
+                (object)['name' => 'C', 'show' => true],
+            ],
+        );
+
+        $this->assertSnippetsMatch('<div>A</div><div>B</div><div>C</div>', $html);
+
+        $html = $this->render(<<<'HTML'
+        <div :if="$show" :foreach="$items as $item">{{ $item->name }}</div>    
+        HTML,
+            show: true,
+            items: [
+                (object)['name' => 'A', 'show' => true],
+                (object)['name' => 'B', 'show' => false],
+                (object)['name' => 'C', 'show' => true],
+            ],
+        );
+
+        $this->assertSnippetsMatch('<div>A</div><div>B</div><div>C</div>', $html);
+
+        $html = $this->render(<<<'HTML'
+        <div :foreach="$items as $item" :if="$show">{{ $item->name }}</div>    
+        HTML,
+            show: false,
+            items: [
+                (object)['name' => 'A', 'show' => true],
+                (object)['name' => 'B', 'show' => false],
+                (object)['name' => 'C', 'show' => true],
+            ],
+        );
+
+        $this->assertSnippetsMatch('', $html);
+
+        $html = $this->render(<<<'HTML'
+        <div :if="$show" :foreach="$items as $item">{{ $item->name }}</div>    
+        HTML,
+            show: false,
+            items: [
+                (object)['name' => 'A', 'show' => true],
+                (object)['name' => 'B', 'show' => false],
+                (object)['name' => 'C', 'show' => true],
+            ],
+        );
+
+        $this->assertSnippetsMatch('', $html);
+
+        $html = $this->render(<<<'HTML'
+        <div :if="$item->show" :foreach="$items as $item">{{ $item->name }}</div>    
+        HTML,
+            item: (object)['show' => true],
+            items: [
+                (object)['name' => 'A', 'show' => true],
+                (object)['name' => 'B', 'show' => false],
+                (object)['name' => 'C', 'show' => true],
+            ],
+        );
+
+        $this->assertSnippetsMatch('<div>A</div><div>B</div><div>C</div>', $html);
+
+        $html = $this->render(<<<'HTML'
+        <div :if="$item->show ?? null" :foreach="$items as $item">{{ $item->name }}</div>    
+        HTML,
+            items: [
+                (object)['name' => 'A', 'show' => true],
+                (object)['name' => 'B', 'show' => false],
+                (object)['name' => 'C', 'show' => true],
+            ],
+        );
+
+        $this->assertSnippetsMatch('', $html);
+    }
+
     private function assertSnippetsMatch(string $expected, string $actual): void
     {
         $expected = str_replace([PHP_EOL, ' '], '', $expected);


### PR DESCRIPTION
This is an attempt to fix #1167

Instead of sorting all attributes, we now only pull out `:if` and `:foreach`, and push them to the end of the attribute list, keeping their relative order. This way you can make both combinations, while ensure `:if` and `:foreach` are always last, thus having access to all other data defined on the element.

@wryk @innocenzi would like your input