### PR TITLE
fix(framework): handle reflection in config show command

### DIFF
--- a/src/Tempest/Framework/Commands/ConfigShowCommand.php
+++ b/src/Tempest/Framework/Commands/ConfigShowCommand.php
@@ -157,6 +157,12 @@ final readonly class ConfigShowCommand
             return '@...';
         }
 
+        if ($value instanceof ClassReflector) {
+            return [
+                '@type' => $value->getName(),
+            ];
+        }
+
         if (is_object($value)) {
             $result = [
                 '@type' => $value::class,

--- a/tests/Integration/Framework/Commands/ConfigShowCommandTest.php
+++ b/tests/Integration/Framework/Commands/ConfigShowCommandTest.php
@@ -11,6 +11,13 @@ use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
  */
 final class ConfigShowCommandTest extends FrameworkIntegrationTestCase
 {
+    public function test_it_shows_config_without_params(): void
+    {
+        $this->console
+            ->call('config:show')
+            ->assertJson();
+    }
+
     public function test_it_shows_config_in_json_format(): void
     {
         $this->console


### PR DESCRIPTION
`Tempest\Core\Middleware` now stores reflections of middleware classes. This resulted in exception for `./tempest config:show` command.

This fixes that + adds a test to catch such regression.