### PR TITLE
fix(database): fixes issues with circular eager relations

### DIFF
--- a/tests/Fixtures/Models/ProfileWithEager.php
+++ b/tests/Fixtures/Models/ProfileWithEager.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Models;
+
+use Tempest\Database\Eager;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\PrimaryKey;
+use Tempest\Database\Table;
+
+#[Table('profiles_with_eager')]
+final class ProfileWithEager
+{
+    use IsDatabaseModel;
+
+    public function __construct(
+        public PrimaryKey $id,
+        public string $bio,
+        #[Eager]
+        public ?UserWithEager $user = null,
+    ) {}
+}

--- a/tests/Fixtures/Models/UserWithEager.php
+++ b/tests/Fixtures/Models/UserWithEager.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Models;
+
+use Tempest\Database\Eager;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\PrimaryKey;
+use Tempest\Database\Table;
+
+#[Table('users_with_eager')]
+final class UserWithEager
+{
+    use IsDatabaseModel;
+
+    public function __construct(
+        public PrimaryKey $id,
+        public string $name,
+        #[Eager]
+        public ?ProfileWithEager $profile = null,
+    ) {}
+}

--- a/tests/Integration/Database/CircularEagerLoadingSimpleTest.php
+++ b/tests/Integration/Database/CircularEagerLoadingSimpleTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Database;
+
+use Tests\Tempest\Fixtures\Models\UserWithEager;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\Database\inspect;
+
+/**
+ * @internal
+ */
+final class CircularEagerLoadingSimpleTest extends FrameworkIntegrationTestCase
+{
+    public function test_circular_eager_loading_does_not_cause_infinite_loop(): void
+    {
+        // This should not cause an infinite loop when resolving eager relations
+        $userInspector = inspect(UserWithEager::class);
+
+        // The resolveEagerRelations method should handle circular references
+        $eagerRelations = $userInspector->resolveEagerRelations();
+        $this->assertArrayHasKey('profile', $eagerRelations);
+
+        // The profile.user relation should NOT be resolved because it would create a circular reference
+        // The circular detection stops at the first occurrence of a repeated model type in the path
+        $this->assertArrayNotHasKey('profile.user', $eagerRelations);
+
+        // Test that only the profile relation is loaded
+        $this->assertCount(1, $eagerRelations);
+    }
+
+    public function test_circular_with_relations_does_not_cause_infinite_loop(): void
+    {
+        $userInspector = inspect(UserWithEager::class);
+
+        // This should handle circular references when using with() syntax
+        $relations = $userInspector->resolveRelations('profile.user.profile');
+
+        // We should get the profile and profile.user relations
+        $this->assertArrayHasKey('profile', $relations);
+        $this->assertArrayHasKey('user', $relations);
+
+        // But not profile again after user (circular detection)
+        $this->assertCount(2, $relations);
+    }
+}


### PR DESCRIPTION
## Summary

Modified `ModelInspector` to track visited model types and prevent infinite recursion:

* `resolveEagerRelations()` method: Added a `$visitedPaths` parameter that tracks which model types have been visited in the current resolution path. When a model type is encountered that's already in the path, the recursion stops.
* `resolveRelations()` method: Applied the same circular reference detection to prevent infinite loops when using the `with()` method.

## How it works

* Tracking visited model types in an array as we traverse the relationship tree
* Before recursing into a relation, check if the target model type is already in the visited path
* If a circular reference is detected, skip that relation to prevent infinite recursion
* Passing the updated visited paths array to recursive calls

Fixes #1494