### PR TITLE
fix(icon): enable icon cache by default

### DIFF
--- a/packages/icon/src/IconCacheInitializer.php
+++ b/packages/icon/src/IconCacheInitializer.php
@@ -15,18 +15,16 @@ final class IconCacheInitializer implements Initializer
     public function initialize(Container $container): IconCache
     {
         return new IconCache(
-            enabled: $this->shouldCacheBeEnabled(
-                $container->get(AppConfig::class)->environment->isProduction(),
-            ),
+            enabled: $this->shouldCacheBeEnabled(),
         );
     }
 
-    private function shouldCacheBeEnabled(bool $isProduction): bool
+    private function shouldCacheBeEnabled(): bool
     {
         if (env('INTERNAL_CACHES') === false) {
             return false;
         }
 
-        return (bool) env('ICON_CACHE', default: $isProduction);
+        return (bool) env('ICON_CACHE', default: true);
     }
 }


### PR DESCRIPTION
This PR fixes the fact that the icon cache was not enabled locally by default, resulting in huge performance losses.