### PR TITLE
feat(response): add a new Response class for json responses

### DIFF
--- a/packages/http/src/Responses/Json.php
+++ b/packages/http/src/Responses/Json.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Responses;
+
+use Tempest\Http\Header;
+use Tempest\Http\IsResponse;
+use Tempest\Http\Response;
+use Tempest\Http\Status;
+
+final class Json implements Response
+{
+    use IsResponse;
+
+    public function __construct(?array $body = null)
+    {
+        $this->status = Status::OK;
+        $this->body = $body;
+        $this->addHeader('Accept', 'application/json');
+        $this->addHeader('Content-Type', 'application/json');
+    }
+}

--- a/packages/http/tests/Responses/CreatedResponseTest.php
+++ b/packages/http/tests/Responses/CreatedResponseTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Tempest\Http\Tests\Responses;
 
 use PHPUnit\Framework\TestCase;
+use Tempest\Http\Header;
 use Tempest\Http\Responses\Created;
+use Tempest\Http\Responses\Json;
 use Tempest\Http\Status;
 
 /**
@@ -21,5 +23,21 @@ final class CreatedResponseTest extends TestCase
         $this->assertSame([], $response->headers);
         $this->assertSame('{"foo":"bar"}', $response->body);
         $this->assertNotSame(Status::OK, $response->status);
+    }
+
+    public function test_json_response(): void
+    {
+        $response = new Json(['foo' => 'bar']);
+
+        $this->assertSame(Status::OK, $response->status);
+        $this->assertSame(['foo' => 'bar'], $response->body);
+
+        $accept = $response->getHeader('Accept');
+        $contentType = $response->getHeader('Content-Type');
+
+        $this->assertSame('Accept', $accept->name);
+        $this->assertSame('application/json', $accept->values[0]);
+        $this->assertSame('Content-Type', $contentType->name);
+        $this->assertSame('application/json', $contentType->values[0]);
     }
 }


### PR DESCRIPTION
While getting my feet wet in creating a web app with Tempest I noticed that there wasn't a `Response` class for json responses.

While it is possible to do the following
```php
#[Get('/books')]
public function books(): Response
{
    $books = Book::all(['author']);

    return new Ok(map($books)->toJson())
        ->addHeader('Accept', 'application/json')
        ->addHeader('Content-Type', 'application/json');
}
```
Why not make it easier with a new `Response` class
```php
#[Get('/books')]
public function books(): Response
{
    $books = Book::all(['author']);

    return new Json($books);
}
```