### PR TITLE
feat(mapper): support converting array of objects to array

### DIFF
--- a/packages/mapper/src/ObjectFactory.php
+++ b/packages/mapper/src/ObjectFactory.php
@@ -13,6 +13,7 @@ use Tempest\Mapper\Mappers\JsonToArrayMapper;
 use Tempest\Mapper\Mappers\ObjectToArrayMapper;
 use Tempest\Mapper\Mappers\ObjectToJsonMapper;
 use Tempest\Reflection\FunctionReflector;
+use Tempest\Support\Arr;
 use Tempest\Support\Json;
 
 /** @template ClassType */
@@ -47,7 +48,7 @@ final class ObjectFactory
     {
         $this->from = $data;
 
-        return $this;
+        return clone $this;
     }
 
     /**
@@ -124,7 +125,14 @@ final class ObjectFactory
         }
 
         if (is_array($this->from)) {
-            return $this->from;
+            if (! $this->isCollection) {
+                return $this->from;
+            }
+
+            return Arr\map_with_keys(
+                array: $this->from,
+                map: fn (mixed $item, mixed $key) => yield $key => $this->withData($item)->toArray(),
+            );
         }
 
         if (Json\is_valid($this->from)) {

--- a/tests/Integration/Mapper/MapperTest.php
+++ b/tests/Integration/Mapper/MapperTest.php
@@ -18,6 +18,7 @@ use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 use Tests\Tempest\Integration\Mapper\Fixtures\EnumToCast;
 use Tests\Tempest\Integration\Mapper\Fixtures\NestedObjectA;
 use Tests\Tempest\Integration\Mapper\Fixtures\NestedObjectB;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectA;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectFactoryA;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectThatShouldUseCasters;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMapFromAttribute;
@@ -354,6 +355,28 @@ final class MapperTest extends FrameworkIntegrationTestCase
                 ['name' => 'a'],
                 ['name' => 'b'],
             ],
+        ], $array);
+    }
+
+    public function test_array_of_objects_to_array(): void
+    {
+        $objects = [
+            new ObjectA('a', 'b'),
+            new ObjectA('c', 'd'),
+            new NestedObjectA(
+                items: [
+                    new NestedObjectB('a'),
+                    new NestedObjectB('b'),
+                ],
+            ),
+        ];
+
+        $array = map($objects)->collection()->toArray();
+
+        $this->assertSame([
+            ['a' => 'a', 'b' => 'b'],
+            ['a' => 'c', 'b' => 'd'],
+            ['items' => [['name' => 'a'], ['name' => 'b']]],
         ], $array);
     }
 }


### PR DESCRIPTION
Closes https://github.com/tempestphp/tempest-framework/issues/1286

This now works:

```php
$users = query(User::class)
  ->select()
  ->all();

$serialized = map($users)
  ->collection()
  ->toArray();

// [
//   ['full_name' => 'Jon Doe'],
//   ['full_name' => 'Jane Doe'],
// ]
```