### PR TITLE
refactor(view): improve slot importing to prevent view compiler failures

### DIFF
--- a/packages/view/src/Elements/ViewComponentElement.php
+++ b/packages/view/src/Elements/ViewComponentElement.php
@@ -123,7 +123,7 @@ final class ViewComponentElement implements Element, WithToken
 
                 // Add dynamic slots to the current scope
                 '<?php $_previousSlots = $slots ?? null; ?>', // Store previous slots in temporary variable to keep scope
-                sprintf('<?php $slots = %s; ?>', ViewObjectExporter::export($slots)), // @mago-expect best-practices/no-debug-symbols Set the new value of $slots for this view component
+                sprintf('<?php $slots = %s; ?>', ViewObjectExporter::export($slots)),
             )
             ->append(
                 // Restore previous slots

--- a/packages/view/src/Elements/ViewComponentElement.php
+++ b/packages/view/src/Elements/ViewComponentElement.php
@@ -9,6 +9,7 @@ use Tempest\Support\Arr\ImmutableArray;
 use Tempest\Support\Str\ImmutableString;
 use Tempest\Support\Str\MutableString;
 use Tempest\View\Element;
+use Tempest\View\Export\ViewObjectExporter;
 use Tempest\View\Parser\TempestViewCompiler;
 use Tempest\View\Parser\TempestViewParser;
 use Tempest\View\Parser\Token;
@@ -112,7 +113,7 @@ final class ViewComponentElement implements Element, WithToken
             );
 
         // Add scoped variables
-        $slots = $this->getSlots()->toArray();
+        $slots = $this->getSlots();
 
         $compiled = $compiled
             ->prepend(
@@ -122,7 +123,7 @@ final class ViewComponentElement implements Element, WithToken
 
                 // Add dynamic slots to the current scope
                 '<?php $_previousSlots = $slots ?? null; ?>', // Store previous slots in temporary variable to keep scope
-                sprintf('<?php $slots = \Tempest\Support\arr(%s); ?>', var_export($slots, true)), // @mago-expect best-practices/no-debug-symbols Set the new value of $slots for this view component
+                sprintf('<?php $slots = %s; ?>', ViewObjectExporter::export($slots)), // @mago-expect best-practices/no-debug-symbols Set the new value of $slots for this view component
             )
             ->append(
                 // Restore previous slots

--- a/packages/view/src/Export/ExportableViewObject.php
+++ b/packages/view/src/Export/ExportableViewObject.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tempest\View\Export;
+
+use Tempest\Support\Arr\ImmutableArray;
+
+interface ExportableViewObject
+{
+    public ImmutableArray $exportData {
+        get;
+    }
+
+    public static function restore(mixed ...$data): self;
+}

--- a/packages/view/src/Export/ViewObjectExporter.php
+++ b/packages/view/src/Export/ViewObjectExporter.php
@@ -12,7 +12,11 @@ final class ViewObjectExporter
             return sprintf(
                 'new \%s([%s])',
                 ImmutableArray::class,
-                $object->map(fn (mixed $value) => rtrim(self::export($value), ';'))->implode(', '),
+                $object->map(function (mixed $value, string|int $key) {
+                    $key = is_int($key) ? $key : "'{$key}'";
+
+                    return $key . ' => ' . rtrim(self::export($value), ';');
+                })->implode(', '),
             );
         }
 

--- a/packages/view/src/Export/ViewObjectExporter.php
+++ b/packages/view/src/Export/ViewObjectExporter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tempest\View\Export;
+
+use Tempest\Support\Arr\ImmutableArray;
+
+final class ViewObjectExporter
+{
+    public static function export(ExportableViewObject|ImmutableArray $object): string
+    {
+        if ($object instanceof ImmutableArray) {
+            return sprintf(
+                'new \%s([%s])',
+                ImmutableArray::class,
+                $object->map(fn (mixed $value) => rtrim(self::export($value), ';'))->implode(', '),
+            );
+        }
+
+        return sprintf(
+            '\%s::restore(%s);',
+            $object::class,
+            $object
+                ->exportData
+                ->map(function (mixed $value, string $key) {
+                    $value = match (true) {
+                        $value instanceof ExportableViewObject => self::export($value),
+                        is_string($value) => "<<<'STRING'" . PHP_EOL . $value . PHP_EOL . 'STRING',
+                        default => var_export($value, true), // @mago-expect best-practices/no-debug-symbols
+                    };
+
+                    return "{$key} : {$value}";
+                })
+                ->implode(','),
+        );
+    }
+}


### PR DESCRIPTION
Including the content of dynamic slots in the template using normal `var_export` can cause compiler errors because `var_export` doesn't properly escape quoted strings within exported values.

To work around that, I added a new `\Tempest\View\Export\ViewObjectExporter` that exports objects to valid PHP code.

For now, this exporter is very hard-coded towards this one specific use-case for exporting slots. We might refactor it in the future to be something reusable, and maybe even integrate it with the mapper (something like `map($object)->toPhp()`, but that's out of scope for now.)