### PR TITLE
fix(intl): force en-US locale in TranslatorTest to prevent locale-dependent failures

### DIFF
--- a/tests/Integration/Intl/TranslatorTest.php
+++ b/tests/Integration/Intl/TranslatorTest.php
@@ -19,6 +19,8 @@ final class TranslatorTest extends FrameworkIntegrationTestCase
 {
     protected function setUp(): void
     {
+        ini_set('intl.default_locale', 'en-US');
+
         parent::setUp();
 
         $config = $this->container->get(IntlConfig::class);


### PR DESCRIPTION
Ensures test consistency across different system locales by explicitly setting intl.default_locale to en-US in the test setup method.

tests/Integration/Intl/TranslatorTest.php failed in my case when running composer qa on my local main branch since my system's default locale is nl_NL