### PR TITLE
feat(view): make default slot available as dynamic slot

### DIFF
--- a/packages/view/src/Elements/ElementFactory.php
+++ b/packages/view/src/Elements/ElementFactory.php
@@ -7,16 +7,14 @@ namespace Tempest\View\Elements;
 use Tempest\Container\Container;
 use Tempest\Core\AppConfig;
 use Tempest\View\Attributes\PhpAttribute;
-use Tempest\View\Components\AnonymousViewComponent;
 use Tempest\View\Components\DynamicViewComponent;
 use Tempest\View\Element;
 use Tempest\View\Parser\TempestViewCompiler;
 use Tempest\View\Parser\Token;
 use Tempest\View\Parser\TokenType;
+use Tempest\View\Slot;
 use Tempest\View\ViewComponent;
 use Tempest\View\ViewConfig;
-
-use function Tempest\Support\str;
 
 final class ElementFactory
 {
@@ -104,7 +102,7 @@ final class ElementFactory
             );
         } elseif ($token->tag === 'x-slot') {
             $element = new SlotElement(
-                name: $token->getAttribute('name') ?? 'slot',
+                name: $token->getAttribute('name') ?? Slot::DEFAULT,
                 attributes: $attributes,
             );
         } else {

--- a/packages/view/src/Slot.php
+++ b/packages/view/src/Slot.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Tempest\View;
 
+use Tempest\View\Elements\CollectionElement;
 use Tempest\View\Elements\SlotElement;
 
 final class Slot
 {
+    public const string DEFAULT = 'default';
+
     public function __construct(
         public string $name,
         public array $attributes,
@@ -19,10 +22,10 @@ final class Slot
         return $this->attributes[$name] ?? null;
     }
 
-    public static function fromElement(SlotElement $element): self
+    public static function fromElement(SlotElement|CollectionElement $element): self
     {
         return new self(
-            name: $element->name,
+            name: $element->name ?? self::DEFAULT,
             attributes: $element->getAttributes(),
             content: $element->compile(),
         );

--- a/tests/Integration/View/TempestViewRendererTest.php
+++ b/tests/Integration/View/TempestViewRendererTest.php
@@ -203,20 +203,14 @@ final class TempestViewRendererTest extends FrameworkIntegrationTestCase
 
     public function test_default_slot(): void
     {
-        $this->assertStringEqualsStringIgnoringLineEndings(
+        $this->assertSnippetsMatch(
             <<<'HTML'
-            <div class="base">
-                
-                    Test
-                
-            </div>
+            <div class="base">Test</div>
             HTML,
             $this->render(
                 <<<'HTML'
                 <x-base-layout>
-                    <x-slot>
-                        Test
-                    </x-slot>
+                    Test
                 </x-base-layout>
                 HTML,
             ),


### PR DESCRIPTION
This PR adds the ability to access the default slot as a dynamic slot as well. This makes it possible to make components like this:

```html
<x-markdown>main content</x-markdown>
```