### PR TITLE
feat(router)!: support signed URIs

### DIFF
--- a/docs/1-essentials/01-routing.md
+++ b/docs/1-essentials/01-routing.md
@@ -165,7 +165,7 @@ public function docsRedirect(string $path): Redirect
 Tempest provides a `\Tempest\uri` function that can be used to generate a URI to a controller method. This function accepts the FQCN of the controller or a callable to a method as its first argument, and named parameters as [the rest of its arguments](https://www.php.net/manual/en/functions.arguments.php#functions.variable-arg-list).
 
 ```php
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 // Invokable classes can be referenced directly:
 uri(HomeController::class);
@@ -191,7 +191,7 @@ A signed URI may be used to ensure that the URI was not modified after it was cr
 To create a signed URI, you may use the `signed_uri` function. This function accepts the same arguments as `uri`, and returns the URI with a `signature` parameter:
 
 ```php
-use function Tempest\signed_uri;
+use function Tempest\Router\signed_uri;
 
 signed_uri(
     action: [MailingListController::class, 'unsubscribe'],
@@ -202,7 +202,7 @@ signed_uri(
 Alternatively, you may use `temporary_signed_uri` to provide a duration after which the signed URI will expire, providing an extra layer of security.
 
 ```php
-use function Tempest\temporary_signed_uri;
+use function Tempest\Router\temporary_signed_uri;
 
 temporary_signed_uri(
     action: PasswordlessAuthenticationController::class,
@@ -236,7 +236,7 @@ final class PasswordlessAuthenticationController
 To determine whether the current request matches a specific controller action, Tempest provides the `is_current_uri` function. This function accepts the same arguments as `uri`, and returns a boolean.
 
 ```php
-use function Tempest\is_current_uri;
+use function Tempest\Router\is_current_uri;
 
 // Current URI is: /aircraft/1
 
@@ -290,7 +290,7 @@ Once you have created a request class, you may simply inject it into a controlle
 use Tempest\Router\Post;
 use Tempest\Http\Responses\Redirect;
 use function Tempest\map;
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 final readonly class AirportController
 {

--- a/docs/4-internals/03-view-spec.md
+++ b/docs/4-internals/03-view-spec.md
@@ -103,7 +103,7 @@ Tempest will merge all imports at the top of the compiled view, meaning that eac
 ```html
 <?php
 use App\PostController;
-use function Tempest\uri;
+use function Tempest\Router\uri;
 ?>
 
 {{ uri([PostController::class, 'show'], post: $post->id) }}
@@ -608,7 +608,7 @@ Referencing a symbol within a view will automatically import it at the top of th
 ```html
 <?php
 use App\PostController;
-use function Tempest\uri;
+use function Tempest\Router\uri;
 ?>
 
 {{ uri([PostController::class, 'show'], post: $post->id) }}

--- a/packages/router/src/GenericRouter.php
+++ b/packages/router/src/GenericRouter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tempest\Router;
 
-use BackedEnum;
 use Psr\Http\Message\ServerRequestInterface as PsrRequest;
 use ReflectionClass;
 use Tempest\Container\Container;
@@ -14,17 +13,12 @@ use Tempest\Http\Mappers\PsrRequestToGenericRequestMapper;
 use Tempest\Http\Request;
 use Tempest\Http\Response;
 use Tempest\Http\Responses\Ok;
-use Tempest\Reflection\ClassReflector;
 use Tempest\Router\Exceptions\ControllerActionHadNoReturn;
-use Tempest\Router\Exceptions\ControllerMethodHadNoRouteAttribute;
 use Tempest\Router\Exceptions\MatchedRouteCouldNotBeResolved;
-use Tempest\Router\Routing\Construction\DiscoveredRoute;
 use Tempest\Router\Routing\Matching\RouteMatcher;
 use Tempest\View\View;
 
 use function Tempest\map;
-use function Tempest\Support\Regex\replace;
-use function Tempest\Support\str;
 
 final readonly class GenericRouter implements Router
 {
@@ -96,79 +90,6 @@ final readonly class GenericRouter implements Router
         }
 
         return $callable;
-    }
-
-    public function toUri(array|string $action, ...$params): string
-    {
-        if (is_string($action) && str_starts_with($action, '/')) {
-            $uri = $action;
-        } else {
-            [$controllerClass, $controllerMethod] = is_array($action) ? $action : [$action, '__invoke'];
-
-            $routeAttribute = new ClassReflector($controllerClass)
-                ->getMethod($controllerMethod)
-                ->getAttribute(Route::class);
-
-            if ($routeAttribute === null) {
-                throw new ControllerMethodHadNoRouteAttribute($controllerClass, $controllerMethod);
-            }
-
-            $uri = $routeAttribute->uri;
-        }
-
-        $uri = str($uri);
-        $queryParams = [];
-
-        foreach ($params as $key => $value) {
-            if (! $uri->matches(sprintf('/\{%s(\}|:)/', $key))) {
-                $queryParams[$key] = $value;
-
-                continue;
-            }
-
-            if ($value instanceof BackedEnum) {
-                $value = $value->value;
-            } elseif ($value instanceof Bindable) {
-                foreach (new ClassReflector($value)->getPublicProperties() as $property) {
-                    if (! $property->hasAttribute(IsBindingValue::class)) {
-                        continue;
-                    }
-
-                    $value = $property->getValue($value);
-                    break;
-                }
-            }
-
-            $uri = $uri->replaceRegex(
-                '#\{' . $key . DiscoveredRoute::ROUTE_PARAM_CUSTOM_REGEX . '\}#',
-                (string) $value,
-            );
-        }
-
-        $uri = $uri->prepend(rtrim($this->appConfig->baseUri, '/'));
-
-        if ($queryParams !== []) {
-            return $uri->append('?' . http_build_query($queryParams))->toString();
-        }
-
-        return $uri->toString();
-    }
-
-    public function isCurrentUri(array|string $action, ...$params): bool
-    {
-        $matchedRoute = $this->container->get(MatchedRoute::class);
-        $candidateUri = $this->toUri($action, ...[...$matchedRoute->params, ...$params]);
-        $currentUri = $this->toUri([$matchedRoute->route->handler->getDeclaringClass(), $matchedRoute->route->handler->getName()]);
-
-        foreach ($matchedRoute->params as $key => $value) {
-            if ($value instanceof BackedEnum) {
-                $value = $value->value;
-            }
-
-            $currentUri = replace($currentUri, '/({' . preg_quote($key, '/') . '(?::.*?)?})/', $value);
-        }
-
-        return $currentUri === $candidateUri;
     }
 
     private function createResponse(string|array|Response|View $input): Response

--- a/packages/router/src/Router.php
+++ b/packages/router/src/Router.php
@@ -5,34 +5,12 @@ declare(strict_types=1);
 namespace Tempest\Router;
 
 use Psr\Http\Message\ServerRequestInterface as PsrRequest;
+use Tempest\DateTime\DateTime;
+use Tempest\DateTime\Duration;
 use Tempest\Http\Request;
 use Tempest\Http\Response;
 
 interface Router
 {
     public function dispatch(Request|PsrRequest $request): Response;
-
-    /**
-     * Creates a valid URI to the given `$action`.
-     *
-     * `$action` is one of :
-     * - Controller FQCN and its method as a tuple
-     * - Invokable controller FQCN
-     * - URI string starting with `/`
-     *
-     * @param array{class-string, string}|class-string|string $action
-     */
-    public function toUri(array|string $action, ...$params): string;
-
-    /**
-     * Checks if the URI to the given `$action` would match the current route.
-     *
-     * `$action` is one of :
-     * - Controller FQCN and its method as a tuple
-     * - Invokable controller FQCN
-     * - URI string starting with `/`
-     *
-     * @param array{class-string, string}|class-string|string $action
-     */
-    public function isCurrentUri(array|string $action, ...$params): bool;
 }

--- a/packages/router/src/Static/StaticGenerateCommand.php
+++ b/packages/router/src/Static/StaticGenerateCommand.php
@@ -34,9 +34,9 @@ use Tempest\View\ViewRenderer;
 use Tempest\Vite\Exceptions\ManifestWasNotFound;
 use Throwable;
 
+use function Tempest\Router\uri;
 use function Tempest\Support\path;
 use function Tempest\Support\str;
-use function Tempest\uri;
 
 final class StaticGenerateCommand
 {

--- a/packages/router/src/UriGenerator.php
+++ b/packages/router/src/UriGenerator.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Tempest\Router;
+
+use BackedEnum;
+use RuntimeException;
+use Tempest\Container\Container;
+use Tempest\Core\AppConfig;
+use Tempest\Cryptography\Signing\Signature;
+use Tempest\Cryptography\Signing\Signer;
+use Tempest\DateTime\DateTime;
+use Tempest\DateTime\Duration;
+use Tempest\Http\Request;
+use Tempest\Reflection\ClassReflector;
+use Tempest\Reflection\MethodReflector;
+use Tempest\Router\Exceptions\ControllerMethodHadNoRouteAttribute;
+use Tempest\Router\Routing\Construction\DiscoveredRoute;
+use Tempest\Support\Arr;
+use Tempest\Support\Regex;
+use Tempest\Support\Str;
+
+use function Tempest\Support\str;
+
+final class UriGenerator
+{
+    public function __construct(
+        private AppConfig $appConfig,
+        private Signer $signer,
+        private Container $container,
+    ) {}
+
+    /**
+     * Checks if the request has a valid signature.
+     */
+    public function hasValidSignature(Request $request): bool
+    {
+        $signature = $request->get('signature');
+        $expiresAt = $request->get('expires_at');
+
+        if ($signature === null) {
+            return false;
+        }
+
+        if ($expiresAt !== null && is_numeric($expiresAt) && DateTime::fromTimestamp((int) $expiresAt)->isPast()) {
+            return false;
+        }
+
+        return $this->signer->verify(
+            data: $this->createUri($request->path, ...Arr\remove_keys($request->query, 'signature')),
+            signature: Signature::from($signature),
+        );
+    }
+
+    /**
+     * Creates an absolute URI that is signed with a secret key and will expire after the specified duration.
+     *
+     * `$action` is one of :
+     * - Controller FQCN and its method as a tuple
+     * - Invokable controller FQCN
+     * - URI string starting with `/`
+     *
+     * @param MethodReflector|array{class-string,string}|class-string|string $action
+     */
+    public function createTemporarySignedUri(array|string|MethodReflector $action, DateTime|Duration|int $duration, mixed ...$params): string
+    {
+        $uri = $this->normalizeActionToUri($action);
+
+        if (array_key_exists('expires_at', $params)) {
+            throw new RuntimeException('Cannot create a signed URI with an "expires_at" parameter. It will be added automatically.');
+        }
+
+        if (is_int($duration)) {
+            $duration = Duration::seconds($duration);
+        }
+
+        if ($duration instanceof Duration) {
+            $duration = DateTime::now()->plusMilliseconds((int) $duration->getTotalMilliseconds());
+        }
+
+        return $this->createSignedUri($uri, ...[
+            ...$params,
+            'expires_at' => $duration->getTimestamp()->getSeconds(),
+        ]);
+    }
+
+    /**
+     * Creates an absolute URI that is signed with a secret key, ensuring that it cannot be tampered with.
+     *
+     * `$action` is one of :
+     * - Controller FQCN and its method as a tuple
+     * - Invokable controller FQCN
+     * - URI string starting with `/`
+     *
+     * @param MethodReflector|array{class-string,string}|class-string|string $action
+     */
+    public function createSignedUri(array|string|MethodReflector $action, mixed ...$params): string
+    {
+        $uri = $this->normalizeActionToUri($action);
+
+        if (array_key_exists('signature', $params)) {
+            throw new RuntimeException('Cannot create a signed URI with a "signature" parameter. It will be added automatically.');
+        }
+
+        $this->signer = $this->container->get(Signer::class);
+
+        ksort($params);
+
+        return $this->createUri($uri, ...[
+            ...$params,
+            'signature' => $this->signer->sign($this->createUri($action, ...$params))->value,
+        ]);
+    }
+
+    /**
+     * Creates an absolute URI to the given `$action`.
+     *
+     * `$action` is one of :
+     * - Controller FQCN and its method as a tuple
+     * - Invokable controller FQCN
+     * - URI string starting with `/`
+     *
+     * @param MethodReflector|array{class-string,string}|class-string|string $action
+     */
+    public function createUri(array|string|MethodReflector $action, mixed ...$params): string
+    {
+        $uri = str($this->normalizeActionToUri($action));
+        $queryParams = [];
+
+        foreach ($params as $key => $value) {
+            if (! $uri->matches(sprintf('/\{%s(\}|:)/', $key))) {
+                $queryParams[$key] = $value;
+
+                continue;
+            }
+
+            if ($value instanceof BackedEnum) {
+                $value = $value->value;
+            } elseif ($value instanceof Bindable) {
+                foreach (new ClassReflector($value)->getPublicProperties() as $property) {
+                    if (! $property->hasAttribute(IsBindingValue::class)) {
+                        continue;
+                    }
+
+                    $value = $property->getValue($value);
+
+                    break;
+                }
+            }
+
+            $uri = $uri->replaceRegex(
+                regex: '#\{' . $key . DiscoveredRoute::ROUTE_PARAM_CUSTOM_REGEX . '\}#',
+                replace: (string) $value,
+            );
+        }
+
+        $uri = $uri->prepend(rtrim($this->appConfig->baseUri, '/'));
+
+        if ($queryParams !== []) {
+            return $uri->append('?' . http_build_query($queryParams))->toString();
+        }
+
+        return $uri->toString();
+    }
+
+    /**
+     * Checks if the URI to the given `$action` would match the current route.
+     *
+     * `$action` is one of :
+     * - Controller FQCN and its method as a tuple
+     * - Invokable controller FQCN
+     * - URI string starting with `/`
+     *
+     * @param MethodReflector|array{class-string,string}|class-string|string $action
+     */
+    public function isCurrentUri(array|string|MethodReflector $action, mixed ...$params): bool
+    {
+        $action = $this->normalizeActionToUri($action);
+
+        $matchedRoute = $this->container->get(MatchedRoute::class);
+        $candidateUri = $this->createUri($action, ...[...$matchedRoute->params, ...$params]);
+        $currentUri = $this->createUri([$matchedRoute->route->handler->getDeclaringClass(), $matchedRoute->route->handler->getName()]);
+
+        foreach ($matchedRoute->params as $key => $value) {
+            if ($value instanceof BackedEnum) {
+                $value = $value->value;
+            }
+
+            $currentUri = Regex\replace($currentUri, '/({' . preg_quote($key, '/') . '(?::.*?)?})/', $value);
+        }
+
+        return $currentUri === $candidateUri;
+    }
+
+    private function normalizeActionToUri(array|string|MethodReflector $action): string
+    {
+        if ($action instanceof MethodReflector) {
+            $action = [
+                $action->getDeclaringClass()->getName(),
+                $action->getName(),
+            ];
+        }
+
+        if (is_string($action) && str_starts_with($action, '/')) {
+            return $action;
+        }
+
+        [$controllerClass, $controllerMethod] = is_array($action) ? $action : [$action, '__invoke'];
+
+        $routeAttribute = new ClassReflector($controllerClass)
+            ->getMethod($controllerMethod)
+            ->getAttribute(Route::class);
+
+        if ($routeAttribute === null) {
+            throw new ControllerMethodHadNoRouteAttribute($controllerClass, $controllerMethod);
+        }
+
+        return Str\ensure_starts_with($routeAttribute->uri, '/');
+    }
+}

--- a/packages/router/src/functions.php
+++ b/packages/router/src/functions.php
@@ -2,47 +2,71 @@
 
 declare(strict_types=1);
 
-namespace Tempest {
-    use Tempest\Reflection\MethodReflector;
-    use Tempest\Router\Router;
+namespace Tempest;
 
-    /**
-     * Creates a valid URI to the given controller `$action`.
-     */
-    function uri(array|string|MethodReflector $action, mixed ...$params): string
-    {
-        if ($action instanceof MethodReflector) {
-            $action = [
-                $action->getDeclaringClass()->getName(),
-                $action->getName(),
-            ];
-        }
+use Tempest\DateTime\DateTime;
+use Tempest\DateTime\Duration;
+use Tempest\Reflection\MethodReflector;
+use Tempest\Router\UriGenerator;
 
-        $router = get(Router::class);
+use function Tempest\get;
 
-        return $router->toUri(
-            $action,
-            ...$params,
-        );
-    }
+/**
+ * Creates a valid URI to the given `$action`.
+ *
+ * `$action` is one of :
+ * - Controller FQCN and its method as a tuple
+ * - Invokable controller FQCN
+ * - URI string starting with `/`
+ *
+ * @param MethodReflector|array{class-string,string}|class-string|string $action
+ */
+function uri(array|string|MethodReflector $action, mixed ...$params): string
+{
+    return get(UriGenerator::class)->createUri($action, ...$params);
+}
 
-    /**
-     * Checks whether the given controller action matches the current URI.
-     */
-    function is_current_uri(array|string|MethodReflector $action, mixed ...$params): bool
-    {
-        if ($action instanceof MethodReflector) {
-            $action = [
-                $action->getDeclaringClass()->getName(),
-                $action->getName(),
-            ];
-        }
+/**
+ * Creates a URI that is signed with a secret key, ensuring that it cannot be tampered with.
+ *
+ * `$action` is one of :
+ * - Controller FQCN and its method as a tuple
+ * - Invokable controller FQCN
+ * - URI string starting with `/`
+ *
+ * @param MethodReflector|array{class-string,string}|class-string|string $action
+ */
+function signed_uri(array|string|MethodReflector $action, mixed ...$params): string
+{
+    return get(UriGenerator::class)->createSignedUri($action, ...$params);
+}
 
-        $router = get(Router::class);
+/**
+ * Creates an absolute URI that is signed with a secret key and will expire after the specified duration.
+ *
+ * `$action` is one of :
+ * - Controller FQCN and its method as a tuple
+ * - Invokable controller FQCN
+ * - URI string starting with `/`
+ *
+ * @param MethodReflector|array{class-string,string}|class-string|string $action
+ */
+function temporary_signed_uri(array|string|MethodReflector $action, DateTime|Duration|int $duration, mixed ...$params): string
+{
+    return get(UriGenerator::class)->createTemporarySignedUri($action, $duration, ...$params);
+}
 
-        return $router->isCurrentUri(
-            $action,
-            ...$params,
-        );
-    }
+/**
+ * Checks if the URI to the given `$action` would match the current route.
+ *
+ * `$action` is one of :
+ * - Controller FQCN and its method as a tuple
+ * - Invokable controller FQCN
+ * - URI string starting with `/`
+ *
+ * @param MethodReflector|array{class-string,string}|class-string|string $action
+ */
+function is_current_uri(array|string|MethodReflector $action, mixed ...$params): bool
+{
+    return get(UriGenerator::class)->isCurrentUri($action, ...$params);
 }

--- a/packages/router/src/functions.php
+++ b/packages/router/src/functions.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tempest;
+namespace Tempest\Router;
 
 use Tempest\DateTime\DateTime;
 use Tempest\DateTime\Duration;

--- a/tests/Fixtures/Controllers/ValidationController.php
+++ b/tests/Fixtures/Controllers/ValidationController.php
@@ -14,7 +14,7 @@ use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
 use Tests\Tempest\Fixtures\Requests\BookRequest;
 use Tests\Tempest\Fixtures\Requests\ValidationRequest;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 final readonly class ValidationController
 {

--- a/tests/Fixtures/Modules/Books/BookController.php
+++ b/tests/Fixtures/Modules/Books/BookController.php
@@ -14,7 +14,7 @@ use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
 use Tests\Tempest\Fixtures\Modules\Books\Requests\CreateBookRequest;
 
 use function Tempest\map;
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 final readonly class BookController
 {

--- a/tests/Fixtures/Modules/Form/form.view.php
+++ b/tests/Fixtures/Modules/Form/form.view.php
@@ -3,7 +3,7 @@
 use Tempest\View\GenericView;
 use Tests\Tempest\Fixtures\Modules\Form\FormController;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 /** @var GenericView $this */
 

--- a/tests/Fixtures/Views/button-usage.view.php
+++ b/tests/Fixtures/Views/button-usage.view.php
@@ -2,7 +2,7 @@
 
 use Tests\Tempest\Fixtures\Controllers\DocsController;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 ?>
 

--- a/tests/Fixtures/Views/x-view-component-with-use-import.view.php
+++ b/tests/Fixtures/Views/x-view-component-with-use-import.view.php
@@ -2,7 +2,7 @@
 
 use Tests\Tempest\Fixtures\Modules\Home\HomeController;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 ?>
 

--- a/tests/Fixtures/x-with-header.view.php
+++ b/tests/Fixtures/x-with-header.view.php
@@ -2,7 +2,7 @@
 
 use Tests\Tempest\Fixtures\Modules\Home\HomeController;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 ?>
 

--- a/tests/Integration/Auth/AuthorizerTest.php
+++ b/tests/Integration/Auth/AuthorizerTest.php
@@ -22,7 +22,7 @@ use Tests\Tempest\Fixtures\Controllers\AdminController;
 use Tests\Tempest\Integration\Auth\Fixtures\UserPermissionUnitEnum;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 /**
  * @internal

--- a/tests/Integration/Core/DeferredTasksTest.php
+++ b/tests/Integration/Core/DeferredTasksTest.php
@@ -11,7 +11,7 @@ use Tests\Tempest\Fixtures\Controllers\DeferController;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 use function Tempest\defer;
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 /**
  * @internal

--- a/tests/Integration/Http/Static/Fixtures/StaticPageController.php
+++ b/tests/Integration/Http/Static/Fixtures/StaticPageController.php
@@ -13,7 +13,7 @@ use Tempest\View\Exceptions\ViewCompilationFailed;
 use Tempest\View\View;
 use Tempest\Vite\Exceptions\ManifestWasNotFound;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 use function Tempest\view;
 
 final readonly class StaticPageController

--- a/tests/Integration/Http/ValidationResponseTest.php
+++ b/tests/Integration/Http/ValidationResponseTest.php
@@ -15,7 +15,7 @@ use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 /**
  * @internal

--- a/tests/Integration/Http/ViewDataTest.php
+++ b/tests/Integration/Http/ViewDataTest.php
@@ -10,7 +10,7 @@ use Tests\Tempest\Fixtures\Controllers\TestController;
 use Tests\Tempest\Fixtures\Views\ViewModel;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 /**
  * @internal

--- a/tests/Integration/Route/RequestTest.php
+++ b/tests/Integration/Route/RequestTest.php
@@ -20,7 +20,7 @@ use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 use Tests\Tempest\Integration\Route\Fixtures\MemoryInputStream;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 /**
  * @internal

--- a/tests/Integration/Route/UriGeneratorTest.php
+++ b/tests/Integration/Route/UriGeneratorTest.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Tests\Tempest\Integration\Route;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use ReflectionException;
+use Tempest\Core\AppConfig;
+use Tempest\Database\PrimaryKey;
+use Tempest\DateTime\Duration;
+use Tempest\Http\GenericRequest;
+use Tempest\Http\Method;
+use Tempest\Router\UriGenerator;
+use Tests\Tempest\Fixtures\Controllers\ControllerWithEnumBinding;
+use Tests\Tempest\Fixtures\Controllers\EnumForController;
+use Tests\Tempest\Fixtures\Controllers\TestController;
+use Tests\Tempest\Fixtures\Controllers\UriGeneratorController;
+use Tests\Tempest\Fixtures\Modules\Books\BookController;
+use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\uri;
+
+final class UriGeneratorTest extends FrameworkIntegrationTestCase
+{
+    private UriGenerator $generator {
+        get => $this->container->get(UriGenerator::class);
+    }
+
+    #[Test]
+    public function generates_uri(): void
+    {
+        $this->assertEquals('/test/1/a', $this->generator->createUri([TestController::class, 'withParams'], id: 1, name: 'a'));
+
+        $this->assertEquals('/test/1', $this->generator->createUri([TestController::class, 'withComplexCustomRegexParams'], id: 1));
+
+        $this->assertEquals('/test/1/a/b', $this->generator->createUri([TestController::class, 'withCustomRegexParams'], id: 1, name: 'a/b'));
+        $this->assertEquals('/test', $this->generator->createUri(TestController::class));
+
+        $this->assertEquals('/test/1/a?q=hi&i=test', $this->generator->createUri([TestController::class, 'withParams'], id: 1, name: 'a', q: 'hi', i: 'test'));
+
+        $this->container->config(new AppConfig(baseUri: 'https://test.com'));
+
+        $this->assertEquals('https://test.com/test/1/a', $this->generator->createUri([TestController::class, 'withParams'], id: 1, name: 'a'));
+
+        $this->assertSame('https://test.com/abc', $this->generator->createUri('/abc'));
+        $this->assertEquals('https://test.com/test/1/a/b/c/d', $this->generator->createUri([TestController::class, 'withCustomRegexParams'], id: 1, name: 'a/b/c/d'));
+    }
+
+    #[Test]
+    public function uri_functions(): void
+    {
+        $this->assertEquals('/test/1/a', uri([TestController::class, 'withParams'], id: 1, name: 'a'));
+    }
+
+    #[Test]
+    public function uri_generation_with_invalid_fqcn(): void
+    {
+        $this->expectException(ReflectionException::class);
+
+        $this->generator->createUri(TestController::class . 'Invalid');
+    }
+
+    #[Test]
+    public function uri_generation_with_query_param(): void
+    {
+        $this->assertSame('/test?test=foo', $this->generator->createUri(TestController::class, test: 'foo'));
+    }
+
+    #[Test]
+    public function generate_uri_with_enum(): void
+    {
+        $this->assertSame(
+            '/with-enum/foo',
+            $this->generator->createUri(ControllerWithEnumBinding::class, input: EnumForController::FOO),
+        );
+
+        $this->assertSame(
+            '/with-enum/bar',
+            $this->generator->createUri(ControllerWithEnumBinding::class, input: EnumForController::BAR),
+        );
+    }
+
+    #[Test]
+    public function generate_uri_with_bindable_model(): void
+    {
+        $book = Book::new(id: new PrimaryKey('abc'));
+
+        $this->assertSame(
+            '/books/abc',
+            uri([BookController::class, 'show'], book: $book),
+        );
+    }
+
+    #[Test]
+    public function generate_uri_with_primary_key(): void
+    {
+        $book = Book::new(id: new PrimaryKey('abc'));
+
+        $this->assertSame(
+            '/books/abc',
+            uri([BookController::class, 'show'], book: $book->id),
+        );
+    }
+
+    #[Test]
+    public function uri_with_query_param_that_collides_partially_with_route_param(): void
+    {
+        $this->assertSame(
+            '/test-with-collision/hi?id=1',
+            $this->generator->createUri([UriGeneratorController::class, 'withCollidingNames'], id: '1', idea: 'hi'),
+        );
+    }
+
+    #[Test]
+    public function is_current_uri(): void
+    {
+        $this->http->get('/test')->assertOk();
+
+        $this->assertTrue($this->generator->isCurrentUri([TestController::class, '__invoke']));
+        $this->assertFalse($this->generator->isCurrentUri([TestController::class, 'withParams']));
+        $this->assertFalse($this->generator->isCurrentUri([TestController::class, 'withParams'], id: 1));
+        $this->assertFalse($this->generator->isCurrentUri([TestController::class, 'withParams'], id: 1, name: 'a'));
+    }
+
+    #[Test]
+    public function is_current_uri_with_constrained_parameters(): void
+    {
+        $this->http->get('/test/1/a')->assertOk();
+
+        $this->assertTrue($this->generator->isCurrentUri([TestController::class, 'withCustomRegexParams']));
+        $this->assertTrue($this->generator->isCurrentUri([TestController::class, 'withCustomRegexParams'], id: 1));
+        $this->assertTrue($this->generator->isCurrentUri([TestController::class, 'withCustomRegexParams'], id: 1, name: 'a'));
+        $this->assertFalse($this->generator->isCurrentUri([TestController::class, 'withCustomRegexParams'], id: 1, name: 'b'));
+        $this->assertFalse($this->generator->isCurrentUri([TestController::class, 'withCustomRegexParams'], id: 0, name: 'a'));
+        $this->assertFalse($this->generator->isCurrentUri([TestController::class, 'withCustomRegexParams'], id: 0, name: 'b'));
+    }
+
+    #[Test]
+    public function is_current_uri_with_enum(): void
+    {
+        $this->http->get('/with-enum/foo')->assertOk();
+
+        $this->assertTrue($this->generator->isCurrentUri(ControllerWithEnumBinding::class));
+        $this->assertTrue($this->generator->isCurrentUri(ControllerWithEnumBinding::class, input: EnumForController::FOO));
+        $this->assertFalse($this->generator->isCurrentUri(ControllerWithEnumBinding::class, input: EnumForController::BAR));
+    }
+
+    #[Test]
+    public function signed_uri(): void
+    {
+        $uri = $this->generator->createSignedUri(
+            action: [TestController::class, 'withParams'],
+            id: 1,
+            name: 'a',
+            foo: 'bar',
+        );
+
+        $this->assertTrue($this->generator->hasValidSignature(
+            new GenericRequest(Method::POST, $uri),
+        ));
+    }
+
+    #[Test]
+    #[TestWith(['/1', '/2'], name: 'tampered path')]
+    #[TestWith(['foo=', 'foo=uwu'], name: 'tampered query param')]
+    #[TestWith(['foo=', 'bar=baz&foo='], name: 'additional query param')]
+    #[TestWith(['signature=', 'signature=invalid'], name: 'tampered signature')]
+    public function tampered_uri(string $fragment, string $tamper): void
+    {
+        $uri = $this->generator->createSignedUri(
+            action: [TestController::class, 'withParams'],
+            id: 1,
+            name: 'a',
+            foo: 'bar',
+        );
+
+        $this->assertFalse($this->generator->hasValidSignature(
+            new GenericRequest(Method::POST, str_replace($fragment, $tamper, $uri)),
+        ));
+    }
+
+    #[Test]
+    public function temporary_signed_uri(): void
+    {
+        $clock = $this->clock();
+
+        $uri = $this->generator->createTemporarySignedUri(
+            action: [TestController::class, 'withParams'],
+            duration: Duration::minutes(20),
+            id: 1,
+            name: 'a',
+            foo: 'bar',
+        );
+
+        $request = new GenericRequest(Method::POST, $uri);
+
+        $this->assertTrue($this->generator->hasValidSignature($request));
+        $clock->plus(Duration::minutes(15));
+        $this->assertTrue($this->generator->hasValidSignature($request));
+        $clock->plus(Duration::minutes(5));
+        $this->assertFalse($this->generator->hasValidSignature($request));
+    }
+
+    #[Test]
+    public function tampered_duration_in_signed_uri(): void
+    {
+        $clock = $this->clock();
+
+        $uri = $this->generator->createTemporarySignedUri(
+            action: [TestController::class, 'withParams'],
+            duration: Duration::minutes(20),
+            id: 1,
+            name: 'a',
+            foo: 'bar',
+        );
+
+        $timestamp = $clock->now()->plusMinutes(20)->getTimestamp()->getSeconds();
+        $tamperedUri = str_replace((string) $timestamp, (string) ($timestamp + 20), $uri);
+
+        $this->assertFalse($this->generator->hasValidSignature(new GenericRequest(Method::POST, $tamperedUri)));
+    }
+
+    #[Test]
+    public function cannot_add_custom_expires_at(): void
+    {
+        $this->expectExceptionMessage('Cannot create a signed URI with an "expires_at" parameter. It will be added automatically.');
+
+        $this->generator->createTemporarySignedUri(
+            action: [TestController::class, 'withParams'],
+            duration: Duration::minutes(20),
+            id: 1,
+            name: 'a',
+            foo: 'bar',
+            expires_at: 'uwu',
+        );
+    }
+
+    #[Test]
+    public function cannot_add_custom_signature(): void
+    {
+        $this->expectExceptionMessage('Cannot create a signed URI with a "signature" parameter. It will be added automatically.');
+
+        $this->generator->createSignedUri(
+            action: [TestController::class, 'withParams'],
+            id: 1,
+            name: 'a',
+            foo: 'bar',
+            signature: 'uwu',
+        );
+    }
+}

--- a/tests/Integration/Route/UriGeneratorTest.php
+++ b/tests/Integration/Route/UriGeneratorTest.php
@@ -19,7 +19,7 @@ use Tests\Tempest\Fixtures\Modules\Books\BookController;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 
 final class UriGeneratorTest extends FrameworkIntegrationTestCase
 {

--- a/tests/Integration/View/TempestViewRendererTest.php
+++ b/tests/Integration/View/TempestViewRendererTest.php
@@ -10,7 +10,7 @@ use Tempest\View\ViewCache;
 use Tests\Tempest\Fixtures\Controllers\RelativeViewController;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 use function Tempest\view;
 
 /**
@@ -560,7 +560,7 @@ final class TempestViewRendererTest extends FrameworkIntegrationTestCase
         </head> 
         <body class="flex justify-center items-center">
 
-        <h1 class="text-5xl font-bold text-[#4f95d1]">Tempest</h1>
+        <h1 class="font-bold text-[#4f95d1] text-5xl">Tempest</h1>
         </body> 
         </html>
         HTML;
@@ -773,7 +773,7 @@ final class TempestViewRendererTest extends FrameworkIntegrationTestCase
                 <x-input
                     name="test"
                     type="text"
-                    class="py-2.5 sm:py-3 px-4 block w-full border-gray-500 border-1 rounded-lg sm:text-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-900 dark:border-neutral-700 dark:text-neutral-400 dark:placeholder-neutral-500 dark:focus:ring-neutral-600" placeholder="This is placeholder" />
+                    class="block dark:bg-neutral-900 disabled:opacity-50 px-4 py-2.5 sm:py-3 border-1 border-gray-500 dark:border-neutral-700 focus:border-blue-500 rounded-lg focus:ring-blue-500 dark:focus:ring-neutral-600 w-full dark:text-neutral-400 sm:text-sm disabled:pointer-events-none dark:placeholder-neutral-500" placeholder="This is placeholder" />
                 <!-- end -->
             </div>
             --}}

--- a/tests/Integration/View/ViewTest.php
+++ b/tests/Integration/View/ViewTest.php
@@ -9,7 +9,7 @@ use Tests\Tempest\Fixtures\Controllers\TestController;
 use Tests\Tempest\Fixtures\Views\ViewModel;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-use function Tempest\uri;
+use function Tempest\Router\uri;
 use function Tempest\view;
 
 /**


### PR DESCRIPTION
This pull request adds support for signed URIs. Additionally, it moves the URI generation methods from the `Router` interface to their own dedicated `UriGenerator` class.

Generating signed URIs can be done with their dedicated functions:

```php
use function Tempest\signed_uri;
use function Tempest\temporary_signed_uri;

// unsubscribe link
signed_uri(
    action: [MailingListController::class, 'unsubscribe'],
    email: $email
);

// magic login link
temporary_signed_uri(
    action: PasswordlessAuthenticationController::class,
    duration: Duration::minutes(10),
    userId: $userId
);
```

To ensure a signature is valid, the `hasValidSignature` method should be called on the UriGenerator` class:

```php
final class PasswordlessAuthenticationController
{
    public function __construct(
        private readonly UriGenerator $uri,
    ) {}

    public function __invoke(Request $request): Response
    {
        if (! $this->uri->hasValidSignature($request)) {
            return new Invalid();
        }

        // ...
    }
}
```

This pull request also moves the `uri` and `is_current_uri` from the `Tempest` namespace to the `Tempest\Router` namespace.