### PR TITLE
fix(mapper): don't overwrite request fields

### DIFF
--- a/packages/http/src/Mappers/PsrRequestToGenericRequestMapper.php
+++ b/packages/http/src/Mappers/PsrRequestToGenericRequestMapper.php
@@ -56,8 +56,6 @@ final readonly class PsrRequestToGenericRequestMapper implements Mapper
             'query' => $query,
             'files' => $uploads,
             'cookies' => Arr\map_iterable($_COOKIE, static fn (string $value, string $key) => new Cookie($key, $value)),
-            ...$data,
-            ...$uploads,
         ])
             ->to(GenericRequest::class);
     }

--- a/tests/Integration/Mapper/PsrRequestToRequestMapperTest.php
+++ b/tests/Integration/Mapper/PsrRequestToRequestMapperTest.php
@@ -10,6 +10,7 @@ use Laminas\Diactoros\UploadedFile;
 use Laminas\Diactoros\Uri;
 use Tempest\Http\GenericRequest;
 use Tempest\Http\Mappers\PsrRequestToGenericRequestMapper;
+use Tempest\Http\Method;
 use Tempest\Http\Request;
 use Tempest\Http\Upload;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -89,5 +90,27 @@ final class PsrRequestToRequestMapperTest extends FrameworkIntegrationTestCase
         $this->assertSame(UPLOAD_ERR_OK, $upload->getError());
         $this->assertSame('hello', $upload->getClientFilename());
         $this->assertSame('application/octet-stream', $upload->getClientMediaType());
+    }
+
+    public function test_body_field_in_body(): void
+    {
+        $psrRequest = $this->http->makePsrRequest(
+            '/',
+            Method::POST,
+            body: [
+                'body' => 'text',
+            ],
+        );
+
+        $mapper = new PsrRequestToGenericRequestMapper();
+
+        $request = $mapper->map($psrRequest, GenericRequest::class);
+
+        $this->assertSame(
+            [
+                'body' => 'text',
+            ],
+            $request->body,
+        );
     }
 }


### PR DESCRIPTION
If you send request
```json
{
    "body": "hello world"
}
```
it will treat request body as `hello world`, but it should be `['body' => 'hello world']`

I think this splat operator have no meaning here? Eventually it could be
```php
[
    ...$body,
   'body' => $data,
]
```
