### PR TITLE
fix(database): handle loading circular eager relations

### DIFF
--- a/tests/Fixtures/Migrations/CreateProfileWithEagerTable.php
+++ b/tests/Fixtures/Migrations/CreateProfileWithEagerTable.php
@@ -13,7 +13,7 @@ use Tests\Tempest\Fixtures\Models\ProfileWithEager;
 
 final class CreateProfileWithEagerTable implements MigratesUp, MigratesDown
 {
-    private(set) string $name = '0000-00-05_create_profiles_table';
+    private(set) string $name = '0000-00-06_create_profiles_table';
 
     public function up(): QueryStatement
     {

--- a/tests/Fixtures/Migrations/CreateProfileWithEagerTable.php
+++ b/tests/Fixtures/Migrations/CreateProfileWithEagerTable.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Migrations;
+
+use Tempest\Database\MigratesDown;
+use Tempest\Database\MigratesUp;
+use Tempest\Database\QueryStatement;
+use Tempest\Database\QueryStatements\CreateTableStatement;
+use Tempest\Database\QueryStatements\DropTableStatement;
+use Tests\Tempest\Fixtures\Models\ProfileWithEager;
+
+final class CreateProfileWithEagerTable implements MigratesUp, MigratesDown
+{
+    private(set) string $name = '0000-00-05_create_profiles_table';
+
+    public function up(): QueryStatement
+    {
+        return CreateTableStatement::forModel(ProfileWithEager::class)
+            ->primary()
+            ->text('bio')
+            ->belongsTo('profiles.user_id', 'users.id', nullable: true);
+    }
+
+    public function down(): QueryStatement
+    {
+        return DropTableStatement::forModel(ProfileWithEager::class);
+    }
+}

--- a/tests/Fixtures/Migrations/CreateUserWithEagerTable.php
+++ b/tests/Fixtures/Migrations/CreateUserWithEagerTable.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Migrations;
+
+use Tempest\Database\MigratesDown;
+use Tempest\Database\MigratesUp;
+use Tempest\Database\QueryStatement;
+use Tempest\Database\QueryStatements\CreateTableStatement;
+use Tempest\Database\QueryStatements\DropTableStatement;
+use Tests\Tempest\Fixtures\Models\UserWithEager;
+
+final class CreateUserWithEagerTable implements MigratesUp, MigratesDown
+{
+    private(set) string $name = '0000-00-06_create_users_table';
+
+    public function up(): QueryStatement
+    {
+        return CreateTableStatement::forModel(UserWithEager::class)
+            ->primary()
+            ->text('name');
+    }
+
+    public function down(): QueryStatement
+    {
+        return DropTableStatement::forModel(UserWithEager::class);
+    }
+}

--- a/tests/Fixtures/Migrations/CreateUserWithEagerTable.php
+++ b/tests/Fixtures/Migrations/CreateUserWithEagerTable.php
@@ -13,7 +13,7 @@ use Tests\Tempest\Fixtures\Models\UserWithEager;
 
 final class CreateUserWithEagerTable implements MigratesUp, MigratesDown
 {
-    private(set) string $name = '0000-00-06_create_users_table';
+    private(set) string $name = '0000-00-05_create_users_table';
 
     public function up(): QueryStatement
     {

--- a/tests/Fixtures/Models/ProfileWithEager.php
+++ b/tests/Fixtures/Models/ProfileWithEager.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Models;
+
+use Tempest\Database\Eager;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\PrimaryKey;
+use Tempest\Database\Table;
+
+#[Table('profiles_with_eager')]
+final class ProfileWithEager
+{
+    use IsDatabaseModel;
+
+    public function __construct(
+        public PrimaryKey $id,
+        public string $bio,
+        #[Eager]
+        public ?UserWithEager $user = null,
+    ) {}
+}

--- a/tests/Fixtures/Models/ProfileWithEager.php
+++ b/tests/Fixtures/Models/ProfileWithEager.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Fixtures\Models;
 
+use Tempest\Database\BelongsTo;
 use Tempest\Database\Eager;
 use Tempest\Database\IsDatabaseModel;
 use Tempest\Database\PrimaryKey;
 use Tempest\Database\Table;
 
-#[Table('profiles_with_eager')]
+#[Table('profiles')]
 final class ProfileWithEager
 {
     use IsDatabaseModel;
@@ -17,7 +18,9 @@ final class ProfileWithEager
     public function __construct(
         public PrimaryKey $id,
         public string $bio,
+        public ?int $user_id,
         #[Eager]
+        #[BelongsTo]
         public ?UserWithEager $user = null,
     ) {}
 }

--- a/tests/Fixtures/Models/UserWithEager.php
+++ b/tests/Fixtures/Models/UserWithEager.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Models;
+
+use Tempest\Database\Eager;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\PrimaryKey;
+use Tempest\Database\Table;
+
+#[Table('users_with_eager')]
+final class UserWithEager
+{
+    use IsDatabaseModel;
+
+    public function __construct(
+        public PrimaryKey $id,
+        public string $name,
+        #[Eager]
+        public ?ProfileWithEager $profile = null,
+    ) {}
+}

--- a/tests/Fixtures/Models/UserWithEager.php
+++ b/tests/Fixtures/Models/UserWithEager.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Tests\Tempest\Fixtures\Models;
 
 use Tempest\Database\Eager;
+use Tempest\Database\HasOne;
 use Tempest\Database\IsDatabaseModel;
 use Tempest\Database\PrimaryKey;
 use Tempest\Database\Table;
 
-#[Table('users_with_eager')]
+#[Table('users')]
 final class UserWithEager
 {
     use IsDatabaseModel;
@@ -18,6 +19,7 @@ final class UserWithEager
         public PrimaryKey $id,
         public string $name,
         #[Eager]
+        #[HasOne]
         public ?ProfileWithEager $profile = null,
     ) {}
 }

--- a/tests/Integration/Database/CircularEagerLoadingTest.php
+++ b/tests/Integration/Database/CircularEagerLoadingTest.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Database;
 
+use Tempest\Database\Migrations\CreateMigrationsTable;
+use Tests\Tempest\Fixtures\Migrations\CreateProfileWithEagerTable;
+use Tests\Tempest\Fixtures\Migrations\CreateUserWithEagerTable;
+use Tests\Tempest\Fixtures\Models\ProfileWithEager;
 use Tests\Tempest\Fixtures\Models\UserWithEager;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 use function Tempest\Database\inspect;
+use function Tempest\Database\query;
 
 /**
  * @internal
@@ -32,5 +37,30 @@ final class CircularEagerLoadingTest extends FrameworkIntegrationTestCase
         $this->assertArrayHasKey('profile', $relations);
         $this->assertArrayHasKey('user', $relations);
         $this->assertCount(2, $relations);
+    }
+
+    public function test_it_saves_and_loads_relations_without_causing_infinite_loop(): void
+    {
+        $this->migrate(
+            CreateMigrationsTable::class,
+            CreateUserWithEagerTable::class,
+            CreateProfileWithEagerTable::class,
+        );
+
+        $user = query(UserWithEager::class)->create(
+            name: 'John Doe',
+        );
+
+        $profile = query(ProfileWithEager::class)->create(
+            bio: 'Test',
+            user_id: $user->id->value,
+        );
+
+        $profile = query(ProfileWithEager::class)->findById($profile->id);
+
+        $user = query(UserWithEager::class)->findById($user->id);
+
+        $this->assertTrue($profile->id->equals($user->profile->id));
+        $this->assertTrue($user->id->equals($profile->user->id));
     }
 }

--- a/tests/Integration/Database/CircularEagerLoadingTest.php
+++ b/tests/Integration/Database/CircularEagerLoadingTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Database;
+
+use Tests\Tempest\Fixtures\Models\UserWithEager;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\Database\inspect;
+
+/**
+ * @internal
+ */
+final class CircularEagerLoadingTest extends FrameworkIntegrationTestCase
+{
+    public function test_circular_eager_loading_does_not_cause_infinite_loop(): void
+    {
+        $userInspector = inspect(UserWithEager::class);
+        $eagerRelations = $userInspector->resolveEagerRelations();
+
+        $this->assertArrayHasKey('profile', $eagerRelations);
+        $this->assertArrayNotHasKey('profile.user', $eagerRelations);
+        $this->assertCount(1, $eagerRelations);
+    }
+
+    public function test_circular_with_relations_does_not_cause_infinite_loop(): void
+    {
+        $userInspector = inspect(UserWithEager::class);
+        $relations = $userInspector->resolveRelations('profile.user.profile');
+
+        $this->assertArrayHasKey('profile', $relations);
+        $this->assertArrayHasKey('user', $relations);
+        $this->assertCount(2, $relations);
+    }
+}


### PR DESCRIPTION
## Summary

Modified `ModelInspector` to track visited model types and prevent infinite recursion:

* Tracking visited model types in an array as we traverse the relationship tree
* Before recursing into a relation, check if the target model type is already in the visited path
* If a circular reference is detected, skip that relation to prevent infinite recursion
* Passing the updated visited paths array to recursive calls

Fixes #1494