### PR TITLE
feat(database): add `Count` query builder and statement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/uid": "^7.1",
         "symfony/var-dumper": "^7.1",
         "symfony/var-exporter": "^7.1",
-        "tempest/highlight": "^2.11.4",
+        "tempest/highlight": "^2.11.2",
         "vlucas/phpdotenv": "^5.6",
         "voku/portable-ascii": "^2.0.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/uid": "^7.1",
         "symfony/var-dumper": "^7.1",
         "symfony/var-exporter": "^7.1",
-        "tempest/highlight": "^2.11.2",
+        "tempest/highlight": "^2.11.4",
         "vlucas/phpdotenv": "^5.6",
         "voku/portable-ascii": "^2.0.3"
     },

--- a/src/Tempest/Database/src/Builder/QueryBuilders/CountQueryBuilder.php
+++ b/src/Tempest/Database/src/Builder/QueryBuilders/CountQueryBuilder.php
@@ -41,14 +41,6 @@ final class CountQueryBuilder
     }
 
     /** @return self<TModelClass> */
-    public function as(string $alias): self
-    {
-        $this->count->alias = $alias;
-
-        return $this;
-    }
-
-    /** @return self<TModelClass> */
     public function distinct(): self
     {
         if ($this->count->column === null || $this->count->column === '*') {

--- a/src/Tempest/Database/src/Builder/QueryBuilders/CountQueryBuilder.php
+++ b/src/Tempest/Database/src/Builder/QueryBuilders/CountQueryBuilder.php
@@ -36,9 +36,15 @@ final class CountQueryBuilder
 
     public function execute(mixed ...$bindings): int
     {
-        $key = "COUNT({$this->count->countArgument})";
+        return $this->build()->fetchFirst(...$bindings)[$this->count->getKey()];
+    }
 
-        return $this->build()->fetchFirst(...$bindings)[$key];
+    /** @return self<TModelClass> */
+    public function as(string $alias): self
+    {
+        $this->count->alias = $alias;
+
+        return $this;
     }
 
     /** @return self<TModelClass> */

--- a/src/Tempest/Database/src/Builder/QueryBuilders/CountQueryBuilder.php
+++ b/src/Tempest/Database/src/Builder/QueryBuilders/CountQueryBuilder.php
@@ -6,6 +6,7 @@ namespace Tempest\Database\Builder\QueryBuilders;
 
 use Tempest\Database\Builder\ModelDefinition;
 use Tempest\Database\Builder\TableDefinition;
+use Tempest\Database\Exceptions\CannotCountDistinctWithoutSpecifyingAColumn;
 use Tempest\Database\Query;
 use Tempest\Database\QueryStatements\CountStatement;
 use Tempest\Database\QueryStatements\WhereStatement;
@@ -43,6 +44,18 @@ final class CountQueryBuilder
     public function as(string $alias): self
     {
         $this->count->alias = $alias;
+
+        return $this;
+    }
+
+    /** @return self<TModelClass> */
+    public function distinct(): self
+    {
+        if ($this->count->column === null || $this->count->column === '*') {
+            throw new CannotCountDistinctWithoutSpecifyingAColumn();
+        }
+
+        $this->count->distinct = true;
 
         return $this;
     }

--- a/src/Tempest/Database/src/Builder/QueryBuilders/CountQueryBuilder.php
+++ b/src/Tempest/Database/src/Builder/QueryBuilders/CountQueryBuilder.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Builder\QueryBuilders;
+
+use Tempest\Database\Builder\ModelDefinition;
+use Tempest\Database\Builder\TableDefinition;
+use Tempest\Database\Query;
+use Tempest\Database\QueryStatements\CountStatement;
+use Tempest\Database\QueryStatements\WhereStatement;
+use Tempest\Support\Conditions\HasConditions;
+
+/**
+ * @template TModelClass of object
+ */
+final class CountQueryBuilder
+{
+    use HasConditions;
+
+    /** @var class-string<TModelClass> $modelClass */
+    private readonly string $modelClass;
+
+    private ?ModelDefinition $modelDefinition;
+
+    private CountStatement $count;
+
+    private array $bindings = [];
+
+    public function __construct(string|object $model, ?string $column = null)
+    {
+        $this->modelDefinition = ModelDefinition::tryFrom($model);
+        $this->modelClass = is_object($model) ? $model::class : $model;
+
+        $this->count = new CountStatement(
+            table: $this->resolveTable($model),
+            column: $column,
+        );
+    }
+
+    public function execute(mixed ...$bindings): int
+    {
+        $key = "COUNT({$this->count->countArgument})";
+
+        return $this->build()->fetchFirst(...$bindings)[$key];
+    }
+
+    /** @return self<TModelClass> */
+    public function where(string $where, mixed ...$bindings): self
+    {
+        $this->count->where[] = new WhereStatement($where);
+
+        $this->bind(...$bindings);
+
+        return $this;
+    }
+
+    public function andWhere(string $where, mixed ...$bindings): self
+    {
+        return $this->where("AND {$where}", ...$bindings);
+    }
+
+    public function orWhere(string $where, mixed ...$bindings): self
+    {
+        return $this->where("OR {$where}", ...$bindings);
+    }
+
+    /** @return self<TModelClass> */
+    public function whereField(string $field, mixed $value): self
+    {
+        $field = $this->modelDefinition->getFieldDefinition($field);
+
+        return $this->where("{$field} = :{$field->name}", ...[$field->name => $value]);
+    }
+
+    /** @return self<TModelClass> */
+    public function bind(mixed ...$bindings): self
+    {
+        $this->bindings = [...$this->bindings, ...$bindings];
+
+        return $this;
+    }
+
+    public function toSql(): string
+    {
+        return $this->build()->getSql();
+    }
+
+    public function build(array $bindings = []): Query
+    {
+        return new Query($this->count, [...$this->bindings, ...$bindings]);
+    }
+
+    private function clone(): self
+    {
+        return clone $this;
+    }
+
+    private function resolveTable(string|object $model): TableDefinition
+    {
+        if ($this->modelDefinition === null) {
+            return new TableDefinition($model);
+        }
+
+        return $this->modelDefinition->getTableDefinition();
+    }
+}

--- a/src/Tempest/Database/src/Builder/QueryBuilders/CountQueryBuilder.php
+++ b/src/Tempest/Database/src/Builder/QueryBuilders/CountQueryBuilder.php
@@ -18,9 +18,6 @@ final class CountQueryBuilder
 {
     use HasConditions;
 
-    /** @var class-string<TModelClass> $modelClass */
-    private readonly string $modelClass;
-
     private ?ModelDefinition $modelDefinition;
 
     private CountStatement $count;
@@ -30,7 +27,6 @@ final class CountQueryBuilder
     public function __construct(string|object $model, ?string $column = null)
     {
         $this->modelDefinition = ModelDefinition::tryFrom($model);
-        $this->modelClass = is_object($model) ? $model::class : $model;
 
         $this->count = new CountStatement(
             table: $this->resolveTable($model),
@@ -89,11 +85,6 @@ final class CountQueryBuilder
     public function build(array $bindings = []): Query
     {
         return new Query($this->count, [...$this->bindings, ...$bindings]);
-    }
-
-    private function clone(): self
-    {
-        return clone $this;
     }
 
     private function resolveTable(string|object $model): TableDefinition

--- a/src/Tempest/Database/src/Builder/QueryBuilders/QueryBuilder.php
+++ b/src/Tempest/Database/src/Builder/QueryBuilders/QueryBuilder.php
@@ -47,4 +47,12 @@ final readonly class QueryBuilder
     {
         return new DeleteQueryBuilder($this->model);
     }
+
+    public function count(?string $column = null): CountQueryBuilder
+    {
+        return new CountQueryBuilder(
+            model: $this->model,
+            column: $column,
+        );
+    }
 }

--- a/src/Tempest/Database/src/Exceptions/CannotCountDistinctWithoutSpecifyingAColumn.php
+++ b/src/Tempest/Database/src/Exceptions/CannotCountDistinctWithoutSpecifyingAColumn.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tempest\Database\Exceptions;
+
+use LogicException;
+
+final class CannotCountDistinctWithoutSpecifyingAColumn extends LogicException
+{
+    public function __construct()
+    {
+        parent::__construct('Cannot count distinct without specifying a column');
+    }
+}

--- a/src/Tempest/Database/src/QueryStatements/CountStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/CountStatement.php
@@ -11,8 +11,6 @@ use function Tempest\Support\arr;
 
 final class CountStatement implements QueryStatement
 {
-    public ?string $alias = null;
-
     public bool $distinct = false;
 
     public function __construct(
@@ -25,9 +23,8 @@ final class CountStatement implements QueryStatement
     {
         $query = arr([
             sprintf(
-                'SELECT COUNT(%s)%s',
+                'SELECT COUNT(%s)',
                 $this->getCountArgument(),
-                $this->alias ? " AS `{$this->alias}`" : '',
             ),
             sprintf('FROM `%s`', $this->table->name),
         ]);
@@ -54,10 +51,6 @@ final class CountStatement implements QueryStatement
 
     public function getKey(): string
     {
-        if ($this->alias !== null) {
-            return $this->alias;
-        }
-
         return "COUNT({$this->getCountArgument()})";
     }
 }

--- a/src/Tempest/Database/src/QueryStatements/CountStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/CountStatement.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tempest\Database\QueryStatements;
+
+use Tempest\Database\Builder\TableDefinition;
+use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\QueryStatement;
+use Tempest\Support\Arr\ImmutableArray;
+
+use function Tempest\Support\arr;
+
+final class CountStatement implements QueryStatement
+{
+    public readonly string $countArgument;
+
+    public function __construct(
+        public readonly TableDefinition $table,
+        public ?string $column = null,
+        public ImmutableArray $where = new ImmutableArray(),
+    ) {
+        $this->countArgument = $this->column === null
+            ? '*'
+            : "`{$this->column}`";
+    }
+
+    public function compile(DatabaseDialect $dialect): string
+    {
+        $query = arr([
+            sprintf('SELECT COUNT(%s)', $this->countArgument),
+            sprintf('FROM `%s`', $this->table->name),
+        ]);
+
+        if ($this->where->isNotEmpty()) {
+            $query[] = 'WHERE ' . $this->where
+                ->map(fn (WhereStatement $where) => $where->compile($dialect))
+                ->implode(PHP_EOL);
+        }
+
+        return $query->implode(PHP_EOL);
+    }
+}

--- a/src/Tempest/Database/src/QueryStatements/CountStatement.php
+++ b/src/Tempest/Database/src/QueryStatements/CountStatement.php
@@ -13,6 +13,8 @@ final class CountStatement implements QueryStatement
 {
     public readonly string $countArgument;
 
+    public ?string $alias = null;
+
     public function __construct(
         public readonly TableDefinition $table,
         public ?string $column = null,
@@ -26,7 +28,11 @@ final class CountStatement implements QueryStatement
     public function compile(DatabaseDialect $dialect): string
     {
         $query = arr([
-            sprintf('SELECT COUNT(%s)', $this->countArgument),
+            sprintf(
+                'SELECT COUNT(%s)%s',
+                $this->countArgument,
+                $this->alias ? " AS `{$this->alias}`" : '',
+            ),
             sprintf('FROM `%s`', $this->table->name),
         ]);
 
@@ -37,5 +43,14 @@ final class CountStatement implements QueryStatement
         }
 
         return $query->implode(PHP_EOL);
+    }
+
+    public function getKey(): string
+    {
+        if ($this->alias !== null) {
+            return $this->alias;
+        }
+
+        return "COUNT({$this->countArgument})";
     }
 }

--- a/src/Tempest/Database/tests/QueryStatements/CountStatementTest.php
+++ b/src/Tempest/Database/tests/QueryStatements/CountStatementTest.php
@@ -37,6 +37,27 @@ final class CountStatementTest extends TestCase
         $this->assertSame($expected, $statement->compile(DatabaseDialect::SQLITE));
     }
 
+    public function test_count_statement_with_alias(): void
+    {
+        $tableDefinition = new TableDefinition('foo', 'bar');
+
+        $statement = new CountStatement(
+            table: $tableDefinition,
+            column: null,
+        );
+
+        $statement->alias = 'foobar';
+
+        $expected = <<<SQL
+        SELECT COUNT(*) AS `foobar`
+        FROM `foo`
+        SQL;
+
+        $this->assertSame($expected, $statement->compile(DatabaseDialect::MYSQL));
+        $this->assertSame($expected, $statement->compile(DatabaseDialect::POSTGRESQL));
+        $this->assertSame($expected, $statement->compile(DatabaseDialect::SQLITE));
+    }
+
     public function test_count_statement_with_specified_column(): void
     {
         $tableDefinition = new TableDefinition('foo', 'bar');

--- a/src/Tempest/Database/tests/QueryStatements/CountStatementTest.php
+++ b/src/Tempest/Database/tests/QueryStatements/CountStatementTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tempest\Database\Tests\QueryStatements;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Database\Builder\FieldDefinition;
+use Tempest\Database\Builder\TableDefinition;
+use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\QueryStatements\CountStatement;
+use Tempest\Database\QueryStatements\GroupByStatement;
+use Tempest\Database\QueryStatements\HavingStatement;
+use Tempest\Database\QueryStatements\JoinStatement;
+use Tempest\Database\QueryStatements\OrderByStatement;
+use Tempest\Database\QueryStatements\SelectStatement;
+use Tempest\Database\QueryStatements\WhereStatement;
+
+use function Tempest\Support\arr;
+
+final class CountStatementTest extends TestCase
+{
+    public function test_count_statement(): void
+    {
+        $tableDefinition = new TableDefinition('foo', 'bar');
+
+        $statement = new CountStatement(
+            table: $tableDefinition,
+            column: null,
+        );
+
+        $expected = <<<SQL
+        SELECT COUNT(*)
+        FROM `foo`
+        SQL;
+
+        $this->assertSame($expected, $statement->compile(DatabaseDialect::MYSQL));
+        $this->assertSame($expected, $statement->compile(DatabaseDialect::POSTGRESQL));
+        $this->assertSame($expected, $statement->compile(DatabaseDialect::SQLITE));
+    }
+
+    public function test_count_statement_with_specified_column(): void
+    {
+        $tableDefinition = new TableDefinition('foo', 'bar');
+
+        $statement = new CountStatement(
+            table: $tableDefinition,
+            column: 'foobar',
+        );
+
+        $expected = <<<SQL
+        SELECT COUNT(`foobar`)
+        FROM `foo`
+        SQL;
+
+        $this->assertSame($expected, $statement->compile(DatabaseDialect::MYSQL));
+        $this->assertSame($expected, $statement->compile(DatabaseDialect::POSTGRESQL));
+        $this->assertSame($expected, $statement->compile(DatabaseDialect::SQLITE));
+    }
+}

--- a/src/Tempest/Database/tests/QueryStatements/CountStatementTest.php
+++ b/src/Tempest/Database/tests/QueryStatements/CountStatementTest.php
@@ -3,18 +3,9 @@
 namespace Tempest\Database\Tests\QueryStatements;
 
 use PHPUnit\Framework\TestCase;
-use Tempest\Database\Builder\FieldDefinition;
 use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\Config\DatabaseDialect;
 use Tempest\Database\QueryStatements\CountStatement;
-use Tempest\Database\QueryStatements\GroupByStatement;
-use Tempest\Database\QueryStatements\HavingStatement;
-use Tempest\Database\QueryStatements\JoinStatement;
-use Tempest\Database\QueryStatements\OrderByStatement;
-use Tempest\Database\QueryStatements\SelectStatement;
-use Tempest\Database\QueryStatements\WhereStatement;
-
-use function Tempest\Support\arr;
 
 final class CountStatementTest extends TestCase
 {
@@ -37,27 +28,6 @@ final class CountStatementTest extends TestCase
         $this->assertSame($expected, $statement->compile(DatabaseDialect::SQLITE));
     }
 
-    public function test_count_statement_with_alias(): void
-    {
-        $tableDefinition = new TableDefinition('foo', 'bar');
-
-        $statement = new CountStatement(
-            table: $tableDefinition,
-            column: null,
-        );
-
-        $statement->alias = 'foobar';
-
-        $expected = <<<SQL
-        SELECT COUNT(*) AS `foobar`
-        FROM `foo`
-        SQL;
-
-        $this->assertSame($expected, $statement->compile(DatabaseDialect::MYSQL));
-        $this->assertSame($expected, $statement->compile(DatabaseDialect::POSTGRESQL));
-        $this->assertSame($expected, $statement->compile(DatabaseDialect::SQLITE));
-    }
-
     public function test_count_statement_with_specified_column(): void
     {
         $tableDefinition = new TableDefinition('foo', 'bar');
@@ -69,6 +39,27 @@ final class CountStatementTest extends TestCase
 
         $expected = <<<SQL
         SELECT COUNT(`foobar`)
+        FROM `foo`
+        SQL;
+
+        $this->assertSame($expected, $statement->compile(DatabaseDialect::MYSQL));
+        $this->assertSame($expected, $statement->compile(DatabaseDialect::POSTGRESQL));
+        $this->assertSame($expected, $statement->compile(DatabaseDialect::SQLITE));
+    }
+
+    public function test_count_statement_with_distinct_specified_column(): void
+    {
+        $tableDefinition = new TableDefinition('foo', 'bar');
+
+        $statement = new CountStatement(
+            table: $tableDefinition,
+            column: 'foobar',
+        );
+
+        $statement->distinct = true;
+
+        $expected = <<<SQL
+        SELECT COUNT(DISTINCT `foobar`)
         FROM `foo`
         SQL;
 

--- a/tests/Integration/Database/Builder/CountQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/CountQueryBuilderTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Database\Builder;
+
+use Tempest\Database\Builder\QueryBuilders\CountQueryBuilder;
+use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\Database\query;
+
+/**
+ * @internal
+ */
+final class CountQueryBuilderTest extends FrameworkIntegrationTestCase
+{
+    public function test_count_query(): void
+    {
+        $query = query('chapters')
+            ->count()
+            ->where('`title` = ?', 'Timeline Taxi')
+            ->andWhere('`index` <> ?', '1')
+            ->orWhere('`createdAt` > ?', '2025-01-01')
+            ->build();
+
+        $expected = <<<SQL
+        SELECT COUNT(*)
+        FROM `chapters`
+        WHERE `title` = ?
+        AND `index` <> ?
+        OR `createdAt` > ?
+        SQL;
+
+        $sql = $query->getSql();
+        $bindings = $query->bindings;
+
+        $this->assertSame($expected, $sql);
+        $this->assertSame(['Timeline Taxi', '1', '2025-01-01'], $bindings);
+    }
+
+    public function test_count_query_with_specified_field(): void
+    {
+        $query = query('chapters')->count('title')->build();
+
+        $sql = $query->getSql();
+
+        $expected = <<<SQL
+        SELECT COUNT(`title`)
+        FROM `chapters`
+        SQL;
+
+        $this->assertSame($expected, $sql);
+    }
+
+    public function test_count_from_model(): void
+    {
+        $query = query(Author::class)->count()->build();
+
+        $sql = $query->getSql();
+
+        $expected = <<<SQL
+        SELECT COUNT(*)
+        FROM `authors`
+        SQL;
+
+        $this->assertSame($expected, $sql);
+    }
+
+    public function test_count_query_with_conditions(): void
+    {
+        $query = query('chapters')
+            ->count()
+            ->when(
+                true,
+                fn (CountQueryBuilder $query) => $query
+                    ->where('`title` = ?', 'Timeline Taxi')
+                    ->andWhere('`index` <> ?', '1')
+                    ->orWhere('`createdAt` > ?', '2025-01-01'),
+            )
+            ->when(
+                false,
+                fn (CountQueryBuilder $query) => $query
+                    ->where('`title` = ?', 'Timeline Uber')
+                    ->andWhere('`index` <> ?', '2')
+                    ->orWhere('`createdAt` > ?', '2025-01-02'),
+            )
+            ->build();
+
+        $expected = <<<SQL
+        SELECT COUNT(*)
+        FROM `chapters`
+        WHERE `title` = ?
+        AND `index` <> ?
+        OR `createdAt` > ?
+        SQL;
+
+        $sql = $query->getSql();
+        $bindings = $query->bindings;
+
+        $this->assertSame($expected, $sql);
+        $this->assertSame(['Timeline Taxi', '1', '2025-01-01'], $bindings);
+    }
+}

--- a/tests/Integration/Database/Builder/CountQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/CountQueryBuilderTest.php
@@ -15,7 +15,7 @@ use function Tempest\Database\query;
  */
 final class CountQueryBuilderTest extends FrameworkIntegrationTestCase
 {
-    public function test_count_query(): void
+    public function test_simple_count_query(): void
     {
         $query = query('chapters')
             ->count()
@@ -26,6 +26,31 @@ final class CountQueryBuilderTest extends FrameworkIntegrationTestCase
 
         $expected = <<<SQL
         SELECT COUNT(*)
+        FROM `chapters`
+        WHERE `title` = ?
+        AND `index` <> ?
+        OR `createdAt` > ?
+        SQL;
+
+        $sql = $query->getSql();
+        $bindings = $query->bindings;
+
+        $this->assertSame($expected, $sql);
+        $this->assertSame(['Timeline Taxi', '1', '2025-01-01'], $bindings);
+    }
+
+    public function test_count_query_with_alias(): void
+    {
+        $query = query('chapters')
+            ->count()
+            ->as('total')
+            ->where('`title` = ?', 'Timeline Taxi')
+            ->andWhere('`index` <> ?', '1')
+            ->orWhere('`createdAt` > ?', '2025-01-01')
+            ->build();
+
+        $expected = <<<SQL
+        SELECT COUNT(*) AS `total`
         FROM `chapters`
         WHERE `title` = ?
         AND `index` <> ?

--- a/tests/Integration/Database/Builder/CountQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/CountQueryBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Tempest\Integration\Database\Builder;
 
 use Tempest\Database\Builder\QueryBuilders\CountQueryBuilder;
+use Tempest\Database\Exceptions\CannotCountDistinctWithoutSpecifyingAColumn;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
@@ -64,6 +65,22 @@ final class CountQueryBuilderTest extends FrameworkIntegrationTestCase
         $this->assertSame(['Timeline Taxi', '1', '2025-01-01'], $bindings);
     }
 
+    public function test_count_query_with_specified_asterisk(): void
+    {
+        $query = query('chapters')
+            ->count('*')
+            ->build();
+
+        $sql = $query->getSql();
+
+        $expected = <<<SQL
+        SELECT COUNT(*)
+        FROM `chapters`
+        SQL;
+
+        $this->assertSame($expected, $sql);
+    }
+
     public function test_count_query_with_specified_field(): void
     {
         $query = query('chapters')->count('title')->build();
@@ -72,6 +89,78 @@ final class CountQueryBuilderTest extends FrameworkIntegrationTestCase
 
         $expected = <<<SQL
         SELECT COUNT(`title`)
+        FROM `chapters`
+        SQL;
+
+        $this->assertSame($expected, $sql);
+    }
+
+    public function test_count_query_with_specified_field_and_alias(): void
+    {
+        $query = query('chapters')
+            ->count('title')
+            ->as('total')
+            ->build();
+
+        $sql = $query->getSql();
+
+        $expected = <<<SQL
+        SELECT COUNT(`title`) AS `total`
+        FROM `chapters`
+        SQL;
+
+        $this->assertSame($expected, $sql);
+    }
+
+    public function test_count_query_without_specifying_column_cannot_be_distinct(): void
+    {
+        $this->expectException(CannotCountDistinctWithoutSpecifyingAColumn::class);
+
+        query('chapters')
+            ->count()
+            ->distinct()
+            ->build();
+    }
+
+    public function test_count_query_with_specified_asterisk_cannot_be_distinct(): void
+    {
+        $this->expectException(CannotCountDistinctWithoutSpecifyingAColumn::class);
+
+        query('chapters')
+            ->count('*')
+            ->distinct()
+            ->build();
+    }
+
+    public function test_count_query_with_distinct_specified_field(): void
+    {
+        $query = query('chapters')
+            ->count('title')
+            ->distinct()
+            ->build();
+
+        $sql = $query->getSql();
+
+        $expected = <<<SQL
+        SELECT COUNT(DISTINCT `title`)
+        FROM `chapters`
+        SQL;
+
+        $this->assertSame($expected, $sql);
+    }
+
+    public function test_count_query_with_distinct_specified_field_and_alias(): void
+    {
+        $query = query('chapters')
+            ->count('title')
+            ->as('total')
+            ->distinct()
+            ->build();
+
+        $sql = $query->getSql();
+
+        $expected = <<<SQL
+        SELECT COUNT(DISTINCT `title`) AS `total`
         FROM `chapters`
         SQL;
 

--- a/tests/Integration/Database/Builder/CountQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/CountQueryBuilderTest.php
@@ -40,31 +40,6 @@ final class CountQueryBuilderTest extends FrameworkIntegrationTestCase
         $this->assertSame(['Timeline Taxi', '1', '2025-01-01'], $bindings);
     }
 
-    public function test_count_query_with_alias(): void
-    {
-        $query = query('chapters')
-            ->count()
-            ->as('total')
-            ->where('`title` = ?', 'Timeline Taxi')
-            ->andWhere('`index` <> ?', '1')
-            ->orWhere('`createdAt` > ?', '2025-01-01')
-            ->build();
-
-        $expected = <<<SQL
-        SELECT COUNT(*) AS `total`
-        FROM `chapters`
-        WHERE `title` = ?
-        AND `index` <> ?
-        OR `createdAt` > ?
-        SQL;
-
-        $sql = $query->getSql();
-        $bindings = $query->bindings;
-
-        $this->assertSame($expected, $sql);
-        $this->assertSame(['Timeline Taxi', '1', '2025-01-01'], $bindings);
-    }
-
     public function test_count_query_with_specified_asterisk(): void
     {
         $query = query('chapters')
@@ -89,23 +64,6 @@ final class CountQueryBuilderTest extends FrameworkIntegrationTestCase
 
         $expected = <<<SQL
         SELECT COUNT(`title`)
-        FROM `chapters`
-        SQL;
-
-        $this->assertSame($expected, $sql);
-    }
-
-    public function test_count_query_with_specified_field_and_alias(): void
-    {
-        $query = query('chapters')
-            ->count('title')
-            ->as('total')
-            ->build();
-
-        $sql = $query->getSql();
-
-        $expected = <<<SQL
-        SELECT COUNT(`title`) AS `total`
         FROM `chapters`
         SQL;
 
@@ -143,24 +101,6 @@ final class CountQueryBuilderTest extends FrameworkIntegrationTestCase
 
         $expected = <<<SQL
         SELECT COUNT(DISTINCT `title`)
-        FROM `chapters`
-        SQL;
-
-        $this->assertSame($expected, $sql);
-    }
-
-    public function test_count_query_with_distinct_specified_field_and_alias(): void
-    {
-        $query = query('chapters')
-            ->count('title')
-            ->as('total')
-            ->distinct()
-            ->build();
-
-        $sql = $query->getSql();
-
-        $expected = <<<SQL
-        SELECT COUNT(DISTINCT `title`) AS `total`
         FROM `chapters`
         SQL;
 


### PR DESCRIPTION
This pull request introduces a new `CountQueryBuilder` to the Tempest database library, enabling efficient SQL `COUNT` queries with fluent condition chaining. It includes the implementation of the builder, integration with existing query builders, and comprehensive unit and integration tests.

### New Feature: `CountQueryBuilder`

* Added the `CountQueryBuilder` class to support building SQL `COUNT` queries with methods for chaining conditions (`where`, `andWhere`, `orWhere`, etc.) and specifying columns. It integrates with `ModelDefinition` and `TableDefinition` for resolving table and field details. (`src/Tempest/Database/src/Builder/QueryBuilders/CountQueryBuilder.php`)
* Introduced a `count()` method in the `QueryBuilder` class to create instances of `CountQueryBuilder`, allowing seamless integration with existing query workflows. (`src/Tempest/Database/src/Builder/QueryBuilders/QueryBuilder.php`)

### Supporting Query Statement

* Implemented the `CountStatement` class, which compiles the SQL for `COUNT` queries, including support for optional `WHERE` clauses and column specification. (`src/Tempest/Database/src/QueryStatements/CountStatement.php`)

### TODOs:

- [ ] ~Add support for `GROUP BY` and `HAVING`~ _(As brought up on discord, this makes more sense on the SELECT query builder only)_
- [x] ~Add support for aliasing the `COUNT`~ _(There's no point aliasing the count if the only thing returned is an `int`)_
- [x] Add support for `DISTINCT`
- [ ] Include `COUNT` in a `->select`

### Caveats (?)

The problem with Tempest's approach of defining the "query type" (`select`/`update`/`delete`) before building the rest of the query can make it difficult to reuse the query conditions.

For example - say you need to implement pagination from a filterable query - you'll need to repeat yourself in order to get the results and also a total count:

```php
$selectQuery = query('books')->select();
$countQuery = query('books')->count();

if ($request->search) { 
    $selectQuery = $selectQuery->where('title LIKE ?', "%{$request->search}%");
    $countQuery = $countQuery->where('title LIKE ?', "%{$request->search}%");
}

//...

$count = $countQuery->execut();

$selectQuery = $selectQuery->limit(10)->offset(10);
$results = $selectQuery->all();

```

Closes #1164