### PR TITLE
fix(vite): prevent syntax errors on prefetching script

### DIFF
--- a/packages/vite/src/TagsResolver/ManifestTagsResolver.php
+++ b/packages/vite/src/TagsResolver/ManifestTagsResolver.php
@@ -177,10 +177,16 @@ final readonly class ManifestTagsResolver implements TagsResolver
             return $assets;
         };
 
-        $assets = Json\encode(array_values(array_map(
+        $assets = array_values(array_map(
             callback: fn (array $asset) => array_map('strval', $asset),
             array: array_unique($findPrefetchableAssets($chunk), flags: SORT_REGULAR),
-        )));
+        ));
+
+        if (empty($assets)) {
+            return null;
+        }
+
+        $assets = Json\encode($assets);
 
         $script = match ($this->viteConfig->prefetching->strategy) {
             PrefetchStrategy::AGGRESSIVE => <<<JS
@@ -191,7 +197,7 @@ final readonly class ManifestTagsResolver implements TagsResolver
                         return link
                     }
 
-                    const fragment = new DocumentFragment()
+                    const fragment = new DocumentFragment();
                     {$assets}.forEach((asset) => fragment.append(makeLink(asset)))
                     document.head.append(fragment)
                 }))

--- a/packages/vite/src/TagsResolver/ManifestTagsResolver.php
+++ b/packages/vite/src/TagsResolver/ManifestTagsResolver.php
@@ -182,7 +182,7 @@ final readonly class ManifestTagsResolver implements TagsResolver
             array: array_unique($findPrefetchableAssets($chunk), flags: SORT_REGULAR),
         ));
 
-        if (empty($assets)) {
+        if (count($assets) === 0) {
             return null;
         }
 


### PR DESCRIPTION
### Description
This PR prevents two potential runtime errors in the browser:

1. An `Uncaught SyntaxError: Unexpected token ']'` when no assets are available to prefetch.
2. An `Uncaught TypeError: Cannot read properties of undefined (reading 'forEach')` when the page's assets are minified.

### Changes Made
**Prevent empty prefetch script injection:**
`resolvePrefetchingScript` now returns early if the list of prefetchable assets is empty, preventing the `SyntaxError`.

**Prevent JS TypeError on minification:**
Added a terminating semicolon to the `new DocumentFragment()` instantiation within the `AGGRESSIVE` strategy's script template to ensure correct statement separation after minification, preventing the `TypeError`.

### Note on Testing
I believe the fixes are straightforward enough not to require dedicated test cases, but I'm happy to add them if you think it's necessary.