### PR TITLE
chore(view): remove unused `illuminate/view`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
     "require-dev": {
         "carthage-software/mago": "0.24.1",
         "guzzlehttp/psr7": "^2.6.1",
-        "illuminate/view": "~11.7.0",
         "league/flysystem-aws-s3-v3": "^3.0",
         "league/flysystem-azure-blob-storage": "^3.0",
         "league/flysystem-ftp": "^3.0",


### PR DESCRIPTION
The package is loaded via the tempest/blade package anyway so there is no need to add it as an explicit dependency on the root composer.json