### PR TITLE
feat(database): add pagination support

### DIFF
--- a/packages/database/src/Builder/ModelInspector.php
+++ b/packages/database/src/Builder/ModelInspector.php
@@ -31,8 +31,9 @@ final class ModelInspector
 
     private(set) object|string $instance;
 
-    public function __construct(object|string $model)
-    {
+    public function __construct(
+        private(set) object|string $model,
+    ) {
         if ($model instanceof HasMany) {
             $model = $model->property->getIterableType()->asClass();
             $this->reflector = $model;

--- a/packages/database/src/Builder/QueryBuilders/SelectQueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/SelectQueryBuilder.php
@@ -20,6 +20,8 @@ use Tempest\Database\QueryStatements\RawStatement;
 use Tempest\Database\QueryStatements\SelectStatement;
 use Tempest\Support\Arr\ImmutableArray;
 use Tempest\Support\Conditions\HasConditions;
+use Tempest\Support\Paginator\PaginatedData;
+use Tempest\Support\Paginator\Paginator;
 
 use function Tempest\Database\model;
 use function Tempest\map;
@@ -76,6 +78,23 @@ final class SelectQueryBuilder implements BuildsQuery
         }
 
         return $result[array_key_first($result)];
+    }
+
+    /** @return PaginatedData<TModelClass> */
+    public function paginate(int $itemsPerPage = 20, int $currentPage = 1, int $maxLinks = 10): PaginatedData
+    {
+        $total = new CountQueryBuilder($this->model->model)->execute();
+
+        $paginator = new Paginator(
+            totalItems: $total,
+            itemsPerPage: $itemsPerPage,
+            currentPage: $currentPage,
+            maxLinks: $maxLinks,
+        );
+
+        return $paginator->paginateWith(
+            callback: fn (int $limit, int $offset) => $this->limit($limit)->offset($offset)->all(),
+        );
     }
 
     /** @return TModelClass|null */

--- a/packages/support/src/Json/functions.php
+++ b/packages/support/src/Json/functions.php
@@ -21,8 +21,16 @@ use const JSON_UNESCAPED_UNICODE;
  *
  * @throws Exception\JsonCouldNotBeDecoded If an error occurred.
  */
-function decode(string $json, bool $associative = true): mixed
+function decode(string $json, bool $associative = true, bool $base64 = false): mixed
 {
+    if ($base64) {
+        $json = base64_decode($json, strict: true);
+
+        if ($json === false) {
+            throw new Exception\JsonCouldNotBeDecoded('The provided base64 string is not valid.');
+        }
+    }
+
     try {
         /** @var mixed $value */
         $value = json_decode($json, $associative, 512, JSON_BIGINT_AS_STRING | JSON_THROW_ON_ERROR);
@@ -40,7 +48,7 @@ function decode(string $json, bool $associative = true): mixed
  *
  * @return non-empty-string
  */
-function encode(mixed $value, bool $pretty = false, int $flags = 0): string
+function encode(mixed $value, bool $pretty = false, int $flags = 0, bool $base64 = false): string
 {
     $flags |= JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR;
 
@@ -53,6 +61,10 @@ function encode(mixed $value, bool $pretty = false, int $flags = 0): string
         $json = json_encode($value, $flags);
     } catch (JsonException $jsonException) {
         throw new Exception\JsonCouldNotBeEncoded(sprintf('%s.', $jsonException->getMessage()), $jsonException->getCode(), $jsonException);
+    }
+
+    if ($base64) {
+        return base64_encode($json);
     }
 
     return $json;

--- a/packages/support/src/Paginator/Exceptions/InvalidArgumentException.php
+++ b/packages/support/src/Paginator/Exceptions/InvalidArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tempest\Support\Paginator\Exceptions;
+
+use InvalidArgumentException as PhpInvalidArgumentException;
+
+final class InvalidArgumentException extends PhpInvalidArgumentException implements PaginationException
+{
+}

--- a/packages/support/src/Paginator/Exceptions/PaginationException.php
+++ b/packages/support/src/Paginator/Exceptions/PaginationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Tempest\Support\Paginator\Exceptions;
+
+interface PaginationException
+{
+}

--- a/packages/support/src/Paginator/PaginatedData.php
+++ b/packages/support/src/Paginator/PaginatedData.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tempest\Support\Paginator;
+
+use JsonSerializable;
+
+/**
+ * @template T
+ */
+final class PaginatedData implements JsonSerializable
+{
+    /**
+     * @param array<T> $data
+     */
+    public function __construct(
+        public array $data,
+        public int $currentPage,
+        public int $totalPages,
+        public int $totalItems,
+        public int $itemsPerPage,
+        public int $offset,
+        public int $limit,
+        public bool $hasNext,
+        public bool $hasPrevious,
+        public ?int $nextPage,
+        public ?int $previousPage,
+        public array $pageRange,
+    ) {}
+
+    public int $count {
+        get => count($this->data);
+    }
+
+    public bool $isEmpty {
+        get => $this->count === 0;
+    }
+
+    public bool $isNotEmpty {
+        get => ! $this->isEmpty;
+    }
+
+    /**
+     * @template U
+     * @param callable(mixed): U $callback
+     * @return PaginatedData<U>
+     */
+    public function map(callable $callback): self
+    {
+        return new self(
+            data: array_map($callback, $this->data),
+            currentPage: $this->currentPage,
+            totalPages: $this->totalPages,
+            totalItems: $this->totalItems,
+            itemsPerPage: $this->itemsPerPage,
+            offset: $this->offset,
+            limit: $this->limit,
+            hasNext: $this->hasNext,
+            hasPrevious: $this->hasPrevious,
+            nextPage: $this->nextPage,
+            previousPage: $this->previousPage,
+            pageRange: $this->pageRange,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'data' => $this->data,
+            'pagination' => [
+                'current_page' => $this->currentPage,
+                'total_pages' => $this->totalPages,
+                'total_items' => $this->totalItems,
+                'items_per_page' => $this->itemsPerPage,
+                'offset' => $this->offset,
+                'limit' => $this->limit,
+                'has_next' => $this->hasNext,
+                'has_previous' => $this->hasPrevious,
+                'next_page' => $this->nextPage,
+                'previous_page' => $this->previousPage,
+                'page_range' => $this->pageRange,
+                'count' => $this->count,
+            ],
+        ];
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/packages/support/src/Paginator/Paginator.php
+++ b/packages/support/src/Paginator/Paginator.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tempest\Support\Paginator;
+
+use Tempest\Support\Paginator\Exceptions\InvalidArgumentException;
+
+final class Paginator
+{
+    public function __construct(
+        private(set) int $totalItems,
+        private(set) int $itemsPerPage = 20,
+        private(set) int $currentPage = 1,
+        private(set) int $maxLinks = 10,
+    ) {
+        if ($this->totalItems < 0) {
+            throw new InvalidArgumentException('Total items cannot be negative');
+        }
+
+        if ($this->itemsPerPage <= 0) {
+            throw new InvalidArgumentException('Items per page must be positive');
+        }
+
+        if ($this->currentPage <= 0) {
+            throw new InvalidArgumentException('Current page must be positive');
+        }
+
+        if ($this->maxLinks <= 0) {
+            throw new InvalidArgumentException('Max links must be positive');
+        }
+
+        $this->currentPage = min(max(1, $this->currentPage), $this->totalPages);
+    }
+
+    public int $totalPages {
+        get => max(1, (int) ceil($this->totalItems / $this->itemsPerPage));
+    }
+
+    public int $offset {
+        get => ($this->currentPage - 1) * $this->itemsPerPage;
+    }
+
+    public int $limit {
+        get => $this->itemsPerPage;
+    }
+
+    public bool $hasNext {
+        get => $this->currentPage < $this->totalPages;
+    }
+
+    public bool $hasPrevious {
+        get => $this->currentPage > 1;
+    }
+
+    public ?int $nextPage {
+        get => $this->hasNext ? ($this->currentPage + 1) : null;
+    }
+
+    public ?int $previousPage {
+        get => $this->hasPrevious ? ($this->currentPage - 1) : null;
+    }
+
+    public ?int $firstPage {
+        get => $this->totalPages > 0 ? 1 : null;
+    }
+
+    public ?int $lastPage {
+        get => $this->totalPages > 0 ? $this->totalPages : null;
+    }
+
+    public array $pageRange {
+        get => $this->calculatePageRange();
+    }
+
+    public function withPage(int $page): self
+    {
+        return new self(
+            totalItems: $this->totalItems,
+            itemsPerPage: $this->itemsPerPage,
+            currentPage: $page,
+            maxLinks: $this->maxLinks,
+        );
+    }
+
+    public function withItemsPerPage(int $itemsPerPage): self
+    {
+        return new self(
+            totalItems: $this->totalItems,
+            itemsPerPage: $itemsPerPage,
+            currentPage: $this->currentPage,
+            maxLinks: $this->maxLinks,
+        );
+    }
+
+    /**
+     * Creates paginated data with the provided items.
+     *
+     * @template T
+     * @param array<T> $data
+     * @return PaginatedData<T>
+     */
+    public function paginate(array $data): PaginatedData
+    {
+        return new PaginatedData(
+            data: $data,
+            currentPage: $this->currentPage,
+            totalPages: $this->totalPages,
+            totalItems: $this->totalItems,
+            itemsPerPage: $this->itemsPerPage,
+            offset: $this->offset,
+            limit: $this->limit,
+            hasNext: $this->hasNext,
+            hasPrevious: $this->hasPrevious,
+            nextPage: $this->nextPage,
+            previousPage: $this->previousPage,
+            pageRange: $this->pageRange,
+        );
+    }
+
+    /**
+     * Creates paginated data from a callable that fetches data.
+     *
+     * @template T
+     * @param callable(int $limit, int $offset): array<T> $callback
+     * @return PaginatedData<T>
+     */
+    public function paginateWith(callable $callback): PaginatedData
+    {
+        return $this->paginate($callback($this->limit, $this->offset));
+    }
+
+    private function calculatePageRange(): array
+    {
+        if ($this->totalPages <= $this->maxLinks) {
+            return range(1, $this->totalPages);
+        }
+
+        $half = (int) floor($this->maxLinks / 2);
+        $start = max(1, $this->currentPage - $half);
+        $end = min($this->totalPages, ($start + $this->maxLinks) - 1);
+
+        if ((($end - $start) + 1) < $this->maxLinks) {
+            $start = max(1, ($end - $this->maxLinks) + 1);
+        }
+
+        return range($start, $end);
+    }
+}

--- a/packages/support/tests/Json/JsonTest.php
+++ b/packages/support/tests/Json/JsonTest.php
@@ -121,4 +121,28 @@ final class JsonTest extends TestCase
         $this->assertFalse(Json\is_valid(['foo' => 'bar']));
         $this->assertFalse(Json\is_valid(1));
     }
+
+    public function test_base64_encode_and_decode(): void
+    {
+        $data = [
+            'name' => 'azjezz/psl',
+            'type' => 'library',
+            'description' => 'PHP Standard Library.',
+            'keywords' => ['php', 'std', 'stdlib', 'utility', 'psl'],
+            'license' => 'MIT',
+        ];
+
+        $encoded = Json\encode($data, base64: true);
+        $decoded = Json\decode($encoded, base64: true);
+
+        $this->assertSame($data, $decoded);
+    }
+
+    public function test_base64_decode_failure(): void
+    {
+        $this->expectException(Json\Exception\JsonCouldNotBeDecoded::class);
+        $this->expectExceptionMessage('The provided base64 string is not valid.');
+
+        Json\decode('invalid_base64', base64: true);
+    }
 }

--- a/packages/support/tests/Paginator/PaginatedDataTest.php
+++ b/packages/support/tests/Paginator/PaginatedDataTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tempest\Support\Tests\Paginator;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Paginator\PaginatedData;
+
+final class PaginatedDataTest extends TestCase
+{
+    private function createSamplePaginatedData(array $data = ['item1', 'item2', 'item3']): PaginatedData
+    {
+        return new PaginatedData(
+            data: $data,
+            currentPage: 2,
+            totalPages: 5,
+            totalItems: 100,
+            itemsPerPage: 20,
+            offset: 20,
+            limit: 20,
+            hasNext: true,
+            hasPrevious: true,
+            nextPage: 3,
+            previousPage: 1,
+            pageRange: [1, 2, 3, 4, 5],
+        );
+    }
+
+    #[Test]
+    public function it_stores_data_and_pagination_info(): void
+    {
+        $data = ['item1', 'item2', 'item3'];
+        $paginatedData = $this->createSamplePaginatedData($data);
+
+        $this->assertSame($data, $paginatedData->data);
+        $this->assertSame(2, $paginatedData->currentPage);
+        $this->assertSame(5, $paginatedData->totalPages);
+        $this->assertSame(100, $paginatedData->totalItems);
+        $this->assertTrue($paginatedData->hasNext);
+        $this->assertTrue($paginatedData->hasPrevious);
+    }
+
+    #[Test]
+    public function it_calculates_count_property(): void
+    {
+        $paginatedData = $this->createSamplePaginatedData(['a', 'b', 'c', 'd']);
+
+        $this->assertSame(4, $paginatedData->count);
+    }
+
+    #[Test]
+    public function it_checks_empty_status(): void
+    {
+        $emptyData = $this->createSamplePaginatedData([]);
+        $nonEmptyData = $this->createSamplePaginatedData(['item']);
+
+        $this->assertTrue($emptyData->isEmpty);
+        $this->assertFalse($emptyData->isNotEmpty);
+
+        $this->assertFalse($nonEmptyData->isEmpty);
+        $this->assertTrue($nonEmptyData->isNotEmpty);
+    }
+
+    #[Test]
+    public function it_maps_data_while_preserving_pagination(): void
+    {
+        $original = $this->createSamplePaginatedData([1, 2, 3]);
+        $mapped = $original->map(fn ($x) => $x * 2);
+
+        $this->assertSame([2, 4, 6], $mapped->data);
+        $this->assertSame($original->currentPage, $mapped->currentPage);
+        $this->assertSame($original->totalPages, $mapped->totalPages);
+        $this->assertSame($original->totalItems, $mapped->totalItems);
+    }
+
+    #[Test]
+    public function it_converts_to_array(): void
+    {
+        $paginatedData = $this->createSamplePaginatedData(['a', 'b']);
+        $array = $paginatedData->toArray();
+
+        $expected = [
+            'data' => ['a', 'b'],
+            'pagination' => [
+                'current_page' => 2,
+                'total_pages' => 5,
+                'total_items' => 100,
+                'items_per_page' => 20,
+                'offset' => 20,
+                'limit' => 20,
+                'has_next' => true,
+                'has_previous' => true,
+                'next_page' => 3,
+                'previous_page' => 1,
+                'page_range' => [1, 2, 3, 4, 5],
+                'count' => 2,
+            ],
+        ];
+
+        $this->assertEquals($expected, $array);
+    }
+}

--- a/packages/support/tests/Paginator/PaginatorTest.php
+++ b/packages/support/tests/Paginator/PaginatorTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tempest\Support\Tests\Paginator;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Paginator\Exceptions\InvalidArgumentException;
+use Tempest\Support\Paginator\PaginatedData;
+use Tempest\Support\Paginator\Paginator;
+
+final class PaginatorTest extends TestCase
+{
+    private function createPaginator(int $totalItems = 100, int $itemsPerPage = 10, int $currentPage = 1, int $maxLinks = 5): Paginator
+    {
+        return new Paginator($totalItems, $itemsPerPage, $currentPage, $maxLinks);
+    }
+
+    #[Test]
+    public function test_it_calculates_basic_pagination_properties(): void
+    {
+        $paginator = $this->createPaginator(totalItems: 100, itemsPerPage: 10, currentPage: 5);
+
+        $this->assertSame(5, $paginator->currentPage);
+        $this->assertSame(10, $paginator->totalPages);
+        $this->assertSame(100, $paginator->totalItems);
+        $this->assertSame(10, $paginator->itemsPerPage);
+        $this->assertSame(40, $paginator->offset);
+        $this->assertSame(10, $paginator->limit);
+    }
+
+    #[Test]
+    public function test_it_handles_navigation_properties(): void
+    {
+        $paginator = $this->createPaginator(totalItems: 100, itemsPerPage: 10, currentPage: 5);
+
+        $this->assertTrue($paginator->hasNext);
+        $this->assertTrue($paginator->hasPrevious);
+        $this->assertSame(6, $paginator->nextPage);
+        $this->assertSame(4, $paginator->previousPage);
+        $this->assertSame(1, $paginator->firstPage);
+        $this->assertSame(10, $paginator->lastPage);
+    }
+
+    #[Test]
+    public function test_it_handles_first_page_navigation(): void
+    {
+        $paginator = $this->createPaginator(currentPage: 1);
+
+        $this->assertFalse($paginator->hasPrevious);
+        $this->assertNull($paginator->previousPage);
+        $this->assertTrue($paginator->hasNext);
+        $this->assertSame(2, $paginator->nextPage);
+    }
+
+    #[Test]
+    public function test_it_handles_last_page_navigation(): void
+    {
+        $paginator = $this->createPaginator(totalItems: 100, itemsPerPage: 10, currentPage: 10);
+
+        $this->assertFalse($paginator->hasNext);
+        $this->assertNull($paginator->nextPage);
+        $this->assertTrue($paginator->hasPrevious);
+        $this->assertSame(9, $paginator->previousPage);
+    }
+
+    #[Test]
+    public function test_it_handles_single_page_scenario(): void
+    {
+        $paginator = $this->createPaginator(totalItems: 5, itemsPerPage: 10, currentPage: 1);
+
+        $this->assertSame(1, $paginator->totalPages);
+        $this->assertFalse($paginator->hasNext);
+        $this->assertFalse($paginator->hasPrevious);
+        $this->assertNull($paginator->nextPage);
+        $this->assertNull($paginator->previousPage);
+    }
+
+    #[Test]
+    public function test_it_handles_empty_results(): void
+    {
+        $paginator = $this->createPaginator(totalItems: 0);
+
+        $this->assertSame(1, $paginator->totalPages);
+        $this->assertSame(1, $paginator->currentPage);
+        $this->assertSame(0, $paginator->offset);
+        $this->assertSame(1, $paginator->firstPage);
+        $this->assertSame(1, $paginator->lastPage);
+    }
+
+    #[Test]
+    #[DataProvider('pageRangeProvider')]
+    public function test_it_calculates_page_ranges_correctly(int $totalItems, int $itemsPerPage, int $currentPage, int $maxLinks, array $expectedRange): void
+    {
+        $paginator = $this->createPaginator($totalItems, $itemsPerPage, $currentPage, $maxLinks);
+
+        $this->assertEquals($expectedRange, $paginator->pageRange);
+    }
+
+    public static function pageRangeProvider(): array
+    {
+        return [
+            'few pages, show all' => [50, 10, 3, 10, [1, 2, 3, 4, 5]],
+            'many pages, beginning' => [1000, 10, 2, 5, [1, 2, 3, 4, 5]],
+            'many pages, middle' => [1000, 10, 50, 5, [48, 49, 50, 51, 52]],
+            'many pages, near end' => [1000, 10, 98, 5, [96, 97, 98, 99, 100]],
+            'exact max links' => [50, 10, 3, 5, [1, 2, 3, 4, 5]],
+            'single page' => [5, 10, 1, 5, [1]],
+        ];
+    }
+
+    #[Test]
+    public function test_it_constrains_current_page_to_valid_range(): void
+    {
+        $paginator = $this->createPaginator(totalItems: 50, itemsPerPage: 10, currentPage: 100);
+
+        $this->assertSame(5, $paginator->currentPage); // Should be capped at max page
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->createPaginator(currentPage: 0);
+    }
+
+    #[Test]
+    public function test_it_creates_paginated_data_with_array(): void
+    {
+        $paginator = $this->createPaginator(totalItems: 100, itemsPerPage: 10, currentPage: 5);
+        $data = ['item1', 'item2', 'item3'];
+
+        $paginatedData = $paginator->paginate($data);
+
+        $this->assertInstanceOf(PaginatedData::class, $paginatedData);
+        $this->assertSame($data, $paginatedData->data);
+        $this->assertSame(5, $paginatedData->currentPage);
+        $this->assertSame(10, $paginatedData->totalPages);
+        $this->assertSame(100, $paginatedData->totalItems);
+    }
+
+    #[Test]
+    public function test_it_creates_paginated_data_with_callback(): void
+    {
+        $paginator = $this->createPaginator(totalItems: 100, itemsPerPage: 10, currentPage: 3);
+
+        $dataFetcher = function (int $_limit, int $offset): array {
+            return ["item_{$offset}_1", "item_{$offset}_2"];
+        };
+
+        $paginatedData = $paginator->paginateWith($dataFetcher);
+
+        $this->assertSame(['item_20_1', 'item_20_2'], $paginatedData->data);
+        $this->assertSame(3, $paginatedData->currentPage);
+    }
+
+    #[Test]
+    public function test_it_creates_immutable_copies_with_different_page(): void
+    {
+        $original = $this->createPaginator(currentPage: 1);
+        $modified = $original->withPage(5);
+
+        $this->assertNotSame($original, $modified);
+        $this->assertSame(1, $original->currentPage);
+        $this->assertSame(5, $modified->currentPage);
+    }
+
+    #[Test]
+    public function test_it_creates_immutable_copies_with_different_items_per_page(): void
+    {
+        $original = $this->createPaginator(itemsPerPage: 10);
+        $modified = $original->withItemsPerPage(25);
+
+        $this->assertNotSame($original, $modified);
+        $this->assertSame(10, $original->itemsPerPage);
+        $this->assertSame(25, $modified->itemsPerPage);
+    }
+
+    #[Test]
+    public function test_it_handles_fractional_pages_correctly(): void
+    {
+        // 105 items with 10 per page should give 11 pages
+        $paginator = $this->createPaginator(totalItems: 105, itemsPerPage: 10);
+
+        $this->assertSame(11, $paginator->totalPages);
+    }
+
+    #[Test]
+    public function test_it_calculates_offset_correctly_for_different_pages(): void
+    {
+        $paginator = $this->createPaginator(totalItems: 100, itemsPerPage: 10);
+
+        $this->assertSame(0, $paginator->offset);
+        $this->assertSame(10, $paginator->withPage(2)->offset);
+        $this->assertSame(20, $paginator->withPage(3)->offset);
+    }
+}

--- a/tests/Integration/Database/Builder/SelectQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/SelectQueryBuilderTest.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Tests\Tempest\Integration\Database\Builder;
 
 use Tempest\Database\Builder\QueryBuilders\SelectQueryBuilder;
-use Tempest\Database\Config\SQLiteConfig;
 use Tempest\Database\Migrations\CreateMigrationsTable;
-use Tempest\Database\Migrations\MigrationManager;
 use Tests\Tempest\Fixtures\Migrations\CreateAuthorTable;
 use Tests\Tempest\Fixtures\Migrations\CreateBookTable;
 use Tests\Tempest\Fixtures\Migrations\CreateChapterTable;
@@ -17,6 +15,7 @@ use Tests\Tempest\Fixtures\Models\AWithEager;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Fixtures\Modules\Books\Models\AuthorType;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
+use Tests\Tempest\Fixtures\Modules\Books\Models\Chapter;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 use function Tempest\Database\query;
@@ -439,6 +438,52 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
         SQL;
 
         $this->assertSameWithoutBackticks($expected, $sql);
+    }
+
+    public function test_paginate(): void
+    {
+        $this->seed();
+
+        $page1 = query(Chapter::class)
+            ->select()
+            ->paginate(itemsPerPage: 2);
+
+        $this->assertSame(1, $page1->currentPage);
+        $this->assertSame(7, $page1->totalPages);
+        $this->assertSame(13, $page1->totalItems);
+        $this->assertSame(2, $page1->itemsPerPage);
+        $this->assertSame(0, $page1->offset);
+        $this->assertSame(2, $page1->limit);
+        $this->assertSame(2, $page1->nextPage);
+        $this->assertSame(null, $page1->previousPage);
+        $this->assertSame(true, $page1->hasNext);
+        $this->assertSame(false, $page1->hasPrevious);
+
+        $this->assertSame('LOTR 1.1', $page1->data[0]->title);
+        $this->assertSame('LOTR 1.2', $page1->data[1]->title);
+
+        $page3 = query(Chapter::class)
+            ->select()
+            ->paginate(itemsPerPage: 2, currentPage: 3);
+
+        $this->assertSame(3, $page3->currentPage);
+        $this->assertSame('LOTR 2.2', $page3->data[0]->title);
+        $this->assertSame('LOTR 2.3', $page3->data[1]->title);
+
+        $page7 = query(Chapter::class)
+            ->select()
+            ->paginate(itemsPerPage: 2, currentPage: 7);
+
+        $this->assertSame(7, $page7->currentPage);
+        $this->assertSame('Timeline Taxi Chapter 4', $page7->data[0]->title);
+
+        // capped to last page, so this will be page 7
+        $page10 = query(Chapter::class)
+            ->select()
+            ->paginate(itemsPerPage: 2, currentPage: 10);
+
+        $this->assertSame(7, $page10->currentPage);
+        $this->assertSame('Timeline Taxi Chapter 4', $page10->data[0]->title);
     }
 
     private function seed(): void


### PR DESCRIPTION
This pull request adds support for pagination in the select query builder:

```php
$users = query(Chapter::class)
    ->select()
    ->paginate(itemsPerPage: 20, currentPage: $request->currentPage);
```

Pagination is powered by a new `Tempest\Support\Paginator` class, which works by first definition parameters, then applying it on a dataset:

```php
// Database pagination
$paginator = new Paginator(
    totalItems: $total,
    itemsPerPage: $itemsPerPage,
    currentPage: $currentPage,
    maxLinks: $maxLinks,
);

return $paginator->paginateWith(
    callback: fn (int $limit, int $offset) => $this->limit($limit)->offset($offset)->all(),
);

// Array pagination
$paginator = new Paginator(
    totalItems: $total,
    itemsPerPage: $itemsPerPage,
    currentPage: $currentPage,
    maxLinks: $maxLinks,
);

return $paginator->paginate(['foo', 'bar', 'baz']);
```