### PR TITLE
feat(mapper): implement serialization mapping for DTOs

### DIFF
--- a/packages/database/src/Builder/ModelInspector.php
+++ b/packages/database/src/Builder/ModelInspector.php
@@ -149,7 +149,7 @@ final class ModelInspector
             return null;
         }
 
-        if ($property->hasAttribute(SerializeWith::class) || $property->getType()->asClass()->haSAttribute(SerializeWith::class)) {
+        if ($property->hasAttribute(SerializeWith::class) || $property->getType()->asClass()->hasAttribute(SerializeWith::class)) {
             return null;
         }
 

--- a/packages/database/src/Builder/QueryBuilders/CountQueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/CountQueryBuilder.php
@@ -15,9 +15,9 @@ use Tempest\Support\Conditions\HasConditions;
 use function Tempest\Database\model;
 
 /**
- * @template TModelClass of object
- * @implements \Tempest\Database\Builder\QueryBuilders\BuildsQuery<TModelClass>
- * @uses \Tempest\Database\Builder\QueryBuilders\HasWhereQueryBuilderMethods<TModelClass>
+ * @template T of object
+ * @implements \Tempest\Database\Builder\QueryBuilders\BuildsQuery<T>
+ * @uses \Tempest\Database\Builder\QueryBuilders\HasWhereQueryBuilderMethods<T>
  */
 final class CountQueryBuilder implements BuildsQuery
 {
@@ -29,11 +29,11 @@ final class CountQueryBuilder implements BuildsQuery
 
     private ModelInspector $model;
 
-    public function __construct(
-        /** @var class-string<TModelClass>|string|TModelClass $model */
-        string|object $model,
-        ?string $column = null,
-    ) {
+    /**
+     * @param class-string<T>|string|T $model
+     */
+    public function __construct(string|object $model, ?string $column = null)
+    {
         $this->model = model($model);
 
         $this->count = new CountStatement(
@@ -47,7 +47,7 @@ final class CountQueryBuilder implements BuildsQuery
         return $this->build()->fetchFirst(...$bindings)[$this->count->getKey()];
     }
 
-    /** @return self<TModelClass> */
+    /** @return self<T> */
     public function distinct(): self
     {
         if ($this->count->column === null || $this->count->column === '*') {
@@ -59,7 +59,7 @@ final class CountQueryBuilder implements BuildsQuery
         return $this;
     }
 
-    /** @return self<TModelClass> */
+    /** @return self<T> */
     public function bind(mixed ...$bindings): self
     {
         $this->bindings = [...$this->bindings, ...$bindings];

--- a/packages/database/src/Builder/QueryBuilders/DeleteQueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/DeleteQueryBuilder.php
@@ -26,10 +26,11 @@ final class DeleteQueryBuilder implements BuildsQuery
 
     private ModelInspector $model;
 
-    public function __construct(
-        /** @var class-string<TModelClass>|string|TModelClass $model */
-        string|object $model,
-    ) {
+    /**
+     * @param class-string<TModelClass>|string|TModelClass $model
+     */
+    public function __construct(string|object $model)
+    {
         $this->model = model($model);
         $this->delete = new DeleteStatement($this->model->getTableDefinition());
     }

--- a/packages/database/src/Builder/QueryBuilders/InsertQueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/InsertQueryBuilder.php
@@ -17,6 +17,10 @@ use Tempest\Support\Conditions\HasConditions;
 
 use function Tempest\Database\model;
 
+/**
+ * @template T of object
+ * @implements \Tempest\Database\Builder\QueryBuilders\BuildsQuery<T>
+ */
 final class InsertQueryBuilder implements BuildsQuery
 {
     use HasConditions, OnDatabase;
@@ -29,8 +33,10 @@ final class InsertQueryBuilder implements BuildsQuery
 
     private ModelInspector $model;
 
+    /**
+     * @param class-string<T>|string|T $model
+     */
     public function __construct(
-        /** @var class-string|string $model */
         string|object $model,
         private readonly array $rows,
         private readonly SerializerFactory $serializerFactory,

--- a/packages/database/src/Builder/QueryBuilders/QueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/QueryBuilder.php
@@ -7,12 +7,21 @@ use Tempest\Mapper\SerializerFactory;
 use function Tempest\get;
 use function Tempest\Support\arr;
 
+/**
+ * @template T of object
+ */
 final readonly class QueryBuilder
 {
+    /**
+     * @param class-string<T>|string|T $model
+     */
     public function __construct(
         private string|object $model,
     ) {}
 
+    /**
+     * @return SelectQueryBuilder<T>
+     */
     public function select(string ...$columns): SelectQueryBuilder
     {
         return new SelectQueryBuilder(
@@ -21,6 +30,9 @@ final readonly class QueryBuilder
         );
     }
 
+    /**
+     * @return InsertQueryBuilder<T>
+     */
     public function insert(mixed ...$values): InsertQueryBuilder
     {
         if (! array_is_list($values)) {
@@ -34,6 +46,9 @@ final readonly class QueryBuilder
         );
     }
 
+    /**
+     * @return UpdateQueryBuilder<T>
+     */
     public function update(mixed ...$values): UpdateQueryBuilder
     {
         return new UpdateQueryBuilder(
@@ -43,11 +58,17 @@ final readonly class QueryBuilder
         );
     }
 
+    /**
+     * @return DeleteQueryBuilder<T>
+     */
     public function delete(): DeleteQueryBuilder
     {
         return new DeleteQueryBuilder($this->model);
     }
 
+    /**
+     * @return CountQueryBuilder<T>
+     */
     public function count(?string $column = null): CountQueryBuilder
     {
         return new CountQueryBuilder(

--- a/packages/database/src/Builder/QueryBuilders/SelectQueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/SelectQueryBuilder.php
@@ -27,9 +27,9 @@ use function Tempest\Database\model;
 use function Tempest\map;
 
 /**
- * @template TModelClass of object
- * @implements \Tempest\Database\Builder\QueryBuilders\BuildsQuery<TModelClass>
- * @uses \Tempest\Database\Builder\QueryBuilders\HasWhereQueryBuilderMethods<TModelClass>
+ * @template T of object
+ * @implements \Tempest\Database\Builder\QueryBuilders\BuildsQuery<T>
+ * @uses \Tempest\Database\Builder\QueryBuilders\HasWhereQueryBuilderMethods<T>
  */
 final class SelectQueryBuilder implements BuildsQuery
 {
@@ -45,11 +45,11 @@ final class SelectQueryBuilder implements BuildsQuery
 
     private array $bindings = [];
 
-    public function __construct(
-        /** @var class-string<TModelClass>|string|TModelClass $model */
-        string|object $model,
-        ?ImmutableArray $fields = null,
-    ) {
+    /**
+     * @param class-string<T>|string|T $model
+     */
+    public function __construct(string|object $model, ?ImmutableArray $fields = null)
+    {
         $this->model = model($model);
 
         $this->select = new SelectStatement(
@@ -60,7 +60,7 @@ final class SelectQueryBuilder implements BuildsQuery
         );
     }
 
-    /** @return TModelClass|null */
+    /** @return T|null */
     public function first(mixed ...$bindings): mixed
     {
         $query = $this->build(...$bindings);
@@ -80,7 +80,7 @@ final class SelectQueryBuilder implements BuildsQuery
         return $result[array_key_first($result)];
     }
 
-    /** @return PaginatedData<TModelClass> */
+    /** @return PaginatedData<T> */
     public function paginate(int $itemsPerPage = 20, int $currentPage = 1, int $maxLinks = 10): PaginatedData
     {
         $total = new CountQueryBuilder($this->model->model)->execute();
@@ -97,13 +97,13 @@ final class SelectQueryBuilder implements BuildsQuery
         );
     }
 
-    /** @return TModelClass|null */
+    /** @return T|null */
     public function get(Id $id): mixed
     {
         return $this->whereField('id', $id)->first();
     }
 
-    /** @return TModelClass[] */
+    /** @return T[] */
     public function all(mixed ...$bindings): array
     {
         $query = $this->build(...$bindings);
@@ -118,7 +118,7 @@ final class SelectQueryBuilder implements BuildsQuery
     }
 
     /**
-     * @param Closure(TModelClass[] $models): void $closure
+     * @param Closure(T[] $models): void $closure
      */
     public function chunk(Closure $closure, int $amountPerChunk = 200): void
     {
@@ -136,7 +136,7 @@ final class SelectQueryBuilder implements BuildsQuery
         } while ($data !== []);
     }
 
-    /** @return self<TModelClass> */
+    /** @return self<T> */
     public function orderBy(string $statement): self
     {
         $this->select->orderBy[] = new OrderByStatement($statement);
@@ -144,7 +144,7 @@ final class SelectQueryBuilder implements BuildsQuery
         return $this;
     }
 
-    /** @return self<TModelClass> */
+    /** @return self<T> */
     public function groupBy(string $statement): self
     {
         $this->select->groupBy[] = new GroupByStatement($statement);
@@ -152,7 +152,7 @@ final class SelectQueryBuilder implements BuildsQuery
         return $this;
     }
 
-    /** @return self<TModelClass> */
+    /** @return self<T> */
     public function having(string $statement, mixed ...$bindings): self
     {
         $this->select->having[] = new HavingStatement($statement);
@@ -162,7 +162,7 @@ final class SelectQueryBuilder implements BuildsQuery
         return $this;
     }
 
-    /** @return self<TModelClass> */
+    /** @return self<T> */
     public function limit(int $limit): self
     {
         $this->select->limit = $limit;
@@ -170,7 +170,7 @@ final class SelectQueryBuilder implements BuildsQuery
         return $this;
     }
 
-    /** @return self<TModelClass> */
+    /** @return self<T> */
     public function offset(int $offset): self
     {
         $this->select->offset = $offset;
@@ -178,7 +178,7 @@ final class SelectQueryBuilder implements BuildsQuery
         return $this;
     }
 
-    /** @return self<TModelClass> */
+    /** @return self<T> */
     public function join(string ...$joins): self
     {
         $this->joins = [...$this->joins, ...$joins];
@@ -186,7 +186,7 @@ final class SelectQueryBuilder implements BuildsQuery
         return $this;
     }
 
-    /** @return self<TModelClass> */
+    /** @return self<T> */
     public function with(string ...$relations): self
     {
         $this->relations = [...$this->relations, ...$relations];
@@ -194,7 +194,7 @@ final class SelectQueryBuilder implements BuildsQuery
         return $this;
     }
 
-    /** @return self<TModelClass> */
+    /** @return self<T> */
     public function raw(string $raw): self
     {
         $this->select->raw[] = new RawStatement($raw);
@@ -202,7 +202,7 @@ final class SelectQueryBuilder implements BuildsQuery
         return $this;
     }
 
-    /** @return self<TModelClass> */
+    /** @return self<T> */
     public function bind(mixed ...$bindings): self
     {
         $this->bindings = [...$this->bindings, ...$bindings];

--- a/packages/database/src/Builder/QueryBuilders/UpdateQueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/UpdateQueryBuilder.php
@@ -18,9 +18,9 @@ use function Tempest\Database\model;
 use function Tempest\Support\arr;
 
 /**
- * @template TModelClass of object
- * @implements \Tempest\Database\Builder\QueryBuilders\BuildsQuery<TModelClass>
- * @uses \Tempest\Database\Builder\QueryBuilders\HasWhereQueryBuilderMethods<TModelClass>
+ * @template T of object
+ * @implements \Tempest\Database\Builder\QueryBuilders\BuildsQuery<T>
+ * @uses \Tempest\Database\Builder\QueryBuilders\HasWhereQueryBuilderMethods<T>
  */
 final class UpdateQueryBuilder implements BuildsQuery
 {
@@ -32,8 +32,10 @@ final class UpdateQueryBuilder implements BuildsQuery
 
     private ModelInspector $model;
 
+    /**
+     * @param class-string<T>|string|T $model
+     */
     public function __construct(
-        /** @var class-string<TModelClass>|string|TModelClass $model */
         string|object $model,
         private readonly array|ImmutableArray $values,
         private readonly SerializerFactory $serializerFactory,
@@ -50,7 +52,7 @@ final class UpdateQueryBuilder implements BuildsQuery
         return $this->build()->execute(...$bindings);
     }
 
-    /** @return self<TModelClass> */
+    /** @return self<T> */
     public function allowAll(): self
     {
         $this->update->allowAll = true;
@@ -58,7 +60,7 @@ final class UpdateQueryBuilder implements BuildsQuery
         return $this;
     }
 
-    /** @return self<TModelClass> */
+    /** @return self<T> */
     public function bind(mixed ...$bindings): self
     {
         $this->bindings = [...$this->bindings, ...$bindings];

--- a/packages/database/src/Mappers/SelectModelMapper.php
+++ b/packages/database/src/Mappers/SelectModelMapper.php
@@ -30,9 +30,7 @@ final class SelectModelMapper implements Mapper
         $idField = $model->getPrimaryFieldName();
 
         $parsed = arr($from)
-            ->groupBy(function (array $data) use ($idField) {
-                return $data[$idField];
-            })
+            ->groupBy(fn (array $data, int $i) => $data[$idField] ?? $i)
             ->map(fn (array $rows) => $this->normalizeFields($model, $rows))
             ->values();
 

--- a/packages/database/src/functions.php
+++ b/packages/database/src/functions.php
@@ -4,11 +4,22 @@ namespace Tempest\Database {
     use Tempest\Database\Builder\ModelInspector;
     use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
 
+    /**
+     * @template T of object
+     * @param class-string<T>|string|T $model
+     * @return QueryBuilder<T>
+     *
+     */
     function query(string|object $model): QueryBuilder
     {
         return new QueryBuilder($model);
     }
 
+    /**
+     * @template T of object
+     * @param class-string<T>|string|T $model
+     * @return ModelInspector<T>
+     */
     function model(string|object $model): ModelInspector
     {
         return new ModelInspector($model);

--- a/packages/mapper/src/Casters/DtoCaster.php
+++ b/packages/mapper/src/Casters/DtoCaster.php
@@ -4,12 +4,18 @@ namespace Tempest\Mapper\Casters;
 
 use Tempest\Mapper\Caster;
 use Tempest\Mapper\Exceptions\ValueCouldNotBeCast;
+use Tempest\Mapper\MapperConfig;
+use Tempest\Support\Arr;
 use Tempest\Support\Json;
 
 use function Tempest\map;
 
-final class DtoCaster implements Caster
+final readonly class DtoCaster implements Caster
 {
+    public function __construct(
+        private MapperConfig $mapperConfig,
+    ) {}
+
     public function cast(mixed $input): mixed
     {
         if (! Json\is_valid($input)) {
@@ -18,6 +24,8 @@ final class DtoCaster implements Caster
 
         ['type' => $type, 'data' => $data] = Json\decode($input);
 
-        return map($data)->to($type);
+        $class = Arr\find_key($this->mapperConfig->serializationMap, $type) ?: $type;
+
+        return map($data)->to($class);
     }
 }

--- a/packages/mapper/src/MapperConfig.php
+++ b/packages/mapper/src/MapperConfig.php
@@ -9,5 +9,19 @@ final class MapperConfig
     public function __construct(
         /** @var class-string[] */
         public array $mappers = [],
+        /** @var array<class-string,string> */
+        public array $serializationMap = [],
     ) {}
+
+    /**
+     * Serialize `$class` using the given `$name`.
+     *
+     * @param class-string $class
+     */
+    public function serializeAs(string $class, string $name): self
+    {
+        $this->serializationMap[$class] = $name;
+
+        return $this;
+    }
 }

--- a/packages/mapper/src/SerializationMapDiscovery.php
+++ b/packages/mapper/src/SerializationMapDiscovery.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tempest\Mapper;
+
+use Tempest\Discovery\Discovery;
+use Tempest\Discovery\DiscoveryLocation;
+use Tempest\Discovery\IsDiscovery;
+use Tempest\Reflection\ClassReflector;
+
+final class SerializationMapDiscovery implements Discovery
+{
+    use IsDiscovery;
+
+    public function __construct(
+        private readonly MapperConfig $mapperConfig,
+    ) {}
+
+    public function discover(DiscoveryLocation $location, ClassReflector $class): void
+    {
+        if ($attribute = $class->getAttribute(SerializeAs::class)) {
+            $this->discoveryItems->add($location, [$class->getName(), $attribute->name]);
+        }
+    }
+
+    public function apply(): void
+    {
+        foreach ($this->discoveryItems as [$className, $serializationName]) {
+            $this->mapperConfig->serializeAs($className, $serializationName);
+        }
+    }
+}

--- a/packages/mapper/src/SerializeAs.php
+++ b/packages/mapper/src/SerializeAs.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tempest\Mapper;
+
+use Attribute;
+
+/**
+ * Defines the name to use when serializing this class, instead of its fully qualified class name.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class SerializeAs
+{
+    public function __construct(
+        public string $name,
+    ) {}
+}

--- a/packages/mapper/src/Serializers/DtoSerializer.php
+++ b/packages/mapper/src/Serializers/DtoSerializer.php
@@ -3,13 +3,18 @@
 namespace Tempest\Mapper\Serializers;
 
 use Tempest\Mapper\Exceptions\ValueCouldNotBeSerialized;
+use Tempest\Mapper\MapperConfig;
 use Tempest\Mapper\Serializer;
 use Tempest\Support\Json;
 
 use function Tempest\map;
 
-final class DtoSerializer implements Serializer
+final readonly class DtoSerializer implements Serializer
 {
+    public function __construct(
+        private MapperConfig $mapperConfig,
+    ) {}
+
     public function serialize(mixed $input): array|string
     {
         if (! is_object($input)) {
@@ -17,9 +22,10 @@ final class DtoSerializer implements Serializer
         }
 
         $data = map($input)->toArray();
+        $type = $this->mapperConfig->serializationMap[get_class($input)] ?? get_class($input);
 
         return Json\encode([
-            'type' => get_class($input),
+            'type' => $type,
             'data' => $data,
         ]);
     }

--- a/tests/Integration/Database/DtoSerializationTest.php
+++ b/tests/Integration/Database/DtoSerializationTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Tempest\Integration\Database;
+
+use Tempest\Database\DatabaseMigration;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\Migrations\CreateMigrationsTable;
+use Tempest\Database\QueryStatement;
+use Tempest\Database\QueryStatements\CreateTableStatement;
+use Tempest\Mapper\Casters\DtoCaster;
+use Tempest\Mapper\CastWith;
+use Tempest\Mapper\SerializeAs;
+use Tempest\Mapper\Serializers\DtoSerializer;
+use Tempest\Mapper\SerializeWith;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\Database\query;
+
+final class DtoSerializationTest extends FrameworkIntegrationTestCase
+{
+    public function test_serializing_object_with_serialization_name(): void
+    {
+        $this->migrate(CreateMigrationsTable::class, new class implements DatabaseMigration {
+            public string $name = '000_model_with_serializable_object';
+
+            public function up(): QueryStatement
+            {
+                return new CreateTableStatement('model_with_settings')
+                    ->primary()
+                    ->json('settings');
+            }
+
+            public function down(): null
+            {
+                return null;
+            }
+        });
+
+        query(ModelWithSettings::class)
+            ->insert(new ModelWithSettings(new Settings(Theme::DARK)))
+            ->execute();
+
+        $model = query(ModelWithSettings::class)
+            ->select()
+            ->first();
+
+        $this->assertSame(Theme::DARK, $model->settings->theme);
+    }
+}
+
+enum Theme: string
+{
+    case LIGHT = 'light';
+    case DARK = 'dark';
+}
+
+final class ModelWithSettings
+{
+    public function __construct(
+        public Settings $settings,
+    ) {}
+}
+
+#[CastWith(DtoCaster::class)]
+#[SerializeWith(DtoSerializer::class)]
+#[SerializeAs('settings')]
+final class Settings
+{
+    public function __construct(
+        public Theme $theme,
+    ) {}
+}

--- a/tests/Integration/Mapper/Casters/DtoCasterTest.php
+++ b/tests/Integration/Mapper/Casters/DtoCasterTest.php
@@ -4,6 +4,7 @@ namespace Tests\Tempest\Integration\Mapper\Casters;
 
 use Tempest\Mapper\Casters\DtoCaster;
 use Tempest\Mapper\Exceptions\ValueCouldNotBeCast;
+use Tempest\Mapper\MapperConfig;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 use Tests\Tempest\Integration\Mapper\Fixtures\MyObject;
 
@@ -13,7 +14,19 @@ final class DtoCasterTest extends FrameworkIntegrationTestCase
     {
         $json = json_encode(['type' => MyObject::class, 'data' => ['name' => 'test']]);
 
-        $dto = new DtoCaster()->cast($json);
+        $dto = new DtoCaster(new MapperConfig())->cast($json);
+
+        $this->assertInstanceOf(MyObject::class, $dto);
+        $this->assertSame('test', $dto->name);
+    }
+
+    public function test_cast_with_map(): void
+    {
+        $config = new MapperConfig()->serializeAs(MyObject::class, 'my-object');
+
+        $json = json_encode(['type' => 'my-object', 'data' => ['name' => 'test']]);
+
+        $dto = new DtoCaster($config)->cast($json);
 
         $this->assertInstanceOf(MyObject::class, $dto);
         $this->assertSame('test', $dto->name);
@@ -25,6 +38,6 @@ final class DtoCasterTest extends FrameworkIntegrationTestCase
 
         $this->expectException(ValueCouldNotBeCast::class);
 
-        new DtoCaster()->cast($json);
+        new DtoCaster(new MapperConfig())->cast($json);
     }
 }

--- a/tests/Integration/Mapper/Serializers/DtoSerializerTest.php
+++ b/tests/Integration/Mapper/Serializers/DtoSerializerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Tempest\Integration\Mapper\Serializers;
 
 use Tempest\Mapper\Exceptions\ValueCouldNotBeSerialized;
+use Tempest\Mapper\MapperConfig;
 use Tempest\Mapper\Serializers\DtoSerializer;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 use Tests\Tempest\Integration\Mapper\Fixtures\MyObject;
@@ -13,7 +14,17 @@ final class DtoSerializerTest extends FrameworkIntegrationTestCase
     {
         $this->assertSame(
             json_encode(['type' => MyObject::class, 'data' => ['name' => 'test']]),
-            new DtoSerializer()->serialize(new MyObject(name: 'test')),
+            new DtoSerializer(new MapperConfig())->serialize(new MyObject(name: 'test')),
+        );
+    }
+
+    public function test_serialize_with_map(): void
+    {
+        $config = new MapperConfig()->serializeAs(MyObject::class, 'my-object');
+
+        $this->assertSame(
+            json_encode(['type' => 'my-object', 'data' => ['name' => 'test']]),
+            new DtoSerializer($config)->serialize(new MyObject(name: 'test')),
         );
     }
 
@@ -21,6 +32,6 @@ final class DtoSerializerTest extends FrameworkIntegrationTestCase
     {
         $this->expectException(ValueCouldNotBeSerialized::class);
 
-        new DtoSerializer()->serialize([]);
+        new DtoSerializer(new MapperConfig())->serialize([]);
     }
 }


### PR DESCRIPTION
Closes #1329

This pull request introduces the ability to map a DTO class name to an arbitrary value for serialization. This would be a practice we need to encourage to avoid leaking class names in the database. This is done by adding the `SerializeAs` attribute to a data class:

```php
#[SerializeAs('settings')]
final class Settings
{
    public function __construct(
        public Theme $theme,
    ) {}
}
```

Additionally, [I typed all the query builders](https://github.com/tempestphp/tempest-framework/commit/82837a423252de63da88b7d4a14e6ce241e958c3), because the `query` function did not return proper types before.

And more importantly, when a model was queried without `IsDatabaseModel`, it would raise a warning due to the access to the `id` property in the [select model mapper](https://github.com/tempestphp/tempest-framework/commit/201e98103803d60b24846ca6d62eb9dec7c0cd29), which this PR fixes.