### PR TITLE
feat(event-bus): support to make assertions on dispatched events even when the event bus was not faked

### DIFF
--- a/docs/2-features/08-events.md
+++ b/docs/2-features/08-events.md
@@ -174,9 +174,6 @@ By extending {`Tempest\Framework\Testing\IntegrationTest`} from your test case, 
 These utilities include a way to replace the event bus with a testing implementation, as well as a few assertion methods to ensure that events have been dispatched or are being listened to.
 
 ```php
-// Prevents events from being handled
-$this->eventBus->preventEventHandling();
-
 // Assert that an event has been dispatched
 $this->eventBus->assertDispatched(AircraftRegistered::class);
 
@@ -197,14 +194,24 @@ $this->eventBus->assertNotDispatched(AircraftRegistered::class);
 $this->eventBus->assertListeningTo(AircraftRegistered::class);
 ```
 
-### Preventing event handling
+**Note:** Event assertions now work automatically without calling `preventEventHandling()`. Events are tracked while still executing their handlers, allowing you to test both event dispatching and their side effects together.
 
-When testing code that dispatches events, you may want to prevent Tempest from handling them. This can be useful when the event’s handlers are tested separately, or when the side-effects of these handlers are not desired for this test case.
+### Preventing event handling (optional)
 
-To disable event handling, the event bus instance must be replaced with a testing implementation in the container. This may be achieved by calling the `preventEventHandling()` method on the `eventBus` property.
+While event assertions now work without preventing handler execution, you may still want to prevent event handlers from running in certain test scenarios. This can be useful when:
+- The event handlers are tested separately
+- The side-effects of handlers are not desired for the test
+- You want to isolate the event dispatching logic from handler execution
+
+To disable event handling, call the `preventEventHandling()` method on the `eventBus` property:
 
 ```php tests/MyServiceTest.php
+// Optionally prevent handlers from executing
 $this->eventBus->preventEventHandling();
+
+// Events will still be tracked for assertions,
+// but their handlers won't be executed
+$this->eventBus->assertDispatched(AircraftRegistered::class);
 ```
 
 ### Testing a method-based handler

--- a/packages/event-bus/src/Testing/TrackedEventBus.php
+++ b/packages/event-bus/src/Testing/TrackedEventBus.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\EventBus\Testing;
+
+use Closure;
+use Tempest\EventBus\EventBus;
+use Tempest\EventBus\EventBusConfig;
+
+final class TrackedEventBus implements EventBus
+{
+    public array $dispatched = [];
+
+    public function __construct(
+        public EventBus $inner,
+        public EventBusConfig $eventBusConfig,
+    ) {}
+
+    public function listen(Closure $handler, ?string $event = null): void
+    {
+        $this->inner->listen($handler, $event);
+    }
+
+    public function dispatch(string|object $event): void
+    {
+        $this->dispatched[] = $event;
+
+        $this->inner->dispatch($event);
+    }
+}

--- a/tests/Integration/EventBus/EventBusTesterTest.php
+++ b/tests/Integration/EventBus/EventBusTesterTest.php
@@ -25,8 +25,31 @@ final class EventBusTesterTest extends FrameworkIntegrationTestCase
 
     public function test_assertion_on_real_event_bus(): void
     {
+        $this->container->get(EventBus::class)->dispatch('event-bus-fake-event');
+
+        $this->eventBus->assertDispatched('event-bus-fake-event');
+    }
+
+    public function test_tracked_event_bus_executes_handlers(): void
+    {
+        $called = false;
+
+        $this->container
+            ->get(EventBus::class)
+            ->listen(function () use (&$called): void {
+                $called = true;
+            }, FakeEvent::class);
+
+        $this->container->get(EventBus::class)->dispatch(new FakeEvent('foo'));
+
+        $this->assertTrue($called);
+        $this->eventBus->assertDispatched(FakeEvent::class);
+    }
+
+    public function test_assert_dispatched_without_count_and_no_event_failure(): void
+    {
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Asserting against the event bus require the `preventEventHandling()` method to be called first.');
+        $this->expectExceptionMessage('The event was not dispatched');
 
         $this->eventBus->assertDispatched('event-bus-fake-event');
     }


### PR DESCRIPTION
## Summary

* TrackedEventBus: A new decorator class that records dispatched events while delegating to the real EventBus
* Automatic Installation: `EventBusTester` now automatically wraps the EventBus with `TrackedEventBus` on construction
* Dual Mode Support: The tester supports both tracked mode (handlers execute) and faked mode (handlers don't execute)
* Backward Compatibility: Existing tests using `preventEventHandling()` continue to work as before
* Merged Event Tracking: The `EventBusTester` now merges dispatched events from both `TrackedEventBus` and `FakeEventBus`, solving edge cases where components hold references to the old EventBus
* Fixed `assertDispatched()` to properly fail when no events were dispatched