### PR TITLE
fix(view): set doctype in `x-base`

### DIFF
--- a/packages/view/src/Components/x-base.view.php
+++ b/packages/view/src/Components/x-base.view.php
@@ -4,6 +4,7 @@
  */
 ?>
 
+<!doctype html>
 <html lang="en" class="h-dvh flex flex-col scroll-smooth">
 <head>
     <title>{{ $title ?? 'Tempest' }}</title>


### PR DESCRIPTION
To avoid this warning in console : This page is in Quirks Mode. Page layout may be impacted. For Standards Mode use “<!DOCTYPE html>”.