### PR TITLE
feat(cache): support stale while revalidate

### DIFF
--- a/packages/cache/src/Cache.php
+++ b/packages/cache/src/Cache.php
@@ -79,7 +79,7 @@ interface Cache
     /**
      * If the specified key already exists in the cache, the value is returned and the `$callback` is not executed. Otherwise, the result of the callback is stored, then returned.
      *
-     * @var null|Duration $stale Allow the value to be stale for the specified amount of time in addition to the time-to-live specified by `$duration`. When a value is stale, it will still be returned, but it will be refreshed in the background.
+     * @var null|Duration $stale Allow the value to be stale for the specified amount of time in addition to the time-to-live specified by `$expiration`. When a value is stale, it will still be returned as-is, but it will be refreshed in the background.
      */
     public function resolve(Stringable|string $key, Closure $callback, null|Duration|DateTimeInterface $expiration = null, ?Duration $stale = null): mixed;
 

--- a/packages/cache/src/Cache.php
+++ b/packages/cache/src/Cache.php
@@ -78,8 +78,10 @@ interface Cache
 
     /**
      * If the specified key already exists in the cache, the value is returned and the `$callback` is not executed. Otherwise, the result of the callback is stored, then returned.
+     *
+     * @var null|Duration $stale Allow the value to be stale for the specified amount of time in addition to the time-to-live specified by `$duration`. When a value is stale, it will still be returned, but it will be refreshed in the background.
      */
-    public function resolve(Stringable|string $key, Closure $callback, null|Duration|DateTimeInterface $expiration = null): mixed;
+    public function resolve(Stringable|string $key, Closure $callback, null|Duration|DateTimeInterface $expiration = null, ?Duration $stale = null): mixed;
 
     /**
      * Removes the specified key from the cache.

--- a/packages/cache/src/CacheInitializer.php
+++ b/packages/cache/src/CacheInitializer.php
@@ -8,6 +8,7 @@ use Tempest\Cache\Config\CacheConfig;
 use Tempest\Container\Container;
 use Tempest\Container\DynamicInitializer;
 use Tempest\Container\Singleton;
+use Tempest\Core\DeferredTasks;
 use Tempest\Reflection\ClassReflector;
 
 use function Tempest\env;
@@ -25,6 +26,7 @@ final readonly class CacheInitializer implements DynamicInitializer
     {
         return new GenericCache(
             cacheConfig: $container->get(CacheConfig::class, $tag),
+            deferredTasks: $container->get(DeferredTasks::class),
             enabled: $this->shouldCacheBeEnabled($tag),
         );
     }

--- a/packages/cache/src/Testing/RestrictedCache.php
+++ b/packages/cache/src/Testing/RestrictedCache.php
@@ -58,7 +58,7 @@ final class RestrictedCache implements Cache
         throw new ForbiddenCacheUsageException($this->tag);
     }
 
-    public function resolve(Stringable|string $key, Closure $callback, null|Duration|DateTimeInterface $expiration = null): mixed
+    public function resolve(Stringable|string $key, Closure $callback, null|Duration|DateTimeInterface $expiration = null, ?Duration $stale = null): mixed
     {
         throw new ForbiddenCacheUsageException($this->tag);
     }

--- a/packages/cache/src/Testing/TestingCache.php
+++ b/packages/cache/src/Testing/TestingCache.php
@@ -12,6 +12,7 @@ use Tempest\Cache\Cache;
 use Tempest\Cache\Config\CustomCacheConfig;
 use Tempest\Cache\GenericCache;
 use Tempest\Cache\GenericLock;
+use Tempest\Core\DeferredTasks;
 use Tempest\DateTime\DateTimeInterface;
 use Tempest\DateTime\Duration;
 use Tempest\Support\Random;
@@ -82,9 +83,9 @@ final class TestingCache implements Cache
         return $this->cache->getMany($key);
     }
 
-    public function resolve(Stringable|string $key, Closure $callback, null|Duration|DateTimeInterface $expiration = null): mixed
+    public function resolve(Stringable|string $key, Closure $callback, null|Duration|DateTimeInterface $expiration = null, ?Duration $stale = null): mixed
     {
-        return $this->cache->resolve($key, $callback, $expiration);
+        return $this->cache->resolve($key, $callback, $expiration, $stale);
     }
 
     public function remove(Stringable|string $key): void

--- a/packages/core/src/DeferredTasks.php
+++ b/packages/core/src/DeferredTasks.php
@@ -6,19 +6,33 @@ namespace Tempest\Core;
 
 use Closure;
 use Tempest\Container\Singleton;
+use Tempest\Support\Arr;
+use Tempest\Support\Random;
 
 #[Singleton]
 final class DeferredTasks
 {
+    /** @var array<string,Closure> */
     private array $tasks = [];
 
-    public function add(Closure $task): void
+    /**
+     * Adds a deferred task to the list of tasks. Optionally, specify a name for uniqueness.
+     */
+    public function add(Closure $task, ?string $name = null): void
     {
-        $this->tasks[] = $task;
+        $this->tasks[$name ?? Random\secure_string(10)] = $task;
     }
 
     public function getTasks(): array
     {
         return $this->tasks;
+    }
+
+    /**
+     * Forgets the given deferred task.
+     */
+    public function forget(string $name): void
+    {
+        Arr\forget_keys($this->tasks, $name);
     }
 }

--- a/packages/core/src/Kernel/FinishDeferredTasks.php
+++ b/packages/core/src/Kernel/FinishDeferredTasks.php
@@ -16,8 +16,9 @@ final readonly class FinishDeferredTasks
 
     public function __invoke(): void
     {
-        foreach ($this->deferredTasks->getTasks() as $task) {
+        foreach ($this->deferredTasks->getTasks() as $name => $task) {
             $this->container->invoke($task);
+            $this->deferredTasks->forget($name);
         }
     }
 }

--- a/tests/Integration/Core/DeferredTasksTest.php
+++ b/tests/Integration/Core/DeferredTasksTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Tempest\Integration\Core;
 
 use Tempest\Container\Container;
+use Tempest\Core\DeferredTasks;
 use Tempest\Core\Kernel\FinishDeferredTasks;
 use Tests\Tempest\Fixtures\Controllers\DeferController;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -28,6 +29,7 @@ final class DeferredTasksTest extends FrameworkIntegrationTestCase
         $this->container->invoke(FinishDeferredTasks::class);
 
         $this->assertTrue(DeferController::$executed);
+        $this->assertEmpty($this->container->get(DeferredTasks::class)->getTasks());
     }
 
     public function test_deferred_tasks_are_executed_with_container_parameters(): void
@@ -43,5 +45,6 @@ final class DeferredTasksTest extends FrameworkIntegrationTestCase
         $this->container->invoke(FinishDeferredTasks::class);
 
         $this->assertTrue($executed);
+        $this->assertEmpty($this->container->get(DeferredTasks::class)->getTasks());
     }
 }


### PR DESCRIPTION
This pull request adds support for the "stale while invalidate" pattern on the cache implementation.

```php
$cache->resolve(
    key: 'cache-key',
    callback: fn () => $this->computeExpensiveValue(),
    expiration: Duration::minute(), // should expire in a minute
    stale: Duration::minute() // but allow a stale period of one more minute
);
```

When requested in the stale window (in this example, from one minute to two minutes after caching the value), a deferred callback will be registered for refreshing the value.