### PR TITLE
feat(http)!: add cross-site request forgery protection

### DIFF
--- a/packages/http/src/Session/CsrfTokenComponent.php
+++ b/packages/http/src/Session/CsrfTokenComponent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Session;
+
+use Tempest\View\Elements\ViewComponentElement;
+use Tempest\View\ViewComponent;
+
+final readonly class CsrfTokenComponent implements ViewComponent
+{
+    public function __construct(
+        private Session $session,
+    ) {}
+
+    public static function getName(): string
+    {
+        return 'x-csrf-token';
+    }
+
+    public function compile(ViewComponentElement $element): string
+    {
+        $name = Session::CSRF_TOKEN_KEY;
+
+        return <<<HTML
+        <input type="hidden" name="{$name}" value="{$this->session->token}">
+        HTML;
+    }
+}

--- a/packages/http/src/Session/CsrfTokenDidNotMatch.php
+++ b/packages/http/src/Session/CsrfTokenDidNotMatch.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tempest\Http\Session;
+
+use Exception;
+
+final class CsrfTokenDidNotMatch extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('The CSRF token did not match.');
+    }
+}

--- a/packages/http/src/Session/Session.php
+++ b/packages/http/src/Session/Session.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Http\Session;
 
 use Tempest\DateTime\DateTimeInterface;
+use Tempest\Support\Random;
 
 use function Tempest\get;
 
@@ -16,7 +17,22 @@ final class Session
 
     public const string PREVIOUS_URL = '_previous_url';
 
+    public const string CSRF_TOKEN_KEY = '_csrf_token';
+
     private array $expiredKeys = [];
+
+    /**
+     * Session token used for cross-site request forgery protection.
+     */
+    public string $token {
+        get {
+            if (! $this->get(self::CSRF_TOKEN_KEY)) {
+                $this->set(self::CSRF_TOKEN_KEY, Random\uuid());
+            }
+
+            return $this->get(self::CSRF_TOKEN_KEY);
+        }
+    }
 
     public function __construct(
         public SessionId $id,

--- a/packages/http/src/Session/VerifyCsrfMiddleware.php
+++ b/packages/http/src/Session/VerifyCsrfMiddleware.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Session;
+
+use Tempest\Clock\Clock;
+use Tempest\Core\AppConfig;
+use Tempest\Core\Priority;
+use Tempest\Http\Cookie\Cookie;
+use Tempest\Http\Cookie\CookieManager;
+use Tempest\Http\Method;
+use Tempest\Http\Request;
+use Tempest\Http\Response;
+use Tempest\Http\Session\Session;
+use Tempest\Router\HttpMiddleware;
+use Tempest\Router\HttpMiddlewareCallable;
+
+#[Priority(Priority::FRAMEWORK)]
+final readonly class VerifyCsrfMiddleware implements HttpMiddleware
+{
+    public const string CSRF_COOKIE_KEY = 'xsrf-token';
+    public const string CSRF_HEADER_KEY = 'x-xsrf-token';
+
+    public function __construct(
+        private Session $session,
+        private AppConfig $appConfig,
+        private SessionConfig $sessionConfig,
+        private CookieManager $cookies,
+        private Clock $clock,
+    ) {}
+
+    public function __invoke(Request $request, HttpMiddlewareCallable $next): Response
+    {
+        $this->cookies->add(new Cookie(
+            key: self::CSRF_COOKIE_KEY,
+            value: $this->session->token,
+            expiresAt: $this->clock->now()->plus($this->sessionConfig->expiration),
+        ));
+
+        if ($this->shouldSkipCheck($request)) {
+            return $next($request);
+        }
+
+        $this->ensureTokenMatches($request);
+
+        return $next($request);
+    }
+
+    private function shouldSkipCheck(Request $request): bool
+    {
+        if (in_array($request->method, [Method::GET, Method::HEAD, Method::OPTIONS], strict: true)) {
+            return true;
+        }
+
+        if ($this->appConfig->environment->isTesting()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function ensureTokenMatches(Request $request): void
+    {
+        $tokenFromRequest = $request->get(
+            key: Session::CSRF_TOKEN_KEY,
+            default: $request->headers->get(self::CSRF_HEADER_KEY),
+        );
+
+        if (! $tokenFromRequest) {
+            throw new CsrfTokenDidNotMatch();
+        }
+
+        if (! hash_equals($this->session->token, $tokenFromRequest)) {
+            throw new CsrfTokenDidNotMatch();
+        }
+    }
+}

--- a/packages/router/src/Exceptions/HttpExceptionHandler.php
+++ b/packages/router/src/Exceptions/HttpExceptionHandler.php
@@ -10,6 +10,7 @@ use Tempest\Core\Kernel;
 use Tempest\Http\GenericResponse;
 use Tempest\Http\HttpRequestFailed;
 use Tempest\Http\Response;
+use Tempest\Http\Session\CsrfTokenDidNotMatch;
 use Tempest\Http\Status;
 use Tempest\Router\ResponseSender;
 use Tempest\Support\Filesystem;
@@ -34,6 +35,7 @@ final readonly class HttpExceptionHandler implements ExceptionHandler
             $response = match (true) {
                 $throwable instanceof ConvertsToResponse => $throwable->toResponse(),
                 $throwable instanceof HttpRequestFailed => $this->renderErrorResponse($throwable->status, $throwable),
+                $throwable instanceof CsrfTokenDidNotMatch => $this->renderErrorResponse(Status::UNPROCESSABLE_CONTENT),
                 default => $this->renderErrorResponse(Status::INTERNAL_SERVER_ERROR),
             };
 
@@ -57,6 +59,7 @@ final readonly class HttpExceptionHandler implements ExceptionHandler
                         Status::NOT_FOUND => 'This page could not be found on the server',
                         Status::FORBIDDEN => 'You do not have permission to access this page',
                         Status::UNAUTHORIZED => 'You must be authenticated in to access this page',
+                        Status::UNPROCESSABLE_CONTENT => 'The request could not be processed due to invalid data',
                         default => null,
                     }
                 ,

--- a/tests/Integration/Http/CsrfTest.php
+++ b/tests/Integration/Http/CsrfTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Tempest\Integration\Http;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use Tempest\Core\AppConfig;
+use Tempest\Core\Environment;
+use Tempest\Http\Cookie\Cookie;
+use Tempest\Http\GenericRequest;
+use Tempest\Http\Method;
+use Tempest\Http\Session\CsrfTokenDidNotMatch;
+use Tempest\Http\Session\Session;
+use Tempest\Http\Session\VerifyCsrfMiddleware;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+final class CsrfTest extends FrameworkIntegrationTestCase
+{
+    public function test_csrf_is_sent_as_cookie(): void
+    {
+        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+
+        $token = $this->container->get(Session::class)->get(Session::CSRF_TOKEN_KEY);
+
+        $this->http
+            ->get('/test')
+            ->assertHasCookie(
+                VerifyCsrfMiddleware::CSRF_COOKIE_KEY,
+                fn (Cookie $cookie) => $cookie->value === $token, // @mago-expect security/no-insecure-comparison
+            );
+    }
+
+    #[TestWith([Method::POST])]
+    #[TestWith([Method::PUT])]
+    #[TestWith([Method::PATCH])]
+    #[TestWith([Method::DELETE])]
+    public function test_throws_when_missing_in_write_verbs(Method $method): void
+    {
+        $this->expectException(CsrfTokenDidNotMatch::class);
+
+        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+        $this->http->sendRequest(new GenericRequest($method, uri: '/test'));
+    }
+
+    #[TestWith([Method::GET])]
+    #[TestWith([Method::OPTIONS])]
+    #[TestWith([Method::HEAD])]
+    public function test_allows_missing_in_read_verbs(Method $method): void
+    {
+        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+
+        $this->http
+            ->sendRequest(new GenericRequest($method, uri: '/test'))
+            ->assertOk();
+    }
+
+    public function test_throws_when_mismatch_from_body(): void
+    {
+        $this->expectException(CsrfTokenDidNotMatch::class);
+
+        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+        $this->container->get(Session::class)->set(Session::CSRF_TOKEN_KEY, 'abc');
+
+        $this->http->post('/test', [Session::CSRF_TOKEN_KEY => 'def']);
+    }
+
+    public function test_throws_when_mismatch_from_header(): void
+    {
+        $this->expectException(CsrfTokenDidNotMatch::class);
+
+        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+        $this->container->get(Session::class)->set(Session::CSRF_TOKEN_KEY, 'abc');
+
+        $this->http->post('/test', [Session::CSRF_TOKEN_KEY => 'def']);
+    }
+
+    public function test_matches_from_body(): void
+    {
+        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+
+        $session = $this->container->get(Session::class);
+
+        $this->http
+            ->post('/test', [Session::CSRF_TOKEN_KEY => $session->token])
+            ->assertOk();
+    }
+
+    public function test_matches_from_header(): void
+    {
+        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+
+        $session = $this->container->get(Session::class);
+
+        $this->http
+            ->post('/test', headers: [VerifyCsrfMiddleware::CSRF_HEADER_KEY => $session->token])
+            ->assertOk();
+    }
+
+    public function test_csrf_component(): void
+    {
+        $rendered = $this->render(<<<HTML
+        <x-csrf-token />
+        HTML);
+
+        $session = $this->container->get(Session::class);
+
+        $this->assertStringMatchesFormat('<input type="hidden" name="_csrf_token" value="%s">', $rendered);
+        $this->assertStringContainsString($session->token, $rendered);
+    }
+}


### PR DESCRIPTION
This pull request introduces support for cross-site request forgery protection. This is a pretty important feature to have, so it will be enabled by default. Technically, this is thus a breaking change.

Non-read requests now require a CSRF token to be present. It can be a `_token` in the request body or in a `x-xsrf-token` header. All requests will return the CSRF token in a `xsrf-token` cookie. This pattern is standard across AJAX clients, which means there is no particular setup needed for them.

For standard HTML forms, a `<x-csrf-token />` component is available. It renders a hidden `_token` input. Otherwise, the token is available as the `token` property of `Tempest\Http\Session`.

Note that after https://github.com/tempestphp/tempest-framework/pull/1346, we might iterate on this so the cookie can be encrypted, instead of a plaintext UUID.