### PR TITLE
chore: give more accurate information about the internal storage path if permissions aren't met

### DIFF
--- a/packages/core/src/FrameworkKernel.php
+++ b/packages/core/src/FrameworkKernel.php
@@ -168,7 +168,15 @@ final class FrameworkKernel implements Kernel
         $path = $this->root . '/.tempest';
 
         if (! is_dir($path)) {
-            mkdir($path, recursive: true);
+            if (file_exists($path)) {
+                throw new \RuntimeException('Unable to create internal storage directory, as a file with the same name (.tempest) already exists.');
+            }
+
+            if (! mkdir($path, recursive: true)) {
+                throw new \RuntimeException('Unable to create internal storage directory because of insufficient user permission.');
+            }
+        } elseif (! is_writable($path)) {
+            throw new \RuntimeException('Insufficient user permission to write to internal storage directory.');
         }
 
         $this->internalStorage = realpath($path);

--- a/packages/core/src/FrameworkKernel.php
+++ b/packages/core/src/FrameworkKernel.php
@@ -173,7 +173,7 @@ final class FrameworkKernel implements Kernel
             }
 
             if (! mkdir($path, recursive: true)) {
-                throw new \RuntimeException('Unable to create internal storage directory because of insufficient user permission.');
+                throw new \RuntimeException('Unable to create internal storage directory because of insufficient user permission on the root directory.');
             }
         } elseif (! is_writable($path)) {
             throw new \RuntimeException('Insufficient user permission to write to internal storage directory.');


### PR DESCRIPTION
This will additionally check the cases and throw an exception for the cases if

- the internal storage directory doesn't exist but is a file
  <img width="485" height="82" alt="image" src="https://github.com/user-attachments/assets/6c63e70e-faf8-4049-808d-b64b656522ca" />
  <img width="1257" height="77" alt="image" src="https://github.com/user-attachments/assets/66264d67-e3f1-412d-aba7-2f21c48a854c" />


- the internal storage directory doesn't exist but the user has no permission to create the dir
   <img width="1230" height="90" alt="image" src="https://github.com/user-attachments/assets/56b5a1a7-68c1-4145-b99c-5eac51fb110e" />
  
- the internal storage directory exist but isn't writeable (e.g. when the `.tempest` dir was created with the root user but is executed with a less privileged user
   <img width="551" height="144" alt="image" src="https://github.com/user-attachments/assets/b55dc080-533f-47ad-8876-0273f021edf2" />
   <img width="1032" height="90" alt="image" src="https://github.com/user-attachments/assets/1c18fade-3d44-4515-b72c-8be509cab65b" />

