### PR TITLE
ci: provide repository to `git-cliff` to fix commit link generation

### DIFF
--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -23,6 +23,8 @@ jobs:
         id: generate_release_notes
         with:
           args: -v --latest --strip header
+        env:
+          GITHUB_REPO: ${{ github.repository }}
 
       - name: Clean up release notes
         run: |


### PR DESCRIPTION
Fixes  #1452

Im not sure how to test this actually works, but in the git-cliff-action docs it is used: https://github.com/orhun/git-cliff-action/blob/98c93442bb05a455a77bee982867857ae748eeea/README.md?plain=1#L100

and when running the command locally it works aswell:

```sh
GITHUB_REPO="tempestphp/tempest-framework" git-cliff --latest --strip header -c  cliff.toml
```

outputs:

---

## [1.5.1](https://github.com/tempestphp/tempest-framework/compare/v1.5.0..v1.5.1)  —  2025-07-29

### 🚀 Features

- **core**: improve exceptions related to internal storage (#1434) ([00caadf](https://github.com/tempestphp/tempest-framework/commit/00caadf2f8d37d927de8f696e035cd446ee2910d))
- **testing**: add view data assertions (#1440) ([f573fd1](https://github.com/tempestphp/tempest-framework/commit/f573fd1cceb29a2a44254422599f03f4858898a9))
- **view**: add csrf token in x-form (#1441) ([e4daa51](https://github.com/tempestphp/tempest-framework/commit/e4daa515e0bdee48179504e9365df1e34eefb019))

<!-- generated by git-cliff -->

---

I use git-cliff for another repo where this works, and there we do it like [this](https://github.com/itiden/statamic-backup/blob/698b98eaf97fd16083d5acc3ed8bcb19f3c80b4d/.github/workflows/release.yml#L39).