### PR TITLE
fix(filesystem): add ability to delete invalid symlinks

### DIFF
--- a/packages/support/src/Filesystem/functions.php
+++ b/packages/support/src/Filesystem/functions.php
@@ -214,6 +214,20 @@ namespace Tempest\Support\Filesystem {
      */
     function delete_file(string $file): void
     {
+        if (namespace\is_symbolic_link($file)) {
+            [$result, $errorMessage] = box(static fn (): bool => unlink($file));
+
+            if ($result === false && namespace\is_symbolic_link($file)) { // @phpstan-ignore booleanAnd.rightAlwaysTrue
+                throw new Exceptions\RuntimeException(sprintf(
+                    'Failed to delete symbolic link "%s": %s.',
+                    $file,
+                    $errorMessage ?? 'internal error',
+                ));
+            }
+
+            return;
+        }
+
         if (! namespace\exists($file)) {
             throw Exceptions\NotFoundException::forFile($file);
         }

--- a/packages/support/tests/Filesystem/UnixFunctionsTest.php
+++ b/packages/support/tests/Filesystem/UnixFunctionsTest.php
@@ -493,4 +493,18 @@ final class UnixFunctionsTest extends TestCase
 
         $this->assertTrue(is_dir($dir));
     }
+
+    public function test_delete_file_for_invalid_symlink(): void
+    {
+        $file = $this->fixtures . '/file.txt';
+        \file_put_contents($file, 'hello');
+        $link = $this->fixtures . '/link.txt';
+        symlink($file, $link);
+        unlink($file);
+
+        Filesystem\delete_file($link);
+
+        $this->assertFalse(is_file($link));
+        $this->assertFalse(is_link($link));
+    }
 }


### PR DESCRIPTION
Attempting to remove a symbolic link pointing to an invalid (non-existing) file caused an error because `file_exists($x)` returns `false` in such a case.

I noticed this because without this change `phpunit` crashes with errors on my OS, my guess is that this is related to the order in which files are removed from the directory during tests.