### PR TITLE
feat(support): add `removeValues` to array utils

### DIFF
--- a/packages/support/src/Arr/ManipulatesArray.php
+++ b/packages/support/src/Arr/ManipulatesArray.php
@@ -115,21 +115,33 @@ trait ManipulatesArray
     }
 
     /**
-     * Removes the specified items from the array.
+     * Removes the specified keys and their values from the array.
      *
      * @param array-key|array<array-key> $keys The keys of the items to remove.
      */
-    public function remove(string|int|array $keys): static
+    public function removeKeys(string|int|array $keys): static
     {
-        return $this->createOrModify(namespace\remove($this->value, $keys));
+        return $this->createOrModify(remove_keys($this->value, $keys));
     }
 
     /**
-     * Alias of {@see \Tempest\Support\Arr\remove}.
+     * Removes the specified keys and their values from the array. Alias of `removeKeys`.
+     *
+     * @param array-key|array<array-key> $keys The keys of the items to remove.
      */
     public function forget(string|int|array $keys): static
     {
-        return $this->createOrModify(namespace\remove($this->value, $keys));
+        return $this->removeKeys($keys);
+    }
+
+    /**
+     * Removes the specified values from the array.
+     *
+     * @param TValue|array<TValue> $values The values to remove.
+     */
+    public function removeValues(string|int|array $values): static
+    {
+        return $this->createOrModify(remove_values($this->value, $values));
     }
 
     /**

--- a/packages/support/src/Arr/functions.php
+++ b/packages/support/src/Arr/functions.php
@@ -96,7 +96,7 @@ namespace Tempest\Support\Arr {
     }
 
     /**
-     * Gets a value from the array and remove it.
+     * Gets a value by its key from the array and remove it. Mutates the array.
      *
      * @template TKey of array-key
      * @template TValue
@@ -107,7 +107,7 @@ namespace Tempest\Support\Arr {
     function pull(array &$array, string|int $key, mixed $default = null): mixed
     {
         $value = get_by_key($array, $key, $default);
-        $array = namespace\remove($array, $key);
+        $array = namespace\forget_keys($array, $key);
 
         return $value;
     }
@@ -127,15 +127,7 @@ namespace Tempest\Support\Arr {
     }
 
     /**
-     * Alias of {@see \Tempest\Support\Arr\remove}.
-     */
-    function forget(iterable $array, string|int|array $keys): array
-    {
-        return namespace\remove(to_array($array), $keys);
-    }
-
-    /**
-     * Removes the specified items from the array.
+     * Removes the specified keys from the array. The array is not mutated.
      *
      * @template TKey of array-key
      * @template TValue
@@ -144,12 +136,65 @@ namespace Tempest\Support\Arr {
      * @param array-key|array<array-key> $keys The keys of the items to remove.
      * @return array<TKey,TValue>
      */
-    function remove(array $array, string|int|array $keys): array
+    function remove_keys(iterable $array, string|int|array $keys): array
+    {
+        return namespace\forget_keys(to_array($array), $keys);
+    }
+
+    /**
+     * Removes the specified values from the array. The array is mutated.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param array<TKey,TValue> $array
+     * @param TValue|array<TValue> $values The values to remove.
+     * @return array<TKey,TValue>
+     */
+    function remove_values(array $array, string|int|array $values): array
+    {
+        return namespace\forget_values(to_array($array), $values);
+    }
+
+    /**
+     * Removes the specified keys from the array. The array is mutated.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param array<TKey,TValue> $array
+     * @param array-key|array<array-key> $keys The keys of the items to remove.
+     * @return array<TKey,TValue>
+     */
+    function forget_keys(array $array, string|int|array $keys): array
     {
         $keys = is_array($keys) ? $keys : [$keys];
 
         foreach ($keys as $key) {
             unset($array[$key]);
+        }
+
+        return $array;
+    }
+
+    /**
+     * Removes the specified values from the array. The array is mutated.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param array<TKey,TValue> $array
+     * @param TValue|array<TValue> $values The values to remove.
+     * @return array<TKey,TValue>
+     */
+    function forget_values(array $array, string|int|array $values): array
+    {
+        $values = is_array($values) ? $values : [$values];
+
+        foreach ($values as $value) {
+            if (! is_null($key = array_find_key($array, fn (mixed $match) => $value === $match))) {
+                unset($array[$key]);
+            }
         }
 
         return $array;

--- a/packages/support/tests/Arr/ImmutableArrayTest.php
+++ b/packages/support/tests/Arr/ImmutableArrayTest.php
@@ -72,12 +72,12 @@ final class ImmutableArrayTest extends TestCase
         $collection = new ImmutableArray([1, 2, 3]);
 
         $this->assertEquals(
-            $collection->remove(1)->toArray(),
+            $collection->removeKeys(1)->toArray(),
             [0 => 1, 2 => 3],
         );
 
         $this->assertEquals(
-            $collection->remove([0, 2])->toArray(),
+            $collection->removeKeys([0, 2])->toArray(),
             [1 => 2],
         );
     }
@@ -91,12 +91,53 @@ final class ImmutableArrayTest extends TestCase
         ]);
 
         $this->assertEquals(
-            $collection->remove('first_name')->toArray(),
+            $collection->removeKeys('first_name')->toArray(),
             ['last_name' => 'Doe', 'age' => 42],
         );
 
         $this->assertEquals(
-            $collection->remove(['last_name', 'age'])->toArray(),
+            $collection->removeKeys(['last_name', 'age'])->toArray(),
+            ['first_name' => 'John'],
+        );
+    }
+
+    public function test_remove_values_with_basic_keys(): void
+    {
+        $collection = new ImmutableArray([1, 2, 3]);
+
+        $this->assertEquals(
+            $collection->removeValues(1)->toArray(),
+            [1 => 2, 2 => 3],
+        );
+
+        $this->assertEquals(
+            $collection->toArray(),
+            [0 => 1, 1 => 2, 2 => 3],
+        );
+
+        $this->assertEquals(
+            $collection->removeValues([0, 2])->toArray(),
+            [0 => 1, 2 => 3],
+        );
+    }
+
+    public function test_remove_values_with_associative_keys(): void
+    {
+        $collection = new ImmutableArray([
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'age' => 42,
+        ]);
+
+        $this->assertEquals(
+            $collection->removeValues('John')->toArray(),
+            ['last_name' => 'Doe', 'age' => 42],
+        );
+
+        $this->assertEquals($collection->count(), 3);
+
+        $this->assertEquals(
+            $collection->removeValues(['Doe', 42])->toArray(),
             ['first_name' => 'John'],
         );
     }

--- a/packages/support/tests/Arr/ManipulatesArrayTest.php
+++ b/packages/support/tests/Arr/ManipulatesArrayTest.php
@@ -1189,12 +1189,12 @@ final class ManipulatesArrayTest extends TestCase
         $collection = arr([1, 2, 3]);
 
         $this->assertEquals(
-            $collection->remove(1)->toArray(),
+            $collection->removeKeys(1)->toArray(),
             [0 => 1, 2 => 3],
         );
 
         $this->assertEquals(
-            $collection->remove([0, 2])->toArray(),
+            $collection->removeKeys([0, 2])->toArray(),
             [1 => 2],
         );
     }
@@ -1208,12 +1208,12 @@ final class ManipulatesArrayTest extends TestCase
         ]);
 
         $this->assertEquals(
-            $collection->remove('first_name')->toArray(),
+            $collection->removeKeys('first_name')->toArray(),
             ['last_name' => 'Doe', 'age' => 42],
         );
 
         $this->assertEquals(
-            $collection->remove(['last_name', 'age'])->toArray(),
+            $collection->removeKeys(['last_name', 'age'])->toArray(),
             ['first_name' => 'John'],
         );
     }
@@ -1224,7 +1224,7 @@ final class ManipulatesArrayTest extends TestCase
 
         $this->assertEquals(
             $collection
-                ->remove(42)
+                ->removeKeys(42)
                 ->toArray(),
             [1, 2, 3],
         );
@@ -1237,7 +1237,7 @@ final class ManipulatesArrayTest extends TestCase
 
         $this->assertEquals(
             $collection
-                ->remove('foo')
+                ->removeKeys('foo')
                 ->toArray(),
             [
                 'first_name' => 'John',
@@ -1248,7 +1248,7 @@ final class ManipulatesArrayTest extends TestCase
 
         $this->assertEquals(
             $collection
-                ->remove(['bar', 'first_name'])
+                ->removeKeys(['bar', 'first_name'])
                 ->toArray(),
             [
                 'last_name' => 'Doe',
@@ -1264,9 +1264,9 @@ final class ManipulatesArrayTest extends TestCase
             'last_name' => 'Doe',
             'age' => 42,
         ])
-            ->remove(42)
-            ->remove('foo')
-            ->remove(['bar', 'first_name']);
+            ->removeKeys(42)
+            ->removeKeys('foo')
+            ->removeKeys(['bar', 'first_name']);
 
         $second_collection = arr([
             'first_name' => 'John',

--- a/packages/support/tests/Arr/MutableArrayTest.php
+++ b/packages/support/tests/Arr/MutableArrayTest.php
@@ -72,12 +72,12 @@ final class MutableArrayTest extends TestCase
         $collection = new MutableArray([1, 2, 3]);
 
         $this->assertEquals(
-            $collection->remove(1)->toArray(),
+            $collection->removeKeys(1)->toArray(),
             [0 => 1, 2 => 3],
         );
 
         $this->assertEquals(
-            $collection->remove([0, 2])->toArray(),
+            $collection->removeKeys([0, 2])->toArray(),
             [],
         );
     }
@@ -91,13 +91,28 @@ final class MutableArrayTest extends TestCase
         ]);
 
         $this->assertEquals(
-            $collection->remove('first_name')->toArray(),
+            $collection->removeKeys('first_name')->toArray(),
             ['last_name' => 'Doe', 'age' => 42],
         );
 
         $this->assertEquals(
-            $collection->remove(['last_name', 'age'])->toArray(),
+            $collection->removeKeys(['last_name', 'age'])->toArray(),
             [],
+        );
+    }
+
+    public function test_remove_values_with_basic_keys(): void
+    {
+        $collection = new MutableArray([1, 2, 3]);
+
+        $this->assertEquals(
+            $collection->removeValues(1)->toArray(),
+            [1 => 2, 2 => 3],
+        );
+
+        $this->assertEquals(
+            $collection->toArray(),
+            [1 => 2, 2 => 3],
         );
     }
 


### PR DESCRIPTION
This pull request adds `removeValues` to array utils.

This allows removing an array key/value pair by its value. The associated functions is `Arr\remove_values`, which does not mutated the array, and `Arr\forget_values`, which does.

The `Arr\remove` function has been renamed to `Arr\remove_keys` for clarity, same with the one on the array objects. `forget` has been kept as-is as a nice shorthand.

Some docblock comments have been updated for clarity as well.