### PR TITLE
feat(database): add `string` method on `CreateTableStatement`

### DIFF
--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -83,6 +83,16 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    public function string(string $name, int $length = 255, bool $nullable = false, ?string $default = null): self
+    {
+        return $this->varchar(
+            name: $name,
+            length: $length,
+            nullable: $nullable,
+            default: $default,
+        );
+    }
+
     public function char(string $name, bool $nullable = false, ?string $default = null): self
     {
         $this->statements[] = new CharStatement(

--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -60,11 +60,8 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
-    public function text(
-        string $name,
-        bool $nullable = false,
-        ?string $default = null,
-    ): self {
+    public function text(string $name, bool $nullable = false, ?string $default = null): self
+    {
         $this->statements[] = new TextStatement(
             name: $name,
             nullable: $nullable,
@@ -74,12 +71,8 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
-    public function varchar(
-        string $name,
-        int $length = 255,
-        bool $nullable = false,
-        ?string $default = null,
-    ): self {
+    public function varchar(string $name, int $length = 255, bool $nullable = false, ?string $default = null): self
+    {
         $this->statements[] = new VarcharStatement(
             name: $name,
             size: $length,
@@ -90,11 +83,8 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
-    public function char(
-        string $name,
-        bool $nullable = false,
-        ?string $default = null,
-    ): self {
+    public function char(string $name, bool $nullable = false, ?string $default = null): self
+    {
         $this->statements[] = new CharStatement(
             name: $name,
             nullable: $nullable,
@@ -104,12 +94,8 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
-    public function integer(
-        string $name,
-        bool $unsigned = false,
-        bool $nullable = false,
-        ?int $default = null,
-    ): self {
+    public function integer(string $name, bool $unsigned = false, bool $nullable = false, ?int $default = null): self
+    {
         $this->statements[] = new IntegerStatement(
             name: $name,
             unsigned: $unsigned,
@@ -120,11 +106,8 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
-    public function float(
-        string $name,
-        bool $nullable = false,
-        ?float $default = null,
-    ): self {
+    public function float(string $name, bool $nullable = false, ?float $default = null): self
+    {
         $this->statements[] = new FloatStatement(
             name: $name,
             nullable: $nullable,
@@ -134,11 +117,8 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
-    public function datetime(
-        string $name,
-        bool $nullable = false,
-        ?string $default = null,
-    ): self {
+    public function datetime(string $name, bool $nullable = false, ?string $default = null): self
+    {
         $this->statements[] = new DatetimeStatement(
             name: $name,
             nullable: $nullable,
@@ -148,11 +128,8 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
-    public function date(
-        string $name,
-        bool $nullable = false,
-        ?string $default = null,
-    ): self {
+    public function date(string $name, bool $nullable = false, ?string $default = null): self
+    {
         $this->statements[] = new DateStatement(
             name: $name,
             nullable: $nullable,
@@ -162,11 +139,8 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
-    public function boolean(
-        string $name,
-        bool $nullable = false,
-        ?bool $default = null,
-    ): self {
+    public function boolean(string $name, bool $nullable = false, ?bool $default = null): self
+    {
         $this->statements[] = new BooleanStatement(
             name: $name,
             nullable: $nullable,
@@ -176,11 +150,8 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
-    public function json(
-        string $name,
-        bool $nullable = false,
-        ?string $default = null,
-    ): self {
+    public function json(string $name, bool $nullable = false, ?string $default = null): self
+    {
         $this->statements[] = new JsonStatement(
             name: $name,
             nullable: $nullable,
@@ -201,11 +172,8 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
-    public function array(
-        string $name,
-        bool $nullable = false,
-        array $default = [],
-    ): self {
+    public function array(string $name, bool $nullable = false, array $default = []): self
+    {
         $this->statements[] = new JsonStatement(
             name: $name,
             nullable: $nullable,
@@ -215,12 +183,8 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
-    public function enum(
-        string $name,
-        string $enumClass,
-        bool $nullable = false,
-        null|UnitEnum|BackedEnum $default = null,
-    ): self {
+    public function enum(string $name, string $enumClass, bool $nullable = false, null|UnitEnum|BackedEnum $default = null): self
+    {
         $this->statements[] = new EnumStatement(
             name: $name,
             enumClass: $enumClass,
@@ -231,12 +195,8 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
-    public function set(
-        string $name,
-        array $values,
-        bool $nullable = false,
-        ?string $default = null,
-    ): self {
+    public function set(string $name, array $values, bool $nullable = false, ?string $default = null): self
+    {
         $this->statements[] = new SetStatement(
             name: $name,
             values: $values,

--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -32,6 +32,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return new self(model($modelClass)->getTableDefinition()->name);
     }
 
+    /**
+     * Adds a primary key column to the table. MySQL and SQLite use an auto-incrementing `INTEGER` column, and PostgreSQL uses `SERIAL`.
+     */
     public function primary(string $name = 'id'): self
     {
         $this->statements[] = new PrimaryKeyStatement($name);
@@ -39,6 +42,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds a foreign key relationship to another table.
+     */
     public function belongsTo(
         string $local,
         string $foreign,
@@ -60,6 +66,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds a `TEXT` column to the table.
+     */
     public function text(string $name, bool $nullable = false, ?string $default = null): self
     {
         $this->statements[] = new TextStatement(
@@ -71,6 +80,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds a `VARCHAR` column to the table.
+     */
     public function varchar(string $name, int $length = 255, bool $nullable = false, ?string $default = null): self
     {
         $this->statements[] = new VarcharStatement(
@@ -83,6 +95,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds a `VARCHAR` column to the table.
+     */
     public function string(string $name, int $length = 255, bool $nullable = false, ?string $default = null): self
     {
         return $this->varchar(
@@ -93,6 +108,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         );
     }
 
+    /**
+     * Adds a `CHAR` column to the table.
+     */
     public function char(string $name, bool $nullable = false, ?string $default = null): self
     {
         $this->statements[] = new CharStatement(
@@ -104,6 +122,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds an `INTEGER` column to the table.
+     */
     public function integer(string $name, bool $unsigned = false, bool $nullable = false, ?int $default = null): self
     {
         $this->statements[] = new IntegerStatement(
@@ -116,6 +137,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds a `FLOAT` column to the table.
+     */
     public function float(string $name, bool $nullable = false, ?float $default = null): self
     {
         $this->statements[] = new FloatStatement(
@@ -127,6 +151,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds a datetime column to the table. Uses `DATETIME` for MySQL/SQLite and `TIMESTAMP` for PostgreSQL.
+     */
     public function datetime(string $name, bool $nullable = false, ?string $default = null): self
     {
         $this->statements[] = new DatetimeStatement(
@@ -138,6 +165,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds a `DATE` column to the table.
+     */
     public function date(string $name, bool $nullable = false, ?string $default = null): self
     {
         $this->statements[] = new DateStatement(
@@ -149,6 +179,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds a `BOOLEAN` column to the table.
+     */
     public function boolean(string $name, bool $nullable = false, ?bool $default = null): self
     {
         $this->statements[] = new BooleanStatement(
@@ -160,6 +193,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds a JSON column to the table. Uses `JSON` for MySQL, `TEXT` for SQLite, and `JSONB` for PostgreSQL.
+     */
     public function json(string $name, bool $nullable = false, ?string $default = null): self
     {
         $this->statements[] = new JsonStatement(
@@ -171,6 +207,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Alias for `json()` method. Adds a JSON column for storing serializable objects.
+     */
     public function object(string $name, bool $nullable = false, ?string $default = null): self
     {
         $this->statements[] = new JsonStatement(
@@ -182,6 +221,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds a JSON column for storing arrays. The default value is automatically JSON-encoded, as opposed to `json` and `object`.
+     */
     public function array(string $name, bool $nullable = false, array $default = []): self
     {
         $this->statements[] = new JsonStatement(
@@ -193,6 +235,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds an enum column to the table. Uses the `ENUM` type for MySQL, falls back to `TEXT` for SQLite, and uses a custom enum type for PostgreSQL.
+     */
     public function enum(string $name, string $enumClass, bool $nullable = false, null|UnitEnum|BackedEnum $default = null): self
     {
         $this->statements[] = new EnumStatement(
@@ -205,6 +250,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds a `SET` column to the table. Only supported in MySQL.
+     */
     public function set(string $name, array $values, bool $nullable = false, ?string $default = null): self
     {
         $this->statements[] = new SetStatement(
@@ -217,6 +265,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds a unique constraint on the specified columns.
+     */
     public function unique(string ...$columns): self
     {
         $this->trailingStatements[] = new UniqueStatement(
@@ -227,6 +278,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds an index on the specified columns.
+     */
     public function index(string ...$columns): self
     {
         $this->trailingStatements[] = new IndexStatement(
@@ -237,6 +291,9 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
+    /**
+     * Adds a raw SQL statement to the table definition.
+     */
     public function raw(string $statement): self
     {
         $this->statements[] = new RawStatement($statement);

--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -190,11 +190,8 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
         return $this;
     }
 
-    public function dto(
-        string $name,
-        bool $nullable = false,
-        ?string $default = null,
-    ): self {
+    public function object(string $name, bool $nullable = false, ?string $default = null): self
+    {
         $this->statements[] = new JsonStatement(
             name: $name,
             nullable: $nullable,

--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -210,7 +210,7 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
     /**
      * Alias for `json()` method. Adds a JSON column for storing serializable objects.
      */
-    public function object(string $name, bool $nullable = false, ?string $default = null): self
+    public function dto(string $name, bool $nullable = false, ?string $default = null): self
     {
         $this->statements[] = new JsonStatement(
             name: $name,

--- a/tests/Integration/Database/ModelWithDtoTest.php
+++ b/tests/Integration/Database/ModelWithDtoTest.php
@@ -29,7 +29,7 @@ final class ModelWithDtoTest extends FrameworkIntegrationTestCase
             {
                 return CreateTableStatement::forModel(ModelWithSerializedDto::class)
                     ->primary()
-                    ->dto('dto');
+                    ->object('dto');
             }
 
             public function down(): null

--- a/tests/Integration/Database/ModelWithDtoTest.php
+++ b/tests/Integration/Database/ModelWithDtoTest.php
@@ -29,7 +29,7 @@ final class ModelWithDtoTest extends FrameworkIntegrationTestCase
             {
                 return CreateTableStatement::forModel(ModelWithSerializedDto::class)
                     ->primary()
-                    ->object('dto');
+                    ->dto('dto');
             }
 
             public function down(): null

--- a/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
@@ -200,7 +200,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
             public function up(): QueryStatement
             {
                 return new CreateTableStatement('test_table')
-                    ->object('dto');
+                    ->dto('dto');
             }
 
             public function down(): ?QueryStatement

--- a/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
@@ -200,7 +200,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
             public function up(): QueryStatement
             {
                 return new CreateTableStatement('test_table')
-                    ->dto('dto');
+                    ->object('dto');
             }
 
             public function down(): ?QueryStatement

--- a/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
@@ -242,4 +242,43 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
             $migration,
         );
     }
+
+    public function test_string_method_integration(): void
+    {
+        $migration = new class() implements DatabaseMigration {
+            private(set) string $name = '0';
+
+            public function up(): QueryStatement
+            {
+                return new CreateTableStatement('frieren_table')
+                    ->primary()
+                    ->string('name', length: 100, nullable: false, default: 'Frieren')
+                    ->string('type', nullable: true);
+            }
+
+            public function down(): ?QueryStatement
+            {
+                return null;
+            }
+        };
+
+        $this->migrate(CreateMigrationsTable::class, $migration);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function test_string_method_with_custom_parameters(): void
+    {
+        $varcharStatement = new CreateTableStatement('frieren_mages')
+            ->primary()
+            ->varchar('name', length: 120, nullable: true, default: 'Himmel')
+            ->compile(DatabaseDialect::MYSQL);
+
+        $stringStatement = new CreateTableStatement('frieren_mages')
+            ->primary()
+            ->varchar('name', length: 120, nullable: true, default: 'Himmel')
+            ->compile(DatabaseDialect::MYSQL);
+
+        $this->assertSame($varcharStatement, $stringStatement);
+    }
 }


### PR DESCRIPTION
This pull request is a minor quality of life regarding the creation of tables. I added a `string` method to create a `VARCHAR` column (as an alias to the existing `varchar` method). 

I also renamed `dto` to `object`, because `dto` is very generic. I'm also considering renaming `DtoCaster` and `DtoSerializer` in another PR, let me know.

And last, I added comments for each method to give a little more context to developers. :)