### PR TITLE
fix(database): prepend backslash when creating enum columns

### DIFF
--- a/packages/database/src/QueryStatements/CreateEnumTypeStatement.php
+++ b/packages/database/src/QueryStatements/CreateEnumTypeStatement.php
@@ -23,6 +23,7 @@ final readonly class CreateEnumTypeStatement implements QueryStatement
     {
         $cases = arr($this->enumClass::cases())
             ->map(fn (UnitEnum|BackedEnum $case) => ($case instanceof BackedEnum) ? $case->value : $case->name)
+            ->map(fn (string $value) => str_replace('\\', '\\\\', $value))
             ->map(fn (string $value) => "'{$value}'");
 
         return match ($dialect) {

--- a/packages/database/src/QueryStatements/EnumStatement.php
+++ b/packages/database/src/QueryStatements/EnumStatement.php
@@ -26,6 +26,7 @@ final readonly class EnumStatement implements QueryStatement
     {
         $cases = arr($this->enumClass::cases())
             ->map(fn (UnitEnum|BackedEnum $case) => ($case instanceof BackedEnum) ? $case->value : $case->name)
+            ->map(fn (string $value) => str_replace('\\', '\\\\', $value))
             ->map(fn (string $value) => "'{$value}'");
 
         if ($this->default !== null) {

--- a/tests/Integration/Database/Fixtures/EnumForCreateTable.php
+++ b/tests/Integration/Database/Fixtures/EnumForCreateTable.php
@@ -6,4 +6,5 @@ enum EnumForCreateTable: string
 {
     case FOO = 'foo';
     case BAR = 'bar';
+    case SELF = self::class;
 }

--- a/tests/Integration/Database/QueryStatements/CreateEnumTypeStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/CreateEnumTypeStatementTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Tempest\Integration\Database\QueryStatements;
+
+use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\QueryStatements\CreateEnumTypeStatement;
+use Tests\Tempest\Integration\Database\Fixtures\EnumForCreateTable;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+class CreateEnumTypeStatementTest extends FrameworkIntegrationTestCase
+{
+    public function test_it_can_compile_create_enum_type_statement(): void
+    {
+        $enumStatement = new CreateEnumTypeStatement(
+            enumClass: EnumForCreateTable::class,
+        );
+
+        $this->assertSame(
+            <<<SQL
+            DO $$ BEGIN
+                CREATE TYPE Tests\Tempest\Integration\Database\Fixtures\EnumForCreateTable AS ('foo', 'bar', 'Tests\\\\Tempest\\\\Integration\\\\Database\\\\Fixtures\\\\EnumForCreateTable');
+            EXCEPTION
+                WHEN duplicate_object THEN null;
+            END $$;
+            SQL,
+            $enumStatement->compile(DatabaseDialect::POSTGRESQL),
+        );
+    }
+}

--- a/tests/Integration/Database/QueryStatements/CreateEnumTypeStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/CreateEnumTypeStatementTest.php
@@ -7,7 +7,7 @@ use Tempest\Database\QueryStatements\CreateEnumTypeStatement;
 use Tests\Tempest\Integration\Database\Fixtures\EnumForCreateTable;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-class CreateEnumTypeStatementTest extends FrameworkIntegrationTestCase
+final class CreateEnumTypeStatementTest extends FrameworkIntegrationTestCase
 {
     public function test_it_can_compile_create_enum_type_statement(): void
     {

--- a/tests/Integration/Database/QueryStatements/EnumStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/EnumStatementTest.php
@@ -7,7 +7,7 @@ use Tempest\Database\QueryStatements\EnumStatement;
 use Tests\Tempest\Integration\Database\Fixtures\EnumForCreateTable;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-class EnumStatementTest extends FrameworkIntegrationTestCase
+final class EnumStatementTest extends FrameworkIntegrationTestCase
 {
     public function test_it_can_compile_an_enum_statement_for_mysql(): void
     {

--- a/tests/Integration/Database/QueryStatements/EnumStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/EnumStatementTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Tempest\Integration\Database\QueryStatements;
+
+use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\QueryStatements\EnumStatement;
+use Tests\Tempest\Integration\Database\Fixtures\EnumForCreateTable;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+class EnumStatementTest extends FrameworkIntegrationTestCase
+{
+    public function test_it_can_compile_an_enum_statement_for_mysql(): void
+    {
+        $enumStatement = new EnumStatement(
+            name: 'enum',
+            enumClass: EnumForCreateTable::class,
+        );
+
+        $this->assertSame(
+            "`enum` ENUM('foo', 'bar', 'Tests\\\\Tempest\\\\Integration\\\\Database\\\\Fixtures\\\\EnumForCreateTable')  NOT NULL",
+            $enumStatement->compile(DatabaseDialect::MYSQL),
+        );
+    }
+
+    public function test_it_can_compile_an_enum_statement_for_sqlite(): void
+    {
+        $enumStatement = new EnumStatement(
+            name: 'enum',
+            enumClass: EnumForCreateTable::class,
+        );
+
+        $this->assertSame(
+            '`enum` TEXT  NOT NULL',
+            $enumStatement->compile(DatabaseDialect::SQLITE),
+        );
+    }
+
+    public function test_it_can_compile_an_enum_statement_for_postgresql(): void
+    {
+        $enumStatement = new EnumStatement(
+            name: 'enum',
+            enumClass: EnumForCreateTable::class,
+        );
+
+        $this->assertSame(
+            '`enum` Tests\Tempest\Integration\Database\Fixtures\EnumForCreateTable  NOT NULL',
+            $enumStatement->compile(DatabaseDialect::POSTGRESQL),
+        );
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/tempestphp/tempest-framework/issues/963