### PR TITLE
fix(http): properly handle cookies lifecycle

### DIFF
--- a/packages/http/src/Cookie/CookieManager.php
+++ b/packages/http/src/Cookie/CookieManager.php
@@ -7,9 +7,11 @@ namespace Tempest\Http\Cookie;
 use Tempest\Clock\Clock;
 use Tempest\Core\AppConfig;
 use Tempest\DateTime\DateTimeInterface;
+use Tempest\Support\Str;
 
-use function Tempest\Support\str;
-
+/**
+ * Manages cookies that will be sent to the client.
+ */
 final class CookieManager
 {
     /** @var \Tempest\Http\Cookie\Cookie[] */
@@ -31,12 +33,15 @@ final class CookieManager
         return $this->cookies[$key] ?? null;
     }
 
+    /**
+     * Adds or updates a cookie that will be sent to the client in this request.
+     */
     public function set(string $key, string $value, DateTimeInterface|int|null $expiresAt = null): Cookie
     {
         $cookie = $this->get($key) ?? new Cookie(
             key: $key,
-            secure: str($this->appConfig->baseUri)->startsWith('https'),
             path: '/',
+            secure: Str\starts_with($this->appConfig->baseUri, 'https'),
             httpOnly: true,
             sameSite: SameSite::LAX,
         );
@@ -49,6 +54,9 @@ final class CookieManager
         return $cookie;
     }
 
+    /**
+     * Adds a cookie that will be sent to the client in this request.
+     */
     public function add(Cookie $cookie): void
     {
         if ($cookie->expiresAt !== null) {

--- a/packages/http/src/Cookie/CookieManagerInitializer.php
+++ b/packages/http/src/Cookie/CookieManagerInitializer.php
@@ -15,15 +15,9 @@ final readonly class CookieManagerInitializer implements Initializer
     #[Singleton]
     public function initialize(Container $container): CookieManager
     {
-        $cookieManager = new CookieManager(
+        return new CookieManager(
             appConfig: $container->get(AppConfig::class),
             clock: $container->get(Clock::class),
         );
-
-        foreach ($_COOKIE as $key => $value) {
-            $cookieManager->add(new Cookie($key, $value));
-        }
-
-        return $cookieManager;
     }
 }

--- a/packages/http/src/Input/StdinInputStream.php
+++ b/packages/http/src/Input/StdinInputStream.php
@@ -23,7 +23,7 @@ final class StdinInputStream implements InputStream
             ->mapWithKeys(function (string $item) {
                 $parts = explode('=', $item, 2);
 
-                $key = $parts[0];
+                $key = urldecode($parts[0]);
 
                 $value = $_POST[str_replace('.', '_', $key)] ?? $parts[1] ?? '';
 

--- a/packages/http/src/IsRequest.php
+++ b/packages/http/src/IsRequest.php
@@ -42,9 +42,12 @@ trait IsRequest
     private(set) array $files;
 
     #[SkipValidation]
-    public array $cookies {
-        get => get(CookieManager::class)->all();
+    public Session $session {
+        get => get(Session::class);
     }
+
+    #[SkipValidation]
+    public array $cookies = [];
 
     public function __construct(
         Method $method,
@@ -88,10 +91,7 @@ trait IsRequest
 
     public function getCookie(string $name): ?Cookie
     {
-        /** @var CookieManager $cookies */
-        $cookies = get(CookieManager::class);
-
-        return $cookies->get($name);
+        return $this->cookies[$name] ?? null;
     }
 
     private function resolvePath(): string

--- a/packages/http/src/Mappers/PsrRequestToGenericRequestMapper.php
+++ b/packages/http/src/Mappers/PsrRequestToGenericRequestMapper.php
@@ -6,11 +6,13 @@ namespace Tempest\Http\Mappers;
 
 use Psr\Http\Message\ServerRequestInterface as PsrRequest;
 use Psr\Http\Message\UploadedFileInterface;
+use Tempest\Http\Cookie\Cookie;
 use Tempest\Http\GenericRequest;
 use Tempest\Http\Method;
 use Tempest\Http\RequestHeaders;
 use Tempest\Http\Upload;
 use Tempest\Mapper\Mapper;
+use Tempest\Support\Arr;
 
 use function Tempest\map;
 use function Tempest\Support\arr;
@@ -53,6 +55,7 @@ final readonly class PsrRequestToGenericRequestMapper implements Mapper
             'path' => $from->getUri()->getPath(),
             'query' => $query,
             'files' => $uploads,
+            'cookies' => Arr\map_iterable($_COOKIE, static fn (string $value, string $key) => new Cookie($key, $value)),
             ...$data,
             ...$uploads,
         ])

--- a/packages/http/src/Session/Config/FileSessionConfig.php
+++ b/packages/http/src/Session/Config/FileSessionConfig.php
@@ -17,8 +17,6 @@ final class FileSessionConfig implements SessionConfig
         public string $path,
 
         public Duration $expiration,
-
-        public string $sessionIdResolver = CookieSessionIdResolver::class,
     ) {}
 
     public function createManager(Container $container): FileSessionManager

--- a/packages/http/src/Session/Resolvers/CookieSessionIdResolver.php
+++ b/packages/http/src/Session/Resolvers/CookieSessionIdResolver.php
@@ -10,6 +10,7 @@ use Tempest\Core\AppConfig;
 use Tempest\Http\Cookie\Cookie;
 use Tempest\Http\Cookie\CookieManager;
 use Tempest\Http\Cookie\SameSite;
+use Tempest\Http\Request;
 use Tempest\Http\Session\SessionConfig;
 use Tempest\Http\Session\SessionId;
 use Tempest\Http\Session\SessionIdResolver;
@@ -20,6 +21,7 @@ final readonly class CookieSessionIdResolver implements SessionIdResolver
 {
     public function __construct(
         private AppConfig $appConfig,
+        private Request $request,
         private CookieManager $cookies,
         private SessionConfig $sessionConfig,
         private Clock $clock,
@@ -32,7 +34,7 @@ final readonly class CookieSessionIdResolver implements SessionIdResolver
             ->append('_session_id')
             ->toString();
 
-        $id = $this->cookies->get($sessionKey)->value ?? null;
+        $id = $this->request->getCookie($sessionKey)?->value;
 
         if (! $id) {
             $id = (string) Uuid::v4();

--- a/packages/http/src/Session/SessionConfig.php
+++ b/packages/http/src/Session/SessionConfig.php
@@ -15,14 +15,5 @@ interface SessionConfig
         get;
     }
 
-    /**
-     * Class responsible for resolving the session identifier.
-     *
-     * @var class-string<SessionIdResolver>
-     */
-    public string $sessionIdResolver {
-        get;
-    }
-
     public function createManager(Container $container): SessionManager;
 }

--- a/packages/http/src/Session/SessionIdResolverInitializer.php
+++ b/packages/http/src/Session/SessionIdResolverInitializer.php
@@ -4,16 +4,25 @@ declare(strict_types=1);
 
 namespace Tempest\Http\Session;
 
+use Tempest\Clock\Clock;
 use Tempest\Container\Container;
 use Tempest\Container\Initializer;
+use Tempest\Core\AppConfig;
+use Tempest\Http\Cookie\CookieManager;
+use Tempest\Http\Request;
+use Tempest\Http\Session\Resolvers\CookieSessionIdResolver;
 use Tempest\Http\Session\SessionConfig;
 
 final readonly class SessionIdResolverInitializer implements Initializer
 {
     public function initialize(Container $container): SessionIdResolver
     {
-        $config = $container->get(SessionConfig::class);
-
-        return $container->get($config->sessionIdResolver);
+        return new CookieSessionIdResolver(
+            appConfig: $container->get(AppConfig::class),
+            request: $container->get(Request::class),
+            cookies: $container->get(CookieManager::class),
+            sessionConfig: $container->get(SessionConfig::class),
+            clock: $container->get(Clock::class),
+        );
     }
 }

--- a/packages/http/src/Session/VerifyCsrfMiddleware.php
+++ b/packages/http/src/Session/VerifyCsrfMiddleware.php
@@ -15,6 +15,7 @@ use Tempest\Http\Response;
 use Tempest\Http\Session\Session;
 use Tempest\Router\HttpMiddleware;
 use Tempest\Router\HttpMiddlewareCallable;
+use Tempest\Support\Str;
 
 #[Priority(Priority::FRAMEWORK)]
 final readonly class VerifyCsrfMiddleware implements HttpMiddleware
@@ -37,7 +38,7 @@ final readonly class VerifyCsrfMiddleware implements HttpMiddleware
             value: $this->session->token,
             expiresAt: $this->clock->now()->plus($this->sessionConfig->expiration),
             path: '/',
-            secure: true,
+            secure: Str\starts_with($this->appConfig->baseUri, 'https'),
         ));
 
         if ($this->shouldSkipCheck($request)) {

--- a/packages/router/src/GenericResponseSender.php
+++ b/packages/router/src/GenericResponseSender.php
@@ -53,7 +53,7 @@ final readonly class GenericResponseSender implements ResponseSender
         }
 
         foreach ($this->resolveHeaders($response) as $header) {
-            header($header);
+            header($header, replace: false);
         }
 
         http_response_code($response->status->value);

--- a/packages/router/src/SetCookieMiddleware.php
+++ b/packages/router/src/SetCookieMiddleware.php
@@ -9,6 +9,9 @@ use Tempest\Http\Cookie\CookieManager;
 use Tempest\Http\Request;
 use Tempest\Http\Response;
 
+/**
+ * Adds the `Set-Cookie` headers to the response based on the cookie manager.
+ */
 #[Priority(Priority::FRAMEWORK)]
 final readonly class SetCookieMiddleware implements HttpMiddleware
 {

--- a/tests/Integration/Http/CookieManagerTest.php
+++ b/tests/Integration/Http/CookieManagerTest.php
@@ -15,13 +15,13 @@ use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
  */
 final class CookieManagerTest extends FrameworkIntegrationTestCase
 {
-    public function test_existing_cookies(): void
+    public function test_cookie_manager_does_not_get_initialized_with_request_cookies(): void
     {
         $_COOKIE['existing'] = 'value';
 
         $cookies = $this->container->get(CookieManager::class);
 
-        $this->assertEquals('value', $cookies->get('existing')->value);
+        $this->assertNull($cookies->get('existing'));
     }
 
     public function test_creating_a_cookie(): void

--- a/tests/Integration/Http/CsrfTest.php
+++ b/tests/Integration/Http/CsrfTest.php
@@ -106,7 +106,7 @@ final class CsrfTest extends FrameworkIntegrationTestCase
         HTML);
 
         $this->assertSame(
-            '<input type="hidden" name="_csrf_token" value="test">',
+            '<input type="hidden" name="#csrf_token" value="test">',
             $rendered,
         );
     }

--- a/tests/Integration/Http/SessionFromCookieTest.php
+++ b/tests/Integration/Http/SessionFromCookieTest.php
@@ -22,7 +22,6 @@ final class SessionFromCookieTest extends FrameworkIntegrationTestCase
         $this->container->config(new FileSessionConfig(
             path: 'test_sessions',
             expiration: Duration::hours(2),
-            sessionIdResolver: CookieSessionIdResolver::class,
         ));
 
         $cookieManager = $this->container->get(CookieManager::class);

--- a/tests/Integration/Http/SessionFromHeaderTest.php
+++ b/tests/Integration/Http/SessionFromHeaderTest.php
@@ -23,7 +23,6 @@ final class SessionFromHeaderTest extends FrameworkIntegrationTestCase
         $this->container->config(new FileSessionConfig(
             path: 'test_sessions',
             expiration: Duration::hours(2),
-            sessionIdResolver: HeaderSessionIdResolver::class,
         ));
 
         $this->setSessionId('session_a');

--- a/tests/Integration/Mapper/PsrRequestToRequestMapperTest.php
+++ b/tests/Integration/Mapper/PsrRequestToRequestMapperTest.php
@@ -37,6 +37,8 @@ final class PsrRequestToRequestMapperTest extends FrameworkIntegrationTestCase
         $stream->write(json_encode(['foo' => 'bar']));
         $stream->rewind();
 
+        $_COOKIE['test'] = 'cookie-value';
+
         $request = new PsrRequestToGenericRequestMapper()->map(new ServerRequest(
             uri: new Uri('/json-endpoint'),
             method: 'POST',
@@ -48,6 +50,7 @@ final class PsrRequestToRequestMapperTest extends FrameworkIntegrationTestCase
 
         $this->assertEquals(json_encode(['foo' => 'bar']), $request->raw);
         $this->assertEquals(['foo' => 'bar'], $request->body);
+        $this->assertEquals('cookie-value', $request->getCookie('test')?->value);
     }
 
     public function test_files(): void


### PR DESCRIPTION
This pull request fixes our cookie handling.

Previously, the `CookieManager` was instantiated with all cookies sent by the client (from `$_COOKIE`), and was also used to send back cookies to the client (using `Set-Cookie`). Now, cookies sent by the client are defined on the `Request` class only, and the cookie manager is only used for managing cookies that are going to be sent to the client.

Additionally, this pull request fixes an important issue with sending headers to the client, where sending a header would replace a previously-set header with the same name, preventing from sending multiple `Set-Cookie` headers, notably.

Last, there is some minor clean-up and I added some docblocks on confusing classes and methods.