### PR TITLE
feat(router): detect dead links when generating static pages

### DIFF
--- a/packages/console/src/Testing/ConsoleTester.php
+++ b/packages/console/src/Testing/ConsoleTester.php
@@ -319,7 +319,7 @@ final class ConsoleTester
 
     public function dd(): self
     {
-        ld($this->output->asFormattedString());
+        ld($this->output->asUnformattedString());
 
         return $this;
     }

--- a/packages/router/src/Static/Exceptions/DeadLinksDetectedException.php
+++ b/packages/router/src/Static/Exceptions/DeadLinksDetectedException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tempest\Router\Static\Exceptions;
+
+final class DeadLinksDetectedException extends StaticPageException
+{
+    public function __construct(
+        string $uri,
+        public readonly array $links,
+    ) {
+        parent::__construct(sprintf('%s has %s dead links', $uri, count($links)), $uri);
+    }
+}

--- a/packages/router/src/Static/StaticGenerateCommand.php
+++ b/packages/router/src/Static/StaticGenerateCommand.php
@@ -10,41 +10,53 @@ use Tempest\Console\ConsoleCommand;
 use Tempest\Console\ExitCode;
 use Tempest\Console\HasConsole;
 use Tempest\Container\Container;
+use Tempest\Core\AppConfig;
 use Tempest\Core\Kernel;
 use Tempest\EventBus\EventBus;
 use Tempest\Http\GenericRequest;
 use Tempest\Http\Method;
 use Tempest\Http\Status;
+use Tempest\HttpClient\HttpClient;
 use Tempest\Router\DataProvider;
 use Tempest\Router\Router;
+use Tempest\Router\Static\Exceptions\DeadLinksDetectedException;
 use Tempest\Router\Static\Exceptions\InvalidStatusCodeException;
 use Tempest\Router\Static\Exceptions\NoTextualBodyException;
+use Tempest\Support\Regex;
+use Tempest\Support\Str;
 use Tempest\View\Exceptions\ViewCompilationError;
 use Tempest\View\View;
 use Tempest\View\ViewRenderer;
 use Tempest\Vite\Exceptions\ManifestNotFoundException;
 use Throwable;
 
+use function Tempest\Support\Language\pluralize;
 use function Tempest\Support\path;
 use function Tempest\uri;
 
-final readonly class StaticGenerateCommand
+final class StaticGenerateCommand
 {
     use HasConsole;
 
+    private array $verifiedLinks = [];
+
     public function __construct(
-        private Console $console,
-        private Kernel $kernel,
-        private Container $container,
-        private StaticPageConfig $staticPageConfig,
-        private Router $router,
-        private ViewRenderer $viewRenderer,
-        private EventBus $eventBus,
+        private readonly AppConfig $appConfig,
+        private readonly Console $console,
+        private readonly Kernel $kernel,
+        private readonly Container $container,
+        private readonly StaticPageConfig $staticPageConfig,
+        private readonly Router $router,
+        private readonly ViewRenderer $viewRenderer,
+        private readonly EventBus $eventBus,
+        private readonly HttpClient $httpClient,
     ) {}
 
     #[ConsoleCommand(name: 'static:generate', description: 'Compiles static pages')]
     public function __invoke(
         ?string $filter = null,
+        bool $allowDeadLinks = false,
+        bool $allowExternalDeadLinks = true,
         #[ConsoleArgument(aliases: ['v'])]
         bool $verbose = false,
     ): ExitCode {
@@ -52,6 +64,7 @@ final readonly class StaticGenerateCommand
 
         $generated = 0;
         $failures = 0;
+        $deadlinks = [];
 
         $this->console->header('Generating static pages');
 
@@ -64,6 +77,10 @@ final readonly class StaticGenerateCommand
             $failures++;
 
             match (true) {
+                $event->exception instanceof DeadLinksDetectedException => $this->keyValue(
+                    "<style='fg-gray'>{$event->path}</style>",
+                    sprintf("<style='fg-red'>%s DEAD %s</style>", count($event->exception->links), pluralize('LINK', count($event->exception->links))),
+                ),
                 $event->exception instanceof InvalidStatusCodeException => $this->keyValue(
                     "<style='fg-gray'>{$event->path}</style>",
                     "<style='fg-red'>HTTP {$event->exception->status->value}</style>",
@@ -126,6 +143,11 @@ final readonly class StaticGenerateCommand
                         mkdir($directory->toString(), recursive: true);
                     }
 
+                    if (! $allowDeadLinks && count($links = $this->detectDeadLinks($uri, $content, checkExternal: ! $allowExternalDeadLinks)) > 0) {
+                        $deadlinks[$uri] = $links;
+                        throw new DeadLinksDetectedException($uri, $links);
+                    }
+
                     file_put_contents($file->toString(), $content);
 
                     $this->eventBus->dispatch(new StaticPageGenerated($uri, $file->toString(), $content));
@@ -152,8 +174,119 @@ final readonly class StaticGenerateCommand
 
         $this->keyValue('Static pages generated', "<style='fg-green'>{$generated}</style>");
 
-        return $failures > 0
+        if ($deadlinks) {
+            $this->console->header('Dead links');
+
+            foreach ($deadlinks as $uri => $links) {
+                foreach ($links as $link) {
+                    $this->keyValue("<style='fg-gray'>{$uri}</style>", "<style='fg-red'>{$link}</style>");
+                }
+            }
+        }
+
+        return $failures > 0 || count($deadlinks) > 0
             ? ExitCode::ERROR
             : ExitCode::SUCCESS;
+    }
+
+    private function detectDeadLinks(string $uri, string $html, bool $checkExternal = false): array
+    {
+        $deadlinks = [];
+        $links = Regex\get_all_matches($html, '/<a\s+(?<ignore>ssg-ignore)?[^>]*href=["\'](?<url>[^"\']+)["\'][^>]*>/i', matches: ['url', 'ignore']);
+
+        foreach ($links as ['url' => $link, 'ignore' => $ignore]) {
+            // Links can be ignored with the ssg-ignore attribute
+            if ($ignore ?: false) {
+                continue;
+            }
+
+            // Check anchors (#)
+            if (Str\starts_with($link, '#')) {
+                if (! Regex\matches($html, "/id=\"" . preg_quote(Str\strip_start($link, '#'), '/') . "\"/")) {
+                    $deadlinks[] = $link;
+                }
+
+                continue;
+            }
+
+            // Resolve relative links (../ or ./)
+            if (Str\starts_with($link, ['../', './'])) {
+                $link = $this->resolveRelativeLink($uri, $link);
+            }
+
+            // Don't ping the same link multiple times
+            if (in_array($link, $this->verifiedLinks, strict: true)) {
+                continue;
+            }
+
+            $this->verifiedLinks[] = $link;
+
+            // Check internal links with router (/ or same base uri)
+            if (Str\starts_with($link, '/') || Str\starts_with($this->getLinkWithoutProtocol($link), $this->getLinkWithoutProtocol($this->appConfig->baseUri))) {
+                $response = $this->router->dispatch(new GenericRequest(
+                    method: Method::GET,
+                    uri: match (true) {
+                        Str\starts_with($link, '/') => $this->appConfig->baseUri . '/' . Str\strip_start($link, '/'),
+                        default => $link,
+                    },
+                ));
+
+                if ($response->status->isClientError() || $response->status->isServerError()) {
+                    $deadlinks[] = $link;
+                }
+
+                continue;
+            }
+
+            if (! $checkExternal) {
+                continue;
+            }
+
+            if (Str\starts_with($link, 'http')) {
+                $response = $this->httpClient->get($link);
+
+                if ($response->status->isClientError() || $response->status->isServerError()) {
+                    $deadlinks[] = $link;
+                }
+
+                continue;
+            }
+
+            // If we reach this, there is an unknown kind of link.
+        }
+
+        return $deadlinks;
+    }
+
+    /**
+     * Resolves paths starting with ./ or ../ to a canonical URI.
+     */
+    private function resolveRelativeLink(string $basePath, string $relativePath): string
+    {
+        $basePath = Str\strip_end($basePath, '/');
+
+        if (Str\starts_with($relativePath, ['../', './'])) {
+            $baseParts = explode('/', $basePath);
+            $relativeParts = explode('/', $relativePath);
+
+            array_pop($baseParts);
+
+            foreach ($relativeParts as $part) {
+                if ($part === '..') {
+                    array_pop($baseParts);
+                } elseif ($part !== '.') {
+                    $baseParts[] = $part;
+                }
+            }
+
+            return implode('/', $baseParts);
+        }
+
+        return $basePath . '/' . Str\strip_start($relativePath, './');
+    }
+
+    private function getLinkWithoutProtocol(string $link): string
+    {
+        return Str\strip_start($link, ['https://', 'http://']);
     }
 }

--- a/packages/storage/composer.json
+++ b/packages/storage/composer.json
@@ -16,7 +16,8 @@
 				"league/flysystem-ziparchive": "^3.0",
 				"league/flysystem-sftp-v3": "^3.0",
 				"league/flysystem-azure-blob-storage": "^3.0",
-				"league/flysystem-google-cloud-storage": "^3.0"
+				"league/flysystem-google-cloud-storage": "^3.0",
+				"tempest/support": "dev-main"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Integration/Http/Static/Fixtures/StaticPageController.php
+++ b/tests/Integration/Http/Static/Fixtures/StaticPageController.php
@@ -12,6 +12,7 @@ use Tempest\View\Exceptions\ViewCompilationError;
 use Tempest\View\View;
 use Tempest\Vite\Exceptions\ManifestNotFoundException;
 
+use function Tempest\uri;
 use function Tempest\view;
 
 final readonly class StaticPageController
@@ -46,5 +47,15 @@ final readonly class StaticPageController
         string $bar, // @mago-expect best-practices/no-unused-parameter
     ): void {
         throw new ViewCompilationError('view.php', '', new ManifestNotFoundException('fake-manifest.json'));
+    }
+
+    #[Get('/static/dead-link')]
+    #[StaticPage]
+    public function deadLink(): string
+    {
+        return implode(PHP_EOL, [
+            sprintf('<a href="%s">foo</a>', uri('/404')),
+            '<a href="https://google.com/404">foo</a>',
+        ]);
     }
 }

--- a/tests/Integration/Http/Static/Fixtures/StaticPageController.php
+++ b/tests/Integration/Http/Static/Fixtures/StaticPageController.php
@@ -58,4 +58,11 @@ final readonly class StaticPageController
             '<a href="https://google.com/404">foo</a>',
         ]);
     }
+
+    #[Get('/static/allowed-dead-link')]
+    #[StaticPage]
+    public function allowedDeadLink(): string
+    {
+        return sprintf('<a ssg-ignore href="%s">foo</a>', uri('/404'));
+    }
 }

--- a/tests/Integration/Http/Static/Fixtures/StaticPageController.php
+++ b/tests/Integration/Http/Static/Fixtures/StaticPageController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Tempest\Integration\Http\Static\Fixtures;
 
 use Tempest\Http\Response;
+use Tempest\Http\Responses\Redirect;
 use Tempest\Http\Responses\ServerError;
 use Tempest\Router\Get;
 use Tempest\Router\StaticPage;
@@ -57,6 +58,19 @@ final readonly class StaticPageController
             sprintf('<a href="%s">foo</a>', uri('/404')),
             '<a href="https://google.com/404">foo</a>',
         ]);
+    }
+
+    #[Get('/static/redirecting-route')]
+    #[StaticPage]
+    public function hasRedirect(): string
+    {
+        return sprintf('<a href="%s">foo</a>', uri('/redirecting-route'));
+    }
+
+    #[Get('/redirecting-route')]
+    public function redirectingRoute(): Redirect
+    {
+        return new Redirect('https://google.com');
     }
 
     #[Get('/static/allowed-dead-link')]

--- a/tests/Integration/Http/Static/StaticGenerateCommandTest.php
+++ b/tests/Integration/Http/Static/StaticGenerateCommandTest.php
@@ -103,6 +103,18 @@ final class StaticGenerateCommandTest extends FrameworkIntegrationTestCase
             ->assertExitCode(ExitCode::ERROR);
     }
 
+    public function test_allow_dead_links(): void
+    {
+        $this->registerRoute([StaticPageController::class, 'deadLink']);
+        $this->registerStaticPage([StaticPageController::class, 'deadLink']);
+
+        $this->container->config(new AppConfig(baseUri: 'https://test.com'));
+
+        $this->console
+            ->call(StaticGenerateCommand::class, ['--allow-dead-links' => true])
+            ->assertExitCode(ExitCode::SUCCESS);
+    }
+
     public function test_external_dead_links(): void
     {
         $this->registerRoute([StaticPageController::class, 'deadLink']);
@@ -116,5 +128,17 @@ final class StaticGenerateCommandTest extends FrameworkIntegrationTestCase
             ->assertSee('https://test.com/404')
             ->assertSee('https://google.com/404')
             ->assertExitCode(ExitCode::ERROR);
+    }
+
+    public function test_ignore_dead_links(): void
+    {
+        $this->registerRoute([StaticPageController::class, 'allowedDeadLink']);
+        $this->registerStaticPage([StaticPageController::class, 'allowedDeadLink']);
+
+        $this->container->config(new AppConfig(baseUri: 'https://test.com'));
+
+        $this->console
+            ->call(StaticGenerateCommand::class)
+            ->assertExitCode(ExitCode::SUCCESS);
     }
 }

--- a/tests/Integration/Http/Static/StaticGenerateCommandTest.php
+++ b/tests/Integration/Http/Static/StaticGenerateCommandTest.php
@@ -103,6 +103,19 @@ final class StaticGenerateCommandTest extends FrameworkIntegrationTestCase
             ->assertExitCode(ExitCode::ERROR);
     }
 
+    public function test_dead_link_with_redirect(): void
+    {
+        $this->registerRoute([StaticPageController::class, 'redirectingRoute']);
+        $this->registerRoute([StaticPageController::class, 'hasRedirect']);
+        $this->registerStaticPage([StaticPageController::class, 'hasRedirect']);
+
+        $this->container->config(new AppConfig(baseUri: 'https://test.com'));
+
+        $this->console
+            ->call(StaticGenerateCommand::class, ['--allow-external-dead-links' => false])
+            ->assertExitCode(ExitCode::SUCCESS);
+    }
+
     public function test_allow_dead_links(): void
     {
         $this->registerRoute([StaticPageController::class, 'deadLink']);

--- a/tests/Integration/Http/Static/StaticGenerateCommandTest.php
+++ b/tests/Integration/Http/Static/StaticGenerateCommandTest.php
@@ -27,8 +27,7 @@ final class StaticGenerateCommandTest extends FrameworkIntegrationTestCase
 
     public function test_static_site_generate_command(): void
     {
-        $appConfig = new AppConfig(baseUri: 'https://test.com');
-        $this->container->config($appConfig);
+        $this->container->config(new AppConfig(baseUri: 'https://test.com'));
 
         $this->console
             ->call(StaticGenerateCommand::class)
@@ -56,8 +55,7 @@ final class StaticGenerateCommandTest extends FrameworkIntegrationTestCase
         $this->registerRoute([StaticPageController::class, 'http500']);
         $this->registerStaticPage([StaticPageController::class, 'http500']);
 
-        $appConfig = new AppConfig(baseUri: 'https://test.com');
-        $this->container->config($appConfig);
+        $this->container->config(new AppConfig(baseUri: 'https://test.com'));
 
         $this->console
             ->call(StaticGenerateCommand::class)
@@ -70,8 +68,7 @@ final class StaticGenerateCommandTest extends FrameworkIntegrationTestCase
         $this->registerRoute([StaticPageController::class, 'noTextualContent']);
         $this->registerStaticPage([StaticPageController::class, 'noTextualContent']);
 
-        $appConfig = new AppConfig(baseUri: 'https://test.com');
-        $this->container->config($appConfig);
+        $this->container->config(new AppConfig(baseUri: 'https://test.com'));
 
         $this->console
             ->call(StaticGenerateCommand::class)
@@ -84,12 +81,40 @@ final class StaticGenerateCommandTest extends FrameworkIntegrationTestCase
         $this->registerRoute([StaticPageController::class, 'vite']);
         $this->registerStaticPage([StaticPageController::class, 'vite']);
 
-        $appConfig = new AppConfig(baseUri: 'https://test.com');
-        $this->container->config($appConfig);
+        $this->container->config(new AppConfig(baseUri: 'https://test.com'));
 
         $this->console
             ->call(StaticGenerateCommand::class)
             ->assertSee('A Vite build is needed for [/static/vite/a/b]')
+            ->assertExitCode(ExitCode::ERROR);
+    }
+
+    public function test_dead_link(): void
+    {
+        $this->registerRoute([StaticPageController::class, 'deadLink']);
+        $this->registerStaticPage([StaticPageController::class, 'deadLink']);
+
+        $this->container->config(new AppConfig(baseUri: 'https://test.com'));
+
+        $this->console
+            ->call(StaticGenerateCommand::class)
+            ->assertSee('1 DEAD LINK')
+            ->assertSee('https://test.com/404')
+            ->assertExitCode(ExitCode::ERROR);
+    }
+
+    public function test_external_dead_links(): void
+    {
+        $this->registerRoute([StaticPageController::class, 'deadLink']);
+        $this->registerStaticPage([StaticPageController::class, 'deadLink']);
+
+        $this->container->config(new AppConfig(baseUri: 'https://test.com'));
+
+        $this->console
+            ->call(StaticGenerateCommand::class, ['--allow-external-dead-links' => false])
+            ->assertSee('2 DEAD LINKS')
+            ->assertSee('https://test.com/404')
+            ->assertSee('https://google.com/404')
             ->assertExitCode(ExitCode::ERROR);
     }
 }


### PR DESCRIPTION
Closes https://github.com/tempestphp/tempest-framework/issues/1101

This pull request implements dead link detection when running `static:generate`. Using `--allow-dead-links` skips this process. Adding `{:ssg-ignore="true"}` to a link ignores that link explicitely.

I'll write tests after https://github.com/tempestphp/tempest-framework/pull/1186