### PR TITLE
feat(support): add `Uri` utils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -179,6 +179,7 @@
             "packages/support/src/Regex/functions.php",
             "packages/support/src/Str/constants.php",
             "packages/support/src/Str/functions.php",
+            "packages/support/src/Uri/functions.php",
             "packages/support/src/functions.php",
             "packages/view/src/functions.php",
             "packages/vite/src/functions.php"

--- a/packages/support/composer.json
+++ b/packages/support/composer.json
@@ -27,7 +27,8 @@
             "src/Math/constants.php",
             "src/Math/functions.php",
             "src/Json/functions.php",
-            "src/Filesystem/functions.php"
+            "src/Filesystem/functions.php",
+            "src/Uri/functions.php"
         ]
     },
     "autoload-dev": {

--- a/packages/support/src/Uri/Uri.php
+++ b/packages/support/src/Uri/Uri.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Uri;
+
+use Tempest\Support\Str;
+use Tempest\Support\Str\ImmutableString;
+use Tempest\Support\Str\MutableString;
+
+use function parse_url;
+
+final class Uri
+{
+    /**
+     * The path segments as an array.
+     */
+    public array $segments {
+        get {
+            if ($this->path === null || $this->path === '' || $this->path === '/') {
+                return [];
+            }
+
+            return array_values(array_filter(explode('/', $this->path), fn (string $segment) => $segment !== ''));
+        }
+    }
+
+    /**
+     * The parsed query parameters as an associative array.
+     */
+    public array $query {
+        get {
+            if ($this->queryString === null || $this->queryString === '') {
+                return [];
+            }
+
+            parse_str($this->queryString, $query);
+
+            return $query;
+        }
+    }
+
+    /**
+     * @param null|string $scheme The scheme component of the URI.
+     * @param null|string $user The user component of the URI.
+     * @param null|string $password The password component of the URI.
+     * @param null|string $host The host component of the URI.
+     * @param null|int $port The port component of the URI.
+     * @param null|string $path The path component of the URI.
+     * @param null|string $queryString The query string component of the URI.
+     * @param null|string $fragment The fragment component of the URI.
+     */
+    public function __construct(
+        public readonly ?string $scheme = null,
+        public readonly ?string $user = null,
+        public readonly ?string $password = null,
+        public readonly ?string $host = null,
+        public readonly ?int $port = null,
+        public readonly ?string $path = null,
+        public readonly ?string $queryString = null,
+        public readonly ?string $fragment = null,
+    ) {}
+
+    /**
+     * Creates a Uri instance from a URI string.
+     */
+    public static function from(string $uri): self
+    {
+        $parts = parse_url($uri);
+
+        if ($parts === false) {
+            return new self(path: $uri);
+        }
+
+        return new self(
+            scheme: $parts['scheme'] ?? null,
+            user: $parts['user'] ?? null,
+            password: $parts['pass'] ?? null,
+            host: $parts['host'] ?? null,
+            port: $parts['port'] ?? null,
+            path: $parts['path'] ?? null,
+            queryString: $parts['query'] ?? null,
+            fragment: $parts['fragment'] ?? null,
+        );
+    }
+
+    /**
+     * Returns a new Uri with the provided scheme.
+     */
+    public function withScheme(string $scheme): self
+    {
+        return $this->with(scheme: $scheme);
+    }
+
+    /**
+     * Returns a new Uri with the provided user.
+     */
+    public function withUser(string $user): self
+    {
+        return $this->with(user: $user);
+    }
+
+    /**
+     * Returns a new Uri with the provided password.
+     */
+    public function withPassword(string $password): self
+    {
+        return $this->with(
+            user: $this->user ?? '',
+            password: $password,
+        );
+    }
+
+    /**
+     * Returns a new Uri with the provided host.
+     */
+    public function withHost(string $host): self
+    {
+        return $this->with(host: $host);
+    }
+
+    /**
+     * Returns a new Uri with the provided port.
+     */
+    public function withPort(int $port): self
+    {
+        return $this->with(port: $port);
+    }
+
+    /**
+     * Returns a new Uri with the provided path.
+     */
+    public function withPath(string $path): self
+    {
+        return $this->with(path: $path);
+    }
+
+    /**
+     * Returns a new Uri with the provided query parameters (replaces existing).
+     */
+    public function withQuery(mixed ...$query): self
+    {
+        return $this->with(queryString: $this->buildQueryString($query));
+    }
+
+    /**
+     * Returns a new Uri with added query parameters (merges with existing).
+     */
+    public function addQuery(mixed ...$query): self
+    {
+        return $this->with(queryString: $this->buildQueryString(
+            query: array_merge($this->query, $query),
+        ));
+    }
+
+    /**
+     * Returns a new Uri with all query parameters removed.
+     */
+    public function removeQuery(): self
+    {
+        return new self(
+            scheme: $this->scheme,
+            user: $this->user,
+            password: $this->password,
+            host: $this->host,
+            port: $this->port,
+            path: $this->path,
+            queryString: null,
+            fragment: $this->fragment,
+        );
+    }
+
+    /**
+     * Returns a new Uri with specific query parameters removed.
+     */
+    public function withoutQuery(mixed ...$query): self
+    {
+        $currentQuery = $this->query;
+
+        foreach ($query as $key => $value) {
+            if (is_int($key)) {
+                unset($currentQuery[$value]);
+            } else {
+                if (isset($currentQuery[$key]) && $currentQuery[$key] === $value) {
+                    unset($currentQuery[$key]);
+                }
+            }
+        }
+
+        $newQueryString = $this->buildQueryString($currentQuery);
+
+        return new self(
+            scheme: $this->scheme,
+            user: $this->user,
+            password: $this->password,
+            host: $this->host,
+            port: $this->port,
+            path: $this->path,
+            queryString: $newQueryString,
+            fragment: $this->fragment,
+        );
+    }
+
+    /**
+     * Returns a new Uri with the provided fragment.
+     */
+    public function withFragment(string $fragment): self
+    {
+        return $this->with(fragment: $fragment);
+    }
+
+    /**
+     * Returns a new Uri with the specified components changed.
+     */
+    private function with(
+        ?string $scheme = null,
+        ?string $user = null,
+        ?string $password = null,
+        ?string $host = null,
+        ?int $port = null,
+        ?string $path = null,
+        ?string $queryString = null,
+        array $query = [],
+        ?string $fragment = null,
+    ): self {
+        return new self(
+            scheme: $scheme ?? $this->scheme,
+            user: $user ?? $this->user,
+            password: $password ?? $this->password,
+            host: $host ?? $this->host,
+            port: $port ?? $this->port,
+            path: Str\ensure_starts_with($path ?? $this->path, '/'),
+            queryString: match (true) {
+                $queryString !== null => $queryString,
+                $query !== [] => $this->buildQueryString($query),
+                default => $this->queryString,
+            },
+            fragment: $fragment ?? $this->fragment,
+        );
+    }
+
+    /**
+     * Builds a query string from an array of query parameters.
+     */
+    private function buildQueryString(array $query): ?string
+    {
+        if ($query === []) {
+            return null;
+        }
+
+        $processedQuery = [];
+
+        foreach ($query as $key => $value) {
+            if (is_int($key) && is_string($value)) {
+                $processedQuery[$value] = '';
+            } else {
+                if (is_bool($value)) {
+                    $value = $value ? 'true' : 'false';
+                }
+
+                $processedQuery[$key] = $value;
+            }
+        }
+
+        $queryString = http_build_query($processedQuery, arg_separator: '&', encoding_type: PHP_QUERY_RFC3986);
+        $queryString = preg_replace('/([^=&]+)=(?=&|$)/', replacement: '$1', subject: $queryString);
+
+        return $queryString;
+    }
+
+    /**
+     * Builds the URI string from its components.
+     */
+    public function toString(): string
+    {
+        $uri = '';
+
+        if ($this->scheme !== null) {
+            $uri .= $this->scheme . ':';
+        }
+
+        if ($this->user !== null || $this->host !== null) {
+            $uri .= '//';
+
+            if ($this->user !== null) {
+                $uri .= $this->user;
+
+                if ($this->password !== null) {
+                    $uri .= ':' . $this->password;
+                }
+
+                $uri .= '@';
+            }
+
+            if ($this->host !== null) {
+                $uri .= $this->host;
+            }
+
+            if ($this->port !== null) {
+                $uri .= ':' . $this->port;
+            }
+        }
+
+        if ($this->path !== null) {
+            $uri .= $this->path;
+        }
+
+        if ($this->queryString !== null && $this->queryString !== '') {
+            $uri .= '?' . $this->queryString;
+        }
+
+        if ($this->fragment !== null) {
+            $uri .= '#' . $this->fragment;
+        }
+
+        return $uri;
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+
+    public function toImmutableString(): ImmutableString
+    {
+        return new ImmutableString($this->toString());
+    }
+
+    public function toMutableString(): MutableString
+    {
+        return new MutableString($this->toString());
+    }
+}

--- a/packages/support/src/Uri/functions.php
+++ b/packages/support/src/Uri/functions.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Uri;
+
+/**
+ * Updates the given URI to include the provided query parameters. Previous parameters are removed.
+ */
+function set_query(string $uri, mixed ...$query): string
+{
+    return Uri::from($uri)->withQuery(...$query)->toString();
+}
+
+/**
+ * Adds query parameters to the existing ones in the URI.
+ */
+function merge_query(string $uri, mixed ...$query): string
+{
+    return Uri::from($uri)->addQuery(...$query)->toString();
+}
+
+/**
+ * Removes specific query parameters from the URI.
+ */
+function without_query(string $uri, mixed ...$query): string
+{
+    if (count($query) === 0) {
+        return Uri::from($uri)->removeQuery()->toString();
+    }
+
+    return Uri::from($uri)->withoutQuery(...$query)->toString();
+}
+
+/**
+ * Extracts the query parameters from the given URI as an associative array.
+ */
+function get_query(string $uri): array
+{
+    return Uri::from($uri)->query;
+}
+
+/**
+ * Updates the given URI to include the provided fragment.
+ */
+function set_fragment(string $uri, string $fragment): string
+{
+    return Uri::from($uri)->withFragment($fragment)->toString();
+}
+
+/**
+ * Extracts the fragment from the given URI.
+ */
+function get_fragment(string $uri): ?string
+{
+    return Uri::from($uri)->fragment;
+}
+
+/**
+ * Updates the given URI to use the provided host.
+ */
+function set_host(string $uri, string $host): string
+{
+    return Uri::from($uri)->withHost($host)->toString();
+}
+
+/**
+ * Extracts the host from the given URI.
+ */
+function get_host(string $uri): ?string
+{
+    return Uri::from($uri)->host;
+}
+
+/**
+ * Updates the given URI to use the provided scheme.
+ */
+function set_scheme(string $uri, string $scheme): string
+{
+    return Uri::from($uri)->withScheme($scheme)->toString();
+}
+
+/**
+ * Extracts the scheme from the given URI.
+ */
+function get_scheme(string $uri): ?string
+{
+    return Uri::from($uri)->scheme;
+}
+
+/**
+ * Updates the given URI to use the provided port.
+ */
+function set_port(string $uri, int $port): string
+{
+    return Uri::from($uri)->withPort($port)->toString();
+}
+
+/**
+ * Extracts the port from the given URI.
+ */
+function get_port(string $uri): ?int
+{
+    return Uri::from($uri)->port;
+}
+
+/**
+ * Updates the given URI to use the provided user.
+ */
+function set_user(string $uri, string $user): string
+{
+    return Uri::from($uri)->withUser($user)->toString();
+}
+
+/**
+ * Extracts the user from the given URI.
+ */
+function get_user(string $uri): ?string
+{
+    return Uri::from($uri)->user;
+}
+
+/**
+ * Updates the given URI to use the provided password.
+ */
+function set_password(string $uri, string $password): string
+{
+    return Uri::from($uri)->withPassword($password)->toString();
+}
+
+/**
+ * Extracts the password from the given URI.
+ */
+function get_password(string $uri): ?string
+{
+    return Uri::from($uri)->password;
+}
+
+/**
+ * Updates the given URI to use the provided path.
+ */
+function set_path(string $uri, string $path): string
+{
+    return Uri::from($uri)->withPath($path)->toString();
+}
+
+/**
+ * Extracts the path from the given URI.
+ */
+function get_path(string $uri): ?string
+{
+    return Uri::from($uri)->path;
+}
+
+/**
+ * Extracts the path segments from the URI as an array.
+ */
+function get_segments(string $uri): array
+{
+    return Uri::from($uri)->segments;
+}

--- a/packages/support/tests/Uri/FunctionsTest.php
+++ b/packages/support/tests/Uri/FunctionsTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Tests\Uri;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+use function Tempest\Support\Uri\get_fragment;
+use function Tempest\Support\Uri\get_host;
+use function Tempest\Support\Uri\get_password;
+use function Tempest\Support\Uri\get_path;
+use function Tempest\Support\Uri\get_port;
+use function Tempest\Support\Uri\get_query;
+use function Tempest\Support\Uri\get_scheme;
+use function Tempest\Support\Uri\get_segments;
+use function Tempest\Support\Uri\get_user;
+use function Tempest\Support\Uri\merge_query;
+use function Tempest\Support\Uri\set_fragment;
+use function Tempest\Support\Uri\set_host;
+use function Tempest\Support\Uri\set_password;
+use function Tempest\Support\Uri\set_path;
+use function Tempest\Support\Uri\set_port;
+use function Tempest\Support\Uri\set_query;
+use function Tempest\Support\Uri\set_scheme;
+use function Tempest\Support\Uri\set_user;
+use function Tempest\Support\Uri\without_query;
+
+final class FunctionsTest extends TestCase
+{
+    #[Test]
+    #[TestWith(['https://example.com', ['foo' => 'bar'], 'https://example.com?foo=bar'])]
+    #[TestWith(['https://example.com?existing=value', ['foo' => 'bar'], 'https://example.com?foo=bar'])]
+    #[TestWith(['https://example.com', ['foo' => 'bar', 'baz' => 'qux'], 'https://example.com?foo=bar&baz=qux'])]
+    #[TestWith(['https://example.com/path', [], 'https://example.com/path'])]
+    #[TestWith(['malformed-uri', ['foo' => 'bar'], 'malformed-uri?foo=bar'])]
+    #[TestWith(['https://example.com', ['foo'], 'https://example.com?foo'])]
+    #[TestWith(['https://example.com', ['foo' => true], 'https://example.com?foo=true'])]
+    #[TestWith(['https://example.com', ['foo' => false], 'https://example.com?foo=false'])]
+    public function set_query(string $uri, array $query, string $expected): void
+    {
+        $this->assertSame($expected, set_query($uri, ...$query));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com?foo=bar', ['foo' => 'bar']])]
+    #[TestWith(['https://example.com?foo=bar&baz=qux', ['foo' => 'bar', 'baz' => 'qux']])]
+    #[TestWith(['https://example.com', []])]
+    #[TestWith(['https://example.com?', []])]
+    #[TestWith(['malformed-uri', []])]
+    public function get_query(string $uri, array $expected): void
+    {
+        $this->assertSame($expected, get_query($uri));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com', 'frieren', 'https://example.com#frieren'])]
+    #[TestWith(['https://example.com#old', 'stark', 'https://example.com#stark'])]
+    #[TestWith(['https://example.com/path?query=value', 'fern', 'https://example.com/path?query=value#fern'])]
+    #[TestWith(['malformed-uri', 'fragment', 'malformed-uri#fragment'])]
+    public function set_fragment(string $uri, string $fragment, string $expected): void
+    {
+        $this->assertSame($expected, set_fragment($uri, $fragment));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com#frieren', 'frieren'])]
+    #[TestWith(['https://example.com', null])]
+    #[TestWith(['https://example.com#', ''])]
+    #[TestWith(['malformed-uri', null])]
+    public function get_fragment(string $uri, ?string $expected): void
+    {
+        $this->assertSame($expected, get_fragment($uri));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com', 'flamme.org', 'https://flamme.org'])]
+    #[TestWith(['https://old.com/path', 'neue.com', 'https://neue.com/path'])]
+    #[TestWith(['http://user:pass@old.com:8080', 'serie.com', 'http://user:pass@serie.com:8080'])]
+    #[TestWith(['malformed-uri', 'domain.com', '//domain.commalformed-uri'])]
+    public function set_host(string $uri, string $host, string $expected): void
+    {
+        $this->assertSame($expected, set_host($uri, $host));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com', 'example.com'])]
+    #[TestWith(['https://flamme.org/path', 'flamme.org'])]
+    #[TestWith(['http://user:pass@serie.com:8080', 'serie.com'])]
+    #[TestWith(['relative/path', null])]
+    #[TestWith(['malformed-uri', null])]
+    public function get_host(string $uri, ?string $expected): void
+    {
+        $this->assertSame($expected, get_host($uri));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com', 'http', 'http://example.com'])]
+    #[TestWith(['http://example.com', 'https', 'https://example.com'])]
+    #[TestWith(['ftp://files.example.com', 'sftp', 'sftp://files.example.com'])]
+    #[TestWith(['malformed-uri', 'https', 'https:malformed-uri'])]
+    public function set_scheme(string $uri, string $scheme, string $expected): void
+    {
+        $this->assertSame($expected, set_scheme($uri, $scheme));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com', 'https'])]
+    #[TestWith(['http://example.com', 'http'])]
+    #[TestWith(['ftp://files.example.com', 'ftp'])]
+    #[TestWith(['//example.com', null])]
+    #[TestWith(['malformed-uri', null])]
+    public function get_scheme(string $uri, ?string $expected): void
+    {
+        $this->assertSame($expected, get_scheme($uri));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com', 8080, 'https://example.com:8080'])]
+    #[TestWith(['https://example.com:80', 9000, 'https://example.com:9000'])]
+    #[TestWith(['http://user:pass@example.com', 3000, 'http://user:pass@example.com:3000'])]
+    #[TestWith(['malformed-uri', 8080, 'malformed-uri'])]
+    public function set_port(string $uri, int $port, string $expected): void
+    {
+        $this->assertSame($expected, set_port($uri, $port));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com:8080', 8080])]
+    #[TestWith(['https://example.com', null])]
+    #[TestWith(['http://user:pass@example.com:3000', 3000])]
+    #[TestWith(['malformed-uri', null])]
+    public function get_port(string $uri, ?int $expected): void
+    {
+        $this->assertSame($expected, get_port($uri));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com', 'frieren', 'https://frieren@example.com'])]
+    #[TestWith(['https://old@example.com', 'fern', 'https://fern@example.com'])]
+    #[TestWith(['https://old:pass@example.com', 'stark', 'https://stark:pass@example.com'])]
+    #[TestWith(['malformed-uri', 'user', '//user@malformed-uri'])]
+    public function set_user(string $uri, string $user, string $expected): void
+    {
+        $this->assertSame($expected, set_user($uri, $user));
+    }
+
+    #[Test]
+    #[TestWith(['https://frieren@example.com', 'frieren'])]
+    #[TestWith(['https://example.com', null])]
+    #[TestWith(['https://fern:secret@example.com', 'fern'])]
+    #[TestWith(['malformed-uri', null])]
+    public function get_user(string $uri, ?string $expected): void
+    {
+        $this->assertSame($expected, get_user($uri));
+    }
+
+    #[Test]
+    #[TestWith(['https://user@example.com', 'magic', 'https://user:magic@example.com'])]
+    #[TestWith(['https://user:old@example.com', 'spell', 'https://user:spell@example.com'])]
+    #[TestWith(['https://example.com', 'secret', 'https://:secret@example.com'])]
+    #[TestWith(['malformed-uri', 'pass', '//:pass@malformed-uri'])]
+    public function set_password(string $uri, string $pass, string $expected): void
+    {
+        $this->assertSame($expected, set_password($uri, $pass));
+    }
+
+    #[Test]
+    #[TestWith(['https://user:magic@example.com', 'magic'])]
+    #[TestWith(['https://example.com', null])]
+    #[TestWith(['https://user@example.com', null])]
+    #[TestWith(['malformed-uri', null])]
+    public function get_password(string $uri, ?string $expected): void
+    {
+        $this->assertSame($expected, get_password($uri));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com', '/frieren/journey', 'https://example.com/frieren/journey'])]
+    #[TestWith(['https://example.com/old/path', '/new/path', 'https://example.com/new/path'])]
+    #[TestWith(['https://example.com?query=value', '/path', 'https://example.com/path?query=value'])]
+    #[TestWith(['malformed-uri', '/path', '/path'])]
+    public function set_path(string $uri, string $path, string $expected): void
+    {
+        $this->assertSame($expected, set_path($uri, $path));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com/frieren/journey', '/frieren/journey'])]
+    #[TestWith(['https://example.com', null])]
+    #[TestWith(['https://example.com/', '/'])]
+    #[TestWith(['malformed-uri', 'malformed-uri'])]
+    public function get_path(string $uri, ?string $expected): void
+    {
+        $this->assertSame($expected, get_path($uri));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com/path/to/resource', ['path', 'to', 'resource']])]
+    #[TestWith(['https://example.com/', []])]
+    #[TestWith(['https://example.com', []])]
+    #[TestWith(['https://example.com/single', ['single']])]
+    #[TestWith(['https://example.com/path/with/empty//segments', ['path', 'with', 'empty', 'segments']])]
+    #[TestWith(['malformed-uri/path/segments', ['malformed-uri', 'path', 'segments']])]
+    public function get_segments(string $uri, array $expected): void
+    {
+        $this->assertSame($expected, get_segments($uri));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com?foo=bar', ['baz' => 'qux'], 'https://example.com?foo=bar&baz=qux'])]
+    #[TestWith(['https://example.com', ['foo' => 'bar'], 'https://example.com?foo=bar'])]
+    #[TestWith(['https://example.com?existing=value', ['new' => 'param'], 'https://example.com?existing=value&new=param'])]
+    #[TestWith(['https://example.com?foo=old', ['foo' => 'new'], 'https://example.com?foo=new'])]
+    #[TestWith(['malformed-uri?foo=bar', ['baz' => 'qux'], 'malformed-uri?foo=bar&baz=qux'])]
+    public function merge_query(string $uri, array $query, string $expected): void
+    {
+        $this->assertSame($expected, merge_query($uri, ...$query));
+    }
+
+    #[Test]
+    #[TestWith(['https://example.com?foo=bar&baz=qux', ['foo'], 'https://example.com?baz=qux'])]
+    #[TestWith(['https://example.com?foo=bar&baz=qux', ['foo', 'baz'], 'https://example.com'])]
+    #[TestWith(['https://example.com?foo=bar&baz=qux', ['foo' => 'bar'], 'https://example.com?baz=qux'])]
+    #[TestWith(['https://example.com?foo=bar&baz=qux', ['foo' => 'wrong'], 'https://example.com?foo=bar&baz=qux'])]
+    #[TestWith(['https://example.com', ['nonexistent'], 'https://example.com'])]
+    #[TestWith(['malformed-uri?foo=bar', ['foo'], 'malformed-uri'])]
+    public function without_query(string $uri, array $query, string $expected): void
+    {
+        $this->assertSame($expected, without_query($uri, ...$query));
+    }
+
+    #[Test]
+    public function complex_uri_manipulation(): void
+    {
+        $uri = 'https://user:pass@example.com:8080/old/path?old=value#old-fragment';
+
+        $uri = set_scheme($uri, 'http');
+        $uri = set_host($uri, 'neue.com');
+        $uri = set_port($uri, 9000);
+        $uri = set_user($uri, 'frieren');
+        $uri = set_password($uri, 'magic');
+        $uri = set_path($uri, '/journey/north');
+        $uri = set_query($uri, destination: 'aureole', companion: 'fern');
+        $uri = set_fragment($uri, 'adventure');
+
+        $expected = 'http://frieren:magic@neue.com:9000/journey/north?destination=aureole&companion=fern#adventure';
+        $this->assertSame($expected, $uri);
+
+        $this->assertSame('http', get_scheme($uri));
+        $this->assertSame('neue.com', get_host($uri));
+        $this->assertSame(9000, get_port($uri));
+        $this->assertSame('frieren', get_user($uri));
+        $this->assertSame('magic', get_password($uri));
+        $this->assertSame('/journey/north', get_path($uri));
+        $this->assertSame(['destination' => 'aureole', 'companion' => 'fern'], get_query($uri));
+        $this->assertSame('adventure', get_fragment($uri));
+    }
+
+    #[Test]
+    public function segments_and_query_manipulation(): void
+    {
+        $uri = 'https://example.com/frieren/journey/north?mage=true&party=4';
+
+        $this->assertSame(['frieren', 'journey', 'north'], get_segments($uri));
+
+        $uri = merge_query($uri, destination: 'aureole');
+        $this->assertSame(['mage' => 'true', 'party' => '4', 'destination' => 'aureole'], get_query($uri));
+
+        $uri = without_query($uri, 'party');
+        $this->assertSame(['mage' => 'true', 'destination' => 'aureole'], get_query($uri));
+
+        $uri = without_query($uri, mage: 'true');
+        $this->assertSame(['destination' => 'aureole'], get_query($uri));
+    }
+}

--- a/packages/support/tests/Uri/UriTest.php
+++ b/packages/support/tests/Uri/UriTest.php
@@ -1,0 +1,305 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Tests\Uri;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Uri\Uri;
+
+final class UriTest extends TestCase
+{
+    #[Test]
+    public function is_stringable(): void
+    {
+        $uri = Uri::from('https://example.com');
+
+        $this->assertSame('https://example.com', $uri->toString());
+        $this->assertSame('https://example.com', (string) $uri);
+    }
+
+    #[Test]
+    public function can_be_made_statically(): void
+    {
+        $this->assertSame('https://example.com', Uri::from('https://example.com')->toString());
+    }
+
+    #[Test]
+    public function scheme_manipulation(): void
+    {
+        $uri = Uri::from('https://example.com');
+
+        $this->assertSame('https', $uri->scheme);
+
+        $clone = $uri->withScheme('http');
+        $this->assertSame('http://example.com', $clone->toString());
+        $this->assertSame('http', $clone->scheme);
+
+        $this->assertSame('https://example.com', $uri->toString());
+    }
+
+    #[Test]
+    public function user_manipulation(): void
+    {
+        $uri = Uri::from('https://example.com');
+
+        $this->assertNull($uri->user);
+
+        $clone = $uri->withUser('frieren');
+        $this->assertSame('https://frieren@example.com', $clone->toString());
+        $this->assertSame('frieren', $clone->user);
+
+        $this->assertNull($uri->user);
+    }
+
+    #[Test]
+    public function password_manipulation(): void
+    {
+        $uri = Uri::from('https://frieren@example.com');
+
+        $this->assertNull($uri->password);
+
+        $clone = $uri->withPassword('magic');
+        $this->assertSame('https://frieren:magic@example.com', $clone->toString());
+        $this->assertSame('magic', $clone->password);
+    }
+
+    #[Test]
+    public function host_manipulation(): void
+    {
+        $uri = Uri::from('https://example.com');
+
+        $this->assertSame('example.com', $uri->host);
+
+        $clone = $uri->withHost('aureole.magic');
+        $this->assertSame('https://aureole.magic', $clone->toString());
+        $this->assertSame('aureole.magic', $clone->host);
+
+        $this->assertSame('example.com', $uri->host);
+    }
+
+    #[Test]
+    public function port_manipulation(): void
+    {
+        $uri = Uri::from('https://example.com');
+
+        $this->assertNull($uri->port);
+
+        $clone = $uri->withPort(8080);
+        $this->assertSame('https://example.com:8080', $clone->toString());
+        $this->assertSame(8080, $clone->port);
+
+        $this->assertNull($uri->port);
+    }
+
+    #[Test]
+    public function path_manipulation(): void
+    {
+        $uri = Uri::from('https://example.com');
+
+        $this->assertNull($uri->path);
+
+        $clone = $uri->withPath('foo/bar');
+        $this->assertSame('https://example.com/foo/bar', $clone->toString());
+        $this->assertSame('/foo/bar', $clone->path);
+
+        $this->assertNull($uri->path);
+    }
+
+    #[Test]
+    #[TestWith(['/foo/bar', '/foo/bar'])]
+    #[TestWith(['foo/bar', '/foo/bar'])]
+    #[TestWith(['foo-bar', '/foo-bar'])]
+    public function path_prefix(string $path, string $expected): void
+    {
+        $this->assertSame($expected, Uri::from('https://example.com')->withPath($path)->path);
+    }
+
+    #[Test]
+    public function query_manipulation(): void
+    {
+        $uri = Uri::from('https://example.com');
+
+        $this->assertSame([], $uri->query);
+
+        $clone = $uri->withQuery(destination: 'aureole', companion: 'fern');
+        $this->assertSame('https://example.com?destination=aureole&companion=fern', $clone->toString());
+        $this->assertSame(['destination' => 'aureole', 'companion' => 'fern'], $clone->query);
+
+        $this->assertSame([], $uri->query);
+    }
+
+    #[Test]
+    public function query_with_special_values(): void
+    {
+        $uri = Uri::from('https://example.com');
+
+        $clone = $uri->withQuery('standalone');
+        $this->assertSame('https://example.com?standalone', $clone->toString());
+
+        $clone = $uri->withQuery(active: true, disabled: false);
+        $this->assertSame('https://example.com?active=true&disabled=false', $clone->toString());
+    }
+
+    #[Test]
+    public function fragment_manipulation(): void
+    {
+        $uri = Uri::from('https://example.com');
+
+        $this->assertNull($uri->fragment);
+
+        $clone = $uri->withFragment('adventure');
+        $this->assertSame('https://example.com#adventure', $clone->toString());
+        $this->assertSame('adventure', $clone->fragment);
+
+        $this->assertNull($uri->fragment);
+    }
+
+    #[Test]
+    public function segments_property(): void
+    {
+        $this->assertSame([], Uri::from('https://example.com')->segments);
+        $this->assertSame([], Uri::from('https://example.com/')->segments);
+        $this->assertSame(['journey'], Uri::from('https://example.com/journey')->segments);
+        $this->assertSame(['journey', 'to', 'aureole'], Uri::from('https://example.com/journey/to/aureole')->segments);
+        $this->assertSame(['journey', 'north'], Uri::from('https://example.com/journey/north/')->segments);
+        $this->assertSame(['journey', 'north'], Uri::from('https://example.com//journey//north//')->segments);
+    }
+
+    #[Test]
+    public function add_query(): void
+    {
+        $uri = Uri::from('https://example.com?existing=value');
+
+        $clone = $uri->addQuery(destination: 'aureole', companion: 'fern');
+        $this->assertSame('https://example.com?existing=value&destination=aureole&companion=fern', $clone->toString());
+        $this->assertSame(['existing' => 'value', 'destination' => 'aureole', 'companion' => 'fern'], $clone->query);
+
+        $this->assertSame(['existing' => 'value'], $uri->query);
+    }
+
+    #[Test]
+    public function remove_query(): void
+    {
+        $uri = Uri::from('https://example.com?foo=bar&baz=qux');
+
+        $this->assertSame(['foo' => 'bar', 'baz' => 'qux'], $uri->query);
+
+        $clone = $uri->removeQuery();
+        $this->assertSame('https://example.com', $clone->toString());
+        $this->assertSame([], $clone->query);
+
+        $this->assertSame(['foo' => 'bar', 'baz' => 'qux'], $uri->query);
+    }
+
+    #[Test]
+    public function remove_query_when_there_was_no_query(): void
+    {
+        $uri = Uri::from('https://example.com');
+        $withoutQuery = $uri->removeQuery();
+
+        $this->assertSame('https://example.com', $withoutQuery->toString());
+        $this->assertSame([], $withoutQuery->query);
+    }
+
+    #[Test]
+    public function without_query_removes_specific_parameters(): void
+    {
+        $uri = Uri::from('https://example.com?foo=bar&baz=qux&active=true');
+
+        $clone = $uri->withoutQuery('foo');
+        $this->assertSame('https://example.com?baz=qux&active=true', $clone->toString());
+        $this->assertSame(['baz' => 'qux', 'active' => 'true'], $clone->query);
+
+        $clone = $uri->withoutQuery('foo', 'baz');
+        $this->assertSame('https://example.com?active=true', $clone->toString());
+        $this->assertSame(['active' => 'true'], $clone->query);
+
+        $clone = $uri->withoutQuery(foo: 'bar');
+        $this->assertSame('https://example.com?baz=qux&active=true', $clone->toString());
+        $this->assertSame(['baz' => 'qux', 'active' => 'true'], $clone->query);
+
+        $clone = $uri->withoutQuery(foo: 'different');
+        $this->assertSame('https://example.com?foo=bar&baz=qux&active=true', $clone->toString());
+        $this->assertSame(['foo' => 'bar', 'baz' => 'qux', 'active' => 'true'], $clone->query);
+
+        $clone = $uri->withoutQuery('nonexistent');
+        $this->assertSame('https://example.com?foo=bar&baz=qux&active=true', $clone->toString());
+
+        $this->assertSame(['foo' => 'bar', 'baz' => 'qux', 'active' => 'true'], $uri->query);
+    }
+
+    #[Test]
+    public function without_query_on_empty_uri(): void
+    {
+        $uri = Uri::from('https://example.com');
+
+        $clone = $uri->withoutQuery('foo', 'bar');
+        $this->assertSame('https://example.com', $clone->toString());
+        $this->assertSame([], $clone->query);
+    }
+
+    #[Test]
+    public function method_chaining(): void
+    {
+        $uri = Uri::from('https://old.example.com')
+            ->withScheme('http')
+            ->withHost('neue.com')
+            ->withPort(8080)
+            ->withUser('frieren')
+            ->withPassword('magic')
+            ->withPath('/journey')
+            ->withQuery(destination: 'aureole', party: 'stark,fern')
+            ->withFragment('adventure');
+
+        $expected = 'http://frieren:magic@neue.com:8080/journey?destination=aureole&party=stark%2Cfern#adventure';
+        $this->assertSame($expected, $uri->toString());
+    }
+
+    #[Test]
+    public function immutability(): void
+    {
+        $original = Uri::from('https://example.com/path?foo=bar#fragment');
+        $modified = $original
+            ->withScheme('http')
+            ->withHost('andere.com')
+            ->withPort(9000)
+            ->withPath('/new')
+            ->withQuery(baz: 'qux')
+            ->withFragment('new-fragment');
+
+        $this->assertSame('https://example.com/path?foo=bar#fragment', $original->toString());
+        $this->assertSame('http://andere.com:9000/new?baz=qux#new-fragment', $modified->toString());
+
+        $this->assertSame('https', $original->scheme);
+        $this->assertSame('example.com', $original->host);
+        $this->assertNull($original->port);
+        $this->assertSame('/path', $original->path);
+        $this->assertSame(['foo' => 'bar'], $original->query);
+        $this->assertSame('fragment', $original->fragment);
+    }
+
+    #[Test]
+    public function edge_cases(): void
+    {
+        $uri = Uri::from('');
+        $this->assertSame('', $uri->toString());
+
+        $uri = Uri::from('malformed-uri');
+        $this->assertSame('malformed-uri', $uri->toString());
+
+        $complexUri = 'https://user:pass@example.com:8080/path?query=value#fragment';
+        $uri = Uri::from($complexUri);
+        $this->assertSame($complexUri, $uri->toString());
+        $this->assertSame('https', $uri->scheme);
+        $this->assertSame('user', $uri->user);
+        $this->assertSame('pass', $uri->password);
+        $this->assertSame('example.com', $uri->host);
+        $this->assertSame(8080, $uri->port);
+        $this->assertSame('/path', $uri->path);
+        $this->assertSame(['query' => 'value'], $uri->query);
+        $this->assertSame('fragment', $uri->fragment);
+    }
+}


### PR DESCRIPTION
This pull request adds URI utilities, in the form of a set of functions and a `Uri` immutable class with utility methods.

```php
Uri::from('http://tempestphp.com')
    ->withScheme('https')
    ->withPath('docs')
	->addQuery(version: '2.x');

// https://tempestphp.com/docs?version=2.x
```
```php
$uri = Uri\set_query($request->uri, page: 1);

// /foo/bar?filter=abc&page=1
```