### PR TITLE
refactor(http): split session configs by manager

### DIFF
--- a/packages/core/src/AppConfig.php
+++ b/packages/core/src/AppConfig.php
@@ -13,6 +13,8 @@ final class AppConfig
     public string $baseUri;
 
     public function __construct(
+        public ?string $name = null,
+
         ?Environment $environment = null,
 
         ?string $baseUri = null,
@@ -26,7 +28,6 @@ final class AppConfig
         public array $insightsProviders = [],
     ) {
         $this->environment = $environment ?? Environment::fromEnv();
-
         $this->baseUri = $baseUri ?? env('BASE_URI') ?? '';
     }
 }

--- a/packages/core/src/Config/app.config.php
+++ b/packages/core/src/Config/app.config.php
@@ -4,4 +4,9 @@ declare(strict_types=1);
 
 use Tempest\Core\AppConfig;
 
-return new AppConfig();
+use function Tempest\env;
+
+return new AppConfig(
+    name: env('APPLICATION_NAME'),
+    baseUri: env('BASE_URI'),
+);

--- a/packages/http/src/Session/CleanupSessionsCommand.php
+++ b/packages/http/src/Session/CleanupSessionsCommand.php
@@ -8,6 +8,7 @@ use Tempest\Console\Console;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\Schedule;
 use Tempest\Console\Scheduler\Every;
+use Tempest\EventBus\EventBus;
 
 use function Tempest\listen;
 

--- a/packages/http/src/Session/Config/FileSessionConfig.php
+++ b/packages/http/src/Session/Config/FileSessionConfig.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tempest\Http\Session\Config;
+
+use Tempest\Container\Container;
+use Tempest\Http\Session\Managers\FileSessionManager;
+use Tempest\Http\Session\Resolvers\CookieSessionIdResolver;
+use Tempest\Http\Session\SessionConfig;
+
+final class FileSessionConfig implements SessionConfig
+{
+    public function __construct(
+        /**
+         * Path to the sessions storage directory, relative to the internal storage.
+         */
+        public string $path,
+
+        public int $expirationInSeconds = 60 * 60 * 24 * 30,
+
+        public string $idResolverClass = CookieSessionIdResolver::class,
+    ) {}
+
+    public function createManager(Container $container): FileSessionManager
+    {
+        return $container->get(FileSessionManager::class);
+    }
+}

--- a/packages/http/src/Session/Config/session.config.php
+++ b/packages/http/src/Session/Config/session.config.php
@@ -1,0 +1,7 @@
+<?php
+
+use Tempest\Http\Session\Config\FileSessionConfig;
+
+return new FileSessionConfig(
+    path: 'sessions',
+);

--- a/packages/http/src/Session/Resolvers/CookieSessionIdResolver.php
+++ b/packages/http/src/Session/Resolvers/CookieSessionIdResolver.php
@@ -6,15 +6,18 @@ namespace Tempest\Http\Session\Resolvers;
 
 use Symfony\Component\Uid\Uuid;
 use Tempest\Clock\Clock;
+use Tempest\Core\AppConfig;
 use Tempest\Http\Cookie\CookieManager;
-use Tempest\Http\Session\Session;
 use Tempest\Http\Session\SessionConfig;
 use Tempest\Http\Session\SessionId;
 use Tempest\Http\Session\SessionIdResolver;
 
+use function Tempest\Support\str;
+
 final readonly class CookieSessionIdResolver implements SessionIdResolver
 {
     public function __construct(
+        private AppConfig $appConfig,
         private CookieManager $cookies,
         private SessionConfig $sessionConfig,
         private Clock $clock,
@@ -22,13 +25,18 @@ final readonly class CookieSessionIdResolver implements SessionIdResolver
 
     public function resolve(): SessionId
     {
-        $id = $this->cookies->get(Session::ID)->value ?? null;
+        $sessionId = str($this->appConfig->name ?? 'tempest')
+            ->snake()
+            ->append('_session_id')
+            ->toString();
+
+        $id = $this->cookies->get($sessionId)->value ?? null;
 
         if (! $id) {
             $id = (string) Uuid::v4();
 
             $this->cookies->set(
-                key: Session::ID,
+                key: $sessionId,
                 value: $id,
                 expiresAt: $this->clock->now()->plusSeconds($this->sessionConfig->expirationInSeconds),
             );

--- a/packages/http/src/Session/Resolvers/HeaderSessionIdResolver.php
+++ b/packages/http/src/Session/Resolvers/HeaderSessionIdResolver.php
@@ -5,21 +5,27 @@ declare(strict_types=1);
 namespace Tempest\Http\Session\Resolvers;
 
 use Symfony\Component\Uid\Uuid;
+use Tempest\Core\AppConfig;
 use Tempest\Http\Request;
-use Tempest\Http\Session\Session;
 use Tempest\Http\Session\SessionId;
 use Tempest\Http\Session\SessionIdResolver;
 
 final readonly class HeaderSessionIdResolver implements SessionIdResolver
 {
     public function __construct(
+        private AppConfig $appConfig,
         private Request $request,
     ) {}
 
     public function resolve(): SessionId
     {
-        $id = $this->request->headers[Session::ID] ?? null;
+        $sessionId = str($this->appConfig->name ?? 'tempest')
+            ->snake()
+            ->append('_session_id')
+            ->toString();
 
-        return new SessionId($id ?? ((string) Uuid::v4()));
+        return new SessionId(
+            id: $this->request->headers[$sessionId] ?? Uuid::v4()->toString(),
+        );
     }
 }

--- a/packages/http/src/Session/Session.php
+++ b/packages/http/src/Session/Session.php
@@ -10,8 +10,6 @@ use function Tempest\get;
 
 final class Session
 {
-    public const string ID = 'tempest_session_id';
-
     public const string VALIDATION_ERRORS = 'validation_errors';
 
     public const string ORIGINAL_VALUES = 'original_values';

--- a/packages/http/src/Session/SessionConfig.php
+++ b/packages/http/src/Session/SessionConfig.php
@@ -1,35 +1,26 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Tempest\Http\Session;
 
-use Tempest\Http\Session\Managers\FileSessionManager;
-use Tempest\Http\Session\Resolvers\CookieSessionIdResolver;
+use Tempest\Container\Container;
+use Tempest\Http\Session\SessionIdResolver;
 
-final class SessionConfig
+interface SessionConfig
 {
-    public function __construct(
-        /**
-         * Path to the sessions storage directory, relative to the internal storage.
-         */
-        public string $path = 'sessions',
+    /**
+     * Time required for a session to expire. Defaults to one month.
+     */
+    public int $expirationInSeconds {
+        get;
+    }
 
-        /**
-         * Time required for a session to expire. Defaults to one month.
-         */
-        public int $expirationInSeconds = 60 * 60 * 24 * 30,
+    /**
+     * @template SessionIdResolver of \Tempest\Http\Session\SessionIdResolver
+     * @var class-string<SessionIdResolver>
+     */
+    public string $idResolverClass {
+        get;
+    }
 
-        /**
-         * @template SessionManager of \Tempest\Http\Session\SessionManager
-         * @var class-string<SessionManager>
-         */
-        public string $managerClass = FileSessionManager::class,
-
-        /**
-         * @template SessionIdResolver of \Tempest\Http\Session\SessionIdResolver
-         * @var class-string<SessionIdResolver>
-         */
-        public string $idResolverClass = CookieSessionIdResolver::class,
-    ) {}
+    public function createManager(Container $container): SessionManager;
 }

--- a/packages/http/src/Session/SessionIdResolverInitializer.php
+++ b/packages/http/src/Session/SessionIdResolverInitializer.php
@@ -6,6 +6,7 @@ namespace Tempest\Http\Session;
 
 use Tempest\Container\Container;
 use Tempest\Container\Initializer;
+use Tempest\Http\Session\SessionConfig;
 
 final readonly class SessionIdResolverInitializer implements Initializer
 {

--- a/packages/http/src/Session/SessionInitializer.php
+++ b/packages/http/src/Session/SessionInitializer.php
@@ -14,7 +14,6 @@ final readonly class SessionInitializer implements Initializer
     public function initialize(Container $container): Session
     {
         $sessionManager = $container->get(SessionManager::class);
-
         $sessionIdResolver = $container->get(SessionIdResolver::class);
 
         return $sessionManager->create($sessionIdResolver->resolve());

--- a/packages/http/src/Session/SessionManagerInitializer.php
+++ b/packages/http/src/Session/SessionManagerInitializer.php
@@ -13,8 +13,8 @@ final readonly class SessionManagerInitializer implements Initializer
     #[Singleton]
     public function initialize(Container $container): SessionManager
     {
-        $config = $container->get(SessionConfig::class);
-
-        return $container->get($config->managerClass);
+        return $container
+            ->get(SessionConfig::class)
+            ->createManager($container);
     }
 }

--- a/tests/Integration/Auth/AuthorizerTest.php
+++ b/tests/Integration/Auth/AuthorizerTest.php
@@ -12,6 +12,7 @@ use Tempest\Auth\Install\User;
 use Tempest\Clock\Clock;
 use Tempest\Core\FrameworkKernel;
 use Tempest\Database\Migrations\CreateMigrationsTable;
+use Tempest\Http\Session\Config\FileSessionConfig;
 use Tempest\Http\Session\Managers\FileSessionManager;
 use Tempest\Http\Session\SessionConfig;
 use Tempest\Http\Session\SessionManager;
@@ -46,7 +47,7 @@ final class AuthorizerTest extends FrameworkIntegrationTestCase
 
         $this->container->get(FrameworkKernel::class)->internalStorage = realpath($this->path);
 
-        $this->container->config(new SessionConfig(path: 'sessions'));
+        $this->container->config(new FileSessionConfig(path: 'sessions'));
         $this->container->singleton(
             SessionManager::class,
             fn () => new FileSessionManager(

--- a/tests/Integration/Auth/SessionAuthenticatorTest.php
+++ b/tests/Integration/Auth/SessionAuthenticatorTest.php
@@ -14,6 +14,7 @@ use Tempest\Auth\SessionAuthenticator;
 use Tempest\Clock\Clock;
 use Tempest\Core\FrameworkKernel;
 use Tempest\Database\Migrations\CreateMigrationsTable;
+use Tempest\Http\Session\Config\FileSessionConfig;
 use Tempest\Http\Session\Managers\FileSessionManager;
 use Tempest\Http\Session\Session;
 use Tempest\Http\Session\SessionConfig;
@@ -38,7 +39,7 @@ final class SessionAuthenticatorTest extends FrameworkIntegrationTestCase
 
         $this->container->get(FrameworkKernel::class)->internalStorage = realpath($this->path);
 
-        $this->container->config(new SessionConfig(path: 'sessions'));
+        $this->container->config(new FileSessionConfig(path: 'sessions'));
         $this->container->singleton(
             SessionManager::class,
             fn () => new FileSessionManager(

--- a/tests/Integration/Http/CleanupSessionsCommandTest.php
+++ b/tests/Integration/Http/CleanupSessionsCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Http;
 
+use Tempest\Http\Session\Config\FileSessionConfig;
 use Tempest\Http\Session\SessionConfig;
 use Tempest\Http\Session\SessionId;
 use Tempest\Http\Session\SessionManager;
@@ -23,7 +24,7 @@ final class CleanupSessionsCommandTest extends FrameworkIntegrationTestCase
 
         $clock = $this->clock('2024-01-01 00:00:00');
 
-        $this->container->config(new SessionConfig(
+        $this->container->config(new FileSessionConfig(
             path: 'tests/sessions',
             expirationInSeconds: 10,
         ));

--- a/tests/Integration/Http/FileSessionTest.php
+++ b/tests/Integration/Http/FileSessionTest.php
@@ -6,6 +6,7 @@ namespace Tests\Tempest\Integration\Http;
 
 use Tempest\Clock\Clock;
 use Tempest\Core\FrameworkKernel;
+use Tempest\Http\Session\Config\FileSessionConfig;
 use Tempest\Http\Session\Managers\FileSessionManager;
 use Tempest\Http\Session\Session;
 use Tempest\Http\Session\SessionConfig;
@@ -32,7 +33,7 @@ final class FileSessionTest extends FrameworkIntegrationTestCase
         $this->path = realpath($this->path);
 
         $this->container->get(FrameworkKernel::class)->internalStorage = realpath($this->path);
-        $this->container->config(new SessionConfig(path: 'sessions'));
+        $this->container->config(new FileSessionConfig(path: 'sessions'));
         $this->container->singleton(
             SessionManager::class,
             fn () => new FileSessionManager(
@@ -99,7 +100,7 @@ final class FileSessionTest extends FrameworkIntegrationTestCase
     {
         $clock = $this->clock('2023-01-01 00:00:00');
 
-        $this->container->config(new SessionConfig(
+        $this->container->config(new FileSessionConfig(
             path: 'test_sessions',
             expirationInSeconds: 1,
         ));

--- a/tests/Integration/Http/SessionFromCookieTest.php
+++ b/tests/Integration/Http/SessionFromCookieTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Tempest\Integration\Http;
 
 use Tempest\Http\Cookie\CookieManager;
+use Tempest\Http\Session\Config\FileSessionConfig;
 use Tempest\Http\Session\Resolvers\CookieSessionIdResolver;
 use Tempest\Http\Session\Session;
 use Tempest\Http\Session\SessionConfig;
@@ -17,7 +18,7 @@ final class SessionFromCookieTest extends FrameworkIntegrationTestCase
 {
     public function test_resolving_session_from_cookie(): void
     {
-        $this->container->config(new SessionConfig(
+        $this->container->config(new FileSessionConfig(
             path: 'test_sessions',
             idResolverClass: CookieSessionIdResolver::class,
         ));
@@ -37,7 +38,7 @@ final class SessionFromCookieTest extends FrameworkIntegrationTestCase
     {
         $clock = $this->clock('2023-01-01 00:00:00');
 
-        $this->container->config(new SessionConfig(
+        $this->container->config(new FileSessionConfig(
             path: 'test_sessions',
             expirationInSeconds: 1,
         ));
@@ -46,7 +47,7 @@ final class SessionFromCookieTest extends FrameworkIntegrationTestCase
         $this->container->get(Session::class);
 
         $cookieManager = $this->container->get(CookieManager::class);
-        $cookie = $cookieManager->get(Session::ID);
+        $cookie = $cookieManager->get('tempest_session_id');
 
         $this->assertEquals(1, $cookie->maxAge);
         $this->assertEquals($clock->seconds() + 1, $cookie->getExpiresAtTime());

--- a/tests/Integration/Http/SessionFromHeaderTest.php
+++ b/tests/Integration/Http/SessionFromHeaderTest.php
@@ -7,9 +7,9 @@ namespace Tests\Tempest\Integration\Http;
 use Tempest\Http\GenericRequest;
 use Tempest\Http\Method;
 use Tempest\Http\Request;
+use Tempest\Http\Session\Config\FileSessionConfig;
 use Tempest\Http\Session\Resolvers\HeaderSessionIdResolver;
 use Tempest\Http\Session\Session;
-use Tempest\Http\Session\SessionConfig;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 /**
@@ -19,7 +19,7 @@ final class SessionFromHeaderTest extends FrameworkIntegrationTestCase
 {
     public function test_resolving_session_from_header(): void
     {
-        $this->container->config(new SessionConfig(
+        $this->container->config(new FileSessionConfig(
             path: 'test_sessions',
             idResolverClass: HeaderSessionIdResolver::class,
         ));
@@ -34,7 +34,7 @@ final class SessionFromHeaderTest extends FrameworkIntegrationTestCase
 
     private function setSessionId(string $id): void
     {
-        $request = new GenericRequest(Method::GET, '/', [], [Session::ID => $id]);
+        $request = new GenericRequest(Method::GET, '/', [], ['tempest_session_id' => $id]);
 
         $this->container->singleton(Request::class, fn () => $request);
         $this->container->singleton(GenericRequest::class, fn () => $request);


### PR DESCRIPTION
This pull request refactors the `SessionConfig` into an interface and a `FileSessionConfig` implementation, to be in-line with other manager/driver-based implementations.

Additionally, instead of using `tempest_session_id` as the cookie key, it will use the `APPLICATION_NAME` if specified. eg. if `APPLICATION_NAME="Tempest Cloud"`, the cookie key would be `tempest_cloud_session_id`.

This is still draft because I'd like to fix [this bug](https://discord.com/channels/1236153076688359495/1236153079603269766/1385340017496555721) as well in this PR.