### PR TITLE
fix(router): handle `HEAD` requests

### DIFF
--- a/packages/router/src/GenericResponseSender.php
+++ b/packages/router/src/GenericResponseSender.php
@@ -31,7 +31,7 @@ final readonly class GenericResponseSender implements ResponseSender
         $this->sendHeaders($response);
         ob_flush();
 
-        if (! $this->shouldSendContent()) {
+        if ($this->shouldSendContent()) {
             $this->sendContent($response);
         }
 

--- a/packages/router/src/GenericRouter.php
+++ b/packages/router/src/GenericRouter.php
@@ -39,6 +39,8 @@ final readonly class GenericRouter implements Router
             $request = map($request)->with(PsrRequestToGenericRequestMapper::class)->do();
         }
 
+        $this->container->singleton(Request::class, $request);
+
         $callable = $this->getCallable();
 
         return $this->processResponse($callable($request));

--- a/packages/router/src/HttpApplication.php
+++ b/packages/router/src/HttpApplication.php
@@ -52,12 +52,10 @@ final readonly class HttpApplication implements Application
         $router = $this->container->get(Router::class);
 
         $psrRequest = $this->container->get(RequestFactory::class)->make();
+        $response = $router->dispatch($psrRequest);
 
         $responseSender = $this->container->get(ResponseSender::class);
-
-        $responseSender->send(
-            $router->dispatch($psrRequest),
-        );
+        $responseSender->send($response);
 
         $this->container->get(Session::class)->cleanup();
 

--- a/packages/router/src/ResponseSenderInitializer.php
+++ b/packages/router/src/ResponseSenderInitializer.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tempest\Router;
 
-use Tempest\Clock\Clock;
 use Tempest\Container\Container;
 use Tempest\Container\Initializer;
 use Tempest\Container\Singleton;
+use Tempest\Http\Request;
 use Tempest\View\ViewRenderer;
 
 final class ResponseSenderInitializer implements Initializer
@@ -15,6 +15,9 @@ final class ResponseSenderInitializer implements Initializer
     #[Singleton]
     public function initialize(Container $container): ResponseSender
     {
-        return new GenericResponseSender($container->get(ViewRenderer::class));
+        return new GenericResponseSender(
+            request: $container->get(Request::class),
+            viewRenderer: $container->get(ViewRenderer::class),
+        );
     }
 }

--- a/packages/router/src/Routing/Construction/RouteConfigurator.php
+++ b/packages/router/src/Routing/Construction/RouteConfigurator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Router\Routing\Construction;
 
 use Tempest\Container\Singleton;
+use Tempest\Http\Method;
 use Tempest\Router\RouteConfig;
 
 /**
@@ -46,16 +47,19 @@ final class RouteConfigurator
     {
         $markedRoute = $this->markRoute($route);
         $this->dynamicRoutes[$route->method->value][$markedRoute->mark] = $route;
+        $this->dynamicRoutes[Method::HEAD->value][$markedRoute->mark] = $route;
 
         $this->routingTree->add($markedRoute);
     }
 
     private function addStaticRoute(DiscoveredRoute $route): void
     {
-        $uriWithTrailingSlash = rtrim($route->uri, '/');
+        $uriWithoutTrailingSlash = rtrim($route->uri, '/');
 
-        $this->staticRoutes[$route->method->value][$uriWithTrailingSlash] = $route;
-        $this->staticRoutes[$route->method->value][$uriWithTrailingSlash . '/'] = $route;
+        $this->staticRoutes[$route->method->value][$uriWithoutTrailingSlash] = $route;
+        $this->staticRoutes[$route->method->value][$uriWithoutTrailingSlash . '/'] = $route;
+        $this->staticRoutes[Method::HEAD->value][$uriWithoutTrailingSlash] = $route;
+        $this->staticRoutes[Method::HEAD->value][$uriWithoutTrailingSlash . '/'] = $route;
     }
 
     private function markRoute(DiscoveredRoute $route): MarkedRoute


### PR DESCRIPTION
Closes https://github.com/tempestphp/tempest-framework/issues/1323

There are probably things that are wrong here, as I didn't dive into the topic:
- not sure if `fastcgi_finish_request` should still be called when handling `HEAD` requests
- not sure for which routes we should register matching `HEAD` routes
- not sure if we should actually register them or if we should tweak the route matcher

@brendt or @blackshadev, you can take over this PR or fix the issue in another one, as you wish :D 