### PR TITLE
fix(mapper): support casting `bool`, `int`, `float` and enums

### DIFF
--- a/packages/mapper/src/CasterFactoryInitializer.php
+++ b/packages/mapper/src/CasterFactoryInitializer.php
@@ -14,12 +14,16 @@ use Tempest\Container\Singleton;
 use Tempest\DateTime\DateTime;
 use Tempest\DateTime\DateTimeInterface;
 use Tempest\Mapper\Casters\ArrayToObjectCollectionCaster;
+use Tempest\Mapper\Casters\BooleanCaster;
 use Tempest\Mapper\Casters\DateTimeCaster;
 use Tempest\Mapper\Casters\EnumCaster;
+use Tempest\Mapper\Casters\FloatCaster;
+use Tempest\Mapper\Casters\IntegerCaster;
 use Tempest\Mapper\Casters\JsonToArrayCaster;
 use Tempest\Mapper\Casters\NativeDateTimeCaster;
 use Tempest\Mapper\Casters\ObjectCaster;
 use Tempest\Reflection\PropertyReflector;
+use UnitEnum;
 
 final class CasterFactoryInitializer implements Initializer
 {
@@ -28,9 +32,15 @@ final class CasterFactoryInitializer implements Initializer
     {
         return new CasterFactory()
             ->addCaster('array', JsonToArrayCaster::class)
+            ->addCaster('bool', BooleanCaster::class)
+            ->addCaster('boolean', BooleanCaster::class)
+            ->addCaster('int', IntegerCaster::class)
+            ->addCaster('integer', IntegerCaster::class)
+            ->addCaster('float', FloatCaster::class)
+            ->addCaster('double', FloatCaster::class)
             ->addCaster(fn (PropertyReflector $property) => $property->getIterableType() !== null, fn (PropertyReflector $property) => new ArrayToObjectCollectionCaster($property))
             ->addCaster(fn (PropertyReflector $property) => $property->getType()->isClass(), fn (PropertyReflector $property) => new ObjectCaster($property->getType()))
-            ->addCaster(BackedEnum::class, fn (PropertyReflector $property) => new EnumCaster($property->getType()->getName()))
+            ->addCaster(UnitEnum::class, fn (PropertyReflector $property) => new EnumCaster($property->getType()->getName()))
             ->addCaster(DateTimeInterface::class, DateTimeCaster::fromProperty(...))
             ->addCaster(NativeDateTimeImmutable::class, NativeDateTimeCaster::fromProperty(...))
             ->addCaster(NativeDateTime::class, NativeDateTimeCaster::fromProperty(...))

--- a/packages/mapper/src/Casters/BooleanCaster.php
+++ b/packages/mapper/src/Casters/BooleanCaster.php
@@ -10,6 +10,13 @@ final readonly class BooleanCaster implements Caster
 {
     public function cast(mixed $input): bool
     {
-        return boolval($input);
+        if (is_string($input)) {
+            $input = mb_strtolower($input);
+        }
+
+        return match ($input) {
+            1, '1', true, 'true', 'enabled', 'on', 'yes' => true,
+            default => false,
+        };
     }
 }

--- a/packages/mapper/src/Casters/EnumCaster.php
+++ b/packages/mapper/src/Casters/EnumCaster.php
@@ -5,21 +5,29 @@ declare(strict_types=1);
 namespace Tempest\Mapper\Casters;
 
 use Tempest\Mapper\Caster;
+use UnitEnum;
 
 final readonly class EnumCaster implements Caster
 {
+    /**
+     * @param class-string<UnitEnum> $enum
+     */
     public function __construct(
         private string $enum,
     ) {}
 
     public function cast(mixed $input): ?object
     {
-        if ($input instanceof $this->enum) {
+        if ($input === null) {
+            return null;
+        }
+
+        if (is_a($input, $this->enum)) {
             return $input;
         }
 
-        if ($input === null) {
-            return null;
+        if (defined("{$this->enum}::{$input}")) {
+            return constant("{$this->enum}::{$input}");
         }
 
         return forward_static_call("{$this->enum}::from", $input);

--- a/packages/mapper/src/SerializerFactoryInitializer.php
+++ b/packages/mapper/src/SerializerFactoryInitializer.php
@@ -28,7 +28,7 @@ use Tempest\Mapper\Serializers\NativeDateTimeSerializer;
 use Tempest\Mapper\Serializers\SerializableSerializer;
 use Tempest\Mapper\Serializers\StringSerializer;
 use Tempest\Reflection\PropertyReflector;
-use Tempest\Reflection\TypeReflector;
+use UnitEnum;
 
 final class SerializerFactoryInitializer implements Initializer
 {
@@ -51,6 +51,7 @@ final class SerializerFactoryInitializer implements Initializer
             ->addSerializer(Serializable::class, SerializableSerializer::class)
             ->addSerializer(JsonSerializable::class, SerializableSerializer::class)
             ->addSerializer(Stringable::class, StringSerializer::class)
+            ->addSerializer(UnitEnum::class, EnumSerializer::class)
             ->addSerializer(BackedEnum::class, EnumSerializer::class)
             ->addSerializer(DateTime::class, DateTimeSerializer::fromReflector(...))
             ->addSerializer(

--- a/tests/Integration/Mapper/CasterFactoryTest.php
+++ b/tests/Integration/Mapper/CasterFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Tempest\Integration\Mapper;
+
+use BackedEnum;
+use Tempest\Mapper\CasterFactory;
+use Tempest\Mapper\Casters\BooleanCaster;
+use Tempest\Mapper\Casters\DateTimeCaster;
+use Tempest\Mapper\Casters\EnumCaster;
+use Tempest\Mapper\Casters\FloatCaster;
+use Tempest\Mapper\Casters\IntegerCaster;
+use Tempest\Mapper\Casters\NativeDateTimeCaster;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithSerializerProperties;
+use UnitEnum;
+
+use function Tempest\reflect;
+
+final class CasterFactoryTest extends FrameworkIntegrationTestCase
+{
+    public function test_for_property(): void
+    {
+        $factory = $this->container->get(CasterFactory::class);
+        $class = reflect(ObjectWithSerializerProperties::class);
+
+        $this->assertInstanceOf(IntegerCaster::class, $factory->forProperty($class->getProperty('intProp')));
+        $this->assertInstanceOf(FloatCaster::class, $factory->forProperty($class->getProperty('floatProp')));
+        $this->assertInstanceOf(BooleanCaster::class, $factory->forProperty($class->getProperty('boolProp')));
+        $this->assertInstanceOf(NativeDateTimeCaster::class, $factory->forProperty($class->getProperty('nativeDateTimeImmutableProp')));
+        $this->assertInstanceOf(NativeDateTimeCaster::class, $factory->forProperty($class->getProperty('nativeDateTimeProp')));
+        $this->assertInstanceOf(NativeDateTimeCaster::class, $factory->forProperty($class->getProperty('nativeDateTimeInterfaceProp')));
+        $this->assertInstanceOf(DateTimeCaster::class, $factory->forProperty($class->getProperty('dateTimeProp')));
+        $this->assertInstanceOf(EnumCaster::class, $factory->forProperty($class->getProperty('unitEnum')));
+        $this->assertInstanceOf(EnumCaster::class, $factory->forProperty($class->getProperty('backedEnum')));
+    }
+}

--- a/tests/Integration/Mapper/Casters/BooleanCasterTest.php
+++ b/tests/Integration/Mapper/Casters/BooleanCasterTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Tempest\Integration\Mapper\Casters;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use Tempest\Mapper\Casters\BooleanCaster;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+final class BooleanCasterTest extends FrameworkIntegrationTestCase
+{
+    #[TestWith(['true', true])]
+    #[TestWith(['false', false])]
+    #[TestWith([true, true])]
+    #[TestWith([false, false])]
+    #[TestWith(['on', true])]
+    #[TestWith(['enabled', true])]
+    #[TestWith(['yes', true])]
+    #[TestWith(['ON', true])]
+    #[TestWith(['ENABLED', true])]
+    #[TestWith(['YES', true])]
+    #[TestWith(['off', false])]
+    #[TestWith(['disabled', false])]
+    #[TestWith(['no', false])]
+    public function test_cast(mixed $input, bool $expected): void
+    {
+        $this->assertSame($expected, new BooleanCaster()->cast($input));
+    }
+}

--- a/tests/Integration/Mapper/Casters/EnumCasterTest.php
+++ b/tests/Integration/Mapper/Casters/EnumCasterTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Tempest\Integration\Mapper\Casters;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use Tempest\Mapper\Casters\BooleanCaster;
+use Tempest\Mapper\Casters\EnumCaster;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+use Tests\Tempest\Integration\Mapper\Fixtures\BackedEnumToSerialize;
+use Tests\Tempest\Integration\Mapper\Fixtures\UnitEnumToSerialize;
+use UnitEnum;
+
+final class EnumCasterTest extends FrameworkIntegrationTestCase
+{
+    #[TestWith(['FOO', UnitEnumToSerialize::FOO, UnitEnumToSerialize::class])]
+    #[TestWith(['BAR', UnitEnumToSerialize::BAR, UnitEnumToSerialize::class])]
+    #[TestWith(['foo', BackedEnumToSerialize::FOO, BackedEnumToSerialize::class])]
+    #[TestWith(['bar', BackedEnumToSerialize::BAR, BackedEnumToSerialize::class])]
+    public function test_cast(mixed $input, UnitEnum $expected, string $class): void
+    {
+        $this->assertSame($expected, new EnumCaster($class)->cast($input));
+    }
+}

--- a/tests/Integration/Mapper/Fixtures/ObjectWithSerializerProperties.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithSerializerProperties.php
@@ -41,6 +41,10 @@ final class ObjectWithSerializerProperties
 
     public DateTime $dateTimeProp;
 
+    public UnitEnumToSerialize $unitEnum;
+
+    public BackedEnumToSerialize $backedEnum;
+
     public function __construct()
     {
         $this->stringableProp = \Tempest\Support\str('a');
@@ -51,5 +55,7 @@ final class ObjectWithSerializerProperties
         $this->nativeDateTimeProp = new NativeDateTime('2025-01-01');
         $this->nativeDateTimeInterfaceProp = new NativeDateTimeImmutable('2025-01-01');
         $this->dateTimeProp = DateTime::parse('2025-01-01');
+        $this->unitEnum = UnitEnumToSerialize::BAR;
+        $this->backedEnum = BackedEnumToSerialize::FOO;
     }
 }

--- a/tests/Integration/Mapper/Mappers/ArrayToObjectMapperTestCase.php
+++ b/tests/Integration/Mapper/Mappers/ArrayToObjectMapperTestCase.php
@@ -6,6 +6,7 @@ namespace Tests\Tempest\Integration\Mapper\Mappers;
 
 use DateTimeImmutable;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\TestWith;
 use Tempest\Http\Method;
 use Tempest\Mapper\Exceptions\MappingValuesWereMissing;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -71,7 +72,7 @@ final class ArrayToObjectMapperTestCase extends FrameworkIntegrationTestCase
             'dateTimeImmutable' => '2024-01-01 10:10:10',
             'dateTime' => '2024-01-01 10:10:10',
             'dateTimeWithFormat' => '01/12/2024 10:10:10',
-            'bool' => 'yes',
+            'bool' => 'no',
             'float' => '0.1',
             'int' => '1',
         ])
@@ -82,7 +83,7 @@ final class ArrayToObjectMapperTestCase extends FrameworkIntegrationTestCase
         $this->assertSame('2024-01-01 10:10:10', $object->dateTime->format('Y-m-d H:i:s'));
         $this->assertSame('2024-12-01 10:10:10', $object->dateTimeWithFormat->format('Y-m-d H:i:s'));
         $this->assertNull($object->nullableDateTimeImmutable);
-        $this->assertSame(true, $object->bool);
+        $this->assertSame(false, $object->bool);
         $this->assertSame(0.1, $object->float);
         $this->assertSame(1, $object->int);
     }

--- a/tests/Integration/Mapper/Serializers/ArrayOfObjectsSerializerTest.php
+++ b/tests/Integration/Mapper/Serializers/ArrayOfObjectsSerializerTest.php
@@ -32,6 +32,8 @@ final class ArrayOfObjectsSerializerTest extends FrameworkIntegrationTestCase
                     'nativeDateTimeProp' => '2025-01-01 00:00:00',
                     'nativeDateTimeInterfaceProp' => '2025-01-01 00:00:00',
                     'dateTimeProp' => '2025-01-01 00:00:00',
+                    'unitEnum' => 'BAR',
+                    'backedEnum' => 'foo',
                 ],
             ],
             new ArrayOfObjectsSerializer()->serialize([new ObjectWithSerializerProperties()]),


### PR DESCRIPTION
This pull request fixes casting of `bool`, `int`, `float` and backed/unit enums, as well as serializing unit enums.

I first discovered missing support for this when creating a request class with a boolean property, which was always set to true (because the `false` in the query was a string).