### PR TITLE
fix(router): require hard-coded uris to start with a slash in `Router::toUri`

### DIFF
--- a/packages/router/src/Router.php
+++ b/packages/router/src/Router.php
@@ -14,11 +14,25 @@ interface Router
 
     /**
      * Creates a valid URI to the given `$action`.
+     *
+     * `$action` is one of :
+     * - Controller FQCN and its method as a tuple
+     * - Invokable controller FQCN
+     * - URI string starting with `/`
+     *
+     * @param array{class-string, string}|class-string|string $action
      */
     public function toUri(array|string $action, ...$params): string;
 
     /**
      * Checks if the URI to the given `$action` would match the current route.
+     *
+     * `$action` is one of :
+     * - Controller FQCN and its method as a tuple
+     * - Invokable controller FQCN
+     * - URI string starting with `/`
+     *
+     * @param array{class-string, string}|class-string|string $action
      */
     public function isCurrentUri(array|string $action, ...$params): bool;
 }

--- a/tests/Integration/Route/RouterTest.php
+++ b/tests/Integration/Route/RouterTest.php
@@ -7,6 +7,7 @@ namespace Tests\Tempest\Integration\Route;
 use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\Stream;
 use Laminas\Diactoros\Uri;
+use ReflectionException;
 use Tempest\Core\AppConfig;
 use Tempest\Database\Migrations\CreateMigrationsTable;
 use Tempest\Http\Responses\Ok;
@@ -92,6 +93,14 @@ final class RouterTest extends FrameworkIntegrationTestCase
 
         $this->assertSame('https://test.com/abc', $router->toUri('/abc'));
         $this->assertEquals('https://test.com/test/1/a/b/c/d', $router->toUri([TestController::class, 'withCustomRegexParams'], id: 1, name: 'a/b/c/d'));
+    }
+
+    public function test_uri_generation_with_invalid_fqcn(): void
+    {
+        $router = $this->container->get(GenericRouter::class);
+
+        $this->expectException(ReflectionException::class);
+        $router->toUri(TestController::class . 'Invalid');
     }
 
     public function test_uri_generation_with_query_param(): void


### PR DESCRIPTION
Closes #1182.

Hard-coded uris must now starts with a slash.

I'll add tests after #1186.

This function signature is barebone, do the framework have a stance on external documentation vs docblocks ? I can address this issue in a later PR.