### PR TITLE
refactor(support): clarify `has` and `contains` methods

### DIFF
--- a/packages/console/src/Middleware/ResolveOrRescueMiddleware.php
+++ b/packages/console/src/Middleware/ResolveOrRescueMiddleware.php
@@ -84,7 +84,7 @@ final readonly class ResolveOrRescueMiddleware implements ConsoleMiddleware
             $currentName = str($consoleCommand->getName());
 
             // Already added to suggestions
-            if ($suggestions->contains($currentName->toString())) {
+            if ($suggestions->hasValue($currentName->toString())) {
                 continue;
             }
 

--- a/packages/console/src/Middleware/ValidateNamedArgumentsMiddleware.php
+++ b/packages/console/src/Middleware/ValidateNamedArgumentsMiddleware.php
@@ -29,7 +29,7 @@ final class ValidateNamedArgumentsMiddleware implements ConsoleMiddleware
 
         $invalidInput = arr($invocation->argumentBag->arguments)
             ->filter(fn (ConsoleInputArgument $argument) => $argument->name !== null)
-            ->filter(fn (ConsoleInputArgument $argument) => ! $allowedParameterNames->contains(ltrim($argument->name, '-')))
+            ->filter(fn (ConsoleInputArgument $argument) => ! $allowedParameterNames->hasValue(ltrim($argument->name, '-')))
             ->filter(fn (ConsoleInputArgument $argument) => ! in_array($argument->name, GlobalFlags::values(), strict: true));
 
         if ($invalidInput->isNotEmpty()) {

--- a/packages/database/src/Mappers/SelectModelMapper.php
+++ b/packages/database/src/Mappers/SelectModelMapper.php
@@ -103,7 +103,7 @@ final class SelectModelMapper implements Mapper
 
                     $originalKey .= $relation->name . '.';
 
-                    if (! $data->has(trim($originalKey, '.'))) {
+                    if (! $data->hasKey(trim($originalKey, '.'))) {
                         $data->set(trim($originalKey, '.'), []);
                     }
 

--- a/packages/http/src/IsRequest.php
+++ b/packages/http/src/IsRequest.php
@@ -11,7 +11,7 @@ use Tempest\Validation\SkipValidation;
 
 use function Tempest\get;
 use function Tempest\Support\Arr\get_by_key;
-use function Tempest\Support\Arr\has;
+use function Tempest\Support\Arr\has_key;
 
 /** @phpstan-require-implements \Tempest\Http\Request */
 trait IsRequest
@@ -125,7 +125,7 @@ trait IsRequest
     public function hasBody(?string $key = null): bool
     {
         if ($key) {
-            return has($this->body, $key);
+            return has_key($this->body, $key);
         }
 
         return count($this->body) || ((bool) $this->raw);
@@ -133,6 +133,6 @@ trait IsRequest
 
     public function hasQuery(string $key): bool
     {
-        return has($this->query, $key);
+        return has_key($this->query, $key);
     }
 }

--- a/packages/http/src/Mappers/PsrRequestToGenericRequestMapper.php
+++ b/packages/http/src/Mappers/PsrRequestToGenericRequestMapper.php
@@ -28,7 +28,7 @@ final readonly class PsrRequestToGenericRequestMapper implements Mapper
         $data = (array) $from->getParsedBody();
         $raw = $from->getBody()->getContents();
 
-        if (arr($from->getHeader('content-type'))->contains('application/json') && json_validate($raw)) {
+        if (arr($from->getHeader('content-type'))->hasValue('application/json') && json_validate($raw)) {
             $data = [...$data, ...json_decode($raw, associative: true)];
         }
 

--- a/packages/support/src/Arr/ManipulatesArray.php
+++ b/packages/support/src/Arr/ManipulatesArray.php
@@ -517,7 +517,7 @@ trait ManipulatesArray
      */
     public function get(int|string $key, mixed $default = null): mixed
     {
-        return get_by_key($this->value, $key, $default);
+        return namespace\get_by_key($this->value, $key, $default);
     }
 
     /**
@@ -537,19 +537,43 @@ trait ManipulatesArray
     }
 
     /**
-     * Asserts whether a value identified by the specified `$key` exists.
-     */
-    public function has(int|string $key): bool
-    {
-        return namespace\has($this->value, $key);
-    }
-
-    /**
-     * Asserts whether the instance contains an item that can be identified by `$search`.
+     * Asserts whether the instance has the given item. A callback may be used instead of a value.
+     *
+     * @see `hasValue`
+     * @param TValue|Closure(TValue, TKey): bool $search
      */
     public function contains(mixed $search): bool
     {
         return namespace\contains($this->value, $search);
+    }
+
+    /**
+     * Asserts whether a value identified by the specified `$key` exists. Dot notation is supported.
+     */
+    public function hasKey(int|string $key): bool
+    {
+        return namespace\has_key($this->value, $key);
+    }
+
+    /**
+     * Asserts whether the instance contains the specified value.
+     *
+     * @param TValue: bool $search
+     */
+    public function hasValue(mixed $search): bool
+    {
+        return namespace\contains($this->value, $search);
+    }
+
+    /**
+     * Asserts whether the instance contains the specified value.
+     *
+     * @see `hasValue`
+     * @param TValue|Closure(TValue, TKey): bool $search
+     */
+    public function includes(mixed $search): bool
+    {
+        return $this->hasValue($search);
     }
 
     /**

--- a/packages/support/src/Arr/functions.php
+++ b/packages/support/src/Arr/functions.php
@@ -807,9 +807,9 @@ namespace Tempest\Support\Arr {
     }
 
     /**
-     * Asserts whether a value identified by the specified `$key` exists.
+     * Asserts whether a value identified by the specified `$key` exists. Dot notation is supported.
      */
-    function has(iterable $array, int|string $key): bool
+    function has_key(iterable $array, int|string $key): bool
     {
         $array = to_array($array);
 
@@ -833,11 +833,21 @@ namespace Tempest\Support\Arr {
     }
 
     /**
-     * Asserts whether the given array contains an item that can be identified by `$search`.
+     * Asserts whether the given array contains a value that can be identified by `$search`.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param iterable<TKey,TValue> $array
+     * @param TValue|Closure(TValue, TKey): bool $search
      */
     function contains(iterable $array, mixed $search): bool
     {
-        return namespace\first(to_array($array), fn (mixed $value) => $value === $search) !== null;
+        $search = ($search instanceof Closure)
+            ? $search
+            : static fn (mixed $value) => $value === $search;
+
+        return namespace\first(to_array($array), $search) !== null;
     }
 
     /**

--- a/packages/support/tests/Arr/ManipulatesArrayTest.php
+++ b/packages/support/tests/Arr/ManipulatesArrayTest.php
@@ -92,7 +92,7 @@ final class ManipulatesArrayTest extends TestCase
         $this->assertSame('b', arr($array)->get('a'));
     }
 
-    public function test_arr_has(): void
+    public function test_arr_has_key(): void
     {
         $array = [
             'a' => [
@@ -100,9 +100,9 @@ final class ManipulatesArrayTest extends TestCase
             ],
         ];
 
-        $this->assertTrue(arr($array)->has('a.b'));
-        $this->assertTrue(arr($array)->has('a'));
-        $this->assertFalse(arr($array)->has('a.x'));
+        $this->assertTrue(arr($array)->hasKey('a.b'));
+        $this->assertTrue(arr($array)->hasKey('a'));
+        $this->assertFalse(arr($array)->hasKey('a.x'));
     }
 
     public function test_arr_set(): void
@@ -330,6 +330,21 @@ final class ManipulatesArrayTest extends TestCase
     {
         $this->assertTrue(arr(['a', 'b', 'c'])->contains('b'));
         $this->assertFalse(arr(['a', 'b', 'c'])->contains('d'));
+
+        $this->assertTrue(arr(['a', 'b', 'c'])->includes('b'));
+        $this->assertFalse(arr(['a', 'b', 'c'])->includes('d'));
+
+        $this->assertTrue(arr(['a', 'b', 'c'])->hasValue('b'));
+        $this->assertFalse(arr(['a', 'b', 'c'])->hasValue('d'));
+
+        $this->assertTrue(arr(['a', 'b', 'c'])->contains(fn (string $v) => $v === 'b'));
+        $this->assertFalse(arr(['a', 'b', 'c'])->contains(fn (string $v) => $v === 'd'));
+
+        $this->assertTrue(arr(['a', 'b', 'c'])->hasValue(fn (string $v) => $v === 'b'));
+        $this->assertFalse(arr(['a', 'b', 'c'])->hasValue(fn (string $v) => $v === 'd'));
+
+        $this->assertTrue(arr(['a', 'b', 'c'])->includes(fn (string $v) => $v === 'b'));
+        $this->assertFalse(arr(['a', 'b', 'c'])->includes(fn (string $v) => $v === 'd'));
     }
 
     public function test_explode(): void

--- a/packages/validation/src/Validator.php
+++ b/packages/validation/src/Validator.php
@@ -63,7 +63,7 @@ final readonly class Validator
 
             $key = $prefix . $property->getName();
 
-            if (! $values->has($key) && $property->hasDefaultValue()) {
+            if (! $values->hasKey($key) && $property->hasDefaultValue()) {
                 continue;
             }
 

--- a/src/Tempest/Framework/Testing/InstallerTester.php
+++ b/src/Tempest/Framework/Testing/InstallerTester.php
@@ -121,7 +121,7 @@ final class InstallerTester
     public function assertCommandExecuted(string $command): self
     {
         Assert::assertTrue(
-            condition: arr($this->executor->executedCommands)->contains($command),
+            condition: arr($this->executor->executedCommands)->hasValue($command),
             message: sprintf('The command `%s` was not executed', $command),
         );
 


### PR DESCRIPTION
This pull request changes the name of the `has` and `contains` array utilities to clarify what they do. Everytime I use them, I have to look them to to find out which one looks for a key, a value or accepts a callback.

- `has` is now `hasKey`
- A new `hasValue` method checks for the existence of a value
- `contains` now supports a closure and has better types
- `includes` is an alias to `contains` (if you work a lot with JavaScript, you know)