### PR TITLE
chore(release): automatically update branch protection during release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -18,6 +18,9 @@ use Composer\Semver\VersionParser;
 use Tempest\Console\Console;
 use Tempest\Console\ConsoleApplication;
 use Tempest\Console\Exceptions\InterruptException;
+use Tempest\Http\Status;
+use Tempest\HttpClient\HttpClient;
+use Tempest\Support\Json;
 
 use function Tempest\get;
 use function Tempest\Support\arr;
@@ -156,8 +159,34 @@ function performPreReleaseChecks(string $remote, string $branch): void
         throw new Exception("You must be on the {$remote}/{$branch} branch to release.");
     }
 
+    if (null === Tempest\env('RELEASE_GITHUB_TOKEN')) {
+        throw new Exception('`RELEASE_GITHUB_TOKEN` environment variable must be set to release.');
+    }
+
     if ($behindCount = trim(shell_exec("git rev-list HEAD..{$remote}/{$branch} --count") ?? '0') !== '0') {
         throw new Exception("Local branch is behind {$remote}/{$branch} by {$behindCount} commits. Please pull first.");
+    }
+}
+
+/** 
+ * Disables the protection ruleset, so the release branch can be pushed to without a pull request.
+ */
+function updateBranchProtection(bool $enabled): void
+{
+    // https://github.com/tempestphp/tempest-framework/settings/rules/1879240
+    $ruleset = '1879240';
+    $token = Tempest\env('RELEASE_GITHUB_TOKEN');
+    $url = "https://api.github.com/repos/innocenzi/tempest-framework/rulesets/{$ruleset}";
+
+    $httpClient = Tempest\get(HttpClient::class);
+    $response = $httpClient->put(
+        uri: $url, 
+        headers: ['Authorization' => "Bearer {$token}"],
+        body: Json\encode(['enforcement' => $enabled ? 'active' : 'disabled'])
+    );
+
+    if ($response->status !== Status::OK) {
+        throw new Exception('Failed to update branch ruleset.');
     }
 }
 
@@ -338,6 +367,9 @@ try {
         handler: fn () => updateChangelog($version),
     );
 
+    // Disable protection
+    updateBranchProtection(enabled: false);
+
     // Push tags
     $console->task(
         label: 'Releasing',
@@ -359,6 +391,9 @@ try {
             executeCommands('git push'),
         ],
     );
+
+    // Re-enable protection
+    updateBranchProtection(enabled: true);
 
     $console->success(sprintf(
         'Released <em>%1$s</em>. The <href="https://github.com/tempestphp/tempest-framework/releases/tag/%1$s">GitHub release</href> will be created automatically in a few seconds.',

--- a/bin/release
+++ b/bin/release
@@ -176,7 +176,7 @@ function updateBranchProtection(bool $enabled): void
     // https://github.com/tempestphp/tempest-framework/settings/rules/1879240
     $ruleset = '1879240';
     $token = Tempest\env('RELEASE_GITHUB_TOKEN');
-    $url = "https://api.github.com/repos/innocenzi/tempest-framework/rulesets/{$ruleset}";
+    $url = "https://api.github.com/repos/tempestphp/tempest-framework/rulesets/{$ruleset}";
 
     $httpClient = Tempest\get(HttpClient::class);
     $response = $httpClient->put(


### PR DESCRIPTION
Closes https://github.com/tempestphp/tempest-framework/issues/898

I couldn't test on Tempest's actual ruleset because I can't create a personal token for it, but I did try it out on one of my repositories and it properly disables/enables the protection.

@brendt You'll need to create a PAT with **admin** permission on `tempestphp/tempest-framework`, and add it to the `.env` of your local clone of the repository as `RELEASE_GITHUB_TOKEN`.

I didn't re-try the full release script with that though, so you'll find out for v1.0.2 :D