### PR TITLE
fix(log): fix driver resolving not accounting log level

### DIFF
--- a/packages/log/src/GenericLogger.php
+++ b/packages/log/src/GenericLogger.php
@@ -91,14 +91,16 @@ final class GenericLogger implements Logger
 
     private function resolveDriver(LogChannel $channel, MonologLogLevel $level): Monolog
     {
-        if (! isset($this->drivers[spl_object_id($channel)])) {
-            $this->drivers[spl_object_id($channel)] = new Monolog(
+        $key = spl_object_id($channel) . $level->value;
+
+        if (! isset($this->drivers[$key])) {
+            $this->drivers[$key] = new Monolog(
                 name: $this->logConfig->prefix,
                 handlers: $channel->getHandlers($level),
                 processors: $channel->getProcessors(),
             );
         }
 
-        return $this->drivers[spl_object_id($channel)];
+        return $this->drivers[$key];
     }
 }

--- a/tests/Integration/Log/GenericLoggerTest.php
+++ b/tests/Integration/Log/GenericLoggerTest.php
@@ -148,6 +148,26 @@ final class GenericLoggerTest extends FrameworkIntegrationTestCase
         $logger->log($level, 'This is a log message of level: ' . $level->value, context: ['foo' => 'bar']);
     }
 
+    public function test_different_log_levels_works(): void
+    {
+        $filePath = __DIR__ . '/logs/tempest.log';
+        $config = new LogConfig(
+            prefix: 'tempest',
+            channels: [
+                new AppendLogChannel($filePath),
+            ],
+        );
+
+        $logger = new GenericLogger($config, $this->container->get(EventBus::class));
+        $logger->critical('critical');
+        $logger->debug('debug');
+
+        $this->assertFileExists($filePath);
+        $content = file_get_contents($filePath);
+        $this->assertStringContainsString('critical', $content);
+        $this->assertStringContainsString('debug', $content);
+    }
+
     public static function tempestLevelProvider(): array
     {
         return array_map(fn (LogLevel $level) => [$level, strtoupper($level->value)], LogLevel::cases());


### PR DESCRIPTION
This fixes case when someone first logs something at high severity (for example critical) and next by lower severity (debug).

Before, it would cache a Handler with LEVEL set to CRITICAL, and DEBUG log would be ignored.

Now, new handler will be created (and cached).