### PR TITLE
feat(http): implement named error bags

### DIFF
--- a/packages/http/src/Mappers/RequestToObjectMapper.php
+++ b/packages/http/src/Mappers/RequestToObjectMapper.php
@@ -60,7 +60,7 @@ final readonly class RequestToObjectMapper implements Mapper
         $failingRules = $this->validator->validateValuesForClass($to, $data);
 
         if ($failingRules !== []) {
-            throw $this->validator->createValidationFailureException($failingRules, $from);
+            throw $this->validator->createValidationFailureException($failingRules, $to);
         }
 
         return map($data)->with(ArrayToObjectMapper::class)->to($to);

--- a/packages/http/src/Session/Session.php
+++ b/packages/http/src/Session/Session.php
@@ -19,6 +19,8 @@ final class Session
 
     public const string CSRF_TOKEN_KEY = '#csrf_token';
 
+    public const string DEFAULT_ERROR_BAG = 'default';
+
     private array $expiredKeys = [];
 
     private SessionManager $manager {
@@ -84,14 +86,28 @@ final class Session
     }
 
     /** @return \Tempest\Validation\Rule[] */
-    public function getErrorsFor(string $name): array
+    public function getErrorsFor(string $name, ?string $bagName = null): array
     {
-        return $this->get(self::VALIDATION_ERRORS)[$name] ?? [];
+        $bagName ??= self::DEFAULT_ERROR_BAG;
+        $errors = $this->get(self::VALIDATION_ERRORS);
+
+        if ($errors !== null && ! $this->isBaggedStructure($errors)) {
+            return $bagName === self::DEFAULT_ERROR_BAG ? ($errors[$name] ?? []) : [];
+        }
+
+        return $errors[$bagName][$name] ?? [];
     }
 
-    public function getOriginalValueFor(string $name, mixed $default = ''): mixed
+    public function getOriginalValueFor(string $name, mixed $default = '', ?string $bagName = null): mixed
     {
-        return $this->get(self::ORIGINAL_VALUES)[$name] ?? $default;
+        $bagName ??= self::DEFAULT_ERROR_BAG;
+        $values = $this->get(self::ORIGINAL_VALUES);
+
+        if ($values !== null && ! $this->isBaggedStructure($values)) {
+            return $bagName === self::DEFAULT_ERROR_BAG ? ($values[$name] ?? $default) : $default;
+        }
+
+        return $values[$bagName][$name] ?? $default;
     }
 
     public function getPreviousUrl(): string
@@ -141,5 +157,97 @@ final class Session
         foreach ($this->expiredKeys as $key) {
             $this->manager->remove($this->id, $key);
         }
+    }
+
+    public function flashValidationErrors(array $errors, ?string $bagName = null): void
+    {
+        $bagName ??= self::DEFAULT_ERROR_BAG;
+        $currentErrors = $this->get(self::VALIDATION_ERRORS) ?? [];
+
+        if (! $this->isBaggedStructure($currentErrors)) {
+            $currentErrors = empty($currentErrors) ? [] : [self::DEFAULT_ERROR_BAG => $currentErrors];
+        }
+
+        $currentErrors[$bagName] = $errors;
+        $this->flash(self::VALIDATION_ERRORS, $currentErrors);
+    }
+
+    public function flashOriginalValues(array $values, ?string $bagName = null): void
+    {
+        $bagName ??= self::DEFAULT_ERROR_BAG;
+        $currentValues = $this->get(self::ORIGINAL_VALUES) ?? [];
+
+        if (! $this->isBaggedStructure($currentValues)) {
+            $currentValues = empty($currentValues) ? [] : [self::DEFAULT_ERROR_BAG => $currentValues];
+        }
+
+        $currentValues[$bagName] = $values;
+        $this->flash(self::ORIGINAL_VALUES, $currentValues);
+    }
+
+    public function getAllErrors(?string $bagName = null): array
+    {
+        $bagName ??= self::DEFAULT_ERROR_BAG;
+        $errors = $this->get(self::VALIDATION_ERRORS);
+
+        if ($errors !== null && ! $this->isBaggedStructure($errors)) {
+            return $bagName === self::DEFAULT_ERROR_BAG ? $errors : [];
+        }
+
+        return $errors[$bagName] ?? [];
+    }
+
+    public function clearErrors(?string $bagName = null): void
+    {
+        $bagName ??= self::DEFAULT_ERROR_BAG;
+        $errors = $this->get(self::VALIDATION_ERRORS) ?? [];
+
+        if ($this->isBaggedStructure($errors)) {
+            unset($errors[$bagName]);
+            if (empty($errors)) {
+                $this->remove(self::VALIDATION_ERRORS);
+            } else {
+                $this->set(self::VALIDATION_ERRORS, $errors);
+            }
+        } elseif ($bagName === self::DEFAULT_ERROR_BAG) {
+            $this->remove(self::VALIDATION_ERRORS);
+        }
+    }
+
+    private function isBaggedStructure(array $data): bool
+    {
+        if (empty($data)) {
+            return false; // Empty arrays are considered non-bagged for backward compatibility
+        }
+
+        // Check if this looks like a bagged structure:
+        // - Bagged: ['default' => ['field' => [...]], 'other' => ['field' => [...]]]
+        // - Old: ['field' => [...], 'field2' => [...]]
+
+        // A bagged structure should have at least one known bag name as key
+        // or all values should be arrays of arrays (not arrays of objects)
+        foreach ($data as $key => $value) {
+            if ($key === self::DEFAULT_ERROR_BAG) {
+                return true;
+            }
+
+            // If value is not an array, it's definitely not bagged
+            if (! is_array($value)) {
+                return false;
+            }
+
+            // Check if the value contains objects (old structure for validation errors)
+            // Old structure: ['field' => [Rule, Rule]]
+            // New structure: ['bag' => ['field' => [Rule, Rule]]]
+            foreach ($value as $item) {
+                if (is_object($item)) {
+                    // Contains objects directly, so it's the old structure
+                    return false;
+                }
+            }
+        }
+
+        // If all values are arrays of arrays (no objects), it's likely bagged
+        return true;
     }
 }

--- a/packages/validation/src/ErrorBag.php
+++ b/packages/validation/src/ErrorBag.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Validation;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+final readonly class ErrorBag
+{
+    public function __construct(
+        public string $name,
+    ) {}
+}

--- a/packages/view/src/Components/x-form.view.php
+++ b/packages/view/src/Components/x-form.view.php
@@ -3,12 +3,14 @@
  * @var string|null $action
  * @var string|Method|null $method
  * @var string|null $enctype
+ * @var string|null $bag
  */
 
 use Tempest\Http\Method;
 
 $action ??= null;
 $method ??= Method::POST;
+$bag ??= null;
 
 if ($method instanceof Method) {
     $method = $method->value;
@@ -17,6 +19,10 @@ if ($method instanceof Method) {
 
 <form :action="$action" :method="$method" :enctype="$enctype">
     <x-csrf-token />
+    
+    <?php if ($bag !== null): ?>
+        <input type="hidden" name="__error_bag" value="{{ $bag }}" />
+    <?php endif; ?>
 
     <x-slot />
 </form>

--- a/packages/view/src/Components/x-input.view.php
+++ b/packages/view/src/Components/x-input.view.php
@@ -5,6 +5,7 @@
  * @var string|null $id
  * @var string|null $type
  * @var string|null $default
+ * @var string|null $bag
  */
 
 use Tempest\Http\Session\Session;
@@ -23,9 +24,10 @@ $label ??= str($name)->title();
 $id ??= $name;
 $type ??= 'text';
 $default ??= null;
+$bag ??= null;
 
-$errors = $session->getErrorsFor($name);
-$original = $session->getOriginalValueFor($name, $default);
+$errors = $session->getErrorsFor($name, $bag);
+$original = $session->getOriginalValueFor($name, $default, $bag);
 ?>
 
 <div>

--- a/tests/Fixtures/Controllers/MultiFormController.php
+++ b/tests/Fixtures/Controllers/MultiFormController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Controllers;
+
+use Tempest\Http\Response;
+use Tempest\Http\Responses\Ok;
+use Tempest\Router\Post;
+use Tests\Tempest\Fixtures\Requests\LoginRequest;
+use Tests\Tempest\Fixtures\Requests\RegisterRequest;
+use Tests\Tempest\Fixtures\Requests\ValidationRequest;
+
+final readonly class MultiFormController
+{
+    #[Post('/multi-form/default')]
+    public function defaultForm(ValidationRequest $request): Response
+    {
+        return new Ok('Success');
+    }
+
+    #[Post('/multi-form/login')]
+    public function login(LoginRequest $_request): Response
+    {
+        return new Ok('Logged in');
+    }
+
+    #[Post('/multi-form/register')]
+    public function register(RegisterRequest $_request): Response
+    {
+        return new Ok('Registered');
+    }
+}

--- a/tests/Fixtures/Requests/LoginRequest.php
+++ b/tests/Fixtures/Requests/LoginRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Requests;
+
+use Tempest\Http\IsRequest;
+use Tempest\Http\Request;
+use Tempest\Validation\ErrorBag;
+use Tempest\Validation\Rules\IsEmail;
+use Tempest\Validation\Rules\IsNotEmptyString;
+
+#[ErrorBag('login')]
+final class LoginRequest implements Request
+{
+    use IsRequest;
+
+    #[IsEmail]
+    public string $email;
+
+    #[IsNotEmptyString]
+    public string $password;
+}

--- a/tests/Fixtures/Requests/RegisterRequest.php
+++ b/tests/Fixtures/Requests/RegisterRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Requests;
+
+use Tempest\Http\IsRequest;
+use Tempest\Http\Request;
+use Tempest\Validation\ErrorBag;
+use Tempest\Validation\Rules\IsEmail;
+use Tempest\Validation\Rules\IsNotEmptyString;
+
+#[ErrorBag('register')]
+final class RegisterRequest implements Request
+{
+    use IsRequest;
+
+    #[IsEmail]
+    public string $email;
+
+    #[IsNotEmptyString]
+    public string $password;
+
+    #[IsNotEmptyString]
+    public string $name;
+}

--- a/tests/Integration/Http/NamedErrorBagsTest.php
+++ b/tests/Integration/Http/NamedErrorBagsTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Http;
+
+use Tempest\Http\Session\Session;
+use Tempest\Validation\Rule;
+use Tempest\Validation\Rules\IsEmail;
+use Tests\Tempest\Fixtures\Controllers\MultiFormController;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\uri;
+
+/**
+ * @internal
+ */
+final class NamedErrorBagsTest extends FrameworkIntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Ensure a clean session for each test
+        $this->container->get(Session::class)->destroy();
+    }
+
+    public function test_default_error_bag_works_without_attribute(): void
+    {
+        $this->http
+            ->post(
+                uri: uri([MultiFormController::class, 'defaultForm']),
+                body: ['number' => 11],
+                headers: ['referer' => '/form'],
+            )
+            ->assertRedirect('/form')
+            ->assertHasSession(Session::VALIDATION_ERRORS, function (Session $_session, array $data): void {
+                $this->assertArrayHasKey('default', $data);
+                $this->assertArrayHasKey('number', $data['default']);
+            });
+    }
+
+    public function test_named_error_bags_separate_errors(): void
+    {
+        $this->http
+            ->post(
+                uri: uri([MultiFormController::class, 'login']),
+                body: ['email' => 'invalid', 'password' => ''],
+                headers: ['referer' => '/login'],
+            )
+            ->assertRedirect('/login')
+            ->assertHasSession(Session::VALIDATION_ERRORS, function (Session $_session, array $data): void {
+                $this->assertArrayHasKey('login', $data);
+                $this->assertArrayHasKey('email', $data['login']);
+                $this->assertArrayHasKey('password', $data['login']);
+                $this->assertArrayNotHasKey('register', $data);
+            });
+
+        $this->http
+            ->post(
+                uri: uri([MultiFormController::class, 'register']),
+                body: ['email' => 'invalid', 'password' => '', 'name' => ''],
+                headers: ['referer' => '/register'],
+            )
+            ->assertRedirect('/register')
+            ->assertHasSession(Session::VALIDATION_ERRORS, function (Session $_session, array $data): void {
+                $this->assertArrayHasKey('register', $data);
+                $this->assertArrayHasKey('email', $data['register']);
+                $this->assertArrayHasKey('password', $data['register']);
+                $this->assertArrayHasKey('name', $data['register']);
+            });
+    }
+
+    public function test_session_methods_with_named_bags(): void
+    {
+        $session = $this->container->get(Session::class);
+
+        $session->set(Session::VALIDATION_ERRORS, [
+            'login' => ['email' => ['error1']],
+            'register' => ['email' => ['error2']],
+        ]);
+
+        $loginErrors = $session->getErrorsFor('email', 'login');
+        $registerErrors = $session->getErrorsFor('email', 'register');
+
+        $this->assertEquals(['error1'], $loginErrors);
+        $this->assertEquals(['error2'], $registerErrors);
+
+        $session->set(Session::ORIGINAL_VALUES, [
+            'login' => ['email' => 'login@example.com'],
+            'register' => ['email' => 'register@example.com'],
+        ]);
+
+        $loginEmail = $session->getOriginalValueFor('email', '', 'login');
+        $registerEmail = $session->getOriginalValueFor('email', '', 'register');
+
+        $this->assertEquals('login@example.com', $loginEmail);
+        $this->assertEquals('register@example.com', $registerEmail);
+    }
+
+    public function test_backward_compatibility_with_old_session_structure(): void
+    {
+        $session = $this->container->get(Session::class);
+
+        $rule = new IsEmail();
+        $session->set(Session::VALIDATION_ERRORS, ['email' => [$rule]]);
+        $session->set(Session::ORIGINAL_VALUES, ['email' => 'old@example.com']);
+
+        $errors = $session->getErrorsFor('email');
+        $value = $session->getOriginalValueFor('email');
+
+        $this->assertCount(1, $errors);
+        $this->assertInstanceOf(Rule::class, $errors[0]);
+        $this->assertEquals('old@example.com', $value);
+
+        $namedErrors = $session->getErrorsFor('email', 'other');
+        $namedValue = $session->getOriginalValueFor('email', 'default', 'other');
+
+        $this->assertEquals([], $namedErrors);
+        $this->assertEquals('default', $namedValue);
+    }
+
+    public function test_clear_errors_for_specific_bag(): void
+    {
+        $session = $this->container->get(Session::class);
+
+        $session->flashValidationErrors(['field' => ['error']], 'bag1');
+        $session->flashValidationErrors(['field' => ['error']], 'bag2');
+
+        $session->clearErrors('bag1');
+
+        $this->assertEquals([], $session->getAllErrors('bag1'));
+        $this->assertEquals(['field' => ['error']], $session->getAllErrors('bag2'));
+    }
+
+    public function test_invalid_response_with_error_bag(): void
+    {
+        $response = $this->http
+            ->post(
+                uri: uri([MultiFormController::class, 'login']),
+                body: ['email' => 'invalid'],
+                headers: ['referer' => '/login'],
+            )
+            ->assertRedirect('/login');
+
+        $this->assertEquals('login', $response->response->getHeader('x-validation-bag')->values[0]);
+    }
+}

--- a/tests/Integration/Http/Responses/InvalidTest.php
+++ b/tests/Integration/Http/Responses/InvalidTest.php
@@ -35,8 +35,13 @@ final class InvalidTest extends FrameworkIntegrationTestCase
 
         $session = $this->container->get(Session::class);
 
-        $this->assertArrayHasKey('foo', $session->get(Session::VALIDATION_ERRORS));
-        $this->assertArrayHasKey('foo', $session->get(Session::ORIGINAL_VALUES));
+        $errors = $session->get(Session::VALIDATION_ERRORS);
+        $originals = $session->get(Session::ORIGINAL_VALUES);
+
+        $this->assertArrayHasKey('default', $errors);
+        $this->assertArrayHasKey('foo', $errors['default']);
+        $this->assertArrayHasKey('default', $originals);
+        $this->assertArrayHasKey('foo', $originals['default']);
     }
 
     public function test_invalid_with_request(): void
@@ -62,7 +67,12 @@ final class InvalidTest extends FrameworkIntegrationTestCase
 
         $session = $this->container->get(Session::class);
 
-        $this->assertArrayHasKey('foo', $session->get(Session::VALIDATION_ERRORS));
-        $this->assertArrayHasKey('foo', $session->get(Session::ORIGINAL_VALUES));
+        $errors = $session->get(Session::VALIDATION_ERRORS);
+        $originals = $session->get(Session::ORIGINAL_VALUES);
+
+        $this->assertArrayHasKey('default', $errors);
+        $this->assertArrayHasKey('foo', $errors['default']);
+        $this->assertArrayHasKey('default', $originals);
+        $this->assertArrayHasKey('foo', $originals['default']);
     }
 }

--- a/tests/Integration/Http/ValidationResponseTest.php
+++ b/tests/Integration/Http/ValidationResponseTest.php
@@ -47,7 +47,8 @@ final class ValidationResponseTest extends FrameworkIntegrationTestCase
             ->assertRedirect(uri([ValidationController::class, 'store']))
             ->assertHasValidationError('number')
             ->assertHasSession(Session::ORIGINAL_VALUES, function (Session $_session, array $data) use ($values): void {
-                $this->assertEquals($values, $data);
+                $this->assertArrayHasKey('default', $data);
+                $this->assertEquals($values, $data['default']);
             });
     }
 

--- a/tests/Integration/View/FormWithErrorBagTest.php
+++ b/tests/Integration/View/FormWithErrorBagTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\View;
+
+use Tempest\Http\Session\Session;
+use Tempest\View\GenericView;
+use Tempest\View\ViewRenderer;
+use Tests\Tempest\Fixtures\Controllers\MultiFormController;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\uri;
+
+/**
+ * @internal
+ */
+final class FormWithErrorBagTest extends FrameworkIntegrationTestCase
+{
+    public function test_form_with_bag_sends_hidden_input(): void
+    {
+        $view = $this->renderTemplate('
+            <x-form action="/test" bag="login">
+                <input type="text" name="email" />
+                <input type="password" name="password" />
+            </x-form>
+        ');
+
+        $this->assertStringContainsString('<input type="hidden" name="__error_bag" value="login"', $view);
+    }
+
+    public function test_form_without_bag_has_no_hidden_input(): void
+    {
+        $view = $this->renderTemplate('
+            <x-form action="/test">
+                <input type="text" name="email" />
+            </x-form>
+        ');
+
+        $this->assertStringNotContainsString('__error_bag', $view);
+    }
+
+    public function test_form_with_bag_hidden_input_is_handled_by_middleware(): void
+    {
+        $response = $this->http
+            ->post(
+                uri: uri([MultiFormController::class, 'defaultForm']),
+                body: [
+                    'number' => 11,
+                    '__error_bag' => 'custom-bag',
+                ],
+                headers: ['referer' => '/form'],
+            );
+
+        $session = $this->container->get(Session::class);
+        $errors = $session->get(Session::VALIDATION_ERRORS);
+
+        $this->assertArrayHasKey('custom-bag', $errors);
+        $this->assertArrayHasKey('number', $errors['custom-bag']);
+    }
+
+    public function test_error_bag_from_hidden_input_takes_precedence_over_attribute(): void
+    {
+        $response = $this->http
+            ->post(
+                uri: uri([MultiFormController::class, 'login']),
+                body: [
+                    'email' => 'invalid',
+                    'password' => '',
+                    '__error_bag' => 'form-override',
+                ],
+                headers: ['referer' => '/login'],
+            );
+
+        $session = $this->container->get(Session::class);
+        $errors = $session->get(Session::VALIDATION_ERRORS);
+
+        $this->assertArrayHasKey('form-override', $errors);
+        $this->assertArrayHasKey('email', $errors['form-override']);
+        $this->assertArrayHasKey('password', $errors['form-override']);
+        $this->assertArrayNotHasKey('login', $errors);
+    }
+
+    private function renderTemplate(string $template): string
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'test_view_') . '.view.php';
+        file_put_contents($tempFile, $template);
+
+        try {
+            $view = new GenericView($tempFile);
+            $renderer = $this->container->get(ViewRenderer::class);
+            return $renderer->render($view);
+        } finally {
+            unlink($tempFile);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

### Session Class (packages/http/src/Session/Session.php)
* Added `DEFAULT_ERROR_BAG` to handle when no specific error bag is configured
* Added methods for managing the error bags
* Implemented backward compatibility with the `isBaggedStructure()` method that detects and converts old non-bagged structures

### Invalid Response (packages/http/src/Responses/Invalid.php)
* Added support for optional `$errorBag` parameter in constructor
* Stores errors and original values in the specified error bag
* Adds `x-validation-bag` header when a custom bag is specified

### ErrorBag Attribute (packages/validation/src/ErrorBag.php)
* Created a new attribute class to mark request classes with a specific error bag name
* Usage: `#[ErrorBag('login')]` on request classes

### Middleware (packages/router/src/HandleRouteExceptionMiddleware.php)
* Updated to detect error bag from two sources (in order of precedence):
  1. `__error_bag` field in request body (from form hidden input)
  2. `ErrorBag` attribute on request class
* Passes the resolved error bag name to the Invalid response

### x-form Component (packages/view/src/Components/x-form.view.php)
* Added support for bag attribute
* When specified, renders a hidden input `<input type="hidden" name="__error_bag" value="bag-name" />`
* This allows all validation errors from the form to be automatically grouped in the specified bag

### x-input Component (packages/view/src/Components/x-input.view.php)
* Added support for an optional bag parameter
* Uses the specified bag when retrieving errors and original values from the session

### RequestToObjectMapper (packages/http/src/Mappers/RequestToObjectMapper.php)
* Updated to pass the target request class (not the base request) to validation exceptions. This allows the middleware to detect ErrorBag attributes on custom request classes

### Test Helper (src/Tempest/Framework/Testing/Http/TestResponseHelper.php)
* Updated `assertHasValidationError` to handle bagged structure
* Updated `assertHasJsonValidationErrors` to use bag-aware methods

## Usage Examples:

### Using ErrorBag Attribute on Request Classes:

```php
#[ErrorBag('login')]
final class LoginRequest implements Request
{
    use IsRequest;
    
    #[IsEmail]
    public string $email;
    
    #[IsNotEmptyString]
    public string $password;
}
```

### Using bag attribute on x-form:

```html
<x-form action="/login" method="POST" bag="login">
    <x-input name="email" type="email" />
    <x-input name="password" type="password" />
    <button type="submit">Login</button>
</x-form>

<x-form action="/register" method="POST" bag="register">
    <x-input name="email" type="email" />
    <x-input name="password" type="password" />
    <x-input name="name" />
    <button type="submit">Register</button>
</x-form>
```

### Accessing errors from specific bags in views:

```html
<x-input name="email" bag="login" />
```

Fixes #1504