### PR TITLE
refactor(router): improve exception handling

### DIFF
--- a/packages/http/src/HttpException.php
+++ b/packages/http/src/HttpException.php
@@ -3,11 +3,12 @@
 namespace Tempest\Http;
 
 use Exception;
+use Tempest\Core\HasContext;
 
 /**
  * Represents an HTTP exception.
  */
-final class HttpException extends Exception
+final class HttpException extends Exception implements HasContext
 {
     public function __construct(
         public readonly Status $status,
@@ -16,5 +17,15 @@ final class HttpException extends Exception
         ?\Throwable $previous = null,
     ) {
         parent::__construct($message ?: '', $status->value, $previous);
+    }
+
+    public function context(): array
+    {
+        return [
+            'status' => $this->status->value,
+            'message' => $this->message,
+            'response' => $this->response,
+            'previous' => $this->getPrevious()?->getMessage(),
+        ];
     }
 }

--- a/packages/http/src/Responses/ServerError.php
+++ b/packages/http/src/Responses/ServerError.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Http\Responses;
 
+use Exception;
 use Generator;
 use Tempest\Http\IsResponse;
 use Tempest\Http\Response;
@@ -14,9 +15,12 @@ final class ServerError implements Response
 {
     use IsResponse;
 
-    public function __construct(View|Generator|string|array|null $body = null)
+    private(set) ?Exception $exception = null;
+
+    public function __construct(View|Generator|string|array|null $body = null, ?Exception $exception = null)
     {
         $this->status = Status::INTERNAL_SERVER_ERROR;
         $this->body = $body;
+        $this->exception = $exception;
     }
 }

--- a/packages/router/src/Exceptions/HttpErrorResponseProcessor.php
+++ b/packages/router/src/Exceptions/HttpErrorResponseProcessor.php
@@ -6,35 +6,35 @@ use Tempest\Core\AppConfig;
 use Tempest\Http\HttpException;
 use Tempest\Http\Response;
 use Tempest\Router\ResponseProcessor;
+use Tempest\Router\RouteConfig;
 
 final readonly class HttpErrorResponseProcessor implements ResponseProcessor
 {
     public function __construct(
         private AppConfig $appConfig,
+        private RouteConfig $routeConfig,
     ) {}
 
     public function process(Response $response): Response
     {
-        // Throwing an HttpException during tests would make testing more
-        // complex, and is not strictly needed. During development, we
-        // don't need exceptions either, since the exception handler
-        // is different. For this reason, we skip processing here.
-        if (! $this->appConfig->environment->isProduction()) {
+        // If the response is not a server or client error, we don't need to
+        // handle it. In this case, we simply return back the response.
+        if (! $response->status->isServerError() && ! $response->status->isClientError()) {
             return $response;
         }
 
-        // Don't handle responses that already have a body. This is to avoid
-        // interferring with error responses voluntarily thrown in userland.
+        // If the response already has a body, it means it is most likely
+        // meant to be returned as-is, so we don't have to throw an exception.
         if ($response->body) {
             return $response;
         }
 
-        // We throw an exception on server and client errors,
-        // which is handled in the HTTP exception handler.
-        if ($response->status->isServerError() || $response->status->isClientError()) {
-            throw new HttpException(status: $response->status, response: $response);
+        // During tests, the router is generally configured to not throw HTTP exceptions in order
+        // to perform assertions on the responses. In this case, we return the response as is.
+        if (! $this->routeConfig->throwHttpExceptions) {
+            return $response;
         }
 
-        return $response;
+        throw new HttpException(status: $response->status, response: $response);
     }
 }

--- a/packages/router/src/RouteConfig.php
+++ b/packages/router/src/RouteConfig.php
@@ -25,6 +25,8 @@ final class RouteConfig
         public Middleware $middleware = new Middleware(
             SetCookieMiddleware::class,
         ),
+
+        public bool $throwHttpExceptions = true,
     ) {}
 
     public function apply(RouteConfig $newConfig): void

--- a/packages/router/src/Static/StaticGenerateCommand.php
+++ b/packages/router/src/Static/StaticGenerateCommand.php
@@ -18,6 +18,7 @@ use Tempest\Http\Method;
 use Tempest\Http\Status;
 use Tempest\HttpClient\HttpClient;
 use Tempest\Router\DataProvider;
+use Tempest\Router\RouteConfig;
 use Tempest\Router\Router;
 use Tempest\Router\Static\Exceptions\DeadLinksDetectedException;
 use Tempest\Router\Static\Exceptions\InvalidStatusCodeException;
@@ -44,6 +45,7 @@ final class StaticGenerateCommand
 
     public function __construct(
         private readonly AppConfig $appConfig,
+        private readonly RouteConfig $routeConfig,
         private readonly Console $console,
         private readonly Kernel $kernel,
         private readonly Container $container,
@@ -95,6 +97,8 @@ final class StaticGenerateCommand
                 default => $this->keyValue("<style='fg-gray'>{$event->path}</style>", "<style='fg-red'>FAILED</style>"),
             };
         });
+
+        $this->routeConfig->throwHttpExceptions = false;
 
         foreach ($this->staticPageConfig->staticPages as $staticPage) {
             /** @var DataProvider $dataProvider */

--- a/tests/Integration/Application/HttpApplicationTest.php
+++ b/tests/Integration/Application/HttpApplicationTest.php
@@ -14,7 +14,6 @@ final class HttpApplicationTest extends FrameworkIntegrationTestCase
     public function test_http_application_run(): void
     {
         $this->http
-            ->throwExceptions()
             ->get('/')
             ->assertOk();
     }

--- a/tests/Integration/Http/GenericResponseSenderTest.php
+++ b/tests/Integration/Http/GenericResponseSenderTest.php
@@ -119,6 +119,7 @@ final class GenericResponseSenderTest extends FrameworkIntegrationTestCase
         $response = new EventStream(fn () => yield 'hello');
         $responseSender = $this->container->get(GenericResponseSender::class);
         $responseSender->send($response);
+
         $output = ob_get_clean();
 
         // restore phpunit's output buffer
@@ -137,6 +138,7 @@ final class GenericResponseSenderTest extends FrameworkIntegrationTestCase
         });
         $responseSender = $this->container->get(GenericResponseSender::class);
         $responseSender->send($response);
+
         $output = ob_get_clean();
 
         // restore phpunit's output buffer

--- a/tests/Integration/Route/Fixtures/Http500Controller.php
+++ b/tests/Integration/Route/Fixtures/Http500Controller.php
@@ -4,16 +4,25 @@ namespace Tests\Tempest\Integration\Route\Fixtures;
 
 use Exception;
 use Tempest\Http\Responses\ServerError;
+use Tempest\Router\Get;
 
 final class Http500Controller
 {
-    public function basic500(): string
+    #[Get('/throws-exception')]
+    public function throwsException(): string
     {
         throw new Exception('oops');
     }
 
-    public function custom500(): ServerError
+    #[Get('/returns-server-error')]
+    public function serverError(): ServerError
     {
-        return new ServerError('internal server error');
+        return new ServerError();
+    }
+
+    #[Get('/returns-server-error-with-body')]
+    public function serverErrorWithBody(): ServerError
+    {
+        return new ServerError('custom error');
     }
 }

--- a/tests/Integration/Route/RequestTest.php
+++ b/tests/Integration/Route/RequestTest.php
@@ -86,7 +86,6 @@ final class RequestTest extends FrameworkIntegrationTestCase
     public function test_custom_request_test(): void
     {
         $response = $this->http
-            ->throwExceptions()
             ->post(
                 uri: '/create-post',
                 body: [
@@ -124,7 +123,6 @@ final class RequestTest extends FrameworkIntegrationTestCase
         );
 
         $this->http
-            ->throwExceptions()
             ->post(
                 uri: uri([BookController::class, 'store']),
                 body: [

--- a/tests/Integration/Route/RouterTest.php
+++ b/tests/Integration/Route/RouterTest.php
@@ -4,23 +4,19 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Route;
 
+use Exception;
 use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\Stream;
 use Laminas\Diactoros\Uri;
 use ReflectionException;
 use Tempest\Core\AppConfig;
-use Tempest\Core\Environment;
 use Tempest\Database\Migrations\CreateMigrationsTable;
 use Tempest\Http\HttpException;
 use Tempest\Http\Responses\Ok;
-use Tempest\Http\Responses\ServerError;
 use Tempest\Http\Status;
-use Tempest\Reflection\MethodReflector;
 use Tempest\Router\GenericRouter;
-use Tempest\Router\Get;
 use Tempest\Router\RouteConfig;
 use Tempest\Router\Router;
-use Tempest\Router\Routing\Construction\DiscoveredRoute;
 use Tests\Tempest\Fixtures\Controllers\ControllerWithEnumBinding;
 use Tests\Tempest\Fixtures\Controllers\EnumForController;
 use Tests\Tempest\Fixtures\Controllers\TestController;
@@ -285,37 +281,47 @@ final class RouterTest extends FrameworkIntegrationTestCase
             ->assertOk();
     }
 
-    public function test_error_response_processor_throws_http_exceptions_in_production(): void
+    public function test_error_response_processor_throws_http_exceptions_when_instructed(): void
     {
         $this->expectException(HttpException::class);
+        $this->expectExceptionCode(404);
 
-        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
-        $this->http->get('/non-existent');
+        $this->http
+            ->throwExceptions()
+            ->get('/non-existent');
     }
 
     public function test_error_response_processor_throws_http_exceptions_if_there_is_a_body(): void
     {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('oops');
+
+        $this->registerRoute([Http500Controller::class, 'throwsException']);
+
+        $this->http
+            ->throwExceptions()
+            ->get('/throws-exception');
+    }
+
+    public function test_throws_http_exception_when_returning_server_error(): void
+    {
         $this->expectException(HttpException::class);
+        $this->expectExceptionCode(500);
 
-        $this->container->get(RouteConfig::class)->staticRoutes['GET']['/returns-basic-500'] = DiscoveredRoute::fromRoute(
-            new Get('/returns-basic-500'),
-            MethodReflector::fromParts(Http500Controller::class, 'basic500'),
-        );
+        $this->registerRoute([Http500Controller::class, 'serverError']);
 
-        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
-        $this->http->get('/returns-custom-500');
+        $this->http
+            ->throwExceptions()
+            ->get('/returns-server-error');
     }
 
     public function test_error_response_processor_does_not_throw_http_exceptions_if_there_is_a_body(): void
     {
-        $this->container->get(RouteConfig::class)->staticRoutes['GET']['/returns-custom-500'] = DiscoveredRoute::fromRoute(
-            new Get('/returns-custom-500'),
-            MethodReflector::fromParts(Http500Controller::class, 'custom500'),
-        );
+        $this->registerRoute([Http500Controller::class, 'serverErrorWithBody']);
 
-        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
         $this->http
-            ->get('/returns-custom-500')
-            ->assertStatus(Status::INTERNAL_SERVER_ERROR);
+            ->get('/returns-server-error-with-body')
+            ->assertStatus(Status::INTERNAL_SERVER_ERROR)
+            ->assertSee('custom error');
     }
 }

--- a/tests/Integration/Testing/Http/HttpRouterTesterIntegrationTest.php
+++ b/tests/Integration/Testing/Http/HttpRouterTesterIntegrationTest.php
@@ -128,7 +128,6 @@ final class HttpRouterTesterIntegrationTest extends FrameworkIntegrationTestCase
     public function test_trace_requests(): void
     {
         $this->http
-            ->throwExceptions()
             ->trace('/test')
             ->assertOk();
     }
@@ -138,7 +137,6 @@ final class HttpRouterTesterIntegrationTest extends FrameworkIntegrationTestCase
         $this->expectException(Exception::class);
 
         $this->http
-            ->throwExceptions()
             ->get('/fail');
     }
 


### PR DESCRIPTION
This pull request is a follow-up to https://github.com/tempestphp/tempest-framework/pull/1203. Previously, I didn't touch the `throwException` method on the router and kept the logic as-is. 

However, that feature in combination with the new exception handling made it that 404s in development would still show a blank page, because `HttpException` would not be thrown (they would only in production).

Instead, I refactored the feature outside of `GenericRouter` into `RouteConfig` as a simple boolean flag, used by the error response processor. With this design, and a small update to the HTTP router testing, we can keep the previous behavior (no exception in testing by default), while having a good UX in development and production (HttpExceptions are properly thrown and handled).

The only thing missing is a DX improvement to the `throwException` method in tests, which would show the thrown HttpException and not the underlying exception. We can improve that later.