### PR TITLE
refactor(core)!: update exception processors to no longer return a throwable

### DIFF
--- a/packages/core/src/ExceptionProcessor.php
+++ b/packages/core/src/ExceptionProcessor.php
@@ -9,5 +9,5 @@ interface ExceptionProcessor
     /**
      * Processes the given exception.
      */
-    public function process(Throwable $throwable): Throwable;
+    public function process(Throwable $throwable): void;
 }

--- a/packages/core/src/ExceptionReporter.php
+++ b/packages/core/src/ExceptionReporter.php
@@ -19,7 +19,7 @@ final class ExceptionReporter
     ) {}
 
     /**
-     * Reports the given exception to the registered exceptionm processors.
+     * Reports the given exception to the registered exception processors.
      */
     public function report(Throwable $throwable): void
     {
@@ -29,9 +29,10 @@ final class ExceptionReporter
             return;
         }
 
+        /** @var class-string<\Tempest\Core\ExceptionProcessor> $processor */
         foreach ($this->appConfig->exceptionProcessors as $processor) {
             $handler = $this->container->get($processor);
-            $throwable = $handler->process($throwable);
+            $handler->process($throwable);
         }
     }
 }

--- a/packages/core/src/LogExceptionProcessor.php
+++ b/packages/core/src/LogExceptionProcessor.php
@@ -10,7 +10,7 @@ use Throwable;
  */
 final class LogExceptionProcessor implements ExceptionProcessor
 {
-    public function process(Throwable $throwable): Throwable
+    public function process(Throwable $throwable): void
     {
         $items = [
             'exception' => $throwable->getMessage(),
@@ -20,7 +20,5 @@ final class LogExceptionProcessor implements ExceptionProcessor
         ];
 
         Debug::resolve()->log($items, writeToOut: false);
-
-        return $throwable;
     }
 }

--- a/tests/Integration/Http/Fixtures/NullExceptionProcessor.php
+++ b/tests/Integration/Http/Fixtures/NullExceptionProcessor.php
@@ -11,10 +11,8 @@ final class NullExceptionProcessor implements ExceptionProcessor
 {
     public static array $exceptions = [];
 
-    public function process(Throwable $throwable): Throwable
+    public function process(Throwable $throwable): void
     {
         static::$exceptions[] = $throwable;
-
-        return $throwable;
     }
 }


### PR DESCRIPTION
This pull request updates the `ExceptionProcessor` interface to no longer return an updated throwable, which wasn't taken into account anyway.