### PR TITLE
feat(discovery): discover `autoload-dev` namespaces

### DIFF
--- a/tests/Integration/Core/ComposerTest.php
+++ b/tests/Integration/Core/ComposerTest.php
@@ -140,4 +140,32 @@ final class ComposerTest extends FrameworkIntegrationTestCase
 
         new Composer(root: __DIR__, executor: new NullShellExecutor())->load();
     }
+
+    #[Test]
+    public function loads_both_autoload_and_autoload_dev(): void
+    {
+        $composer = $this->initializeComposer([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'app/',
+                ],
+            ],
+            'autoload-dev' => [
+                'psr-4' => [
+                    'Tests\\' => 'tests/',
+                ],
+            ],
+        ]);
+
+        $this->assertCount(2, $composer->namespaces);
+
+        $this->assertSame('App\\', $composer->mainNamespace->namespace);
+        $this->assertSame('app/', $composer->mainNamespace->path);
+
+        $this->assertSame('App\\', $composer->namespaces[0]->namespace);
+        $this->assertSame('app/', $composer->namespaces[0]->path);
+
+        $this->assertSame('Tests\\', $composer->namespaces[1]->namespace);
+        $this->assertSame('tests/', $composer->namespaces[1]->path);
+    }
 }


### PR DESCRIPTION
Working on some tests and wanted to use a different database than default. Which is SQLite.
I tried adding the database config under the tests directory, only it was never discovered.

After digging it turned out that only the namespaces from `autoload.psr-4` where loaded and not `autoload-dev.psr-4`

This PR updates processing the namespaces from the `composer.json` file and adds `autoload-dev.psr-4` to it.
