### PR TITLE
fix(support): make `Arr\forget_values` and `Arr\forget_keys` mutable

### DIFF
--- a/packages/support/src/Arr/functions.php
+++ b/packages/support/src/Arr/functions.php
@@ -138,11 +138,13 @@ namespace Tempest\Support\Arr {
      */
     function remove_keys(iterable $array, string|int|array $keys): array
     {
-        return namespace\forget_keys(to_array($array), $keys);
+        $array = to_array($array);
+
+        return namespace\forget_keys($array, $keys);
     }
 
     /**
-     * Removes the specified values from the array. The array is mutated.
+     * Removes the specified values from the array. The array is not mutated.
      *
      * @template TKey of array-key
      * @template TValue
@@ -153,7 +155,9 @@ namespace Tempest\Support\Arr {
      */
     function remove_values(array $array, string|int|array $values): array
     {
-        return namespace\forget_values(to_array($array), $values);
+        $array = to_array($array);
+
+        return namespace\forget_values($array, $values);
     }
 
     /**
@@ -166,7 +170,7 @@ namespace Tempest\Support\Arr {
      * @param array-key|array<array-key> $keys The keys of the items to remove.
      * @return array<TKey,TValue>
      */
-    function forget_keys(array $array, string|int|array $keys): array
+    function forget_keys(array &$array, string|int|array $keys): array
     {
         $keys = is_array($keys) ? $keys : [$keys];
 
@@ -187,7 +191,7 @@ namespace Tempest\Support\Arr {
      * @param TValue|array<TValue> $values The values to remove.
      * @return array<TKey,TValue>
      */
-    function forget_values(array $array, string|int|array $values): array
+    function forget_values(array &$array, string|int|array $values): array
     {
         $values = is_array($values) ? $values : [$values];
 

--- a/packages/support/tests/Arr/FunctionsTest.php
+++ b/packages/support/tests/Arr/FunctionsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tempest\Support\Tests\Arr;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Arr;
+
+final class FunctionsTest extends TestCase
+{
+    public function test_forget_values_mutates_array(): void
+    {
+        $original = [
+            'foo',
+            'bar',
+        ];
+
+        Arr\forget_values($original, ['foo']);
+
+        $this->assertCount(1, $original);
+        $this->assertContains('bar', $original);
+    }
+
+    public function test_remove_values_does_not_mutate_array(): void
+    {
+        $original = [
+            'foo',
+            'bar',
+        ];
+
+        $result = Arr\remove_values($original, ['foo']);
+
+        $this->assertCount(2, $original);
+        $this->assertContains('foo', $original);
+        $this->assertContains('bar', $original);
+
+        $this->assertCount(1, $result);
+        $this->assertContains('bar', $result);
+    }
+
+    public function test_forget_keys_mutates_array(): void
+    {
+        $original = [
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ];
+
+        Arr\forget_keys($original, ['foo']);
+
+        $this->assertCount(1, $original);
+        $this->assertArrayNotHasKey('foo', $original);
+        $this->assertArrayHasKey('baz', $original);
+    }
+
+    public function test_remove_keys_does_not_mutate_array(): void
+    {
+        $original = [
+            'foo' => 'bar',
+            'baz' => 'qux',
+        ];
+
+        $result = Arr\remove_keys($original, ['foo']);
+
+        $this->assertCount(2, $original);
+        $this->assertArrayHasKey('foo', $original);
+        $this->assertArrayHasKey('baz', $original);
+
+        $this->assertCount(1, $result);
+        $this->assertArrayNotHasKey('foo', $result);
+        $this->assertArrayHasKey('baz', $result);
+    }
+}


### PR DESCRIPTION
This pull request fixes a typo in the docblocks of `Arr\remove_values` regarding its mutability, and more importantly, actually fixes the mutability of `Arr\forget_values` and `Arr\forget_keys`.

Those two functions were meant to be mutable, and have immutable counterparts (`Arr\remove_values` and `Arr\remove_keys`), but the first argument was not passed as reference.

Tests have been added to cover them.