### PR TITLE
fix(view): remove multiline comments before AST parsing

### DIFF
--- a/packages/view/src/Elements/TextElement.php
+++ b/packages/view/src/Elements/TextElement.php
@@ -19,11 +19,6 @@ final class TextElement implements Element
     public function compile(): string
     {
         return str($this->text)
-            // Render {{-- --}}
-            ->replaceRegex(
-                regex: '/{{--(.|\n)*?--}}/',
-                replace: '',
-            )
             // Render {{
             ->replaceRegex(
                 regex: '/{{(?<match>.*?)}}/',

--- a/packages/view/src/Parser/TempestViewCompiler.php
+++ b/packages/view/src/Parser/TempestViewCompiler.php
@@ -41,22 +41,32 @@ final readonly class TempestViewCompiler
         // 1. Retrieve template
         $template = $this->retrieveTemplate($view);
 
-        // 2. Parse AST
+        // 2. Remove comments before parsing
+        $template = $this->removeComments($template);
+
+        // 3. Parse AST
         $ast = $this->parseAst($template);
 
-        // 3. Map to elements
+        // 4. Map to elements
         $elements = $this->mapToElements($ast);
 
-        // 4. Apply attributes
+        // 5. Apply attributes
         $elements = $this->applyAttributes($elements);
 
-        // 5. Compile to PHP
+        // 6. Compile to PHP
         $compiled = $this->compileElements($elements);
 
-        // 6. Cleanup compiled PHP
+        // 7. Cleanup compiled PHP
         $cleaned = $this->cleanupCompiled($compiled);
 
         return $cleaned;
+    }
+
+    private function removeComments(string $template): string
+    {
+        return str($template)
+            ->replaceRegex('/{{--.*?--}}/s', '')
+            ->toString();
     }
 
     private function retrieveTemplate(string|View $view): string

--- a/tests/Integration/View/TempestViewRendererTest.php
+++ b/tests/Integration/View/TempestViewRendererTest.php
@@ -727,4 +727,24 @@ final class TempestViewRendererTest extends FrameworkIntegrationTestCase
 
         $this->assertSnippetsMatch('<p>this is rendered text</p>', $html);
     }
+
+    public function test_multiline_view_comments(): void
+    {
+        $html = $this->render(<<<'HTML'
+        {{-- this is a comment
+                <div>
+                    <!-- Start -->
+                    <x-label>{{ Tempest\Intl\translate('test_2') }}</x-label>
+                <x-input
+                    name="test"
+                    type="text"
+                    class="py-2.5 sm:py-3 px-4 block w-full border-gray-500 border-1 rounded-lg sm:text-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-900 dark:border-neutral-700 dark:text-neutral-400 dark:placeholder-neutral-500 dark:focus:ring-neutral-600" placeholder="This is placeholder" />
+                <!-- end -->
+            </div>
+            --}}
+        <p>This should be rendered</p>
+        HTML);
+
+        $this->assertSnippetsMatch('<p>This should be rendered</p>', $html);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/tempestphp/tempest-framework/pull/1356#issuecomment-3044774418
Closes https://github.com/tempestphp/tempest-framework/issues/1376