### PR TITLE
refactor(console): update `OutputMode` enum casing

### DIFF
--- a/packages/console/src/Schedule.php
+++ b/packages/console/src/Schedule.php
@@ -15,9 +15,24 @@ final readonly class Schedule
     public Interval $interval;
 
     public function __construct(
+        /**
+         * Interval at which the scheduled task should be executed.
+         */
         Interval|Every $interval,
+
+        /**
+         * Where to send STDOUT output.
+         */
         public string $output = '/dev/null',
-        public OutputMode $outputMode = OutputMode::Append,
+
+        /**
+         * Whether to append or overwrite the output.
+         */
+        public OutputMode $outputMode = OutputMode::APPEND,
+
+        /**
+         * Whether to run the task in the background.
+         */
         public bool $runInBackground = true,
     ) {
         $this->interval = ($interval instanceof Interval) ? $interval : $interval->toInterval();

--- a/packages/console/src/Scheduler/OutputMode.php
+++ b/packages/console/src/Scheduler/OutputMode.php
@@ -6,6 +6,6 @@ namespace Tempest\Console\Scheduler;
 
 enum OutputMode: string
 {
-    case Overwrite = '>';
-    case Append = '>>';
+    case OVERWRITE = '>';
+    case APPEND = '>>';
 }


### PR DESCRIPTION
We use screaming snake case for our enums, this is a consistency change. Took the opportunity to add some docblocks as well.