### PR TITLE
fix(event-bus): reorder `listen` parameters for consistency

### DIFF
--- a/packages/event-bus/src/EventBus.php
+++ b/packages/event-bus/src/EventBus.php
@@ -10,5 +10,5 @@ interface EventBus
 {
     public function dispatch(string|object $event): void;
 
-    public function listen(string|object $event, Closure $handler): void;
+    public function listen(Closure $handler, ?string $event = null): void;
 }

--- a/packages/event-bus/src/GenericEventBus.php
+++ b/packages/event-bus/src/GenericEventBus.php
@@ -16,9 +16,9 @@ final readonly class GenericEventBus implements EventBus
         private EventBusConfig $eventBusConfig,
     ) {}
 
-    public function listen(string|object $event, Closure $handler): void
+    public function listen(Closure $handler, ?string $event = null): void
     {
-        $this->eventBusConfig->addClosureHandler($event, $handler);
+        $this->eventBusConfig->addClosureHandler($handler, $event);
     }
 
     public function dispatch(string|object $event): void

--- a/packages/event-bus/src/Testing/FakeEventBus.php
+++ b/packages/event-bus/src/Testing/FakeEventBus.php
@@ -14,9 +14,9 @@ final class FakeEventBus implements EventBus
         public EventBusConfig $eventBusConfig,
     ) {}
 
-    public function listen(string|object $event, Closure $handler): void
+    public function listen(Closure $handler, ?string $event = null): void
     {
-        $this->eventBusConfig->addClosureHandler($event, $handler);
+        $this->eventBusConfig->addClosureHandler($handler, $event);
     }
 
     public function dispatch(string|object $event): void

--- a/packages/event-bus/src/functions.php
+++ b/packages/event-bus/src/functions.php
@@ -20,10 +20,10 @@ namespace Tempest {
     /**
      * Registers a closure-based event listener for the given `$event`.
      */
-    function listen(string|object $event, Closure $handler): void
+    function listen(Closure $handler, ?string $event = null): void
     {
         $config = get(EventBusConfig::class);
 
-        $config->addClosureHandler($event, $handler);
+        $config->addClosureHandler($handler, $event);
     }
 }

--- a/packages/event-bus/tests/EventBusTest.php
+++ b/packages/event-bus/tests/EventBusTest.php
@@ -126,11 +126,28 @@ final class EventBusTest extends TestCase
         $hasHappened = false;
 
         // @mago-expect best-practices/no-unused-parameter
-        $eventBus->listen('my-event', function (string $event) use (&$hasHappened): void {
+        $eventBus->listen(function (string $event) use (&$hasHappened): void {
+            $hasHappened = true;
+        }, event: 'my-event');
+
+        $eventBus->dispatch('my-event');
+
+        $this->assertTrue($hasHappened);
+    }
+
+    public function test_closure_based_handlers_using_listen_method_and_first_parameter(): void
+    {
+        $container = new GenericContainer();
+        $config = new EventBusConfig();
+        $eventBus = new GenericEventBus($container, $config);
+        $hasHappened = false;
+
+        // @mago-expect best-practices/no-unused-parameter
+        $eventBus->listen(function (ItHappened $event) use (&$hasHappened): void {
             $hasHappened = true;
         });
 
-        $eventBus->dispatch('my-event');
+        $eventBus->dispatch(new ItHappened());
 
         $this->assertTrue($hasHappened);
     }
@@ -145,9 +162,9 @@ final class EventBusTest extends TestCase
         $hasHappened = false;
 
         // @mago-expect best-practices/no-unused-parameter
-        listen('my-event', function (string $event) use (&$hasHappened): void {
+        listen(function (string $event) use (&$hasHappened): void {
             $hasHappened = true;
-        });
+        }, event: 'my-event');
 
         get(EventBus::class)->dispatch('my-event');
 

--- a/packages/http/src/Session/CleanupSessionsCommand.php
+++ b/packages/http/src/Session/CleanupSessionsCommand.php
@@ -8,6 +8,7 @@ use Tempest\Console\Console;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Schedule;
 use Tempest\Console\Scheduler\Every;
+use Tempest\EventBus\EventBus;
 
 use function Tempest\listen;
 
@@ -16,6 +17,7 @@ final readonly class CleanupSessionsCommand
     public function __construct(
         private Console $console,
         private SessionManager $sessionManager,
+        private EventBus $eventBus,
     ) {}
 
     #[ConsoleCommand(
@@ -25,7 +27,7 @@ final readonly class CleanupSessionsCommand
     #[Schedule(Every::MINUTE)]
     public function __invoke(): void
     {
-        listen(SessionDestroyed::class, function (SessionDestroyed $event): void {
+        $this->eventBus->listen(function (SessionDestroyed $event): void {
             $this->console->keyValue((string) $event->id, "<style='bold fg-green'>DESTROYED</style>");
         });
 

--- a/packages/reflection/src/FunctionReflector.php
+++ b/packages/reflection/src/FunctionReflector.php
@@ -7,6 +7,8 @@ namespace Tempest\Reflection;
 use Closure;
 use Generator;
 use ReflectionFunction as PHPReflectionFunction;
+use ReflectionParameter;
+use Tempest\Support\Arr;
 
 final readonly class FunctionReflector implements Reflector
 {
@@ -30,6 +32,20 @@ final readonly class FunctionReflector implements Reflector
         foreach ($this->reflectionFunction->getParameters() as $parameter) {
             yield new ParameterReflector($parameter);
         }
+    }
+
+    public function getParameter(int|string $key): ?ParameterReflector
+    {
+        $parameter = array_find(
+            array: $this->reflectionFunction->getParameters(),
+            callback: fn (ReflectionParameter $parameter) => $parameter->getName() === $key || $parameter->getPosition() === $key,
+        );
+
+        if ($parameter === null) {
+            return null;
+        }
+
+        return new ParameterReflector($parameter);
     }
 
     public function getName(): string

--- a/packages/reflection/tests/FunctionReflectorTest.php
+++ b/packages/reflection/tests/FunctionReflectorTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tempest\Reflection\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Reflection\FunctionReflector;
+
+final class FunctionReflectorTest extends TestCase
+{
+    public function test_get_parameter(): void
+    {
+        $reflector = new FunctionReflector(fn (string $_test) => null);
+
+        $this->assertSame('_test', $reflector->getParameter(key: '_test')->getName());
+        $this->assertSame('_test', $reflector->getParameter(key: 0)->getName());
+        $this->assertNull($reflector->getParameter(key: 'does-not-exist'));
+    }
+}

--- a/packages/router/src/Static/StaticCleanCommand.php
+++ b/packages/router/src/Static/StaticCleanCommand.php
@@ -38,7 +38,7 @@ final readonly class StaticCleanCommand
 
         $removed = 0;
 
-        $this->eventBus->listen(StaticPageRemoved::class, function (StaticPageRemoved $event) use (&$removed): void {
+        $this->eventBus->listen(function (StaticPageRemoved $event) use (&$removed): void {
             $removed++;
             $this->keyValue("<style='fg-gray'>{$event->path}</style>", "<style='fg-green'>REMOVED</style>");
         });

--- a/packages/router/src/Static/StaticGenerateCommand.php
+++ b/packages/router/src/Static/StaticGenerateCommand.php
@@ -72,12 +72,12 @@ final class StaticGenerateCommand
 
         $this->console->header('Generating static pages');
 
-        $this->eventBus->listen(StaticPageGenerated::class, function (StaticPageGenerated $event) use (&$generated): void {
+        $this->eventBus->listen(function (StaticPageGenerated $event) use (&$generated): void {
             $generated++;
             $this->keyValue("<style='fg-gray'>{$event->uri}</style>", "<style='fg-green'>{$event->path}</style>");
         });
 
-        $this->eventBus->listen(StaticPageGenerationFailed::class, function (StaticPageGenerationFailed $event) use (&$failures, $verbose): void {
+        $this->eventBus->listen(function (StaticPageGenerationFailed $event) use (&$failures, $verbose): void {
             $failures++;
 
             match (true) {

--- a/tests/Integration/Debug/DebugTest.php
+++ b/tests/Integration/Debug/DebugTest.php
@@ -20,7 +20,7 @@ final class DebugTest extends FrameworkIntegrationTestCase
         $class = new stdClass();
 
         $eventBus = $this->container->get(EventBus::class);
-        $eventBus->listen(ItemsDebugged::class, function (ItemsDebugged $event) use ($class): void {
+        $eventBus->listen(function (ItemsDebugged $event) use ($class): void {
             $this->assertSame(['foo', $class], $event->items);
         });
 

--- a/tests/Integration/EventBus/EventBusTesterTest.php
+++ b/tests/Integration/EventBus/EventBusTesterTest.php
@@ -148,9 +148,11 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
     {
         $this->eventBus->preventEventHandling();
 
-        $this->container->get(EventBus::class)->listen(FakeEvent::class, function (FakeEvent $_): never {
-            throw new LogicException('This should not be called');
-        });
+        $this->container
+            ->get(EventBus::class)
+            ->listen(function (FakeEvent $_): never {
+                throw new LogicException('This should not be called');
+            });
 
         $this->eventBus->assertListeningTo(FakeEvent::class);
         $this->eventBus->assertListeningTo(FakeEvent::class);
@@ -160,15 +162,19 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
     {
         $this->eventBus->preventEventHandling();
 
-        $this->container->get(EventBus::class)->listen(FakeEvent::class, function (FakeEvent $_): never {
-            throw new LogicException('This should not be called');
-        });
+        $this->container
+            ->get(EventBus::class)
+            ->listen(function (FakeEvent $_): never {
+                throw new LogicException('This should not be called');
+            });
 
         $this->eventBus->assertListeningTo(FakeEvent::class, count: 1);
 
-        $this->container->get(EventBus::class)->listen(FakeEvent::class, function (FakeEvent $_): never {
-            throw new LogicException('This should not be called');
-        });
+        $this->container
+            ->get(EventBus::class)
+            ->listen(function (FakeEvent $_): never {
+                throw new LogicException('This should not be called');
+            });
 
         $this->eventBus->assertListeningTo(FakeEvent::class, count: 2);
     }
@@ -190,9 +196,11 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
 
         $this->eventBus->preventEventHandling();
 
-        $this->container->get(EventBus::class)->listen(FakeEvent::class, function (FakeEvent $_): never {
-            throw new LogicException('This should not be called');
-        });
+        $this->container
+            ->get(EventBus::class)
+            ->listen(function (FakeEvent $_): never {
+                throw new LogicException('This should not be called');
+            });
 
         $this->eventBus->assertListeningTo(FakeEvent::class, count: 2);
     }

--- a/tests/Integration/Log/GenericLoggerTest.php
+++ b/tests/Integration/Log/GenericLoggerTest.php
@@ -138,7 +138,7 @@ final class GenericLoggerTest extends FrameworkIntegrationTestCase
     {
         $eventBus = $this->container->get(EventBus::class);
 
-        $eventBus->listen(MessageLogged::class, function (MessageLogged $event) use ($level): void {
+        $eventBus->listen(function (MessageLogged $event) use ($level): void {
             $this->assertSame($level, $event->level);
             $this->assertSame('This is a log message of level: ' . $level->value, $event->message);
             $this->assertSame(['foo' => 'bar'], $event->context);


### PR DESCRIPTION
Closes https://github.com/tempestphp/tempest-framework/issues/1290

As specified in the issue, there was an inconsistency and a DX papercut here. The first parameter was redundant with the closure's signature. 

Instead of removing the `$event` parameter, I reordered it and made it optional, so string-based events could still be supported by this method.