### PR TITLE
feat(core): support exception reporting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "require-dev": {
         "aidan-casey/mock-client": "dev-master",
-        "carthage-software/mago": "0.22.2",
+        "carthage-software/mago": "0.24.1",
         "guzzlehttp/psr7": "^2.6.1",
         "illuminate/view": "~11.7.0",
         "league/flysystem-aws-s3-v3": "^3.0",

--- a/mago.toml
+++ b/mago.toml
@@ -64,6 +64,11 @@ name = "strictness/require-return-type"
 ignore_arrow_function = true
 ignore_closure = true
 
+# https://github.com/carthage-software/mago/issues/206
+[[linter.rules]]
+name = "best-practices/literal-named-argument"
+level = "off"
+
 # https://github.com/carthage-software/mago/issues/146
 [[linter.rules]]
 name = "strictness/require-strict-types"

--- a/packages/console/src/Exceptions/ConsoleExceptionHandler.php
+++ b/packages/console/src/Exceptions/ConsoleExceptionHandler.php
@@ -12,6 +12,7 @@ use Tempest\Container\Container;
 use Tempest\Container\Tag;
 use Tempest\Core\AppConfig;
 use Tempest\Core\ExceptionHandler;
+use Tempest\Core\ExceptionReporter;
 use Tempest\Core\Kernel;
 use Tempest\Highlight\Escape;
 use Tempest\Highlight\Highlighter;
@@ -29,15 +30,13 @@ final readonly class ConsoleExceptionHandler implements ExceptionHandler
         private Highlighter $highlighter,
         private Console $console,
         private ConsoleArgumentBag $argumentBag,
+        private ExceptionReporter $exceptionReporter,
     ) {}
 
     public function handle(Throwable $throwable): void
     {
         try {
-            foreach ($this->appConfig->exceptionProcessors as $processor) {
-                $handler = $this->container->get($processor);
-                $throwable = $handler->process($throwable);
-            }
+            $this->exceptionReporter->report($throwable);
 
             $this->console
                 ->writeln()

--- a/packages/core/src/DevelopmentExceptionHandler.php
+++ b/packages/core/src/DevelopmentExceptionHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tempest\Core;
+
+use Tempest\Container\Container;
+use Tempest\Http\Request;
+use Tempest\Router\MatchedRoute;
+use Throwable;
+use Whoops\Handler\HandlerInterface;
+use Whoops\Handler\PrettyPageHandler;
+use Whoops\Run;
+
+final readonly class DevelopmentExceptionHandler implements ExceptionHandler
+{
+    private Run $whoops;
+
+    public function __construct(
+        private Container $container,
+        private ExceptionReporter $exceptionReporter,
+    ) {
+        $this->whoops = new Run();
+        $this->whoops->pushHandler($this->createHandler());
+    }
+
+    public function handle(Throwable $throwable): void
+    {
+        $this->exceptionReporter->report($throwable);
+        $this->whoops->handleException($throwable);
+    }
+
+    private function createHandler(): HandlerInterface
+    {
+        $handler = new PrettyPageHandler();
+
+        $handler->addDataTableCallback('Route', function () {
+            $route = $this->container->get(MatchedRoute::class);
+
+            if (! $route) {
+                return [];
+            }
+
+            return [
+                'Handler' => $route->route->handler->getDeclaringClass()->getFileName() . ':' . $route->route->handler->getName(),
+                'URI' => $route->route->uri,
+                'Allowed parameters' => $route->route->parameters,
+                'Received parameters' => $route->params,
+            ];
+        });
+
+        $handler->addDataTableCallback('Request', function () {
+            $request = $this->container->get(Request::class);
+
+            return [
+                'URI' => $request->uri,
+                'Method' => $request->method->value,
+                'Headers' => $request->headers->toArray(),
+                'Parsed body' => array_filter(array_values($request->body)) ? $request->body : [],
+                'Raw body' => $request->raw,
+            ];
+        });
+
+        return $handler;
+    }
+}

--- a/packages/core/src/ExceptionHandlerInitializer.php
+++ b/packages/core/src/ExceptionHandlerInitializer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tempest\Core;
+
+use Tempest\Console\Exceptions\ConsoleExceptionHandler;
+use Tempest\Container\Container;
+use Tempest\Container\Initializer;
+use Tempest\Container\Singleton;
+use Tempest\Router\Exceptions\HttpExceptionHandler;
+
+final class ExceptionHandlerInitializer implements Initializer
+{
+    #[Singleton]
+    public function initialize(Container $container): ExceptionHandler
+    {
+        $config = $container->get(AppConfig::class);
+
+        return match (true) {
+            PHP_SAPI === 'cli' => $container->get(ConsoleExceptionHandler::class),
+            $config->environment->isLocal() => $container->get(DevelopmentExceptionHandler::class),
+            default => $container->get(HttpExceptionHandler::class),
+        };
+    }
+}

--- a/packages/core/src/ExceptionReporter.php
+++ b/packages/core/src/ExceptionReporter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tempest\Core;
+
+use Tempest\Container\Container;
+use Tempest\Container\Singleton;
+use Throwable;
+
+#[Singleton]
+final class ExceptionReporter
+{
+    private(set) array $reported = [];
+
+    public bool $enabled = true;
+
+    public function __construct(
+        private readonly AppConfig $appConfig,
+        private readonly Container $container,
+    ) {}
+
+    /**
+     * Reports the given exception to the registered exceptionm processors.
+     */
+    public function report(Throwable $throwable): void
+    {
+        $this->reported[] = $throwable;
+
+        if (! $this->enabled) {
+            return;
+        }
+
+        foreach ($this->appConfig->exceptionProcessors as $processor) {
+            $handler = $this->container->get($processor);
+            $throwable = $handler->process($throwable);
+        }
+    }
+}

--- a/packages/core/src/ExceptionTester.php
+++ b/packages/core/src/ExceptionTester.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tempest\Core;
+
+use Closure;
+use PHPUnit\Framework\Assert;
+
+final readonly class ExceptionTester
+{
+    public function __construct(
+        private ExceptionReporter $reporter,
+    ) {}
+
+    /**
+     * Prevents the reporter from reporting exceptions.
+     */
+    public function preventReporting(bool $prevent = true): self
+    {
+        $this->reporter->enabled = ! $prevent;
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the given `$exception` has been reported.
+     *
+     * @param null|Closure $callback A callback accepting the exception instance. The assertion fails if the callback returns `false`.
+     * @param null|int $count If specified, the assertion fails if the exception has been reported a different amount of times.
+     */
+    public function assertReported(string|object $exception, ?Closure $callback = null, ?int $count = null): self
+    {
+        Assert::assertNotNull(
+            actual: $reports = $this->findReports($exception),
+            message: 'The exception was not reported.',
+        );
+
+        if ($count !== null) {
+            Assert::assertCount($count, $reports, sprintf('Expected %s report(s), got %s.', $count, count($reports)));
+        }
+
+        if ($callback !== null) {
+            foreach ($reports as $dispatch) {
+                Assert::assertNotFalse($callback($dispatch), 'The callback failed.');
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the given `$exception` was not reported.
+     */
+    public function assertNotReported(string|object $exception): self
+    {
+        Assert::assertEmpty(
+            actual: $this->findReports($exception),
+            message: 'The exception was reported.',
+        );
+
+        return $this;
+    }
+
+    /**
+     * Asserts that no exceptions were reported.
+     */
+    public function assertNothingReported(): self
+    {
+        Assert::assertEmpty(
+            actual: $this->reporter->reported,
+            message: sprintf('There are unexpected reported exceptions: [%s]', implode(', ', $this->reporter->reported)),
+        );
+
+        return $this;
+    }
+
+    private function findReports(string|object $exception): array
+    {
+        return array_filter($this->reporter->reported, function (string|object $reported) use ($exception) {
+            if ($reported === $exception) {
+                return true;
+            }
+
+            if (class_exists($exception) && is_a($reported, $exception, allow_string: true)) {
+                return true;
+            }
+
+            return false;
+        });
+    }
+}

--- a/packages/core/src/FrameworkKernel.php
+++ b/packages/core/src/FrameworkKernel.php
@@ -205,7 +205,7 @@ final class FrameworkKernel implements Kernel
         // In development, we want to register a developer-friendly error
         // handler as soon as possible to catch any kind of exception.
         if (PHP_SAPI !== 'cli' && ! $environment->isProduction()) {
-            new RegisterEmergencyExceptionHandler($this->container)->register();
+            new RegisterEmergencyExceptionHandler()->register();
         }
 
         return $this;
@@ -220,25 +220,17 @@ final class FrameworkKernel implements Kernel
             return $this;
         }
 
-        // We need an exception handler for the CLI in every
-        // environment, and one for HTTP only in production.
-        $handler = match (true) {
-            PHP_SAPI === 'cli' => $this->container->get(ConsoleExceptionHandler::class),
-            $appConfig->environment->isProduction() => $this->container->get(HttpExceptionHandler::class),
-            default => null,
-        };
+        $handler = $this->container->get(ExceptionHandler::class);
 
-        if ($handler) {
-            set_exception_handler($handler->handle(...));
-            set_error_handler(fn (int $code, string $message, string $filename, int $line) => $handler->handle(
-                new \ErrorException(
-                    message: $message,
-                    code: $code,
-                    filename: $filename,
-                    line: $line,
-                ),
-            ));
-        }
+        set_exception_handler($handler->handle(...));
+        set_error_handler(fn (int $code, string $message, string $filename, int $line) => $handler->handle(
+            new \ErrorException(
+                message: $message,
+                code: $code,
+                filename: $filename,
+                line: $line,
+            ),
+        ));
 
         return $this;
     }

--- a/packages/core/src/Kernel/RegisterEmergencyExceptionHandler.php
+++ b/packages/core/src/Kernel/RegisterEmergencyExceptionHandler.php
@@ -2,57 +2,15 @@
 
 namespace Tempest\Core\Kernel;
 
-use Tempest\Container\Container;
-use Tempest\Http\Request;
-use Tempest\Router\MatchedRoute;
-use Whoops\Handler\HandlerInterface;
 use Whoops\Handler\PrettyPageHandler;
 use Whoops\Run;
 
 final readonly class RegisterEmergencyExceptionHandler
 {
-    public function __construct(
-        private Container $container,
-    ) {}
-
     public function register(): void
     {
         $whoops = new Run();
-        $whoops->pushHandler($this->createHandler());
+        $whoops->pushHandler(new PrettyPageHandler());
         $whoops->register();
-    }
-
-    private function createHandler(): HandlerInterface
-    {
-        $handler = new PrettyPageHandler();
-
-        $handler->addDataTableCallback('Route', function () {
-            $route = $this->container->get(MatchedRoute::class);
-
-            if (! $route) {
-                return [];
-            }
-
-            return [
-                'Handler' => $route->route->handler->getDeclaringClass()->getFileName() . ':' . $route->route->handler->getName(),
-                'URI' => $route->route->uri,
-                'Allowed parameters' => $route->route->parameters,
-                'Received parameters' => $route->params,
-            ];
-        });
-
-        $handler->addDataTableCallback('Request', function () {
-            $request = $this->container->get(Request::class);
-
-            return [
-                'URI' => $request->uri,
-                'Method' => $request->method->value,
-                'Headers' => $request->headers->toArray(),
-                'Parsed body' => array_filter(array_values($request->body)) ? $request->body : [],
-                'Raw body' => $request->raw,
-            ];
-        });
-
-        return $handler;
     }
 }

--- a/packages/core/src/functions.php
+++ b/packages/core/src/functions.php
@@ -7,8 +7,10 @@ namespace Tempest {
     use Stringable;
     use Tempest\Core\Composer;
     use Tempest\Core\DeferredTasks;
+    use Tempest\Core\ExceptionReporter;
     use Tempest\Core\Kernel;
     use Tempest\Support\Namespace\PathCouldNotBeMappedToNamespaceException;
+    use Throwable;
 
     use function Tempest\Support\Namespace\to_psr4_namespace;
     use function Tempest\Support\Path\to_absolute_path;
@@ -82,5 +84,13 @@ namespace Tempest {
     function defer(Closure $closure): void
     {
         get(DeferredTasks::class)->add($closure);
+    }
+
+    /**
+     * Passes the given exception through registered exception processors.
+     */
+    function report(Throwable $throwable): void
+    {
+        get(ExceptionReporter::class)->report($throwable);
     }
 }

--- a/packages/http/src/HttpException.php
+++ b/packages/http/src/HttpException.php
@@ -13,7 +13,8 @@ final class HttpException extends Exception implements HasContext
     public function __construct(
         public readonly Status $status,
         ?string $message = null,
-        public readonly ?Response $response = null,
+        public readonly ?Response $cause = null,
+        public ?Response $response = null,
         ?\Throwable $previous = null,
     ) {
         parent::__construct($message ?: '', $status->value, $previous);
@@ -24,7 +25,7 @@ final class HttpException extends Exception implements HasContext
         return [
             'status' => $this->status->value,
             'message' => $this->message,
-            'response' => $this->response,
+            'cause' => $this->cause,
             'previous' => $this->getPrevious()?->getMessage(),
         ];
     }

--- a/packages/router/src/Exceptions/HttpErrorResponseProcessor.php
+++ b/packages/router/src/Exceptions/HttpErrorResponseProcessor.php
@@ -35,6 +35,9 @@ final readonly class HttpErrorResponseProcessor implements ResponseProcessor
             return $response;
         }
 
-        throw new HttpException(status: $response->status, response: $response);
+        throw new HttpException(
+            status: $response->status,
+            cause: $response,
+        );
     }
 }

--- a/src/Tempest/Framework/Testing/IntegrationTest.php
+++ b/src/Tempest/Framework/Testing/IntegrationTest.php
@@ -9,9 +9,9 @@ use Tempest\Cache\Testing\CacheTester;
 use Tempest\Clock\Clock;
 use Tempest\Clock\MockClock;
 use Tempest\Console\Testing\ConsoleTester;
-use Tempest\Container\Container;
 use Tempest\Container\GenericContainer;
 use Tempest\Core\AppConfig;
+use Tempest\Core\ExceptionTester;
 use Tempest\Core\FrameworkKernel;
 use Tempest\Core\Kernel;
 use Tempest\Database\Migrations\MigrationManager;
@@ -53,6 +53,8 @@ abstract class IntegrationTest extends TestCase
 
     protected CacheTester $cache;
 
+    protected ExceptionTester $exceptions;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -74,6 +76,9 @@ abstract class IntegrationTest extends TestCase
         $this->eventBus = $this->container->get(EventBusTester::class);
         $this->storage = $this->container->get(StorageTester::class);
         $this->cache = $this->container->get(CacheTester::class);
+
+        $this->exceptions = $this->container->get(ExceptionTester::class);
+        $this->exceptions->preventReporting();
 
         $this->vite = $this->container->get(ViteTester::class);
         $this->vite->preventTagResolution();

--- a/tests/Integration/Core/ExceptionReporterTest.php
+++ b/tests/Integration/Core/ExceptionReporterTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Tempest\Integration\Core;
 
 use Exception;
+use GPBMetadata\Google\Type\Expr;
 use Tempest\Core\AppConfig;
 use Tempest\Core\ExceptionReporter;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -16,6 +17,7 @@ final class ExceptionReporterTest extends FrameworkIntegrationTestCase
     {
         parent::setUp();
 
+        $this->exceptions->preventReporting(prevent: false);
         $this->container->get(AppConfig::class)->exceptionProcessors = [NullExceptionProcessor::class];
     }
 

--- a/tests/Integration/Core/ExceptionReporterTest.php
+++ b/tests/Integration/Core/ExceptionReporterTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Tempest\Integration\Core;
+
+use Exception;
+use Tempest\Core\AppConfig;
+use Tempest\Core\ExceptionReporter;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+use Tests\Tempest\Integration\Http\Fixtures\NullExceptionProcessor;
+
+use function Tempest\report;
+
+final class ExceptionReporterTest extends FrameworkIntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container->get(AppConfig::class)->exceptionProcessors = [NullExceptionProcessor::class];
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        NullExceptionProcessor::$exceptions = [];
+    }
+
+    public function test_exception_reporter_processes_exception_processors(): void
+    {
+        /** @var ExceptionReporter $reporter */
+        $reporter = $this->container->get(ExceptionReporter::class);
+        $reporter->report(new Exception('foo'));
+
+        $this->assertCount(1, NullExceptionProcessor::$exceptions);
+        $this->assertInstanceOf(Exception::class, NullExceptionProcessor::$exceptions[0]);
+        $this->assertSame('foo', NullExceptionProcessor::$exceptions[0]->getMessage());
+
+        $this->assertCount(1, $reporter->reported);
+        $this->assertInstanceOf(Exception::class, $reporter->reported[0]);
+        $this->assertSame('foo', $reporter->reported[0]->getMessage());
+    }
+
+    public function test_report_function(): void
+    {
+        report(new Exception('foo'));
+
+        $this->assertCount(1, NullExceptionProcessor::$exceptions);
+        $this->assertInstanceOf(Exception::class, NullExceptionProcessor::$exceptions[0]);
+        $this->assertSame('foo', NullExceptionProcessor::$exceptions[0]->getMessage());
+
+        /** @var ExceptionReporter $reporter */
+        $reporter = $this->container->get(ExceptionReporter::class);
+
+        $this->assertCount(1, $reporter->reported);
+        $this->assertInstanceOf(Exception::class, $reporter->reported[0]);
+        $this->assertSame('foo', $reporter->reported[0]->getMessage());
+    }
+}

--- a/tests/Integration/Core/ExceptionTesterTest.php
+++ b/tests/Integration/Core/ExceptionTesterTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Tempest\Integration\Core;
+
+use Exception;
+use InvalidArgumentException;
+use Tempest\Core\AppConfig;
+use Tempest\Core\ExceptionReporter;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+use Tests\Tempest\Integration\Http\Fixtures\NullExceptionProcessor;
+
+use function Tempest\report;
+
+final class ExceptionTesterTest extends FrameworkIntegrationTestCase
+{
+    public function test_assert_reported(): void
+    {
+        $this->exceptions->assertNothingReported();
+
+        $this->container->get(ExceptionReporter::class)->report(new Exception('foo'));
+        report(new Exception('bar'));
+
+        $this->exceptions->assertReported(Exception::class, count: 2);
+        $this->exceptions->assertNotReported(InvalidArgumentException::class);
+    }
+
+    public function test_prevent_reporting(): void
+    {
+        $this->container->get(AppConfig::class)->exceptionProcessors = [NullExceptionProcessor::class];
+
+        $this->exceptions->preventReporting();
+
+        $this->container->get(ExceptionReporter::class)->report(new Exception('foo'));
+
+        $this->exceptions->assertReported(Exception::class);
+
+        $this->assertEmpty(NullExceptionProcessor::$exceptions);
+    }
+}

--- a/tests/Integration/FrameworkIntegrationTestCase.php
+++ b/tests/Integration/FrameworkIntegrationTestCase.php
@@ -71,11 +71,6 @@ abstract class FrameworkIntegrationTestCase extends IntegrationTest
         $this->rollbackDatabase();
     }
 
-    protected function tearDown(): void
-    {
-        //        $this->container->get(Connection::class)->close();
-    }
-
     protected function actAsConsoleApplication(string $command = ''): Application
     {
         $application = new ConsoleApplication(

--- a/tests/Integration/Http/HttpExceptionHandlerTest.php
+++ b/tests/Integration/Http/HttpExceptionHandlerTest.php
@@ -143,6 +143,8 @@ final class HttpExceptionHandlerTest extends FrameworkIntegrationTestCase
 
     public function test_exception_handler_runs_exception_processors(): void
     {
+        $this->exceptions->preventReporting(false);
+
         $this->container->get(AppConfig::class)->exceptionProcessors[] = NullExceptionProcessor::class;
 
         $thrown = new ExceptionWithContext();

--- a/tests/Integration/Http/HttpExceptionHandlerTest.php
+++ b/tests/Integration/Http/HttpExceptionHandlerTest.php
@@ -154,6 +154,8 @@ final class HttpExceptionHandlerTest extends FrameworkIntegrationTestCase
 
         $this->assertContains($thrown, NullExceptionProcessor::$exceptions);
         $this->assertArrayHasKey('foo', NullExceptionProcessor::$exceptions[0]->context());
+
+        NullExceptionProcessor::$exceptions = [];
     }
 
     private function callExceptionHandler(Closure $callback): void


### PR DESCRIPTION
This pull request improves on the concept of exception processor by refactoring them into a dedicated `ExceptionReporter` class, which can be used to report exceptions without throwing them, just like Laravel.

Calling the `Tempest\report()` function will call the registered exception processors. Additionally, I added testing utilities that can make assertions on reported exceptions.

Documentation PR: https://github.com/tempestphp/tempest-docs/pull/82