### PR TITLE
fix(core): discover vendor directory first on all platforms

### DIFF
--- a/packages/core/src/Kernel/LoadConfig.php
+++ b/packages/core/src/Kernel/LoadConfig.php
@@ -58,7 +58,7 @@ final readonly class LoadConfig
             })
             ->sortByCallback(function (string $path1, string $path2) use ($suffixes): int {
                 $getPriority = fn (string $path): int => match (true) {
-                    Str\contains($path, '/vendor/') => 0,
+                    Str\contains($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR) => 0,
                     Str\contains($path, $suffixes['testing']) => 6,
                     Str\contains($path, $suffixes['development']) => 5,
                     Str\contains($path, $suffixes['production']) => 4,


### PR DESCRIPTION
The vendor directory is string matched to give it the lowest priority when loading configuration files during discovery. This change sets the prefixed and suffixed directory separator to the PHP constant DIRECTORY_SEPARATOR rather than hard-coding '/'. This allows the match to work when PHP is running on Windows (which uses '\' as a directory separator), as well as on other platforms.

Resolves tempestphp/tempest-framework#1526