### PR TITLE
feat(core): add debug exception processor

### DIFF
--- a/packages/core/src/DebugExceptionProcessor.php
+++ b/packages/core/src/DebugExceptionProcessor.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tempest\Core;
+
+use Tempest\Debug\Debug;
+use Throwable;
+
+final class DebugExceptionProcessor implements ExceptionProcessor
+{
+    public function process(Throwable $throwable): Throwable
+    {
+        $items = [
+            'exception' => $throwable->getMessage(),
+            'context' => ($throwable instanceof HasContext)
+                ? $throwable->context()
+                : [],
+        ];
+
+        Debug::resolve()->log($items, writeToOut: false);
+
+        return $throwable;
+    }
+}

--- a/packages/core/src/LogExceptionProcessor.php
+++ b/packages/core/src/LogExceptionProcessor.php
@@ -2,8 +2,10 @@
 
 namespace Tempest\Core;
 
-use Tempest\Debug\Debug;
+use Tempest\Log\Logger;
 use Throwable;
+
+use function Tempest\get;
 
 /**
  * An exception processor that logs exceptions.
@@ -12,14 +14,13 @@ final class LogExceptionProcessor implements ExceptionProcessor
 {
     public function process(Throwable $throwable): Throwable
     {
-        $items = [
-            'exception' => $throwable->getMessage(),
-            'context' => ($throwable instanceof HasContext)
-                ? $throwable->context()
-                : [],
-        ];
-
-        Debug::resolve()->log($items, writeToOut: false);
+        get(Logger::class)
+            ?->error(
+                $throwable->getMessage(),
+                [
+                    'exception' => $throwable,
+                ],
+            );
 
         return $throwable;
     }


### PR DESCRIPTION
I would expect the framework to log exceptions using the logger I set up in the config.

I always log everything to `php://stdout` and I don't want to keep track of some log path during development. This is especially useful in docker.

I decided to go with using `get(Logger::class)` instead of injecting it, as I thought that this should be *a bit* safer if framework fails at some really early stage? I'm not sure, I would be happy to be corrected if that's not the case.