### PR TITLE
fix(core): display clean version in `about` command

### DIFF
--- a/packages/core/src/EnvironmentInsightsProvider.php
+++ b/packages/core/src/EnvironmentInsightsProvider.php
@@ -38,8 +38,8 @@ final class EnvironmentInsightsProvider implements InsightsProvider
 
         return \Tempest\Support\Regex\get_match(
             subject: $output,
-            pattern: "/Composer version (\S+)/",
-            match: 0,
+            pattern: "/Composer version (?<version>\S+)/",
+            match: 'version',
             default: new Insight('Unknown', Insight::ERROR),
         );
     }


### PR DESCRIPTION
Quick follow-up for https://github.com/tempestphp/tempest-framework/pull/1226, which had a logic issue that was making the command display `Composer version 2.0.0` instead of `2.0.0`.