### PR TITLE
feat(storage): support multiple storage configurations

### DIFF
--- a/packages/container/src/Container.php
+++ b/packages/container/src/Container.php
@@ -12,7 +12,7 @@ interface Container
 {
     public function register(string $className, callable $definition): self;
 
-    public function unregister(string $className): self;
+    public function unregister(string $className, bool $tagged = false): self;
 
     public function singleton(string $className, mixed $definition, ?string $tag = null): self;
 

--- a/packages/container/src/GenericContainer.php
+++ b/packages/container/src/GenericContainer.php
@@ -16,7 +16,6 @@ use Tempest\Reflection\FunctionReflector;
 use Tempest\Reflection\MethodReflector;
 use Tempest\Reflection\ParameterReflector;
 use Tempest\Reflection\TypeReflector;
-use Tempest\Support\Arr;
 use Throwable;
 
 final class GenericContainer implements Container
@@ -98,9 +97,10 @@ final class GenericContainer implements Container
         unset($this->definitions[$className], $this->singletons[$className]);
 
         if ($tagged) {
-            $singletons = Arr\filter(
+            $singletons = array_filter(
                 array: $this->getSingletons(),
-                filter: static fn (mixed $_, string $key) => ! str_starts_with($key, "{$className}#"),
+                callback: static fn (mixed $_, string $key) => ! str_starts_with($key, "{$className}#"),
+                mode: \ARRAY_FILTER_USE_BOTH,
             );
 
             $this->setSingletons($singletons);

--- a/packages/container/tests/ContainerTest.php
+++ b/packages/container/tests/ContainerTest.php
@@ -443,6 +443,25 @@ final class ContainerTest extends TestCase
         $container->get(InterfaceA::class);
     }
 
+    public function test_unregister_tagged(): void
+    {
+        $container = new GenericContainer();
+
+        $container->singleton(
+            TaggedDependency::class,
+            new TaggedDependency('web'),
+            tag: 'web',
+        );
+
+        $this->assertInstanceOf(TaggedDependency::class, $container->get(TaggedDependency::class, 'web'));
+
+        $container->unregister(TaggedDependency::class, tagged: true);
+
+        $this->expectException(CannotResolveTaggedDependency::class);
+
+        $container->get(TaggedDependency::class, 'web');
+    }
+
     public function test_has(): void
     {
         $container = new GenericContainer();

--- a/packages/storage/composer.json
+++ b/packages/storage/composer.json
@@ -5,7 +5,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^8.4",
-        "league/flysystem": "^3.29.1"
+        "league/flysystem": "^3.29.1",
+        "tempest/container": "dev-main"
     },
     "require-dev": {
         "league/flysystem-aws-s3-v3": "^3.0",

--- a/packages/storage/src/Config/AzureStorageConfig.php
+++ b/packages/storage/src/Config/AzureStorageConfig.php
@@ -5,6 +5,7 @@ namespace Tempest\Storage\Config;
 use League\Flysystem\AzureBlobStorage\AzureBlobStorageAdapter;
 use League\Flysystem\FilesystemAdapter;
 use MicrosoftAzure\Storage\Blob\BlobRestProxy;
+use UnitEnum;
 
 final class AzureStorageConfig implements StorageConfig
 {
@@ -30,6 +31,11 @@ final class AzureStorageConfig implements StorageConfig
          * Whether the storage is read-only.
          */
         public bool $readonly = false,
+
+        /**
+         * Identifier for this storage configuration.
+         */
+        public null|string|UnitEnum $tag = null,
     ) {}
 
     public function createAdapter(): FilesystemAdapter

--- a/packages/storage/src/Config/CustomStorageConfig.php
+++ b/packages/storage/src/Config/CustomStorageConfig.php
@@ -3,6 +3,7 @@
 namespace Tempest\Storage\Config;
 
 use League\Flysystem\FilesystemAdapter;
+use UnitEnum;
 
 use function Tempest\get;
 
@@ -20,6 +21,11 @@ final class CustomStorageConfig implements StorageConfig
          * Whether the storage is read-only.
          */
         public bool $readonly = false,
+
+        /**
+         * Identifier for this storage configuration.
+         */
+        public null|string|UnitEnum $tag = null,
     ) {}
 
     public function createAdapter(): FilesystemAdapter

--- a/packages/storage/src/Config/FTPStorageConfig.php
+++ b/packages/storage/src/Config/FTPStorageConfig.php
@@ -5,6 +5,7 @@ namespace Tempest\Storage\Config;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\Ftp\FtpAdapter;
 use League\Flysystem\Ftp\FtpConnectionOptions;
+use UnitEnum;
 
 final class FTPStorageConfig implements StorageConfig
 {
@@ -29,7 +30,16 @@ final class FTPStorageConfig implements StorageConfig
         public ?bool $ignorePassiveAddress = null,
         public bool $recurseManually = true,
         public bool $timestampsOnUnixListingsEnabled = false,
+
+        /**
+         * Whether the storage is read-only.
+         */
         public bool $readonly = false,
+
+        /**
+         * Identifier for this storage configuration.
+         */
+        public null|string|UnitEnum $tag = null,
     ) {}
 
     public function createAdapter(): FilesystemAdapter

--- a/packages/storage/src/Config/GoogleCloudStorageConfig.php
+++ b/packages/storage/src/Config/GoogleCloudStorageConfig.php
@@ -5,6 +5,7 @@ namespace Tempest\Storage\Config;
 use Google\Cloud\Storage\StorageClient;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\GoogleCloudStorage\GoogleCloudStorageAdapter;
+use UnitEnum;
 
 final class GoogleCloudStorageConfig implements StorageConfig
 {
@@ -45,6 +46,11 @@ final class GoogleCloudStorageConfig implements StorageConfig
          * Whether the storage is read-only.
          */
         public bool $readonly = false,
+
+        /**
+         * Identifier for this storage configuration.
+         */
+        public null|string|UnitEnum $tag = null,
     ) {}
 
     public function createAdapter(): FilesystemAdapter

--- a/packages/storage/src/Config/InMemoryStorageConfig.php
+++ b/packages/storage/src/Config/InMemoryStorageConfig.php
@@ -4,6 +4,7 @@ namespace Tempest\Storage\Config;
 
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use UnitEnum;
 
 final class InMemoryStorageConfig implements StorageConfig
 {
@@ -14,6 +15,11 @@ final class InMemoryStorageConfig implements StorageConfig
          * Whether the storage is read-only.
          */
         public bool $readonly = false,
+
+        /**
+         * Identifier for this storage configuration.
+         */
+        public null|string|UnitEnum $tag = null,
     ) {}
 
     public function createAdapter(): FilesystemAdapter

--- a/packages/storage/src/Config/LocalStorageConfig.php
+++ b/packages/storage/src/Config/LocalStorageConfig.php
@@ -4,6 +4,7 @@ namespace Tempest\Storage\Config;
 
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use UnitEnum;
 
 final class LocalStorageConfig implements StorageConfig
 {
@@ -19,6 +20,11 @@ final class LocalStorageConfig implements StorageConfig
          * Whether the storage is read-only.
          */
         public bool $readonly = false,
+
+        /**
+         * Identifier for this storage configuration.
+         */
+        public null|string|UnitEnum $tag = null,
     ) {}
 
     public function createAdapter(): FilesystemAdapter

--- a/packages/storage/src/Config/R2StorageConfig.php
+++ b/packages/storage/src/Config/R2StorageConfig.php
@@ -4,6 +4,7 @@ namespace Tempest\Storage\Config;
 
 use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use League\Flysystem\FilesystemAdapter;
+use UnitEnum;
 
 final class R2StorageConfig implements StorageConfig
 {
@@ -44,6 +45,11 @@ final class R2StorageConfig implements StorageConfig
          * Other options.
          */
         public array $options = [],
+
+        /**
+         * Identifier for this storage configuration.
+         */
+        public null|string|UnitEnum $tag = null,
     ) {}
 
     public function createAdapter(): FilesystemAdapter

--- a/packages/storage/src/Config/S3StorageConfig.php
+++ b/packages/storage/src/Config/S3StorageConfig.php
@@ -5,6 +5,7 @@ namespace Tempest\Storage\Config;
 use Aws\S3\S3Client;
 use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use League\Flysystem\FilesystemAdapter;
+use UnitEnum;
 
 final class S3StorageConfig implements StorageConfig
 {
@@ -60,6 +61,11 @@ final class S3StorageConfig implements StorageConfig
          * Other options.
          */
         public array $options = [],
+
+        /**
+         * Identifier for this storage configuration.
+         */
+        public null|string|UnitEnum $tag = null,
     ) {}
 
     public function createAdapter(): FilesystemAdapter

--- a/packages/storage/src/Config/SFTPStorageConfig.php
+++ b/packages/storage/src/Config/SFTPStorageConfig.php
@@ -5,6 +5,7 @@ namespace Tempest\Storage\Config;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\PhpseclibV3\SftpAdapter;
 use League\Flysystem\PhpseclibV3\SftpConnectionProvider;
+use UnitEnum;
 
 final class SFTPStorageConfig implements StorageConfig
 {
@@ -22,7 +23,16 @@ final class SFTPStorageConfig implements StorageConfig
         public int $timeoutInSeconds = 10,
         public int $maxTries = 3,
         public ?string $hostFingerprint = null,
+
+        /**
+         * Whether the storage is read-only.
+         */
         public bool $readonly = false,
+
+        /**
+         * Identifier for this storage configuration.
+         */
+        public null|string|UnitEnum $tag = null,
     ) {}
 
     public function createAdapter(): FilesystemAdapter

--- a/packages/storage/src/Config/StorageConfig.php
+++ b/packages/storage/src/Config/StorageConfig.php
@@ -3,8 +3,9 @@
 namespace Tempest\Storage\Config;
 
 use League\Flysystem\FilesystemAdapter;
+use Tempest\Container\HasTag;
 
-interface StorageConfig
+interface StorageConfig extends HasTag
 {
     /**
      * Whether the storage is read-only.

--- a/packages/storage/src/Config/ZipArchiveStorageConfig.php
+++ b/packages/storage/src/Config/ZipArchiveStorageConfig.php
@@ -6,6 +6,7 @@ use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Flysystem\ZipArchive\FilesystemZipArchiveProvider;
 use League\Flysystem\ZipArchive\ZipArchiveAdapter;
+use UnitEnum;
 
 final class ZipArchiveStorageConfig implements StorageConfig
 {
@@ -26,6 +27,11 @@ final class ZipArchiveStorageConfig implements StorageConfig
          * Whether the storage is read-only.
          */
         public bool $readonly = false,
+
+        /**
+         * Identifier for this storage configuration.
+         */
+        public null|string|UnitEnum $tag = null,
     ) {}
 
     public function createAdapter(): FilesystemAdapter

--- a/packages/storage/src/StorageInitializer.php
+++ b/packages/storage/src/StorageInitializer.php
@@ -3,17 +3,23 @@
 namespace Tempest\Storage;
 
 use Tempest\Container\Container;
-use Tempest\Container\Initializer;
+use Tempest\Container\DynamicInitializer;
 use Tempest\Container\Singleton;
+use Tempest\Reflection\ClassReflector;
 use Tempest\Storage\Config\StorageConfig;
 
-final class StorageInitializer implements Initializer
+final class StorageInitializer implements DynamicInitializer
 {
+    public function canInitialize(ClassReflector $class, ?string $tag): bool
+    {
+        return $class->getType()->matches(Storage::class);
+    }
+
     #[Singleton]
-    public function initialize(Container $container): Storage
+    public function initialize(ClassReflector $class, ?string $tag, Container $container): Storage
     {
         return new GenericStorage(
-            storageConfig: $container->get(StorageConfig::class), // TODO(innocenzi): tag
+            storageConfig: $container->get(StorageConfig::class, $tag),
         );
     }
 }

--- a/packages/storage/src/Testing/RestrictedStorageInitializer.php
+++ b/packages/storage/src/Testing/RestrictedStorageInitializer.php
@@ -3,17 +3,23 @@
 namespace Tempest\Storage\Testing;
 
 use Tempest\Container\Container;
-use Tempest\Container\Initializer;
+use Tempest\Container\DynamicInitializer;
 use Tempest\Container\Singleton;
 use Tempest\Discovery\SkipDiscovery;
+use Tempest\Reflection\ClassReflector;
 use Tempest\Storage\Storage;
 
 #[SkipDiscovery]
-final class RestrictedStorageInitializer implements Initializer
+final class RestrictedStorageInitializer implements DynamicInitializer
 {
-    #[Singleton]
-    public function initialize(Container $container): Storage
+    public function canInitialize(ClassReflector $class, ?string $tag): bool
     {
-        return new RestrictedStorage();
+        return $class->getType()->matches(Storage::class);
+    }
+
+    #[Singleton]
+    public function initialize(ClassReflector $class, ?string $tag, Container $container): Storage
+    {
+        return new RestrictedStorage($tag);
     }
 }

--- a/packages/storage/src/Testing/StorageTester.php
+++ b/packages/storage/src/Testing/StorageTester.php
@@ -18,9 +18,9 @@ final readonly class StorageTester
     ) {}
 
     /**
-     * Forces the usage of a testing storage.
+     * Forces the usage of a testing storage. When setting `$persist` to `true`, the disk is not erased.
      */
-    public function fake(null|string|UnitEnum $tag = null): TestingStorage
+    public function fake(null|string|UnitEnum $tag = null, bool $persist = false): TestingStorage
     {
         $storage = new TestingStorage(match (true) {
             is_string($tag) => to_kebab_case($tag),
@@ -30,7 +30,9 @@ final readonly class StorageTester
 
         $this->container->singleton(Storage::class, $storage, $tag);
 
-        return $storage->cleanDirectory();
+        return $persist
+            ? $storage->createDirectory()
+            : $storage->cleanDirectory();
     }
 
     /**

--- a/packages/storage/src/Testing/StorageTester.php
+++ b/packages/storage/src/Testing/StorageTester.php
@@ -2,40 +2,35 @@
 
 namespace Tempest\Storage\Testing;
 
-use Closure;
-use DateTimeInterface;
-use League\Flysystem\Config;
-use League\Flysystem\UrlGeneration\PublicUrlGenerator;
-use League\Flysystem\UrlGeneration\TemporaryUrlGenerator;
-use PHPUnit\Framework\Assert;
 use Tempest\Container\Container;
+use Tempest\Container\GenericContainer;
 use Tempest\Storage\Storage;
+use Tempest\Storage\StorageInitializer;
+use Tempest\Support\Arr;
 use UnitEnum;
 
 use function Tempest\Support\Str\to_kebab_case;
 
-final class StorageTester
+final readonly class StorageTester
 {
-    private ?TestingStorage $storage = null;
-
     public function __construct(
-        private readonly Container $container,
+        private Container $container,
     ) {}
 
     /**
      * Forces the usage of a testing storage.
      */
-    public function fake(null|string|UnitEnum $tag = null): void
+    public function fake(null|string|UnitEnum $tag = null): TestingStorage
     {
-        $this->storage = new TestingStorage(match (true) {
+        $storage = new TestingStorage(match (true) {
             is_string($tag) => to_kebab_case($tag),
             $tag instanceof UnitEnum => to_kebab_case($tag->name),
             default => 'default',
         });
 
-        $this->storage->cleanDirectory();
+        $this->container->singleton(Storage::class, $storage, $tag);
 
-        $this->container->singleton(Storage::class, $this->storage, $tag);
+        return $storage->cleanDirectory();
     }
 
     /**
@@ -43,122 +38,12 @@ final class StorageTester
      */
     public function preventUsageWithoutFake(): void
     {
-        // TODO(innocenzi): unregister for all tags when this is implemented
-        $this->container->unregister(Storage::class);
+        if (! ($this->container instanceof GenericContainer)) {
+            throw new \RuntimeException('Container is not a GenericContainer, unable to prevent usage without fake.');
+        }
+
+        $this->container->unregister(Storage::class, tagged: true);
+        $this->container->removeInitializer(StorageInitializer::class);
         $this->container->addInitializer(RestrictedStorageInitializer::class);
-    }
-
-    public function createTemporaryUrlsUsing(Closure $closure): void
-    {
-        $generator = new class($closure) implements TemporaryUrlGenerator {
-            public function __construct(
-                private readonly Closure $closure,
-            ) {}
-
-            public function temporaryUrl(string $path, DateTimeInterface $expiresAt, Config $config): string
-            {
-                return ($this->closure)($path, $expiresAt);
-            }
-        };
-
-        $this->storage->setTemporaryUrlGenerator($generator);
-    }
-
-    public function createPublicUrlsUsing(Closure $closure): void
-    {
-        $generator = new class($closure) implements PublicUrlGenerator {
-            public function __construct(
-                private readonly Closure $closure,
-            ) {}
-
-            public function publicUrl(string $path, Config $config): string
-            {
-                return ($this->closure)($path);
-            }
-        };
-
-        $this->storage->setPublicUrlGenerator($generator);
-    }
-
-    public function assertFileExists(string $path): void
-    {
-        $storage = $this->container->get(Storage::class);
-
-        Assert::assertTrue($storage->fileExists($path), sprintf('File `%s` does not exist.', $path));
-    }
-
-    public function assertChecksumEquals(string $path, string $checksum): void
-    {
-        $storage = $this->container->get(Storage::class);
-
-        $this->assertFileExists($path);
-        Assert::assertEquals($checksum, $storage->checksum($path), sprintf('File `%s` checksum does not match `%s`.', $path, $checksum));
-    }
-
-    public function assertSee(string $path, string $contents): void
-    {
-        $storage = $this->container->get(Storage::class);
-
-        $this->assertFileExists($path);
-        Assert::assertStringContainsString($contents, $storage->read($path), sprintf('File `%s` does not contain `%s`.', $path, $contents));
-    }
-
-    public function assertDontSee(string $path, string $contents): void
-    {
-        $storage = $this->container->get(Storage::class);
-
-        $this->assertFileExists($path);
-        Assert::assertStringNotContainsString($contents, $storage->read($path), sprintf('File `%s` contains `%s`.', $path, $contents));
-    }
-
-    public function assertFileDoesNotExist(string $path): void
-    {
-        $storage = $this->container->get(Storage::class);
-
-        Assert::assertFalse($storage->fileExists($path), sprintf('File `%s` exists.', $path));
-    }
-
-    public function assertDirectoryExists(string $path): void
-    {
-        $storage = $this->container->get(Storage::class);
-
-        Assert::assertTrue($storage->directoryExists($path), sprintf('Directory `%s` does not exist.', $path));
-    }
-
-    public function assertDirectoryEmpty(string $path = ''): void
-    {
-        $storage = $this->container->get(Storage::class);
-
-        $this->assertDirectoryExists($path);
-        Assert::assertEmpty($storage->list($path)->toArray(), sprintf('Directory `%s` is not empty.', $path));
-    }
-
-    public function assertDirectoryNotEmpty(string $path): void
-    {
-        $storage = $this->container->get(Storage::class);
-
-        $this->assertDirectoryExists($path);
-        Assert::assertNotEmpty($storage->list($path)->toArray(), sprintf('Directory `%s` is empty.', $path));
-    }
-
-    public function assertDirectoryDoesNotExist(string $path): void
-    {
-        $storage = $this->container->get(Storage::class);
-
-        Assert::assertFalse($storage->directoryExists($path), sprintf('Directory `%s` exists.', $path));
-    }
-
-    public function assertFileOrDirectoryExists(string $path): void
-    {
-        $storage = $this->container->get(Storage::class);
-
-        Assert::assertTrue($storage->fileOrDirectoryExists($path), sprintf('File or directory `%s` does not exist.', $path));
-    }
-
-    public function assertFileOrDirectoryDoesNotExist(string $path): void
-    {
-        $storage = $this->container->get(Storage::class);
-
-        Assert::assertFalse($storage->fileOrDirectoryExists($path), sprintf('File or directory `%s` exists.', $path));
     }
 }

--- a/packages/storage/tests/StorageTest.php
+++ b/packages/storage/tests/StorageTest.php
@@ -4,10 +4,9 @@ namespace Tempest\Storage\Tests;
 
 use League\Flysystem\UnableToWriteFile;
 use PHPUnit\Framework\TestCase;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use Tempest\Storage\Config\LocalStorageConfig;
 use Tempest\Storage\GenericStorage;
+use Tempest\Support\Filesystem;
 
 final class StorageTest extends TestCase
 {
@@ -17,18 +16,7 @@ final class StorageTest extends TestCase
     {
         parent::tearDown();
 
-        $files = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($this->fixtures, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST,
-        );
-
-        foreach ($files as $file) {
-            $file->isDir()
-                ? @rmdir($file->getRealPath())
-                : @unlink($file->getRealPath());
-        }
-
-        @rmdir($this->fixtures);
+        Filesystem\delete_directory($this->fixtures);
     }
 
     public function test_storage_write(): void

--- a/tests/Integration/Container/Commands/ContainerShowCommandTest.php
+++ b/tests/Integration/Container/Commands/ContainerShowCommandTest.php
@@ -34,7 +34,7 @@ final class ContainerShowCommandTest extends FrameworkIntegrationTestCase
                     return $this;
                 }
 
-                public function unregister(string $className): self
+                public function unregister(string $className, bool $tagged = false): self
                 {
                     $this->container->unregister($className);
 

--- a/tests/Integration/Storage/MultipleStoragesTest.php
+++ b/tests/Integration/Storage/MultipleStoragesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Tempest\Integration\Storage;
+
+use Tempest\Storage\Config\LocalStorageConfig;
+use Tempest\Storage\Storage;
+use Tempest\Support\Filesystem;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\Support\Filesystem\exists;
+
+final class MultipleStoragesTest extends FrameworkIntegrationTestCase
+{
+    private string $fixtures = __DIR__ . '/Fixtures/';
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Filesystem\delete_directory($this->fixtures);
+    }
+
+    public function test_basic(): void
+    {
+        $this->container->config(new LocalStorageConfig(
+            path: $this->fixtures . '/storage1',
+            tag: 'storage1',
+        ));
+
+        $this->container->config(new LocalStorageConfig(
+            path: $this->fixtures . '/storage2',
+            tag: 'storage2',
+        ));
+
+        $storage1 = $this->container->get(Storage::class, tag: 'storage1');
+        $storage1->write('test1.txt', '');
+
+        $storage2 = $this->container->get(Storage::class, tag: 'storage2');
+        $storage2->write('test2.txt', '');
+
+        $this->assertTrue(exists($this->fixtures . '/storage1/test1.txt'));
+        $this->assertTrue(exists($this->fixtures . '/storage2/test2.txt'));
+    }
+}

--- a/tests/Integration/Storage/StorageTesterTest.php
+++ b/tests/Integration/Storage/StorageTesterTest.php
@@ -6,80 +6,127 @@ use DateTime;
 use DateTimeInterface;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use Tempest\Storage\Config\InMemoryStorageConfig;
 use Tempest\Storage\Config\StorageConfig;
 use Tempest\Storage\ForbiddenStorageUsageException;
 use Tempest\Storage\MissingAdapterException;
 use Tempest\Storage\Storage;
+use Tempest\Storage\Testing\TestingStorage;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+use UnitEnum;
 
 final class StorageTesterTest extends FrameworkIntegrationTestCase
 {
+    public function test_fake_storage_is_registered_in_container(): void
+    {
+        $faked = $this->storage->fake();
+        $actual = $this->container->get(Storage::class);
+
+        $this->assertInstanceOf(TestingStorage::class, $faked);
+        $this->assertInstanceOf(TestingStorage::class, $actual);
+        $this->assertSame($faked, $actual);
+    }
+
+    public function test_multiple_fake_storage_are_registered_in_container(): void
+    {
+        $faked1 = $this->storage->fake('storage1');
+        $faked2 = $this->storage->fake('storage2');
+
+        $actual1 = $this->container->get(Storage::class, 'storage1');
+        $actual2 = $this->container->get(Storage::class, 'storage2');
+
+        $this->assertInstanceOf(TestingStorage::class, $faked1);
+        $this->assertInstanceOf(TestingStorage::class, $actual1);
+        $this->assertSame($faked1, $actual1);
+
+        $this->assertInstanceOf(TestingStorage::class, $faked2);
+        $this->assertInstanceOf(TestingStorage::class, $actual2);
+        $this->assertSame($faked2, $actual2);
+
+        $this->assertNotSame($actual1, $actual2);
+    }
+
+    public function test_multiple_storages(): void
+    {
+        $storage1 = $this->storage->fake('storage1');
+        $storage2 = $this->storage->fake('storage2');
+
+        $storage1->write('foo1.txt', 'bar');
+        $storage2->write('foo2.txt', 'bar');
+
+        $storage1->assertFileExists('foo1.txt');
+        $storage1->assertSee('foo1.txt', 'bar');
+        $storage1->assertFileDoesNotExist('foo2.txt');
+
+        $storage2->assertFileExists('foo2.txt');
+        $storage2->assertSee('foo2.txt', 'bar');
+        $storage2->assertFileDoesNotExist('foo1.txt');
+    }
+
     public function test_basic(): void
     {
-        $this->storage->fake();
+        $storage = $this->storage->fake();
 
-        $storage = $this->container->get(Storage::class);
         $storage->write('foo.txt', 'bar');
 
-        $this->storage->assertFileExists('foo.txt');
-        $this->storage->assertSee('foo.txt', 'bar');
+        $storage->assertFileExists('foo.txt');
+        $storage->assertSee('foo.txt', 'bar');
     }
 
     public function test_file_assertions(): void
     {
-        $this->storage->fake();
+        $storage = $this->storage->fake();
 
-        $storage = $this->container->get(Storage::class);
         $storage->write('foo.txt', 'bar');
 
-        $this->storage->assertFileExists('foo.txt');
-        $this->storage->assertFileOrDirectoryExists('foo.txt');
-        $this->storage->assertDontSee('foo.txt', 'kdkdkd');
+        $storage->assertFileExists('foo.txt');
+        $storage->assertFileOrDirectoryExists('foo.txt');
+        $storage->assertDontSee('foo.txt', 'kdkdkd');
 
-        $this->storage->assertFileDoesNotExist('do-not-exists.txt');
-        $this->storage->assertFileOrDirectoryDoesNotExist('do-not-exists.txt');
+        $storage->assertFileDoesNotExist('do-not-exists.txt');
+        $storage->assertFileOrDirectoryDoesNotExist('do-not-exists.txt');
     }
 
     public function test_directory_assertions(): void
     {
-        $this->storage->fake();
+        $storage = $this->storage->fake();
 
-        $storage = $this->container->get(Storage::class);
         $storage->write('foo/bar.txt', 'baz');
         $storage->createDirectory('empty');
 
-        $this->storage->assertChecksumEquals('foo/bar.txt', '73feffa4b7f6bb68e44cf984c85f6e88');
+        $storage->assertChecksumEquals('foo/bar.txt', '73feffa4b7f6bb68e44cf984c85f6e88');
 
-        $this->storage->assertFileExists('foo/bar.txt');
-        $this->storage->assertFileOrDirectoryExists('foo/bar.txt');
-        $this->storage->assertDirectoryExists('foo');
-        $this->storage->assertFileOrDirectoryExists('foo');
-        $this->storage->assertDirectoryNotEmpty('foo');
+        $storage->assertFileExists('foo/bar.txt');
+        $storage->assertFileOrDirectoryExists('foo/bar.txt');
+        $storage->assertDirectoryExists('foo');
+        $storage->assertFileOrDirectoryExists('foo');
+        $storage->assertDirectoryNotEmpty('foo');
 
-        $this->storage->assertSee('foo/bar.txt', 'baz');
-        $this->storage->assertDontSee('foo/bar.txt', 'kdkdkd');
+        $storage->assertSee('foo/bar.txt', 'baz');
+        $storage->assertDontSee('foo/bar.txt', 'kdkdkd');
 
-        $this->storage->assertDirectoryNotEmpty('foo');
-        $this->storage->assertDirectoryEmpty('empty');
+        $storage->assertDirectoryNotEmpty('foo');
+        $storage->assertDirectoryEmpty('empty');
 
         $storage->cleanDirectory('foo');
-        $this->storage->assertDirectoryEmpty('foo');
+        $storage->assertDirectoryEmpty('foo');
 
         $storage->cleanDirectory();
-        $this->storage->assertDirectoryEmpty();
+        $storage->assertDirectoryEmpty();
 
         $storage->write('foo/bar.txt', 'baz');
         $storage->delete('foo/bar.txt');
-        $this->storage->assertDirectoryEmpty('foo');
+        $storage->assertDirectoryEmpty('foo');
 
         $storage->deleteDirectory('foo');
-        $this->storage->assertDirectoryEmpty();
+        $storage->assertDirectoryEmpty();
     }
 
     public function test_public_url(): void
     {
-        $this->storage->fake();
-        $this->storage->createPublicUrlsUsing(fn (string $path) => sprintf('https://localhost/%s', $path));
+        $storage = $this->storage->fake();
+
+        $storage->createPublicUrlsUsing(fn (string $path) => sprintf('https://localhost/%s', $path));
 
         $storage = $this->container->get(Storage::class);
         $storage->write('foo.txt', 'bar');
@@ -89,8 +136,9 @@ final class StorageTesterTest extends FrameworkIntegrationTestCase
 
     public function test_temporary_urls(): void
     {
-        $this->storage->fake();
-        $this->storage->createTemporaryUrlsUsing(fn (string $path, DateTimeInterface $expiresAt) => sprintf(
+        $storage = $this->storage->fake();
+
+        $storage->createTemporaryUrlsUsing(fn (string $path, DateTimeInterface $expiresAt) => sprintf(
             'https://localhost/%s?expires=%s',
             $path,
             $expiresAt->format(DateTimeInterface::RFC3339),
@@ -114,15 +162,34 @@ final class StorageTesterTest extends FrameworkIntegrationTestCase
         $storage->write('bar.txt', 'baz');
     }
 
+    public function test_prevent_usage_without_fake_with_tagged_storage(): void
+    {
+        $this->expectException(ForbiddenStorageUsageException::class);
+
+        $this->container->config(new InMemoryStorageConfig(tag: 'tagged'));
+        $this->storage->preventUsageWithoutFake();
+
+        $storage = $this->container->get(Storage::class, 'tagged');
+        $storage->write('bar.txt', 'baz');
+    }
+
     public function test_prevent_usage_without_fake_with_fake(): void
     {
         $this->storage->preventUsageWithoutFake();
-        $this->storage->fake();
 
-        $storage = $this->container->get(Storage::class);
+        $storage = $this->storage->fake();
         $storage->write('bar.txt', 'baz');
+        $storage->assertFileExists('bar.txt');
+    }
 
-        $this->storage->assertFileExists('bar.txt');
+    public function test_prevent_usage_without_fake_with_fake_tagged_storage(): void
+    {
+        $this->container->config(new InMemoryStorageConfig(tag: 'tagged'));
+        $this->storage->preventUsageWithoutFake();
+
+        $storage = $this->storage->fake('tagged');
+        $storage->write('bar.txt', 'baz');
+        $storage->assertFileExists('bar.txt');
     }
 
     public function test_no_adapter(): void
@@ -132,6 +199,8 @@ final class StorageTesterTest extends FrameworkIntegrationTestCase
 
         $this->container->config(new class implements StorageConfig {
             public string $adapter = 'UnknownClass';
+
+            public null|string|UnitEnum $tag = null;
 
             public bool $readonly = false;
 

--- a/tests/Integration/Storage/StorageTesterTest.php
+++ b/tests/Integration/Storage/StorageTesterTest.php
@@ -213,4 +213,16 @@ final class StorageTesterTest extends FrameworkIntegrationTestCase
         $storage = $this->container->get(Storage::class);
         $storage->write('bar.txt', 'baz');
     }
+
+    public function test_persistent_fake(): void
+    {
+        $storage = $this->storage->fake();
+        $storage->write('test.txt', '');
+
+        $storage = $this->storage->fake(persist: true);
+        $this->assertTrue($storage->fileExists('test.txt'));
+
+        $storage = $this->storage->fake(persist: true);
+        $this->assertTrue($storage->fileExists('test.txt'));
+    }
 }


### PR DESCRIPTION
This pull request adds support for multiple storage by adding the `HasTag` interface to the `StorageConfig` and by adapting the testing helpers.

The latter required the addition of `removeInitializer` to the container, as well as updating `unregister` to support unregistering the dependency along with all its tagged instances.

**Note**: this should be merged after the refactor in https://github.com/tempestphp/tempest-framework/pull/1186, I'll solve the conflicts myself.