### PR TITLE
feat(http): add `csrf_token` function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -151,6 +151,7 @@
             "packages/datetime/src/functions.php",
             "packages/debug/src/functions.php",
             "packages/event-bus/src/functions.php",
+            "packages/http/src/functions.php",
             "packages/icon/src/functions.php",
             "packages/intl/src/Number/functions.php",
             "packages/intl/src/functions.php",

--- a/packages/http/composer.json
+++ b/packages/http/composer.json
@@ -18,7 +18,10 @@
     "autoload": {
         "psr-4": {
             "Tempest\\Http\\": "src"
-        }
+        },
+        "files": [
+            "src/functions.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/packages/http/src/Cookie/Cookie.php
+++ b/packages/http/src/Cookie/Cookie.php
@@ -12,22 +12,30 @@ use Tempest\DateTime\DateTimeInterface;
  */
 final class Cookie implements Stringable
 {
+    /**
+     * @param null|int $maxAge The maximum age of the cookie in seconds. This is an alternative to the expiration date. If set, the cookie will expire after the specified number of seconds.
+     * @param null|string $domain This specifies the domain for which the cookie is valid. If set, the cookie will be sent to this domain and its subdomains. If `⁠null`, it defaults to the current domain.
+     * @param null|string $path The URL path that must exist in the requested URL for the cookie to be sent. If set, the cookie will only be sent for requests to this path and its subdirectories.
+     * @param null|bool $secure When `true`, this cookie is only transmitted over secure connections.
+     * @param null|bool $httpOnly When `true`, this cookie will not be accessible using JavaScript.
+     * @param null|SameSite $sameSite See {@see \Tempest\Http\Cookie\SameSite}.
+     */
     public function __construct(
         public string $key,
-        public string $value = '',
+        public ?string $value = null,
         public DateTimeInterface|int|null $expiresAt = null,
         public ?int $maxAge = null,
         public ?string $domain = null,
         public ?string $path = null,
-        public ?bool $secure = null,
-        public ?bool $httpOnly = null,
+        public bool $secure = false,
+        public bool $httpOnly = false,
         public ?SameSite $sameSite = null,
     ) {}
 
     public function __toString(): string
     {
         $parts = [
-            $this->key . '=' . rawurlencode($this->value),
+            $this->key . '=' . rawurlencode($this->value ?? ''),
         ];
 
         if ($expiresAt = $this->getExpiresAtTime()) {

--- a/packages/http/src/Cookie/Cookie.php
+++ b/packages/http/src/Cookie/Cookie.php
@@ -26,7 +26,7 @@ final class Cookie implements Stringable
         public DateTimeInterface|int|null $expiresAt = null,
         public ?int $maxAge = null,
         public ?string $domain = null,
-        public ?string $path = null,
+        public ?string $path = '/',
         public bool $secure = false,
         public bool $httpOnly = false,
         public ?SameSite $sameSite = null,

--- a/packages/http/src/Cookie/CookieManager.php
+++ b/packages/http/src/Cookie/CookieManager.php
@@ -36,6 +36,7 @@ final class CookieManager
         $cookie = $this->get($key) ?? new Cookie(
             key: $key,
             secure: str($this->appConfig->baseUri)->startsWith('https'),
+            path: '/',
             httpOnly: true,
             sameSite: SameSite::LAX,
         );

--- a/packages/http/src/Session/CsrfTokenComponent.php
+++ b/packages/http/src/Session/CsrfTokenComponent.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Session;
+
+use Tempest\View\Elements\ViewComponentElement;
+use Tempest\View\ViewComponent;
+
+final readonly class CsrfTokenComponent implements ViewComponent
+{
+    public static function getName(): string
+    {
+        return 'x-csrf-token';
+    }
+
+    public function compile(ViewComponentElement $element): string
+    {
+        $name = Session::CSRF_TOKEN_KEY;
+
+        return <<<HTML
+        <input type="hidden" name="{$name}" value="<?= \Tempest\\Http\\csrf_token() ?>">
+        HTML;
+    }
+}

--- a/packages/http/src/Session/VerifyCsrfMiddleware.php
+++ b/packages/http/src/Session/VerifyCsrfMiddleware.php
@@ -36,6 +36,7 @@ final readonly class VerifyCsrfMiddleware implements HttpMiddleware
             key: self::CSRF_COOKIE_KEY,
             value: $this->session->token,
             expiresAt: $this->clock->now()->plus($this->sessionConfig->expiration),
+            secure: true,
         ));
 
         if ($this->shouldSkipCheck($request)) {

--- a/packages/http/src/Session/VerifyCsrfMiddleware.php
+++ b/packages/http/src/Session/VerifyCsrfMiddleware.php
@@ -36,6 +36,7 @@ final readonly class VerifyCsrfMiddleware implements HttpMiddleware
             key: self::CSRF_COOKIE_KEY,
             value: $this->session->token,
             expiresAt: $this->clock->now()->plus($this->sessionConfig->expiration),
+            path: '/',
             secure: true,
         ));
 

--- a/packages/http/src/Session/x-csrf-token.view.php
+++ b/packages/http/src/Session/x-csrf-token.view.php
@@ -1,9 +1,0 @@
-<?php
-
-use Tempest\Http\Session\Session;
-
-use function Tempest\get;
-
-?>
-
-<input type="hidden" name="{{ Session::CSRF_TOKEN_KEY }}" value="{{ get(Session::class)->token }}" />

--- a/packages/http/src/functions.php
+++ b/packages/http/src/functions.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tempest\Http;
+
+use Tempest;
+use Tempest\Http\Session\Session;
+
+/**
+ * Gets the session token used for cross-site request forgery protection.
+ */
+function csrf_token(): string
+{
+    return Tempest\get(Session::class)->token;
+}

--- a/tests/Integration/Http/CookieManagerTest.php
+++ b/tests/Integration/Http/CookieManagerTest.php
@@ -35,7 +35,7 @@ final class CookieManagerTest extends FrameworkIntegrationTestCase
         $this->http
             ->get('/')
             ->assertOk()
-            ->assertHeaderContains('set-cookie', 'new=value; Secure; HttpOnly; SameSite=Lax');
+            ->assertHeaderContains('set-cookie', 'new=value; Path=/; Secure; HttpOnly; SameSite=Lax');
     }
 
     public function test_creating_a_cookie_with_unsecure_local_host(): void
@@ -49,7 +49,7 @@ final class CookieManagerTest extends FrameworkIntegrationTestCase
         $this->http
             ->get('/')
             ->assertOk()
-            ->assertHeaderContains('set-cookie', 'new=value; HttpOnly; SameSite=Lax');
+            ->assertHeaderContains('set-cookie', 'new=value; Path=/; HttpOnly; SameSite=Lax');
     }
 
     public function test_removing_a_cookie(): void
@@ -61,7 +61,7 @@ final class CookieManagerTest extends FrameworkIntegrationTestCase
         $this->http
             ->get('/')
             ->assertOk()
-            ->assertHeaderContains('set-cookie', 'new=; Expires=Wed, 31-Dec-1969 23:59:59 GMT; Max-Age=0');
+            ->assertHeaderContains('set-cookie', 'new=; Expires=Wed, 31-Dec-1969 23:59:59 GMT; Max-Age=0; Path=/');
     }
 
     public function test_manually_adding_a_cookie(): void

--- a/tests/Integration/Http/CsrfTest.php
+++ b/tests/Integration/Http/CsrfTest.php
@@ -111,6 +111,14 @@ final class CsrfTest extends FrameworkIntegrationTestCase
         );
     }
 
+    public function test_csrf_token_function(): void
+    {
+        $session = $this->container->get(Session::class);
+        $session->set(Session::CSRF_TOKEN_KEY, 'test');
+
+        $this->assertSame('test', \Tempest\Http\csrf_token());
+    }
+
     public function test_csrf_with_cached_view(): void
     {
         $this->get(ViewCache::class)->enabled = true;


### PR DESCRIPTION
This pull request:
- reverts `x-csrf-token` to a view component
- introduces a `csrf_token()` function that's a shorthand for accessing the `token` property of `Session`
- makes the CSRF cookie secure
- slightly refactor the `Cookie` class