### PR TITLE
feat(datetime): add convenience comparison and manipulation methods

### DIFF
--- a/packages/datetime/src/DateTime.php
+++ b/packages/datetime/src/DateTime.php
@@ -120,11 +120,6 @@ final readonly class DateTime implements DateTimeInterface
     /**
      * Creates a DateTime instance for a specific time on the current day within the specified timezone.
      *
-     * This method facilitates the creation of a {@see DateTime} object representing a precise time on today's date. It is
-     * particularly useful when you need to set a specific time of day for the current date in a given timezone. The
-     * method combines the current date context with a specific time, offering a convenient way to specify times such
-     * as "today at 14:00" in code.
-     *
      * The time components (hours, minutes, seconds, nanoseconds) must be within their valid ranges. The method
      * enforces these constraints and throws an {@see Exception\InvalidArgumentException} if any component is out of bounds.
      *
@@ -287,7 +282,7 @@ final readonly class DateTime implements DateTimeInterface
     /**
      * Parses a date and time string into an instance of {@see Tempest\DateTime\DateTime} using a specific format pattern, with optional customization for timezone and locale.
      *
-     *  This method is specifically designed for cases where a custom format pattern is used to parse the input string.
+     * This method is specifically designed for cases where a custom format pattern is used to parse the input string.
      * It allows for precise control over the parsing process by specifying the exact format pattern that matches the input string.
      * Additionally, the method supports specifying a timezone and locale for parsing, enabling accurate interpretation of locale-specific formats.
      *
@@ -502,70 +497,6 @@ final readonly class DateTime implements DateTimeInterface
             $seconds,
             $nanoseconds,
         );
-    }
-
-    /**
-     * Returns a new instance set to midnight of the same day.
-     */
-    public function startOfDay(): static
-    {
-        return $this->withTime(0, 0, 0, 0);
-    }
-
-    /**
-     * Returns a new instance set to the end of the day.
-     */
-    public function endOfDay(): static
-    {
-        return $this->withTime(23, 59, 59, 999_999_999);
-    }
-
-    /**
-     * Returns a new instance set to the start of the week.
-     */
-    public function startOfWeek(): static
-    {
-        return $this->withDay($this->day - ($this->getWeekday()->value - 1))->startOfDay();
-    }
-
-    /**
-     * Returns a new instance set to the end of the week.
-     */
-    public function endOfWeek(): static
-    {
-        return $this->withDay($this->getDay() + (7 - $this->getWeekday()->value))->endOfDay();
-    }
-
-    /**
-     * Returns a new instance set to the start of the month.
-     */
-    public function startOfMonth(): static
-    {
-        return $this->withDay(1)->startOfDay();
-    }
-
-    /**
-     * Returns a new instance set to the end of the month.
-     */
-    public function endOfMonth(): static
-    {
-        return $this->withDay(Month::from($this->month)->getDaysForYear($this->year))->endOfDay();
-    }
-
-    /**
-     * Returns a new instance set to the start of the year.
-     */
-    public function startOfYear(): static
-    {
-        return $this->withDate($this->getYear(), 1, 1)->startOfDay();
-    }
-
-    /**
-     * Returns a new instance set to the end of the year.
-     */
-    public function endOfYear(): static
-    {
-        return $this->withDate($this->getYear(), 12, Month::DECEMBER->getDaysForYear($this->getYear()))->endOfDay();
     }
 
     #[\Override]

--- a/packages/datetime/src/DateTimeConvenienceMethods.php
+++ b/packages/datetime/src/DateTimeConvenienceMethods.php
@@ -532,6 +532,382 @@ trait DateTimeConvenienceMethods
     }
 
     /**
+     * Returns a new instance set to midnight of the same day.
+     */
+    public function startOfDay(): static
+    {
+        return $this->withTime(0, 0, 0, 0);
+    }
+
+    /**
+     * Returns a new instance set to the end of the day.
+     */
+    public function endOfDay(): static
+    {
+        return $this->withTime(23, 59, 59, 999_999_999);
+    }
+
+    /**
+     * Returns a new instance set to the start of the week.
+     */
+    public function startOfWeek(): static
+    {
+        return $this->minusDays($this->getWeekday()->value - 1)->startOfDay();
+    }
+
+    /**
+     * Returns a new instance set to the end of the week.
+     */
+    public function endOfWeek(): static
+    {
+        return $this->plusDays(7 - $this->getWeekday()->value)->endOfDay();
+    }
+
+    /**
+     * Returns a new instance set to the start of the month.
+     */
+    public function startOfMonth(): static
+    {
+        return $this->withDay(1)->startOfDay();
+    }
+
+    /**
+     * Returns a new instance set to the end of the month.
+     */
+    public function endOfMonth(): static
+    {
+        return $this->withDay(Month::from($this->getMonth())->getDaysForYear($this->getYear()))->endOfDay();
+    }
+
+    /**
+     * Returns a new instance set to the start of the year.
+     */
+    public function startOfYear(): static
+    {
+        return $this->withDate($this->getYear(), 1, 1)->startOfDay();
+    }
+
+    /**
+     * Returns a new instance set to the end of the year.
+     */
+    public function endOfYear(): static
+    {
+        return $this->withDate($this->getYear(), 12, Month::DECEMBER->getDaysForYear($this->getYear()))->endOfDay();
+    }
+
+    /**
+     * Checks if this date is today.
+     */
+    public function isToday(): bool
+    {
+        $now = DateTime::now($this->getTimezone());
+        return $this->getDate() === $now->getDate();
+    }
+
+    /**
+     * Checks if this date is tomorrow.
+     */
+    public function isTomorrow(): bool
+    {
+        $tomorrow = DateTime::now($this->getTimezone())->plusDay();
+        return $this->getDate() === $tomorrow->getDate();
+    }
+
+    /**
+     * Checks if this date is yesterday.
+     */
+    public function isYesterday(): bool
+    {
+        $yesterday = DateTime::now($this->getTimezone())->minusDay();
+        return $this->getDate() === $yesterday->getDate();
+    }
+
+    /**
+     * Checks if this date is in the current week.
+     */
+    public function isCurrentWeek(): bool
+    {
+        $now = DateTime::now($this->getTimezone());
+        $startOfThisWeek = $this->startOfWeek();
+        $endOfThisWeek = $this->endOfWeek();
+
+        return $now->betweenTimeInclusive($startOfThisWeek, $endOfThisWeek);
+    }
+
+    /**
+     * Checks if this date is in the current month.
+     */
+    public function isCurrentMonth(): bool
+    {
+        $now = DateTime::now($this->getTimezone());
+        return $this->getYear() === $now->getYear() && $this->getMonth() === $now->getMonth();
+    }
+
+    /**
+     * Checks if this date is in the current year.
+     */
+    public function isCurrentYear(): bool
+    {
+        $now = DateTime::now($this->getTimezone());
+        return $this->getYear() === $now->getYear();
+    }
+
+    /**
+     * Checks if two dates are on the same day.
+     */
+    public function isSameDay(DateTimeInterface $other): bool
+    {
+        return $this->getYear() === $other->getYear() && $this->getMonth() === $other->getMonth() && $this->getDay() === $other->getDay();
+    }
+
+    /**
+     * Checks if two dates are in the same week.
+     */
+    public function isSameWeek(DateTimeInterface $other): bool
+    {
+        $thisWeek = $this->getISOWeekNumber();
+        $otherWeek = $other->getISOWeekNumber();
+
+        return $thisWeek[0] === $otherWeek[0] && $thisWeek[1] === $otherWeek[1];
+    }
+
+    /**
+     * Checks if two dates are in the same month.
+     */
+    public function isSameMonth(DateTimeInterface $other): bool
+    {
+        return $this->getYear() === $other->getYear() && $this->getMonth() === $other->getMonth();
+    }
+
+    /**
+     * Checks if two dates are in the same year.
+     */
+    public function isSameYear(DateTimeInterface $other): bool
+    {
+        return $this->getYear() === $other->getYear();
+    }
+
+    /**
+     * Checks if two dates are in the same hour.
+     */
+    public function isSameHour(DateTimeInterface $other): bool
+    {
+        return $this->isSameDay($other) && $this->getHours() === $other->getHours();
+    }
+
+    /**
+     * Checks if two dates are in the same minute.
+     */
+    public function isSameMinute(DateTimeInterface $other): bool
+    {
+        return $this->isSameHour($other) && $this->getMinutes() === $other->getMinutes();
+    }
+
+    /**
+     * Checks if this date is the next day after the other.
+     */
+    public function isNextDay(DateTimeInterface $other): bool
+    {
+        return $this->isSameDay($other->plusDay());
+    }
+
+    /**
+     * Checks if this date is the previous day before the other.
+     */
+    public function isPreviousDay(DateTimeInterface $other): bool
+    {
+        return $this->isSameDay($other->minusDay());
+    }
+
+    /**
+     * Checks if this date is in the next week.
+     */
+    public function isNextWeek(): bool
+    {
+        $now = DateTime::now($this->getTimezone());
+        $nextWeek = $now->plusDays(7);
+
+        return $this->isSameWeek($nextWeek);
+    }
+
+    /**
+     * Checks if this date is in previous week.
+     */
+    public function isPreviousWeek(): bool
+    {
+        $now = DateTime::now($this->getTimezone());
+        $previousWeek = $now->minusDays(7);
+
+        return $this->isSameWeek($previousWeek);
+    }
+
+    /**
+     * Checks if this date is in next month.
+     */
+    public function isNextMonth(): bool
+    {
+        $now = DateTime::now($this->getTimezone());
+        $nextMonth = $now->plusMonth();
+
+        return $this->isSameMonth($nextMonth);
+    }
+
+    /**
+     * Checks if this date is in previous month.
+     */
+    public function isPreviousMonth(): bool
+    {
+        $now = DateTime::now($this->getTimezone());
+        $previousMonth = $now->minusMonth();
+
+        return $this->isSameMonth($previousMonth);
+    }
+
+    /**
+     * Checks if this date is in next year.
+     */
+    public function isNextYear(): bool
+    {
+        $now = DateTime::now($this->getTimezone());
+        return $this->getYear() === ($now->getYear() + 1);
+    }
+
+    /**
+     * Checks if this date is in previous year.
+     */
+    public function isPreviousYear(): bool
+    {
+        $now = DateTime::now($this->getTimezone());
+
+        return $this->getYear() === ($now->getYear() - 1);
+    }
+
+    /**
+     * Checks if this date falls on a weekend (Saturday/Sunday).
+     */
+    public function isWeekend(): bool
+    {
+        $weekday = $this->getWeekday();
+
+        return $weekday === Weekday::SATURDAY || $weekday === Weekday::SUNDAY;
+    }
+
+    /**
+     * Checks if this date falls on a weekday (Monday-Friday).
+     */
+    public function isWeekday(): bool
+    {
+        return ! $this->isWeekend();
+    }
+
+    /**
+     * Checks if this is the 1st day of the month.
+     */
+    public function isFirstDayOfMonth(): bool
+    {
+        return $this->getDay() === 1;
+    }
+
+    /**
+     * Checks if this is the last day of the month.
+     */
+    public function isLastDayOfMonth(): bool
+    {
+        $lastDay = Month::from($this->getMonth())
+            ->getDaysForYear($this->getYear());
+
+        return $this->getDay() === $lastDay;
+    }
+
+    /**
+     * Checks if this is January 1st.
+     */
+    public function isFirstDayOfYear(): bool
+    {
+        return $this->getMonth() === 1 && $this->getDay() === 1;
+    }
+
+    /**
+     * Checks if this is December 31st.
+     */
+    public function isLastDayOfYear(): bool
+    {
+        return $this->getMonth() === 12 && $this->getDay() === 31;
+    }
+
+    /**
+     * Checks if time is in morning (6:00-11:59).
+     */
+    public function isMorning(): bool
+    {
+        $hour = $this->getHours();
+
+        return $hour >= 6 && $hour < 12;
+    }
+
+    /**
+     * Checks if time is in afternoon (12:00-17:59).
+     */
+    public function isAfternoon(): bool
+    {
+        $hour = $this->getHours();
+
+        return $hour >= 12 && $hour < 18;
+    }
+
+    /**
+     * Checks if time is in evening (18:00-21:59).
+     */
+    public function isEvening(): bool
+    {
+        $hour = $this->getHours();
+
+        return $hour >= 18 && $hour < 22;
+    }
+
+    /**
+     * Checks if time is at night (22:00-5:59).
+     */
+    public function isNight(): bool
+    {
+        $hour = $this->getHours();
+
+        return $hour >= 22 || $hour < 6;
+    }
+
+    /**
+     * Checks if time is exactly midnight (00:00:00).
+     */
+    public function isMidnight(): bool
+    {
+        return $this->getHours() === 0 && $this->getMinutes() === 0 && $this->getSeconds() === 0;
+    }
+
+    /**
+     * Checks if time is exactly noon (12:00:00).
+     */
+    public function isNoon(): bool
+    {
+        return $this->getHours() === 12 && $this->getMinutes() === 0 && $this->getSeconds() === 0;
+    }
+
+    /**
+     * Checks if this is Monday.
+     */
+    public function isStartOfWeek(): bool
+    {
+        return $this->getWeekday() === Weekday::MONDAY;
+    }
+
+    /**
+     * Checks if this is Sunday.
+     */
+    public function isEndOfWeek(): bool
+    {
+        return $this->getWeekday() === Weekday::SUNDAY;
+    }
+
+    /**
      * Formats this {@see DateTimeInterface} instance based on a specific pattern, with optional customization for timezone and locale.
      *
      * This method allows for detailed customization of the output string by specifying a format pattern. If no pattern is provided,

--- a/packages/datetime/src/DateTimeInterface.php
+++ b/packages/datetime/src/DateTimeInterface.php
@@ -402,6 +402,216 @@ interface DateTimeInterface extends TemporalInterface
     public function minusDays(int $days): static;
 
     /**
+     * Returns a new instance set to midnight of the same day.
+     */
+    public function startOfDay(): static;
+
+    /**
+     * Returns a new instance set to the end of the day.
+     */
+    public function endOfDay(): static;
+
+    /**
+     * Returns a new instance set to the start of the week.
+     */
+    public function startOfWeek(): static;
+
+    /**
+     * Returns a new instance set to the end of the week.
+     */
+    public function endOfWeek(): static;
+
+    /**
+     * Returns a new instance set to the start of the month.
+     */
+    public function startOfMonth(): static;
+
+    /**
+     * Returns a new instance set to the end of the month.
+     */
+    public function endOfMonth(): static;
+
+    /**
+     * Returns a new instance set to the start of the year.
+     */
+    public function startOfYear(): static;
+
+    /**
+     * Returns a new instance set to the end of the year.
+     */
+    public function endOfYear(): static;
+
+    /**
+     * Checks if this date is today.
+     */
+    public function isToday(): bool;
+
+    /**
+     * Checks if this date is tomorrow.
+     */
+    public function isTomorrow(): bool;
+
+    /**
+     * Checks if this date is yesterday.
+     */
+    public function isYesterday(): bool;
+
+    /**
+     * Checks if this date is in the current week.
+     */
+    public function isCurrentWeek(): bool;
+
+    /**
+     * Checks if this date is in the current month.
+     */
+    public function isCurrentMonth(): bool;
+
+    /**
+     * Checks if this date is in the current year.
+     */
+    public function isCurrentYear(): bool;
+
+    /**
+     * Checks if two dates are on the same day.
+     */
+    public function isSameDay(DateTimeInterface $other): bool;
+
+    /**
+     * Checks if two dates are in the same week.
+     */
+    public function isSameWeek(DateTimeInterface $other): bool;
+
+    /**
+     * Checks if two dates are in the same month.
+     */
+    public function isSameMonth(DateTimeInterface $other): bool;
+
+    /**
+     * Checks if two dates are in the same year.
+     */
+    public function isSameYear(DateTimeInterface $other): bool;
+
+    /**
+     * Checks if two dates are in the same hour.
+     */
+    public function isSameHour(DateTimeInterface $other): bool;
+
+    /**
+     * Checks if two dates are in the same minute.
+     */
+    public function isSameMinute(DateTimeInterface $other): bool;
+
+    /**
+     * Checks if this date is the next day after the other.
+     */
+    public function isNextDay(DateTimeInterface $other): bool;
+
+    /**
+     * Checks if this date is the previous day before the other.
+     */
+    public function isPreviousDay(DateTimeInterface $other): bool;
+
+    /**
+     * Checks if this date is in next week.
+     */
+    public function isNextWeek(): bool;
+
+    /**
+     * Checks if this date is in previous week.
+     */
+    public function isPreviousWeek(): bool;
+
+    /**
+     * Checks if this date is in next month.
+     */
+    public function isNextMonth(): bool;
+
+    /**
+     * Checks if this date is in previous month.
+     */
+    public function isPreviousMonth(): bool;
+
+    /**
+     * Checks if this date is in next year.
+     */
+    public function isNextYear(): bool;
+
+    /**
+     * Checks if this date is in previous year.
+     */
+    public function isPreviousYear(): bool;
+
+    /**
+     * Checks if this date falls on a weekend (Saturday/Sunday).
+     */
+    public function isWeekend(): bool;
+
+    /**
+     * Checks if this date falls on a weekday (Monday-Friday).
+     */
+    public function isWeekday(): bool;
+
+    /**
+     * Checks if this is the 1st day of the month.
+     */
+    public function isFirstDayOfMonth(): bool;
+
+    /**
+     * Checks if this is the last day of the month.
+     */
+    public function isLastDayOfMonth(): bool;
+
+    /**
+     * Checks if this is January 1st.
+     */
+    public function isFirstDayOfYear(): bool;
+
+    /**
+     * Checks if this is December 31st.
+     */
+    public function isLastDayOfYear(): bool;
+
+    /**
+     * Checks if time is in morning (6:00-11:59).
+     */
+    public function isMorning(): bool;
+
+    /**
+     * Checks if time is in afternoon (12:00-17:59).
+     */
+    public function isAfternoon(): bool;
+
+    /**
+     * Checks if time is in evening (18:00-21:59).
+     */
+    public function isEvening(): bool;
+
+    /**
+     * Checks if time is at night (22:00-5:59).
+     */
+    public function isNight(): bool;
+
+    /**
+     * Checks if time is exactly midnight (00:00:00).
+     */
+    public function isMidnight(): bool;
+
+    /**
+     * Checks if time is exactly noon (12:00:00).
+     */
+    public function isNoon(): bool;
+
+    /**
+     * Checks if this is Monday.
+     */
+    public function isStartOfWeek(): bool;
+
+    /**
+     * Checks if this is Sunday.
+     */
+    public function isEndOfWeek(): bool;
+
+    /**
      * Formats this {@see DateTimeInterface} instance based on a specific pattern, with optional customization for timezone and locale.
      *
      * This method allows for detailed customization of the output string by specifying a format pattern. If no pattern is provided,

--- a/packages/datetime/src/TemporalConvenienceMethods.php
+++ b/packages/datetime/src/TemporalConvenienceMethods.php
@@ -116,6 +116,62 @@ trait TemporalConvenienceMethods
         return $ca !== Comparison\Order::EQUAL && $cb !== Comparison\Order::EQUAL && $ca !== $cb;
     }
 
+    /**
+     * Alias for {@see before()}. Checks if this temporal object is before the given one.
+     */
+    public function isBefore(TemporalInterface $other): bool
+    {
+        return $this->before($other);
+    }
+
+    /**
+     * Alias for {@see after()}. Checks if this temporal object is after the given one.
+     */
+    public function isAfter(TemporalInterface $other): bool
+    {
+        return $this->after($other);
+    }
+
+    /**
+     * Alias for {@see beforeOrAtTheSameTime()}. Checks if this temporal object is before or at the same time as the given one.
+     */
+    public function isBeforeOrAt(TemporalInterface $other): bool
+    {
+        return $this->beforeOrAtTheSameTime($other);
+    }
+
+    /**
+     * Alias for {@see afterOrAtTheSameTime()}. Checks if this temporal object is after or at the same time as the given one.
+     */
+    public function isAfterOrAt(TemporalInterface $other): bool
+    {
+        return $this->afterOrAtTheSameTime($other);
+    }
+
+    /**
+     * Alias for {@see betweenTimeInclusive()}. Checks if this temporal object is between the given times (inclusive).
+     */
+    public function isBetween(TemporalInterface $a, TemporalInterface $b): bool
+    {
+        return $this->betweenTimeInclusive($a, $b);
+    }
+
+    /**
+     * Alias for {@see betweenTimeExclusive()}. Checks if this temporal object is between the given times (exclusive).
+     */
+    public function isBetweenExclusive(TemporalInterface $a, TemporalInterface $b): bool
+    {
+        return $this->betweenTimeExclusive($a, $b);
+    }
+
+    /**
+     * Alias for {@see equals()}. Checks if this temporal object represents the same time as the given one.
+     */
+    public function isSameTime(TemporalInterface $other): bool
+    {
+        return $this->equals($other);
+    }
+
     public function isFuture(): bool
     {
         return $this->after(Timestamp::now());
@@ -501,10 +557,12 @@ trait TemporalConvenienceMethods
 
     /**
      * Stops the execution and dumps the current state of this temporal object.
+     *
+     * @phpstan-ignore disallowed.function
+     * @mago-expect best-practices/no-debug-symbols
      */
     public function dd(): void
     {
-        // @phpstan-ignore disallowed.function
-        dd($this); // @mago-expect best-practices/no-debug-symbols
+        dd($this);
     }
 }

--- a/packages/datetime/src/TemporalInterface.php
+++ b/packages/datetime/src/TemporalInterface.php
@@ -94,6 +94,41 @@ interface TemporalInterface extends Comparable, Equable, JsonSerializable, Strin
     public function isPast(): bool;
 
     /**
+     * Alias for {@see before()}. Checks if this temporal object is before the given one.
+     */
+    public function isBefore(TemporalInterface $other): bool;
+
+    /**
+     * Alias for {@see after()}. Checks if this temporal object is after the given one.
+     */
+    public function isAfter(TemporalInterface $other): bool;
+
+    /**
+     * Alias for {@see beforeOrAtTheSameTime()}. Checks if this temporal object is before or at the same time as the given one.
+     */
+    public function isBeforeOrAt(TemporalInterface $other): bool;
+
+    /**
+     * Alias for {@see afterOrAtTheSameTime()}. Checks if this temporal object is after or at the same time as the given one.
+     */
+    public function isAfterOrAt(TemporalInterface $other): bool;
+
+    /**
+     * Alias for {@see betweenTimeInclusive()}. Checks if this temporal object is between the given times (inclusive).
+     */
+    public function isBetween(TemporalInterface $a, TemporalInterface $b): bool;
+
+    /**
+     * Alias for {@see betweenTimeExclusive()}. Checks if this temporal object is between the given times (exclusive).
+     */
+    public function isBetweenExclusive(TemporalInterface $a, TemporalInterface $b): bool;
+
+    /**
+     * Alias for {@see equals()}. Checks if this temporal object represents the same time as the given one.
+     */
+    public function isSameTime(TemporalInterface $other): bool;
+
+    /**
      * Adds the specified duration to this temporal object, returning a new instance with the added duration.
      *
      * @throws Exception\UnderflowException If adding the duration results in an arithmetic underflow.

--- a/packages/datetime/tests/DateTimeTest.php
+++ b/packages/datetime/tests/DateTimeTest.php
@@ -645,38 +645,11 @@ final class DateTimeTest extends TestCase
 
     public function test_end_of_week(): void
     {
-        $date = DateTime::parse('2025-05-21 12:00');
-        $new = $date->endOfWeek();
+        $sunday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 4, 14, 0, 0, 0);
+        $monday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 14, 0, 0, 0);
 
-        $this->assertSame(5, $new->getMonth());
-        $this->assertSame(25, $new->getDay());
-        $this->assertSame(23, $new->getHours());
-        $this->assertSame(59, $new->getMinutes());
-        $this->assertSame(59, $new->getSeconds());
-    }
-
-    public function test_start_of_month(): void
-    {
-        $date = DateTime::parse('2025-05-21 12:00');
-        $new = $date->startOfMonth();
-
-        $this->assertSame(5, $new->getMonth());
-        $this->assertSame(1, $new->getDay());
-        $this->assertSame(Weekday::THURSDAY, $new->getWeekday());
-        $this->assertSame(0, $new->getHours());
-    }
-
-    public function test_end_of_month(): void
-    {
-        $date = DateTime::parse('2025-05-21 12:00', timezone: Timezone::EUROPE_PARIS);
-        $new = $date->endOfMonth();
-
-        $this->assertSame(5, $new->getMonth());
-        $this->assertSame(31, $new->getDay());
-        $this->assertSame(Weekday::SATURDAY, $new->getWeekday());
-        $this->assertSame(23, $new->getHours());
-        $this->assertSame(59, $new->getMinutes());
-        $this->assertSame(59, $new->getSeconds());
+        $this->assertTrue($sunday->isEndOfWeek());
+        $this->assertFalse($monday->isEndOfWeek());
     }
 
     public function test_end_of_month_edge_cases(): void
@@ -719,5 +692,346 @@ final class DateTimeTest extends TestCase
         $this->assertSame($date->getMonth(), $converted->getMonth());
         $this->assertSame($date->getDay(), $converted->getDay());
         $this->assertSame(0, $converted->getHours());
+    }
+
+    public function test_is_same_year(): void
+    {
+        $date1 = DateTime::fromParts(Timezone::default(), 2024, Month::JANUARY, 1, 12, 0, 0, 0);
+        $date2 = DateTime::fromParts(Timezone::default(), 2024, Month::DECEMBER, 31, 23, 59, 59, 999999999);
+        $date3 = DateTime::fromParts(Timezone::default(), 2025, Month::JANUARY, 1, 0, 0, 0, 0);
+
+        $this->assertTrue($date1->isSameYear($date2));
+        $this->assertFalse($date1->isSameYear($date3));
+        $this->assertTrue($date1->isSameYear($date1));
+    }
+
+    public function test_is_same_month(): void
+    {
+        $date1 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 1, 12, 0, 0, 0);
+        $date2 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 29, 23, 59, 59, 999999999);
+        $date3 = DateTime::fromParts(Timezone::default(), 2024, Month::MARCH, 1, 0, 0, 0, 0);
+        $date4 = DateTime::fromParts(Timezone::default(), 2025, Month::FEBRUARY, 15, 12, 0, 0, 0);
+
+        $this->assertTrue($date1->isSameMonth($date2));
+        $this->assertFalse($date1->isSameMonth($date3));
+        $this->assertFalse($date1->isSameMonth($date4));
+        $this->assertTrue($date1->isSameMonth($date1));
+    }
+
+    public function test_is_same_week(): void
+    {
+        $monday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 12, 0, 0, 0);
+        $wednesday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 7, 12, 0, 0, 0);
+        $sunday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 11, 12, 0, 0, 0);
+        $nextMonday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 12, 12, 0, 0, 0);
+
+        $this->assertTrue($monday->isSameWeek($wednesday));
+        $this->assertTrue($monday->isSameWeek($sunday));
+        $this->assertFalse($monday->isSameWeek($nextMonday));
+        $this->assertTrue($monday->isSameWeek($monday));
+    }
+
+    public function test_is_same_day(): void
+    {
+        $morning = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 8, 30, 0, 0);
+        $evening = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 20, 45, 30, 123456789);
+        $nextDay = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 6, 8, 30, 0, 0);
+
+        $this->assertTrue($morning->isSameDay($evening));
+        $this->assertFalse($morning->isSameDay($nextDay));
+        $this->assertTrue($morning->isSameDay($morning));
+    }
+
+    public function test_is_same_hour(): void
+    {
+        $time1 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 14, 15, 30, 0);
+        $time2 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 14, 45, 59, 999999999);
+        $time3 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 15, 15, 30, 0);
+        $differentDay = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 6, 14, 15, 30, 0);
+
+        $this->assertTrue($time1->isSameHour($time2));
+        $this->assertFalse($time1->isSameHour($time3));
+        $this->assertFalse($time1->isSameHour($differentDay));
+        $this->assertTrue($time1->isSameHour($time1));
+    }
+
+    public function test_is_same_minute(): void
+    {
+        $time1 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 14, 30, 15, 0);
+        $time2 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 14, 30, 45, 999999999);
+        $time3 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 14, 31, 15, 0);
+        $differentHour = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 15, 30, 15, 0);
+
+        $this->assertTrue($time1->isSameMinute($time2));
+        $this->assertFalse($time1->isSameMinute($time3));
+        $this->assertFalse($time1->isSameMinute($differentHour));
+        $this->assertTrue($time1->isSameMinute($time1));
+    }
+
+    public function test_is_next_day(): void
+    {
+        $today = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 12, 0, 0, 0);
+        $tomorrow = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 6, 15, 30, 45, 123456789);
+        $dayAfterTomorrow = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 7, 8, 0, 0, 0);
+
+        $this->assertTrue($tomorrow->isNextDay($today));
+        $this->assertFalse($dayAfterTomorrow->isNextDay($today));
+        $this->assertFalse($today->isNextDay($today));
+        $this->assertFalse($today->isNextDay($tomorrow));
+    }
+
+    public function test_is_previous_day(): void
+    {
+        $today = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 12, 0, 0, 0);
+        $yesterday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 4, 8, 15, 30, 987654321);
+        $dayBeforeYesterday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 3, 20, 0, 0, 0);
+
+        $this->assertTrue($yesterday->isPreviousDay($today));
+        $this->assertFalse($dayBeforeYesterday->isPreviousDay($today));
+        $this->assertFalse($today->isPreviousDay($today));
+        $this->assertFalse($today->isPreviousDay($yesterday));
+    }
+
+    public function test_is_weekend(): void
+    {
+        $friday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 9, 12, 0, 0, 0);
+        $saturday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 10, 12, 0, 0, 0);
+        $sunday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 11, 12, 0, 0, 0);
+        $monday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 12, 12, 0, 0, 0);
+
+        $this->assertFalse($friday->isWeekend());
+        $this->assertTrue($saturday->isWeekend());
+        $this->assertTrue($sunday->isWeekend());
+        $this->assertFalse($monday->isWeekend());
+    }
+
+    public function test_is_weekday(): void
+    {
+        $friday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 9, 12, 0, 0, 0);
+        $saturday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 10, 12, 0, 0, 0);
+        $sunday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 11, 12, 0, 0, 0);
+        $monday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 12, 12, 0, 0, 0);
+
+        $this->assertTrue($friday->isWeekday());
+        $this->assertFalse($saturday->isWeekday());
+        $this->assertFalse($sunday->isWeekday());
+        $this->assertTrue($monday->isWeekday());
+    }
+
+    public function test_is_first_day_of_month(): void
+    {
+        $firstDay = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 1, 12, 0, 0, 0);
+        $secondDay = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 2, 12, 0, 0, 0);
+        $lastDay = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 29, 12, 0, 0, 0);
+
+        $this->assertTrue($firstDay->isFirstDayOfMonth());
+        $this->assertFalse($secondDay->isFirstDayOfMonth());
+        $this->assertFalse($lastDay->isFirstDayOfMonth());
+    }
+
+    public function test_is_last_day_of_month(): void
+    {
+        $february28 = DateTime::fromParts(Timezone::default(), 2023, Month::FEBRUARY, 28, 12, 0, 0, 0);
+        $february29 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 29, 12, 0, 0, 0);
+        $march1 = DateTime::fromParts(Timezone::default(), 2024, Month::MARCH, 1, 12, 0, 0, 0);
+        $april30 = DateTime::fromParts(Timezone::default(), 2024, Month::APRIL, 30, 12, 0, 0, 0);
+        $may31 = DateTime::fromParts(Timezone::default(), 2024, Month::MAY, 31, 12, 0, 0, 0);
+
+        $this->assertTrue($february28->isLastDayOfMonth());
+        $this->assertTrue($february29->isLastDayOfMonth());
+        $this->assertFalse($march1->isLastDayOfMonth());
+        $this->assertTrue($april30->isLastDayOfMonth());
+        $this->assertTrue($may31->isLastDayOfMonth());
+    }
+
+    public function test_is_first_day_of_year(): void
+    {
+        $newYearsDay = DateTime::fromParts(Timezone::default(), 2024, Month::JANUARY, 1, 0, 0, 0, 0);
+        $newYearsDayDifferentTime = DateTime::fromParts(Timezone::default(), 2024, Month::JANUARY, 1, 23, 59, 59, 999999999);
+        $secondDay = DateTime::fromParts(Timezone::default(), 2024, Month::JANUARY, 2, 0, 0, 0, 0);
+        $december31 = DateTime::fromParts(Timezone::default(), 2023, Month::DECEMBER, 31, 23, 59, 59, 999999999);
+
+        $this->assertTrue($newYearsDay->isFirstDayOfYear());
+        $this->assertTrue($newYearsDayDifferentTime->isFirstDayOfYear());
+        $this->assertFalse($secondDay->isFirstDayOfYear());
+        $this->assertFalse($december31->isFirstDayOfYear());
+    }
+
+    public function test_is_last_day_of_year(): void
+    {
+        $december31 = DateTime::fromParts(Timezone::default(), 2024, Month::DECEMBER, 31, 0, 0, 0, 0);
+        $december31DifferentTime = DateTime::fromParts(Timezone::default(), 2024, Month::DECEMBER, 31, 23, 59, 59, 999999999);
+        $december30 = DateTime::fromParts(Timezone::default(), 2024, Month::DECEMBER, 30, 23, 59, 59, 999999999);
+        $january1 = DateTime::fromParts(Timezone::default(), 2025, Month::JANUARY, 1, 0, 0, 0, 0);
+
+        $this->assertTrue($december31->isLastDayOfYear());
+        $this->assertTrue($december31DifferentTime->isLastDayOfYear());
+        $this->assertFalse($december30->isLastDayOfYear());
+        $this->assertFalse($january1->isLastDayOfYear());
+    }
+
+    public function test_time_of_day_methods(): void
+    {
+        $earlyMorning = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 3, 30, 0, 0);
+        $morning = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 9, 30, 0, 0);
+        $noon = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 12, 0, 0, 0);
+        $afternoon = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 15, 30, 0, 0);
+        $evening = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 19, 30, 0, 0);
+        $night = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 23, 30, 0, 0);
+        $midnight = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 0, 0, 0, 0);
+
+        $this->assertTrue($earlyMorning->isNight());
+        $this->assertFalse($earlyMorning->isMorning());
+        $this->assertFalse($earlyMorning->isAfternoon());
+        $this->assertFalse($earlyMorning->isEvening());
+
+        $this->assertFalse($morning->isNight());
+        $this->assertTrue($morning->isMorning());
+        $this->assertFalse($morning->isAfternoon());
+        $this->assertFalse($morning->isEvening());
+
+        $this->assertFalse($noon->isNight());
+        $this->assertFalse($noon->isMorning());
+        $this->assertTrue($noon->isAfternoon());
+        $this->assertFalse($noon->isEvening());
+        $this->assertTrue($noon->isNoon());
+
+        $this->assertFalse($afternoon->isNight());
+        $this->assertFalse($afternoon->isMorning());
+        $this->assertTrue($afternoon->isAfternoon());
+        $this->assertFalse($afternoon->isEvening());
+
+        $this->assertFalse($evening->isNight());
+        $this->assertFalse($evening->isMorning());
+        $this->assertFalse($evening->isAfternoon());
+        $this->assertTrue($evening->isEvening());
+
+        $this->assertTrue($night->isNight());
+        $this->assertFalse($night->isMorning());
+        $this->assertFalse($night->isAfternoon());
+        $this->assertFalse($night->isEvening());
+
+        $this->assertTrue($midnight->isMidnight());
+        $this->assertFalse($noon->isMidnight());
+        $this->assertFalse($midnight->isNoon());
+    }
+
+    public function test_time_edge_cases(): void
+    {
+        $boundary5_59 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 5, 59, 59, 999999999);
+        $boundary6_00 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 6, 0, 0, 0);
+        $boundary11_59 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 11, 59, 59, 999999999);
+        $boundary12_00 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 12, 0, 0, 0);
+        $boundary17_59 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 17, 59, 59, 999999999);
+        $boundary18_00 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 18, 0, 0, 0);
+        $boundary21_59 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 21, 59, 59, 999999999);
+        $boundary22_00 = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 22, 0, 0, 0);
+
+        $this->assertTrue($boundary5_59->isNight());
+        $this->assertTrue($boundary6_00->isMorning());
+
+        $this->assertTrue($boundary11_59->isMorning());
+        $this->assertTrue($boundary12_00->isAfternoon());
+
+        $this->assertTrue($boundary17_59->isAfternoon());
+        $this->assertTrue($boundary18_00->isEvening());
+
+        $this->assertTrue($boundary21_59->isEvening());
+        $this->assertTrue($boundary22_00->isNight());
+    }
+
+    public function test_is_start_and_end_of_week(): void
+    {
+        $monday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 5, 12, 0, 0, 0);
+        $tuesday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 6, 12, 0, 0, 0);
+        $saturday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 10, 12, 0, 0, 0);
+        $sunday = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 11, 12, 0, 0, 0);
+
+        $this->assertTrue($monday->isStartOfWeek());
+        $this->assertFalse($tuesday->isStartOfWeek());
+        $this->assertFalse($saturday->isStartOfWeek());
+        $this->assertFalse($sunday->isStartOfWeek());
+
+        $this->assertFalse($monday->isEndOfWeek());
+        $this->assertFalse($tuesday->isEndOfWeek());
+        $this->assertFalse($saturday->isEndOfWeek());
+        $this->assertTrue($sunday->isEndOfWeek());
+    }
+
+    public function test_leap_year_edge_cases_for_last_day_of_month(): void
+    {
+        $feb28_leap = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 28, 12, 0, 0, 0);
+        $feb29_leap = DateTime::fromParts(Timezone::default(), 2024, Month::FEBRUARY, 29, 12, 0, 0, 0);
+        $feb28_nonleap = DateTime::fromParts(Timezone::default(), 2023, Month::FEBRUARY, 28, 12, 0, 0, 0);
+
+        $this->assertFalse($feb28_leap->isLastDayOfMonth());
+        $this->assertTrue($feb29_leap->isLastDayOfMonth());
+        $this->assertTrue($feb28_nonleap->isLastDayOfMonth());
+    }
+
+    public function test_cross_year_same_week(): void
+    {
+        $dec30_2024 = DateTime::fromParts(Timezone::default(), 2024, Month::DECEMBER, 30, 12, 0, 0, 0);
+        $jan5_2025 = DateTime::fromParts(Timezone::default(), 2025, Month::JANUARY, 5, 12, 0, 0, 0);
+        $jan6_2025 = DateTime::fromParts(Timezone::default(), 2025, Month::JANUARY, 6, 12, 0, 0, 0);
+
+        $this->assertTrue($dec30_2024->isSameWeek($jan5_2025));
+        $this->assertFalse($dec30_2024->isSameWeek($jan6_2025));
+    }
+
+    public function test_current_relative_date_methods(): void
+    {
+        $now = DateTime::now();
+        $today = DateTime::todayAt($now->getHours(), $now->getMinutes(), $now->getSeconds());
+        $tomorrow = $today->plusDay();
+        $yesterday = $today->minusDay();
+
+        $this->assertTrue($today->isToday());
+        $this->assertFalse($tomorrow->isToday());
+        $this->assertFalse($yesterday->isToday());
+
+        $this->assertTrue($tomorrow->isTomorrow());
+        $this->assertFalse($today->isTomorrow());
+        $this->assertFalse($yesterday->isTomorrow());
+
+        $this->assertTrue($yesterday->isYesterday());
+        $this->assertFalse($today->isYesterday());
+        $this->assertFalse($tomorrow->isYesterday());
+    }
+
+    public function test_current_week_month_year_methods(): void
+    {
+        $now = DateTime::now();
+
+        $currentWeek = $now->startOfWeek();
+        $nextWeek = $now->plusDays(7);
+        $previousWeek = $now->minusDays(7);
+        $this->assertTrue($currentWeek->isCurrentWeek());
+        $this->assertTrue($nextWeek->isNextWeek());
+        $this->assertTrue($previousWeek->isPreviousWeek());
+
+        $currentMonth = DateTime::fromParts($now->getTimezone(), $now->getYear(), $now->getMonth(), 15);
+        $nextMonth = $now->plusMonth();
+        $previousMonth = $now->minusMonth();
+        $this->assertTrue($currentMonth->isCurrentMonth());
+        $this->assertTrue($nextMonth->isNextMonth());
+        $this->assertTrue($previousMonth->isPreviousMonth());
+
+        $currentYear = DateTime::fromParts($now->getTimezone(), $now->getYear(), Month::JUNE, 15);
+        $nextYear = $now->plusYear();
+        $previousYear = $now->minusYear();
+        $this->assertTrue($currentYear->isCurrentYear());
+        $this->assertTrue($nextYear->isNextYear());
+        $this->assertTrue($previousYear->isPreviousYear());
+    }
+
+    public function test_timezone_considerations_for_same_methods(): void
+    {
+        $utc = DateTime::fromParts(Timezone::UTC, 2024, Month::FEBRUARY, 5, 23, 30, 0, 0);
+        $brussels = DateTime::fromParts(Timezone::EUROPE_BRUSSELS, 2024, Month::FEBRUARY, 6, 0, 30, 0, 0);
+
+        $this->assertFalse($utc->isSameDay($brussels));
+        $this->assertTrue($utc->isSameYear($brussels));
+        $this->assertTrue($utc->isSameMonth($brussels));
     }
 }


### PR DESCRIPTION
This pull request adds many convenience methods to the `DateTime` and `Timestamp` classes. It was a bit of work so I procrastinated that, but we have them now!

```php
$date->isToday();
$date->isSameDay($otherDate);
$date->isEndOfWeek();
$date->isLastDayOfYear();
```