### PR TITLE
feat(mapper): support mapping array of serialized enums

### DIFF
--- a/packages/database/src/Mappers/SelectModelMapper.php
+++ b/packages/database/src/Mappers/SelectModelMapper.php
@@ -31,7 +31,7 @@ final class SelectModelMapper implements Mapper
         $idField = $model->getQualifiedPrimaryKey();
 
         $parsed = arr($from)
-            ->groupBy(fn (array $data, int $i) => $idField !== null ? ($data[$idField] ?? $i) : $i)
+            ->groupBy(fn (array $data, int|string $i) => $idField !== null ? ($data[$idField] ?? $i) : $i)
             ->map(fn (array $rows) => $this->normalizeFields($model, $rows))
             ->values();
 

--- a/packages/mapper/src/Casters/ArrayToObjectCollectionCaster.php
+++ b/packages/mapper/src/Casters/ArrayToObjectCollectionCaster.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tempest\Mapper\Casters;
 
 use Tempest\Mapper\Caster;
-use Tempest\Mapper\Mappers\ObjectToArrayMapper;
 use Tempest\Reflection\PropertyReflector;
+use Tempest\Support\Json;
 
 final readonly class ArrayToObjectCollectionCaster implements Caster
 {
@@ -18,13 +18,20 @@ final readonly class ArrayToObjectCollectionCaster implements Caster
     {
         $values = [];
         $iterableType = $this->property->getIterableType();
-        $objectCaster = new ObjectCaster($iterableType);
+
+        $caster = $iterableType->isEnum()
+            ? new EnumCaster($iterableType->getName())
+            : new ObjectCaster($iterableType);
+
+        if (Json\is_valid($input)) {
+            $input = Json\decode($input);
+        }
 
         foreach ($input as $key => $item) {
             if (is_object($item) && $iterableType->matches($item::class)) {
                 $values[$key] = $item;
             } else {
-                $values[$key] = $objectCaster->cast($item);
+                $values[$key] = $caster->cast($item);
             }
         }
 

--- a/tests/Integration/Database/Mappers/SelectModelMapperTest.php
+++ b/tests/Integration/Database/Mappers/SelectModelMapperTest.php
@@ -121,6 +121,17 @@ final class SelectModelMapperTest extends FrameworkIntegrationTestCase
         $this->assertCount(1, $users[0]->userPermissions);
     }
 
+    public function test_array_of_serialized_enums(): void
+    {
+        $users = map([['id' => 1, 'roles' => json_encode(['admin', 'user'])]])
+            ->with(SelectModelMapper::class)
+            ->to(ObjectWithArrayEnumProperty::class);
+
+        $this->assertCount(2, $users[0]->roles);
+        $this->assertSame(EnumToBeMappedToArray::ADMIN, $users[0]->roles[0]);
+        $this->assertSame(EnumToBeMappedToArray::USER, $users[0]->roles[1]);
+    }
+
     private function data(): array
     {
         return [
@@ -256,4 +267,16 @@ final class SelectModelMapperTest extends FrameworkIntegrationTestCase
             ],
         ];
     }
+}
+
+final class ObjectWithArrayEnumProperty
+{
+    /** @var Integration\Database\Mappers\EnumToBeMappedToArray[] */
+    public array $roles;
+}
+
+enum EnumToBeMappedToArray: string
+{
+    case ADMIN = 'admin';
+    case USER = 'user';
 }

--- a/tests/Integration/Mapper/Mappers/ArrayToObjectMapperTestCase.php
+++ b/tests/Integration/Mapper/Mappers/ArrayToObjectMapperTestCase.php
@@ -149,4 +149,33 @@ final class ArrayToObjectMapperTestCase extends FrameworkIntegrationTestCase
 
         $this->assertSame('magic', $object->a);
     }
+
+    public function test_map_array_of_enums(): void
+    {
+        $object = map(['roles' => ['admin', 'user']])->to(ObjectWithArrayEnumProperty::class);
+
+        $this->assertCount(2, $object->roles);
+        $this->assertSame(EnumToBeMappedToArray::ADMIN, $object->roles[0]);
+        $this->assertSame(EnumToBeMappedToArray::USER, $object->roles[1]);
+    }
+
+    public function test_map_array_of_serialized_enums(): void
+    {
+        $object = map(['roles' => json_encode(['admin'])])->to(ObjectWithArrayEnumProperty::class);
+
+        $this->assertCount(1, $object->roles);
+        $this->assertSame(EnumToBeMappedToArray::ADMIN, $object->roles[0]);
+    }
+}
+
+final class ObjectWithArrayEnumProperty
+{
+    /** @var \Tests\Tempest\Integration\Mapper\Mappers\EnumToBeMappedToArray[] */
+    public array $roles;
+}
+
+enum EnumToBeMappedToArray: string
+{
+    case ADMIN = 'admin';
+    case USER = 'user';
 }


### PR DESCRIPTION
This pull request adds support for mapping an array of enums or serialized enums.

```php
final class User
{
    /** @var \App\Role[] */
    public array $roles;
}

enum Role: string
{
    case ADMIN = 'admin';
    case USER = 'user';
}
```

```php
// This now works
query(User::class)->first();

// This as well
map(['roles' => ['admin'])->to(User::class);
```