### PR TITLE
feat(session): add reflash method to session

### DIFF
--- a/packages/http/src/Session/Session.php
+++ b/packages/http/src/Session/Session.php
@@ -35,6 +35,16 @@ final class Session
         $this->getSessionManager()->set($this->id, $key, new FlashValue($value));
     }
 
+    public function reflash(): void
+    {
+        foreach ($this->getSessionManager()->all($this->id) as $key => $value) {
+            if (! ($value instanceof FlashValue))
+                continue;
+
+            unset($this->expiredKeys[$key]);
+        }
+    }
+
     public function get(string $key, mixed $default = null): mixed
     {
         $value = $this->getSessionManager()->get($this->id, $key, $default);

--- a/tests/Integration/Http/FileSessionTest.php
+++ b/tests/Integration/Http/FileSessionTest.php
@@ -118,4 +118,20 @@ final class FileSessionTest extends FrameworkIntegrationTestCase
 
         $this->assertFalse($session->isValid());
     }
+
+    public function test_session_reflash(): void
+    {
+        $session = $this->container->get(Session::class);
+
+        $session->flash('test', 'value');
+        $session->flash('test2', ['key' => 'value']);
+
+        $this->assertEquals('value', $session->get('test'));
+
+        $session->reflash();
+        $session->cleanup();
+
+        $this->assertEquals('value', $session->get('test'));
+        $this->assertEquals(['key' => 'value'], $session->get('test2'));
+    }
 }


### PR DESCRIPTION
I am building an inertia adapter for tempest and to make it work like the laravel one, I need some way of reflashing when "frontend-asset-mismatch" happens and should reload the page for the user.

The test might not be in the correct location, but I couldn't really find a better place :/