### PR TITLE
feat(vite): inject react refresh when needed

### DIFF
--- a/packages/vite-plugin-tempest/src/plugin.ts
+++ b/packages/vite-plugin-tempest/src/plugin.ts
@@ -113,10 +113,15 @@ export default function tempest(): Plugin {
 						? userConfig.server.origin as DevelopmentServerUrl
 						: resolveDevServerUrl(address, server.config)
 
+					const needsReactRefresh = server.config.plugins.some((plugin) =>
+						['vite:react-refresh', 'vite:react-oxc:refresh-runtime'].includes(plugin.name)
+					)
+
 					fs.writeFileSync(
 						bridgeFilePath,
 						JSON.stringify({
 							url: `${viteDevServerUrl}${server.config.base.replace(/\/$/, '')}`,
+							needsReactRefresh,
 						}),
 					)
 

--- a/packages/vite/src/TagsResolver/DevelopmentTagsResolver.php
+++ b/packages/vite/src/TagsResolver/DevelopmentTagsResolver.php
@@ -35,7 +35,7 @@ final readonly class DevelopmentTagsResolver implements TagsResolver
             ->prepend($this->createDevelopmentTag(self::CLIENT_SCRIPT_PATH));
 
         if ($this->bridgeFile->needsReactRefresh) {
-            $tags->prepend($this->createReactRefreshTag());
+            $tags = $tags->prepend($this->createReactRefreshTag());
         }
 
         return $tags->toArray();
@@ -72,11 +72,11 @@ final readonly class DevelopmentTagsResolver implements TagsResolver
     {
         return <<<HTML
             <script type="module">
-                import RefreshRuntime from '{$this->bridgeFile->url}/@react-refresh'
-                RefreshRuntime.injectIntoGlobalHook(window)
-                window.\$RefreshReg$ = () => {}
-                window.\$RefreshSig$ = () => (type) => type
-                window.__vite_plugin_react_preamble_installed__ = true
+                import RefreshRuntime from '{$this->bridgeFile->url}/@react-refresh';
+                RefreshRuntime.injectIntoGlobalHook(window);
+                window.\$RefreshReg$ = () => {};
+                window.\$RefreshSig$ = () => (type) => type;
+                window.__vite_plugin_react_preamble_installed__ = true;
             </script>
         HTML;
     }

--- a/packages/vite/src/Vite.php
+++ b/packages/vite/src/Vite.php
@@ -140,7 +140,7 @@ final class Vite
 
         return static::$bridgeFile = new ViteBridgeFile(
             url: $content->get('url'),
-            needsReactRefresh: $content->get('needsReactRefresh', false),
+            needsReactRefresh: $content->get('needsReactRefresh', default: false),
         );
     }
 

--- a/packages/vite/src/Vite.php
+++ b/packages/vite/src/Vite.php
@@ -140,6 +140,7 @@ final class Vite
 
         return static::$bridgeFile = new ViteBridgeFile(
             url: $content->get('url'),
+            needsReactRefresh: $content->get('needsReactRefresh', false),
         );
     }
 

--- a/packages/vite/src/ViteBridgeFile.php
+++ b/packages/vite/src/ViteBridgeFile.php
@@ -8,5 +8,6 @@ final readonly class ViteBridgeFile
 {
     public function __construct(
         public string $url,
+        public bool $needsReactRefresh = false,
     ) {}
 }


### PR DESCRIPTION
Using the vite react plugins requires this snippet to be present:

> Note if you are using React with @vitejs/plugin-react, you'll also need to add this before the above scripts, since the plugin  is not able to modify the HTML you are serving (substitute http://localhost:5173 with the local URL Vite is running at):
>```html 
> <script type="module">
>  import RefreshRuntime from 'http://localhost:5173/@react-refresh'
>  RefreshRuntime.injectIntoGlobalHook(window)
>  window.$RefreshReg$ = () => {}
>  window.$RefreshSig$ = () => (type) => type
>  window.__vite_plugin_react_preamble_installed__ = true
></script>
>```

This PR adds so the vite plugin detects if this needs to be injected, adds a bool to the bridgefile that the `DevelopmentTagsResolver` reads and injects the "snippet".

One improvement to this would be to use the `TagCompiler` so the nonce and other things would be set, but that would require some changes there (public body setting support), I think atleast.