### PR TITLE
feat(router): allow specifying port using `host:port` syntax

### DIFF
--- a/packages/router/src/Commands/ServeCommand.php
+++ b/packages/router/src/Commands/ServeCommand.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tempest\Router\Commands;
 
 use Tempest\Console\ConsoleCommand;
+use Tempest\Intl\Number;
+use Tempest\Support\Str;
 
 final readonly class ServeCommand
 {
@@ -15,6 +17,12 @@ final readonly class ServeCommand
     public function __invoke(string $host = 'localhost', int $port = 8000, string $publicDir = 'public/'): void
     {
         $routerFile = __DIR__ . '/router.php';
+
+        if (Str\contains($host, ':')) {
+            [$host, $overridenPort] = explode(':', $host, limit: 2);
+            $port = Number\parse($overridenPort, default: $port);
+        }
+
         passthru("php -S {$host}:{$port} -t {$publicDir} {$routerFile}");
     }
 }


### PR DESCRIPTION
Closes #1316

Allows for running `tempest serve host:port`. If `port` in that case is not a valid number, the original `$port` argument is used.