### PR TITLE
feat(support): add uuid utilities

### DIFF
--- a/packages/command-bus/src/AsyncCommandMiddleware.php
+++ b/packages/command-bus/src/AsyncCommandMiddleware.php
@@ -7,6 +7,7 @@ namespace Tempest\CommandBus;
 use Symfony\Component\Uid\Uuid;
 use Tempest\Core\Priority;
 use Tempest\Reflection\ClassReflector;
+use Tempest\Support\Random;
 
 #[Priority(Priority::FRAMEWORK)]
 final readonly class AsyncCommandMiddleware implements CommandBusMiddleware
@@ -20,7 +21,7 @@ final readonly class AsyncCommandMiddleware implements CommandBusMiddleware
         $reflector = new ClassReflector($command);
 
         if ($reflector->hasAttribute(AsyncCommand::class)) {
-            $this->repository->store(Uuid::v7()->toString(), $command);
+            $this->repository->store(Random\uuid(), $command);
 
             return;
         }

--- a/packages/support/composer.json
+++ b/packages/support/composer.json
@@ -7,7 +7,8 @@
         "php": "^8.4",
         "doctrine/inflector": "^2.0",
         "tempest/container": "dev-main",
-        "voku/portable-ascii": "^2.0.3"
+        "voku/portable-ascii": "^2.0.3",
+        "symfony/uid": "^7.1"
     },
     "autoload": {
         "psr-4": {

--- a/packages/support/composer.json
+++ b/packages/support/composer.json
@@ -7,6 +7,7 @@
         "php": "^8.4",
         "doctrine/inflector": "^2.0",
         "tempest/container": "dev-main",
+        "tempest/datetime": "dev-main",
         "voku/portable-ascii": "^2.0.3",
         "symfony/uid": "^7.1"
     },

--- a/packages/support/composer.json
+++ b/packages/support/composer.json
@@ -7,7 +7,6 @@
         "php": "^8.4",
         "doctrine/inflector": "^2.0",
         "tempest/container": "dev-main",
-        "tempest/datetime": "dev-main",
         "voku/portable-ascii": "^2.0.3",
         "symfony/uid": "^7.1"
     },

--- a/packages/support/src/Str/ManipulatesString.php
+++ b/packages/support/src/Str/ManipulatesString.php
@@ -9,10 +9,10 @@ use Closure;
 use Countable;
 use Stringable;
 use Tempest\Support\Arr\ImmutableArray;
+use Tempest\Support\Random;
 use Tempest\Support\Regex;
 
 use function Tempest\Support\arr;
-use function Tempest\Support\Random\secure_string;
 use function Tempest\Support\tap;
 
 /**
@@ -142,7 +142,39 @@ trait ManipulatesString
      */
     public function random(int $length = 16): self
     {
-        return $this->createOrModify(secure_string($length));
+        return $this->createOrModify(Random\secure_string($length));
+    }
+
+    /**
+     * Generates a UUID v7 (time-based) identifier.
+     */
+    public function uuid(): self
+    {
+        return $this->createOrModify(Random\uuid());
+    }
+
+    /**
+     * Generates a 128-bit universally unique lexicographically sortable identifier.
+     */
+    public function ulid(): self
+    {
+        return $this->createOrModify(Random\ulid());
+    }
+
+    /**
+     * Determines whether the specified string is a valid UUID.
+     */
+    public function isUuid(): bool
+    {
+        return Random\is_uuid($this->value);
+    }
+
+    /**
+     * Determines whether the instance is a valid ULID.
+     */
+    public function isUlid(): bool
+    {
+        return Random\is_ulid($this->value);
     }
 
     /**

--- a/packages/support/tests/Random/FunctionsTest.php
+++ b/packages/support/tests/Random/FunctionsTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tempest\Support\Tests\Random;
 
+use DateTimeImmutable;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Ulid;
-use Tempest\DateTime\DateTime;
 use Tempest\Support\Random;
 
 use function Tempest\Support\Str\contains;
@@ -60,13 +60,6 @@ final class FunctionsTest extends TestCase
     public function test_ulid(): void
     {
         $this->assertTrue(Random\is_ulid(Random\ulid()));
-        $this->assertTrue(Random\is_ulid(Random\ulid(time: DateTime::now())));
-
-        $this->assertStringStartsWith('01JVX', Random\ulid(time: DateTime::parse('2025-05-23 02:00:00')));
-
-        $date = Ulid::fromString(Random\ulid(time: DateTime::parse('2025-05-23 02:00:00')))->getDateTime();
-
-        $this->assertTrue(DateTime::parse($date)->equals('2025-05-23 02:00:00'));
     }
 
     public function test_is_uuid(): void

--- a/packages/support/tests/Random/FunctionsTest.php
+++ b/packages/support/tests/Random/FunctionsTest.php
@@ -6,6 +6,8 @@ namespace Tempest\Support\Tests\Random;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Ulid;
+use Tempest\DateTime\DateTime;
 use Tempest\Support\Random;
 
 use function Tempest\Support\Str\contains;
@@ -48,5 +50,60 @@ final class FunctionsTest extends TestCase
         $this->expectExceptionMessage('$alphabet\'s length must be in [2^1, 2^56]');
 
         Random\secure_string(32, 'a');
+    }
+
+    public function test_uuid(): void
+    {
+        $this->assertTrue(Random\is_uuid(Random\uuid()));
+    }
+
+    public function test_ulid(): void
+    {
+        $this->assertTrue(Random\is_ulid(Random\ulid()));
+        $this->assertTrue(Random\is_ulid(Random\ulid(time: DateTime::now())));
+
+        $this->assertStringStartsWith('01JVX', Random\ulid(time: DateTime::parse('2025-05-23 02:00:00')));
+
+        $date = Ulid::fromString(Random\ulid(time: DateTime::parse('2025-05-23 02:00:00')))->getDateTime();
+
+        $this->assertTrue(DateTime::parse($date)->equals('2025-05-23 02:00:00'));
+    }
+
+    public function test_is_uuid(): void
+    {
+        $this->assertTrue(Random\is_uuid(Random\uuid()));
+
+        // UUID v1
+        $this->assertTrue(Random\is_uuid('CB2F46B4-D0C6-11EE-A506-0242AC120002'));
+        $this->assertTrue(Random\is_uuid('cb2f46b4-d0c6-11ee-a506-0242ac120002'));
+
+        // UUID v4
+        $this->assertTrue(Random\is_uuid('0EC29141-3D58-4187-B664-2D93B7DA0D31'));
+        $this->assertTrue(Random\is_uuid('0ec29141-3d58-4187-b664-2d93b7da0d31'));
+
+        // UUID v7
+        $this->assertTrue(Random\is_uuid('018DCC19-7E65-7C4B-9B14-9A11DF3E0FDB'));
+        $this->assertTrue(Random\is_uuid('018dcc19-7e65-7c4b-9b14-9a11df3e0fdb'));
+
+        $this->assertFalse(Random\is_uuid(''));
+        $this->assertFalse(Random\is_uuid('01JVX9G569ETXTZKKCK94T4A6V'));
+        $this->assertFalse(Random\is_uuid('foo'));
+        $this->assertFalse(Random\is_uuid(Random\secure_string(26)));
+        $this->assertFalse(Random\is_uuid(Random\secure_string(36)));
+        $this->assertFalse(Random\is_uuid(null));
+    }
+
+    public function test_is_ulid(): void
+    {
+        $this->assertTrue(Random\is_ulid(Random\ulid()));
+
+        $this->assertTrue(Random\is_ulid('01JVX9G569ETXTZKKCK94T4A6V'));
+
+        $this->assertFalse(Random\is_ulid(''));
+        $this->assertFalse(Random\is_ulid('0ec29141-3d58-4187-b664-2d93b7da0d31'));
+        $this->assertFalse(Random\is_ulid('018dcc19-7e65-7c4b-9b14-9a11df3e0fdb'));
+        $this->assertFalse(Random\is_ulid('foo'));
+        $this->assertFalse(Random\is_ulid(Random\secure_string(26)));
+        $this->assertFalse(Random\is_ulid(null));
     }
 }

--- a/packages/support/tests/Str/ManipulatesStringTest.php
+++ b/packages/support/tests/Str/ManipulatesStringTest.php
@@ -708,4 +708,46 @@ b'));
     {
         $this->assertSame($expected, str($str)->padLeft($totalLength, $padString)->toString());
     }
+
+    public function test_is_uuid(): void
+    {
+        $this->assertTrue(str()->uuid()->isUuid());
+
+        // UUID v1
+        $this->assertTrue(str('CB2F46B4-D0C6-11EE-A506-0242AC120002')->isUuid());
+        $this->assertTrue(str('cb2f46b4-d0c6-11ee-a506-0242ac120002')->isUuid());
+
+        // UUID v4
+        $this->assertTrue(str('0EC29141-3D58-4187-B664-2D93B7DA0D31')->isUuid());
+        $this->assertTrue(str('0ec29141-3d58-4187-b664-2d93b7da0d31')->isUuid());
+
+        // UUID v7
+        $this->assertTrue(str('018DCC19-7E65-7C4B-9B14-9A11DF3E0FDB')->isUuid());
+        $this->assertTrue(str('018dcc19-7e65-7c4b-9b14-9a11df3e0fdb')->isUuid());
+
+        $this->assertFalse(str('')->isUuid());
+        $this->assertFalse(str('01JVX9G569ETXTZKKCK94T4A6V')->isUuid());
+        $this->assertFalse(str('foo')->isUuid());
+        $this->assertFalse(str()->random()->isUuid());
+        $this->assertFalse(str(null)->isUuid());
+    }
+
+    public function test_is_ulid(): void
+    {
+        $this->assertTrue(str()->ulid()->isUlid());
+
+        $this->assertTrue(str('01JVX9G569ETXTZKKCK94T4A6V')->isUlid());
+
+        $this->assertFalse(str('')->isUlid());
+        $this->assertFalse(str('0ec29141-3d58-4187-b664-2d93b7da0d31')->isUlid());
+        $this->assertFalse(str('018dcc19-7e65-7c4b-9b14-9a11df3e0fdb')->isUlid());
+        $this->assertFalse(str('foo')->isUlid());
+        $this->assertFalse(str()->random()->isUlid());
+        $this->assertFalse(str(null)->isUlid());
+    }
+
+    public function test_uuid(): void
+    {
+        $this->assertTrue(str()->uuid()->isUuid());
+    }
 }

--- a/packages/validation/src/Rules/Uuid.php
+++ b/packages/validation/src/Rules/Uuid.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Validation\Rules;
 
 use Attribute;
+use Tempest\Support\Random;
 use Tempest\Validation\Rule;
 
 #[Attribute]
@@ -16,7 +17,7 @@ final readonly class Uuid implements Rule
             return false;
         }
 
-        return boolval(preg_match('/^[a-f\d]{8}(-[a-f\d]{4}){4}[a-f\d]{8}$/i', $value));
+        return Random\is_uuid($value);
     }
 
     public function message(): string


### PR DESCRIPTION
This pull request adds a `Random\uuid()`, `Random\is_uuid()`, `Random\ulid()` and `Random\is_ulid()` utilities. It also updates our `Uuid` validation rule to use those under the hood, and add them to the string objects as well.