### PR TITLE
feat(database): add `#[Hashed]` and `#[Encrypted]` attributes

### DIFF
--- a/packages/cryptography/src/Password/GenericPasswordHasher.php
+++ b/packages/cryptography/src/Password/GenericPasswordHasher.php
@@ -44,9 +44,14 @@ final class GenericPasswordHasher implements PasswordHasher
         return password_needs_rehash($hash, $this->algorithm->value, $this->config->options);
     }
 
-    public function analyze(#[\SensitiveParameter] string $hash): Hash
+    public function analyze(#[\SensitiveParameter] string $hash): ?Hash
     {
         $info = password_get_info($hash);
+
+        if ($info['algo'] === null) {
+            return null;
+        }
+
         $algorithm = HashingAlgorithm::from($info['algo']);
 
         return new Hash(

--- a/packages/cryptography/src/Password/PasswordHasher.php
+++ b/packages/cryptography/src/Password/PasswordHasher.php
@@ -29,5 +29,5 @@ interface PasswordHasher
     /**
      * Returns informations about the given hash, such as the algorithm used and its options.
      */
-    public function analyze(#[\SensitiveParameter] string $hash): Hash;
+    public function analyze(#[\SensitiveParameter] string $hash): ?Hash;
 }

--- a/packages/database/src/Casters/EncryptedCaster.php
+++ b/packages/database/src/Casters/EncryptedCaster.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Tempest\Database\Casters;
 
+use Tempest\Cryptography\Encryption\EncryptedData;
 use Tempest\Cryptography\Encryption\Encrypter;
+use Tempest\Cryptography\Encryption\Exceptions\EncryptionException;
 use Tempest\Mapper\Caster;
+use Tempest\Support\Json\Exception\JsonException;
 
 final readonly class EncryptedCaster implements Caster
 {
@@ -19,6 +22,10 @@ final readonly class EncryptedCaster implements Caster
             return null;
         }
 
-        return $this->encrypter->decrypt($input);
+        try {
+            return $this->encrypter->decrypt($input);
+        } catch (EncryptionException|JsonException) {
+            return $input;
+        }
     }
 }

--- a/packages/database/src/Casters/EncryptedCaster.php
+++ b/packages/database/src/Casters/EncryptedCaster.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Casters;
+
+use Tempest\Cryptography\Encryption\Encrypter;
+use Tempest\Mapper\Caster;
+
+final readonly class EncryptedCaster implements Caster
+{
+    public function __construct(
+        private Encrypter $encrypter,
+    ) {}
+
+    public function cast(mixed $input): ?string
+    {
+        if ($input === null) {
+            return null;
+        }
+
+        return $this->encrypter->decrypt($input);
+    }
+}

--- a/packages/database/src/Encrypted.php
+++ b/packages/database/src/Encrypted.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database;
+
+use Attribute;
+use Tempest\Database\Casters\EncryptedCaster;
+use Tempest\Database\Serializers\EncryptedSerializer;
+use Tempest\Database\Serializers\HashedSerializer;
+use Tempest\Mapper\ProvidesCaster;
+use Tempest\Mapper\ProvidesSerializer;
+
+/**
+ * The associated property will be encrypted during serialization and decrypted during casting.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Encrypted implements ProvidesSerializer, ProvidesCaster
+{
+    public string $serializer {
+        get => EncryptedSerializer::class;
+    }
+
+    public string $caster {
+        get => EncryptedCaster::class;
+    }
+}

--- a/packages/database/src/Hashed.php
+++ b/packages/database/src/Hashed.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database;
+
+use Attribute;
+use Tempest\Database\Serializers\HashedSerializer;
+use Tempest\Mapper\ProvidesSerializer;
+
+/**
+ * The associated property will be hashed during serialization.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Hashed implements ProvidesSerializer
+{
+    public string $serializer {
+        get => HashedSerializer::class;
+    }
+}

--- a/packages/database/src/Serializers/EncryptedSerializer.php
+++ b/packages/database/src/Serializers/EncryptedSerializer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tempest\Database\Serializers;
+
+use Tempest\Cryptography\Encryption\EncryptedData;
+use Tempest\Cryptography\Encryption\Encrypter;
+use Tempest\Cryptography\Encryption\Exceptions\EncryptionException;
+use Tempest\Mapper\Serializer;
+use Tempest\Support\Json\Exception\JsonException;
+
+final readonly class EncryptedSerializer implements Serializer
+{
+    public function __construct(
+        private Encrypter $encrypter,
+    ) {}
+
+    public function serialize(mixed $input): array|string
+    {
+        if (! is_string($input)) {
+            return $input;
+        }
+
+        try {
+            EncryptedData::unserialize($input);
+        } catch (EncryptionException|JsonException) {
+            return $this->encrypter->encrypt($input);
+        }
+
+        return $input;
+    }
+}

--- a/packages/database/src/Serializers/HashedSerializer.php
+++ b/packages/database/src/Serializers/HashedSerializer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tempest\Database\Serializers;
+
+use Tempest\Cryptography\Password\PasswordHasher;
+use Tempest\Mapper\Serializer;
+
+final readonly class HashedSerializer implements Serializer
+{
+    public function __construct(
+        private PasswordHasher $passwordHasher,
+    ) {}
+
+    public function serialize(mixed $input): string
+    {
+        if (! is_string($input)) {
+            return $input;
+        }
+
+        if (! $this->passwordHasher->analyze($input)) {
+            return $this->passwordHasher->hash($input);
+        }
+
+        return $input;
+    }
+}

--- a/packages/mapper/src/CasterFactory.php
+++ b/packages/mapper/src/CasterFactory.php
@@ -49,6 +49,10 @@ final class CasterFactory
             return get($castWith->className);
         }
 
+        if ($casterAttribute = $property->getAttribute(ProvidesCaster::class)) {
+            return get($casterAttribute->caster);
+        }
+
         // Resolve caster from manual additions
         foreach ($this->casters as [$for, $casterClass]) {
             if (is_callable($for) && $for($property) || is_string($for) && $type->matches($for) || $type->getName() === $for) {

--- a/packages/mapper/src/ProvidesCaster.php
+++ b/packages/mapper/src/ProvidesCaster.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tempest\Mapper;
+
+/**
+ * Implemented on an attribute, this interface specifies that a specific caster must be used to serialize the associated property.
+ */
+interface ProvidesCaster
+{
+    /** @var class-string<Caster> */
+    public string $caster {
+        get;
+    }
+}

--- a/packages/mapper/src/ProvidesSerializer.php
+++ b/packages/mapper/src/ProvidesSerializer.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tempest\Mapper;
+
+/**
+ * Implemented on an attribute, this interface specifies that a specific serializer must be used to serialize the associated property.
+ */
+interface ProvidesSerializer
+{
+    /** @var class-string<Serializer> */
+    public string $serializer {
+        get;
+    }
+}

--- a/packages/mapper/src/SerializerFactory.php
+++ b/packages/mapper/src/SerializerFactory.php
@@ -86,6 +86,10 @@ final class SerializerFactory
             return get($serializeWith->className);
         }
 
+        if ($serializerAttribute = $property->getAttribute(ProvidesSerializer::class)) {
+            return get($serializerAttribute->serializer);
+        }
+
         // Resolve serializer from manual additions
         foreach ($this->serializers as [$for, $serializerClass]) {
             if (! $this->serializerMatches($for, $type)) {

--- a/packages/support/src/Json/Exception/JsonCouldNotBeDecoded.php
+++ b/packages/support/src/Json/Exception/JsonCouldNotBeDecoded.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Support\Json\Exception;
 
 use InvalidArgumentException;
+use Tempest\Support\Json\Exception\JsonException;
 
 final class JsonCouldNotBeDecoded extends InvalidArgumentException implements JsonException
 {

--- a/tests/Integration/Database/EncryptedAttributeTest.php
+++ b/tests/Integration/Database/EncryptedAttributeTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Tempest\Integration\Database;
+
+use Tempest\Cryptography\Encryption\Encrypter;
+use Tempest\Database\DatabaseMigration;
+use Tempest\Database\Encrypted;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\Migrations\CreateMigrationsTable;
+use Tempest\Database\PrimaryKey;
+use Tempest\Database\Query;
+use Tempest\Database\QueryStatements\CreateTableStatement;
+use Tempest\Database\Table;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+final class EncryptedAttributeTest extends FrameworkIntegrationTestCase
+{
+    private Encrypter $encrypter {
+        get => $this->container->get(Encrypter::class);
+    }
+
+    public function test_encrypted_attribute_encrypts_value_on_insert(): void
+    {
+        $this->migrate(CreateMigrationsTable::class, CreateUserWithEncryptedDataTable::class);
+
+        $user = new UserWithEncryptedData(
+            email: 'test@example.com',
+            secret: 'sensitive information', // @mago-expect security/no-literal-password
+        )->save()->refresh();
+
+        $this->assertSame('sensitive information', $user->secret);
+
+        $encrypted = new Query('SELECT secret FROM users WHERE email = ?', ['test@example.com'])->fetchFirst();
+
+        $this->assertNotSame('sensitive information', $encrypted['secret']);
+    }
+
+    public function test_encrypted_attribute_encrypts_value_on_update(): void
+    {
+        $this->migrate(CreateMigrationsTable::class, CreateUserWithEncryptedDataTable::class);
+
+        $user = new UserWithEncryptedData(
+            email: 'test@example.com',
+            secret: 'original secret', // @mago-expect security/no-literal-password
+        )->save()->refresh();
+
+        $user->update(secret: 'new secret')->refresh(); // @mago-expect security/no-literal-password
+
+        $this->assertSame('new secret', $user->secret);
+
+        $encrypted = new Query('SELECT secret FROM users WHERE email = ?', ['test@example.com'])->fetchFirst();
+
+        $this->assertNotSame('original secret', $encrypted['secret']);
+        $this->assertNotSame('new secret', $encrypted['secret']);
+    }
+
+    public function test_encrypted_attribute_does_not_re_encrypt_already_encrypted_values(): void
+    {
+        $this->migrate(CreateMigrationsTable::class, CreateUserWithEncryptedDataTable::class);
+
+        $alreadyEncrypted = $this->encrypter->encrypt('sensitive data');
+
+        $user = new UserWithEncryptedData(
+            email: 'test@example.com',
+            secret: $alreadyEncrypted,
+        )->save()->refresh();
+
+        $this->assertSame('sensitive data', $user->secret);
+    }
+
+    public function test_encrypted_attribute_handles_null_values(): void
+    {
+        $this->migrate(CreateMigrationsTable::class, CreateUserWithNullableEncryptedDataTable::class);
+
+        $user = new UserWithNullableEncryptedData(
+            email: 'test@example.com',
+            secret: null,
+        )->save()->refresh();
+
+        $this->assertNull($user->secret);
+    }
+
+    public function test_encrypted_attribute_handles_empty_strings(): void
+    {
+        $this->migrate(CreateMigrationsTable::class, CreateUserWithEncryptedDataTable::class);
+
+        $user = new UserWithEncryptedData(
+            email: 'test@example.com',
+            secret: '',
+        )->save()->refresh();
+
+        $this->assertSame('', $user->secret);
+    }
+}
+
+#[Table('users')]
+final class UserWithEncryptedData
+{
+    use IsDatabaseModel;
+
+    public PrimaryKey $id;
+
+    public function __construct(
+        public string $email,
+        #[Encrypted]
+        public string $secret,
+    ) {}
+}
+
+#[Table('users')]
+final class UserWithNullableEncryptedData
+{
+    use IsDatabaseModel;
+
+    public PrimaryKey $id;
+
+    public function __construct(
+        public string $email,
+        #[Encrypted]
+        public ?string $secret,
+    ) {}
+}
+
+final class CreateUserWithEncryptedDataTable implements DatabaseMigration
+{
+    public string $name = '2024_create_users_with_encrypted_data_table';
+
+    public function up(): CreateTableStatement
+    {
+        return CreateTableStatement::forModel(UserWithEncryptedData::class)
+            ->primary()
+            ->string('email')
+            ->text('secret');
+    }
+
+    public function down(): null
+    {
+        return null;
+    }
+}
+
+final class CreateUserWithNullableEncryptedDataTable implements DatabaseMigration
+{
+    public string $name = '2024_create_users_with_nullable_encrypted_data_table';
+
+    public function up(): CreateTableStatement
+    {
+        return CreateTableStatement::forModel(UserWithNullableEncryptedData::class)
+            ->primary()
+            ->string('email')
+            ->text('secret', nullable: true);
+    }
+
+    public function down(): null
+    {
+        return null;
+    }
+}

--- a/tests/Integration/Database/HashedAttributeTest.php
+++ b/tests/Integration/Database/HashedAttributeTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Tempest\Integration\Database;
+
+use Tempest\Cryptography\Password\PasswordHasher;
+use Tempest\Database\DatabaseMigration;
+use Tempest\Database\Hashed;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\Migrations\CreateMigrationsTable;
+use Tempest\Database\PrimaryKey;
+use Tempest\Database\QueryStatements\CreateTableStatement;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+final class HashedAttributeTest extends FrameworkIntegrationTestCase
+{
+    private PasswordHasher $hasher {
+        get => $this->container->get(PasswordHasher::class);
+    }
+
+    public function test_hashed_attribute_hashes_value_on_insert(): void
+    {
+        $this->migrate(CreateMigrationsTable::class, CreateUserWithHashTable::class);
+
+        $user = new UserWithHash(
+            email: 'test@example.com',
+            password: 'plaintext-password', // @mago-expect security/no-literal-password
+        )->save()->refresh();
+
+        $this->assertNotSame('plaintext-password', $user->password);
+        $this->assertTrue($this->hasher->verify('plaintext-password', $user->password));
+    }
+
+    public function test_hashed_attribute_hashes_value_on_update(): void
+    {
+        $this->migrate(CreateMigrationsTable::class, CreateUserWithHashTable::class);
+
+        $user = new UserWithHash(
+            email: 'test@example.com',
+            password: 'original-password', // @mago-expect security/no-literal-password
+        )->save()->refresh();
+
+        $originalHash = $user->password;
+
+        $user->update(password: 'new-password')->refresh(); // @mago-expect security/no-literal-password
+
+        $this->assertNotSame('new-password', $user->password);
+        $this->assertNotSame($originalHash, $user->password);
+
+        $this->assertTrue($this->hasher->verify('new-password', $user->password));
+        $this->assertFalse($this->hasher->verify('original-password', $user->password));
+    }
+
+    public function test_hashed_attribute_does_not_rehash_already_hashed_values(): void
+    {
+        $this->migrate(CreateMigrationsTable::class, CreateUserWithHashTable::class);
+
+        $alreadyHashed = $this->hasher->hash('plaintext-password');
+
+        $user = new UserWithHash(
+            email: 'test@example.com',
+            password: $alreadyHashed,
+        )->save()->refresh();
+
+        $this->assertSame($alreadyHashed, $user->password);
+        $this->assertTrue($this->hasher->verify('plaintext-password', $user->password));
+    }
+
+    public function test_hashed_attribute_handles_null_values(): void
+    {
+        $this->migrate(CreateMigrationsTable::class, CreateUserWithNullablePasswordTable::class);
+
+        $user = new UserWithNullablePassword(
+            email: 'test@example.com',
+            password: null,
+        )->save()->refresh();
+
+        $this->assertNull($user->password);
+    }
+}
+
+final class UserWithHash
+{
+    use IsDatabaseModel;
+
+    public PrimaryKey $id;
+
+    public function __construct(
+        public string $email,
+        #[Hashed]
+        public string $password,
+    ) {}
+}
+
+final class UserWithNullablePassword
+{
+    use IsDatabaseModel;
+
+    public PrimaryKey $id;
+
+    public function __construct(
+        public string $email,
+        #[Hashed]
+        public ?string $password,
+    ) {}
+}
+
+final class CreateUserWithHashTable implements DatabaseMigration
+{
+    public string $name = '2024_create_users_table';
+
+    public function up(): CreateTableStatement
+    {
+        return CreateTableStatement::forModel(UserWithHash::class)
+            ->primary()
+            ->varchar('email')
+            ->text('password');
+    }
+
+    public function down(): null
+    {
+        return null;
+    }
+}
+
+final class CreateUserWithNullablePasswordTable implements DatabaseMigration
+{
+    public string $name = '2024_create_users_with_nullable_password_table';
+
+    public function up(): CreateTableStatement
+    {
+        return CreateTableStatement::forModel(UserWithNullablePassword::class)
+            ->primary()
+            ->varchar('email')
+            ->text('password', nullable: true);
+    }
+
+    public function down(): null
+    {
+        return null;
+    }
+}

--- a/tests/Integration/Database/Mappers/SelectModelMapperTest.php
+++ b/tests/Integration/Database/Mappers/SelectModelMapperTest.php
@@ -103,24 +103,6 @@ final class SelectModelMapperTest extends FrameworkIntegrationTestCase
         $this->assertCount(2, $authors[0]->books[0]->chapters);
     }
 
-    public function test_map_user_permissions(): void
-    {
-        $data = [
-            [
-                'users.name' => 'Brent',
-                'users.email' => 'brendt@stitcher.io',
-                'users.id' => 1,
-                'userPermissions.user_id' => 1,
-                'userPermissions.permission_id' => 1,
-                'userPermissions.id' => 1,
-            ],
-        ];
-
-        $users = map($data)->with(SelectModelMapper::class)->to(User::class);
-
-        $this->assertCount(1, $users[0]->userPermissions);
-    }
-
     private function data(): array
     {
         return [


### PR DESCRIPTION
This pull request adds support for a new `#[Hashed]` and `#[Encrypted]` attributes, expected to be used on database models.

```php
final class User
{
    public PrimaryKey $id;

    public string $email;

    #[Hashed]
    public ?string $password;

    #[Encrypted]
    public ?string $accessToken;
}
```

To ease their implementation, I came up with a new `ProvidesCaster` and `ProvidesSerializer` interfaces. These interfaces can be implemented by attributes, which may provide specific serializers and casters.

```php
#[Attribute(Attribute::TARGET_PROPERTY)]
final class Hashed implements ProvidesSerializer
{
    public string $serializer {
        get => HashedSerializer::class;
    }
}

#[Attribute(Attribute::TARGET_PROPERTY)]
final class Encrypted implements ProvidesSerializer, ProvidesCaster
{
    public string $serializer {
        get => EncryptedSerializer::class;
    }

    public string $caster {
        get => EncryptedCaster::class;
    }
}
```

This is an alternative to `#[CastWith]` and `#[SerializeWith]`, but they are still useful—their purpose is just slightly different.