### PR TITLE
fix(database): properly display mysql and postgresql versions in `about` command

### DIFF
--- a/packages/database/src/DatabaseInsightsProvider.php
+++ b/packages/database/src/DatabaseInsightsProvider.php
@@ -43,8 +43,8 @@ final class DatabaseInsightsProvider implements InsightsProvider
         // TODO: support displaying multiple databases, after cache PR
         [$versionQuery, $regex] = match (get_class($this->databaseConfig)) {
             SQLiteConfig::class => ['SELECT sqlite_version() AS version;', '/(?<version>.*)/'],
-            PostgresConfig::class => ['SELECT version() AS version;', '/(?<version>.*)/'],
-            MysqlConfig::class => ['SELECT version() AS version;', "/PostgreSQL (?<version>\S+)/"],
+            PostgresConfig::class => ['SELECT version() AS version;', "/PostgreSQL (?<version>\S+)/"],
+            MysqlConfig::class => ['SELECT version() AS version;', '/^(?<version>\d+\.\d+\.\d+)(?:-\w+)?/'],
             default => [null, null],
         };
 

--- a/packages/database/tests/DatabaseInsightsProviderTest.php
+++ b/packages/database/tests/DatabaseInsightsProviderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tempest\Database\Tests;
+
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Tempest\Core\Insight;
+use Tempest\Database\Config\DatabaseConfig;
+use Tempest\Database\Config\MysqlConfig;
+use Tempest\Database\Config\PostgresConfig;
+use Tempest\Database\Config\SQLiteConfig;
+use Tempest\Database\Database;
+use Tempest\Database\DatabaseInsightsProvider;
+
+final class DatabaseInsightsProviderTest extends TestCase
+{
+    #[DataProvider('provide_database_drivers')]
+    public function test_get_insights(DatabaseConfig $config, string $version, array $expected): void
+    {
+        $database = $this->createMock(Database::class);
+        $database
+            ->expects($this->once())
+            ->method('fetchFirst')
+            ->withAnyParameters()
+            ->willReturn(['version' => $version]);
+
+        $databaseInsightsProvider = new DatabaseInsightsProvider(
+            databaseConfig: $config,
+            database: $database,
+        );
+
+        $this->assertEquals($expected, $databaseInsightsProvider->getInsights());
+    }
+
+    public static function provide_database_drivers(): Generator
+    {
+        yield 'sqlite' => [
+            new SQLiteConfig(),
+            '3.45.2',
+            ['Engine' => 'SQLite', 'Version' => new Insight('3.45.2')],
+        ];
+        yield 'mysql (simple)' => [
+            new MysqlConfig(),
+            '8.0.42',
+            ['Engine' => 'MySQL', 'Version' => new Insight('8.0.42')],
+        ];
+        yield 'mysql (distribution specific)' => [
+            new MysqlConfig(),
+            '8.0.42-0ubuntu0.22.04.1',
+            ['Engine' => 'MySQL', 'Version' => new Insight('8.0.42')],
+        ];
+        yield 'postgresql' => [
+            new PostgresConfig(),
+            'PostgreSQL 15.3 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 11.3.0, 64-bit',
+            ['Engine' => 'PostgreSQL', 'Version' => new Insight('15.3')],
+        ];
+    }
+}


### PR DESCRIPTION
This PR fixes an issue where the regex patterns used for MySQL and PostgreSQL version insights were swapped. Additionally, it updates the handling of MySQL's VERSION() output, which may include a suffix with server build or configuration details.