### PR TITLE
fix(database): support inserting empty rows

### DIFF
--- a/packages/database/tests/QueryStatements/InsertStatementTest.php
+++ b/packages/database/tests/QueryStatements/InsertStatementTest.php
@@ -31,6 +31,16 @@ final class InsertStatementTest extends TestCase
         $this->assertSame($expectedPostgres, $statement->compile(DatabaseDialect::POSTGRESQL));
     }
 
+    public function test_insert_empty_row(): void
+    {
+        $tableDefinition = new TableDefinition('foo', 'bar');
+        $statement = new InsertStatement($tableDefinition);
+
+        $this->assertSame('INSERT INTO `foo` AS `bar` () VALUES ()', $statement->compile(DatabaseDialect::MYSQL));
+        $this->assertSame('INSERT INTO `foo` AS `bar` DEFAULT VALUES', $statement->compile(DatabaseDialect::SQLITE));
+        $this->assertSame('INSERT INTO `foo` AS `bar` DEFAULT VALUES RETURNING *', $statement->compile(DatabaseDialect::POSTGRESQL));
+    }
+
     public function test_exception_on_column_mismatch(): void
     {
         $tableDefinition = new TableDefinition('foo', 'bar');


### PR DESCRIPTION
It's a bit of an edge case, but when inserting rows with no column (except an auto-incrementing ID), the insert query must be adapted because there will be no value.

This pull request fixes that.