### PR TITLE
refactor(core): move internal storage to project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /package-lock.json
 
 # Top-level+Sub directories
+.tempest/
 .cache/
 .idea/
 build/

--- a/packages/core/src/FrameworkKernel.php
+++ b/packages/core/src/FrameworkKernel.php
@@ -166,7 +166,7 @@ final class FrameworkKernel implements Kernel
 
     public function registerInternalStorage(): self
     {
-        $path = $this->root . '/vendor/.tempest';
+        $path = $this->root . '/.tempest';
 
         if (! is_dir($path)) {
             mkdir($path, recursive: true);


### PR DESCRIPTION
Closes https://github.com/tempestphp/tempest-framework/issues/1281

Before merging, is `.tempest` the ideal name? Could also be `storage`, `.internal`, or something else. I like a dot directory because it's naturally ignored when scanning the hierarchy, but the name "tempest" is not generic and generally I don't like that

Also, we need to add it to `.gitignore` in `tempestphp/tempest-app`