### PR TITLE
feat(http): offer more control over server sent events format

### DIFF
--- a/packages/http/src/ServerSentEvent.php
+++ b/packages/http/src/ServerSentEvent.php
@@ -2,9 +2,45 @@
 
 namespace Tempest\Http;
 
+use JsonSerializable;
+use Stringable;
+use Tempest\DateTime\Duration;
+
 interface ServerSentEvent
 {
-    public array $datalines {
+    /**
+     * Defines the ID of this event, which sets the `Last-Event-ID` header in case of a reconnection.
+     */
+    public ?int $id {
+        get;
+    }
+
+    /**
+     * Defines the event stream's reconnection time in case of a reconnection attempt.
+     */
+    public null|Duration|int $retryAfter {
+        get;
+    }
+
+    /**
+     * The name of the event, which may be listened to by `EventSource#addEventListener`.
+     *
+     * **Example**
+     * ```js
+     * const eventSource = new EventSource('/events');
+     * eventSource.addEventListener('my-event', (event) => {
+     *   console.log(event.data)
+     * })
+     * ```
+     */
+    public ?string $event {
+        get;
+    }
+
+    /**
+     * Content of the event.
+     */
+    public JsonSerializable|Stringable|string|iterable $data {
         get;
     }
 }

--- a/packages/http/src/ServerSentEvent.php
+++ b/packages/http/src/ServerSentEvent.php
@@ -2,13 +2,9 @@
 
 namespace Tempest\Http;
 
-/**
- * Represents a message streamed through server-sent events.
- */
-final class ServerSentEvent
+interface ServerSentEvent
 {
-    public function __construct(
-        public mixed $data,
-        public string $event = 'message',
-    ) {}
+    public array $datalines {
+        get;
+    }
 }

--- a/packages/http/src/ServerSentMessage.php
+++ b/packages/http/src/ServerSentMessage.php
@@ -2,25 +2,30 @@
 
 namespace Tempest\Http;
 
+use JsonSerializable;
+use Stringable;
+use Tempest\DateTime\Duration;
 use Tempest\Support\Json;
 
 /**
- * Represents a message streamed through server-sent events.
+ * Represents a JSON-encoded message streamed through server-sent events.
  */
 final class ServerSentMessage implements ServerSentEvent
 {
-    public function __construct(
-        public mixed $data,
-        public string $event = 'message',
-    ) {}
+    public JsonSerializable|Stringable|string|iterable $data;
 
-    public array $datalines {
-        get {
-            return [
-                "event: {$this->event}\n",
-                'data: ' . Json\encode($this->data),
-                "\n\n",
-            ];
-        }
+    /**
+     * @param JsonSerializable|Stringable|string|iterable $data Content of the event.
+     * @param string $event The name of the event, which may be listened to by `EventSource#addEventListener`.
+     * @param null|int $id Defines the ID of this event, which sets the `Last-Event-ID` header in case of a reconnection.
+     * @param null|Duration|int $retryAfter Defines the event stream's reconnection time in case of a reconnection attempt.
+     */
+    public function __construct(
+        JsonSerializable|Stringable|string|iterable $data,
+        private(set) string $event = 'message',
+        private(set) ?int $id = null,
+        private(set) null|Duration|int $retryAfter = null,
+    ) {
+        $this->data = Json\encode($data);
     }
 }

--- a/packages/http/src/ServerSentMessage.php
+++ b/packages/http/src/ServerSentMessage.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tempest\Http;
+
+use Tempest\Support\Json;
+
+/**
+ * Represents a message streamed through server-sent events.
+ */
+final class ServerSentMessage implements ServerSentEvent
+{
+    public function __construct(
+        public mixed $data,
+        public string $event = 'message',
+    ) {}
+
+    public array $datalines {
+        get {
+            return [
+                "event: {$this->event}\n",
+                "data: " . Json\encode($this->data),
+                "\n\n",
+            ];
+        }
+    }
+}

--- a/packages/http/src/ServerSentMessage.php
+++ b/packages/http/src/ServerSentMessage.php
@@ -18,7 +18,7 @@ final class ServerSentMessage implements ServerSentEvent
         get {
             return [
                 "event: {$this->event}\n",
-                "data: " . Json\encode($this->data),
+                'data: ' . Json\encode($this->data),
                 "\n\n",
             ];
         }

--- a/packages/router/src/GenericResponseSender.php
+++ b/packages/router/src/GenericResponseSender.php
@@ -16,6 +16,7 @@ use Tempest\Http\Responses\Download;
 use Tempest\Http\Responses\EventStream;
 use Tempest\Http\Responses\File;
 use Tempest\Http\ServerSentEvent;
+use Tempest\Http\ServerSentMessage;
 use Tempest\Support\Json;
 use Tempest\View\View;
 use Tempest\View\ViewRenderer;
@@ -119,17 +120,13 @@ final readonly class GenericResponseSender implements ResponseSender
                 break;
             }
 
-            $event = 'message';
-            $data = Json\encode($message);
-
-            if ($message instanceof ServerSentEvent) {
-                $event = $message->event;
-                $data = Json\encode($message->data);
+            if (! ($message instanceof ServerSentEvent)) {
+                $message = new ServerSentMessage(data: $message);
             }
 
-            echo "event: {$event}\n";
-            echo "data: {$data}";
-            echo "\n\n";
+            foreach ($message->datalines as $dataline) {
+                echo $dataline;
+            }
 
             if (ob_get_level() > 0) {
                 ob_flush();

--- a/packages/router/src/GenericResponseSender.php
+++ b/packages/router/src/GenericResponseSender.php
@@ -155,6 +155,8 @@ final readonly class GenericResponseSender implements ResponseSender
                 echo "data: {$line}\n";
             }
 
+            echo "\n\n";
+
             if (ob_get_level() > 0) {
                 ob_flush();
             }

--- a/tests/Integration/Http/GenericResponseSenderTest.php
+++ b/tests/Integration/Http/GenericResponseSenderTest.php
@@ -13,7 +13,7 @@ use Tempest\Http\Responses\Download;
 use Tempest\Http\Responses\EventStream;
 use Tempest\Http\Responses\File;
 use Tempest\Http\Responses\Ok;
-use Tempest\Http\ServerSentEvent;
+use Tempest\Http\ServerSentMessage;
 use Tempest\Http\Status;
 use Tempest\Router\GenericResponseSender;
 use Tempest\View\ViewRenderer;
@@ -190,8 +190,8 @@ final class GenericResponseSenderTest extends FrameworkIntegrationTestCase
     {
         ob_start();
         $response = new EventStream(function () {
-            yield new ServerSentEvent(data: 'hello', event: 'first');
-            yield new ServerSentEvent(data: 'goodbye', event: 'last');
+            yield new ServerSentMessage(data: 'hello', event: 'first');
+            yield new ServerSentMessage(data: 'goodbye', event: 'last');
         });
         $responseSender = $this->container->get(GenericResponseSender::class);
         $responseSender->send($response);


### PR DESCRIPTION
The current implementation of the `GenericResponseSender` hardcoded the server sent event protocoll to:

```php
 echo "event: {$event}\n";
 echo "data: {$data}";
 echo "\n\n";
```

We cannot use multiple data lines or add something like `id` or `retry` to the fields list https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#fields.

I introduced a Interface `ServerSentEvent` with a hooked property `$datalines` to move the shape of the data transmitted with a single message into the Event itself.

This change allows us to implement the datastar protocoll for example:
```txt
event: datastar-patch-elements
data: elements <div id="hal">
data: elements     I’m sorry, Dave. I’m afraid I can’t do that.
data: elements </div>
```