### PR TITLE
feat(container): service provider with discovery

### DIFF
--- a/packages/container/src/ServiceProvider.php
+++ b/packages/container/src/ServiceProvider.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container;
+
+interface ServiceProvider
+{
+}

--- a/packages/container/src/ServiceProviderDiscovery.php
+++ b/packages/container/src/ServiceProviderDiscovery.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container;
+
+use Tempest\Discovery\Discovery;
+use Tempest\Discovery\DiscoveryLocation;
+use Tempest\Discovery\IsDiscovery;
+use Tempest\Reflection\ClassReflector;
+
+/**
+ * @property GenericContainer $container
+ */
+final class ServiceProviderDiscovery implements Discovery
+{
+    use IsDiscovery;
+
+    public function __construct(
+        protected readonly Container $container,
+    ) {}
+
+    public function discover(DiscoveryLocation $location, ClassReflector $class): void
+    {
+        if (! $class->implements(ServiceProvider::class)) {
+            return;
+        }
+
+        foreach ($class->getPublicMethods() as $method) {
+            $singleton = $method->getAttribute(Singleton::class);
+
+            $this->discoveryItems->add($location, [$method, isset($singleton), $singleton?->tag]);
+        }
+    }
+
+    public function apply(): void
+    {
+        foreach ($this->discoveryItems as [$method, $singleton, $tag]) {
+            $className = $method->getReturnType()->getName();
+            $definition = static fn (Container $container) => $container->invoke($method);
+
+            if ($singleton) {
+                $this->container->singleton($className, $definition, $tag);
+            } else {
+                $this->container->register($className, $definition);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This feature introduces a concept/pattern of service providers which can be used to group multiple initializer methods in a single provider class. It reduces boilerplate code of writing a dedicated initializer class for each service, specially when working with other libraries. All initializer method parameters will be automatically resolved with the dependencies needed. Here is an example how it works:

```php
use Tempest\Container\ServiceProvider;
use Tempest\Container\Singleton;
use Tempest\Log\Logger;

final readonly class MyServiceProvider implements ServiceProvider
{
    public static function createServiceA(): ServiceA
    {
        return new ServiceA(['config' => ...]);
    }

    #[Singleton]
    public static function createServiceB(ServiceA $a, Logger $logger): ServiceB
    {
        return new ServiceB($a, $logger);
    }
}
```

Here is a cache provider which provides two separate caches with file storage using Nette\Caching.

```php
use Nette\Caching\Cache;
use Nette\Caching\Storages\FileStorage;
use Tempest\Container\ServiceProvider;
use Tempest\Container\Singleton;

final readonly class CacheServiceProvider implements ServiceProvider
{
    #[Singleton]
    public static function createFileStorage(): FileStorage
    {
        return new FileStorage($_ENV['CACHE_DIR']);
    }

    #[Singleton]
    public static function createAppCache(FileStorage $storage): Cache
    {
        return new Cache($storage, 'app');
    }

    #[Singleton(tag: 'response')]
    public static function createResponseCache(FileStorage $storage): Cache
    {
        return new Cache($storage, 'response');
    }
}
```

Let me hear your thoughts on this feature.