### PR TITLE
fix(http): register request interface as singleton as soon as possible

### DIFF
--- a/packages/router/src/GenericRouter.php
+++ b/packages/router/src/GenericRouter.php
@@ -39,6 +39,8 @@ final readonly class GenericRouter implements Router
             $request = map($request)->with(PsrRequestToGenericRequestMapper::class)->do();
         }
 
+        $this->container->singleton(Request::class, fn () => $request);
+
         $callable = $this->getCallable();
 
         return $this->processResponse($callable($request));

--- a/packages/router/src/MatchRouteMiddleware.php
+++ b/packages/router/src/MatchRouteMiddleware.php
@@ -43,7 +43,6 @@ final readonly class MatchRouteMiddleware implements HttpMiddleware
         // We register this newly created request object in the container
         // This makes it so that RequestInitializer is bypassed entirely when the controller action needs the request class
         // Making it so that we don't need to set any $_SERVER variables and stuff like that
-        $this->container->singleton(Request::class, fn () => $request);
         $this->container->singleton($request::class, fn () => $request);
 
         return $next($request);


### PR DESCRIPTION
This prevents weird edge cases when the normal request flow is interrupted before `MatchRouteMiddleware` has run, but still a response is sent (which depends on the request)