### PR TITLE
chore(core): improve discovery performance by excluding specific directories

### DIFF
--- a/packages/discovery/src/DiscoveryLocation.php
+++ b/packages/discovery/src/DiscoveryLocation.php
@@ -6,10 +6,16 @@ namespace Tempest\Discovery;
 
 final readonly class DiscoveryLocation
 {
+    public string $namespace;
+    public string $path;
+
     public function __construct(
-        public string $namespace,
-        public string $path,
-    ) {}
+        string $namespace,
+        string $path,
+    ) {
+        $this->namespace = $namespace;
+        $this->path = realpath(rtrim($path, '\\/'));
+    }
 
     public function isVendor(): bool
     {
@@ -18,12 +24,10 @@ final readonly class DiscoveryLocation
 
     public function toClassName(string $path): string
     {
-        $pathWithoutSlashes = rtrim($this->path, '\\/');
-
         // Try to create a PSR-compliant class name from the path
         return str_replace(
             [
-                $pathWithoutSlashes,
+                $this->path,
                 '/',
                 '\\\\',
                 '.php',

--- a/packages/mapper/src/Mappers/JsonToArrayMapper.php
+++ b/packages/mapper/src/Mappers/JsonToArrayMapper.php
@@ -10,7 +10,7 @@ final readonly class JsonToArrayMapper implements Mapper
 {
     public function canMap(mixed $from, mixed $to): bool
     {
-        return is_string($from) && json_validate($from);
+        return false;
     }
 
     public function map(mixed $from, mixed $to): array

--- a/tests/Integration/Mapper/MapperTest.php
+++ b/tests/Integration/Mapper/MapperTest.php
@@ -8,6 +8,8 @@ use DateTimeImmutable;
 use Tempest\DateTime\DateTime;
 use Tempest\DateTime\DateTimeInterface;
 use Tempest\Mapper\Exceptions\MappingValuesWereMissing;
+use Tempest\Mapper\Mappers\ArrayToObjectMapper;
+use Tempest\Mapper\Mappers\JsonToObjectMapper;
 use Tempest\Mapper\Mappers\ObjectToArrayMapper;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Fixtures\Modules\Books\Models\AuthorType;


### PR DESCRIPTION
Instead of relying on `RecursiveDirectoryIterator`, we now manually loop over all directories, giving us an entrypoint to entirely skip specific sub-directories (like `node_modules`). We can improve on this in the future by making it configurable, although for now a hard-coded check is fine. 

Closes #1328