### PR TITLE
feat(database): add testing utilities

### DIFF
--- a/packages/database/src/Testing/DatabaseTester.php
+++ b/packages/database/src/Testing/DatabaseTester.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tempest\Database\Testing;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\ExpectationFailedException;
+use Tempest\Container\Container;
+use Tempest\Database\Migrations\MigrationManager;
+use TypeError;
+use ValueError;
+
+use function Tempest\Database\query;
+
+final class DatabaseTester
+{
+    public function __construct(
+        private Container $container,
+    ) {}
+
+    /**
+     * Resets the database by dropping all tables and re-running all migrations.
+     *
+     * @alias `reset()`
+     */
+    public function setup(bool $migrate = true): self
+    {
+        return $this->reset($migrate);
+    }
+
+    /**
+     * Resets the database by dropping all tables and re-running all migrations.
+     */
+    public function reset(bool $migrate = true): self
+    {
+        $migrationManager = $this->container->get(MigrationManager::class);
+        $migrationManager->dropAll();
+
+        if ($migrate) {
+            $this->migrate();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Migrates the specified migration classes. If no migration is specified, all application migrations will be run.
+     */
+    public function migrate(string|object ...$migrationClasses): void
+    {
+        $migrationManager = $this->container->get(MigrationManager::class);
+
+        if (count($migrationClasses) === 0) {
+            $migrationManager->up();
+            return;
+        }
+
+        foreach ($migrationClasses as $migrationClass) {
+            $migration = is_string($migrationClass) ? $this->container->get($migrationClass) : $migrationClass;
+
+            $migrationManager->executeUp($migration);
+        }
+    }
+
+    /**
+     * Asserts that a row exists in the given table matching the provided data.
+     */
+    public function assertTableHasRow(string $table, mixed ...$data): void
+    {
+        $select = query($table)->count();
+
+        foreach ($data as $key => $value) {
+            $select->whereField($key, $value);
+        }
+
+        Assert::assertTrue($select->execute() > 0, "Failed asserting that a row in the table [{$table}] matches the given data.");
+    }
+
+    /**
+     * Asserts that the given table contains the specified number of rows.
+     */
+    public function assertTableHasCount(string $table, int $count): void
+    {
+        Assert::assertSame(
+            expected: $count,
+            actual: query($table)->count()->execute(),
+            message: "Failed asserting that the table [{$table}] contains [{$count}] rows.",
+        );
+    }
+
+    /**
+     * Asserts that there is no row in the given table matching the provided data.
+     */
+    public function assertTableDoesNotHaveRow(string $table, mixed ...$data): void
+    {
+        $select = query($table)->count();
+
+        foreach ($data as $key => $value) {
+            $select->whereField($key, $value);
+        }
+
+        Assert::assertTrue($select->execute() === 0, "Failed asserting that no row in the table [{$table}] matches the given data.");
+    }
+
+    /**
+     * Asserts that the given table is empty.
+     */
+    public function assertTableEmpty(string $table): void
+    {
+        $this->assertTableHasCount($table, count: 0);
+    }
+
+    /**
+     * Asserts that the given table is not empty.
+     */
+    public function assertTableNotEmpty(string $table): void
+    {
+        $this->assertTableHasRow($table);
+    }
+}

--- a/tests/Integration/Database/Testing/DatabaseTesterTest.php
+++ b/tests/Integration/Database/Testing/DatabaseTesterTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Tempest\Integration\Database\Testing;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\PreCondition;
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Database\MigratesUp;
+use Tempest\Database\Migrations\CreateMigrationsTable;
+use Tempest\Database\PrimaryKey;
+use Tempest\Database\QueryStatement;
+use Tempest\Database\QueryStatements\CreateTableStatement;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\Database\query;
+
+/**
+ * @mago-expect lint:no-empty-catch-clause
+ */
+final class DatabaseTesterTest extends FrameworkIntegrationTestCase
+{
+    #[PreCondition]
+    protected function configure(): void
+    {
+        $this->database->reset(migrate: false);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUsersTable::class);
+    }
+
+    #[Test]
+    public function assert_has_row(): void
+    {
+        query(User::class)
+            ->insert(name: 'Frieren', email: 'frieren@mages.org')
+            ->execute();
+
+        $this->database->assertTableHasRow(User::class, name: 'Frieren');
+        $this->database->assertTableHasRow(User::class, email: 'frieren@mages.org');
+
+        try {
+            $this->database->assertTableHasRow(User::class, name: 'Eisen');
+            Assert::fail('Expected an assertion failure.');
+        } catch (AssertionFailedError) {
+        }
+    }
+
+    #[Test]
+    public function assert_count(): void
+    {
+        $this->database->assertTableHasCount(User::class, count: 0);
+
+        query(User::class)
+            ->insert(name: 'Frieren', email: 'frieren@mages.org')
+            ->execute();
+
+        query(User::class)
+            ->insert(name: 'Eisen', email: 'eisen@mages.org')
+            ->execute();
+
+        $this->database->assertTableHasCount(User::class, count: 2);
+
+        try {
+            $this->database->assertTableHasCount(User::class, count: 3);
+            Assert::fail('Expected an assertion failure.');
+        } catch (AssertionFailedError) {
+        }
+    }
+
+    #[Test]
+    public function assert_no_row(): void
+    {
+        query(User::class)
+            ->insert(name: 'Frieren', email: 'frieren@mages.org')
+            ->execute();
+
+        $this->database->assertTableDoesNotHaveRow(User::class, name: 'Eisen');
+
+        query(User::class)
+            ->insert(name: 'Eisen', email: 'eisen@mages.org')
+            ->execute();
+
+        try {
+            $this->database->assertTableDoesNotHaveRow(User::class, name: 'Eisen');
+            Assert::fail('Expected an assertion failure.');
+        } catch (AssertionFailedError) {
+        }
+    }
+
+    #[Test]
+    public function assert_table_empty(): void
+    {
+        $this->database->assertTableEmpty(User::class);
+
+        query(User::class)
+            ->insert(name: 'Frieren', email: 'frieren@mages.org')
+            ->execute();
+
+        try {
+            $this->database->assertTableEmpty(User::class);
+            Assert::fail('Expected an assertion failure.');
+        } catch (AssertionFailedError) {
+        }
+    }
+
+    #[Test]
+    public function assert_table_not_empty(): void
+    {
+        try {
+            $this->database->assertTableNotEmpty(User::class);
+            Assert::fail('Expected an assertion failure.');
+        } catch (AssertionFailedError) {
+        }
+
+        query(User::class)
+            ->insert(name: 'Frieren', email: 'frieren@mages.org')
+            ->execute();
+
+        $this->database->assertTableNotEmpty(User::class);
+    }
+}
+
+final class User
+{
+    public PrimaryKey $id;
+
+    public string $name;
+
+    public string $email;
+}
+
+final class CreateUsersTable implements MigratesUp
+{
+    public string $name = '0-create_users_table';
+
+    public function up(): QueryStatement
+    {
+        return new CreateTableStatement('users')
+            ->primary()
+            ->string('name')
+            ->string('email');
+    }
+}

--- a/tests/Integration/FrameworkIntegrationTestCase.php
+++ b/tests/Integration/FrameworkIntegrationTestCase.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Tempest\Integration;
 
 use InvalidArgumentException;
-use PHPUnit\Framework\Assert;
 use Stringable;
 use Tempest\Database\DatabaseInitializer;
 use Tempest\Database\Migrations\MigrationManager;


### PR DESCRIPTION
This pull request adds database testing utilities, such as `assertTableHasRow`, `assertTableHasCount`, `assertTableDoesNotHaveRow`, `assertTableEmpty`, and `assertTableNotEmpty`.

Previously, there was our base test case had a `setupDatabase`, `migrateDatabase` and `migrate` methods. They still exists, but are now deprecated in favor of the ones in the new `DatabaseTester` class.

The behavior is different as well:
- The `setupDatabase` method is now `reset` (with a `setup` alias), and migrates *all registered migrations*. You can set the `migrate` argument to `false` to not migrate anything.
- The `migrate` method migrates all registered migrations if no specific migration is provided.
- I removed `migrateDatabase`.

Additionally, discovery is now configured to scan `tests` instead of `tests/Fixtures`.

### Usage

**New assertions**
```php
$this->database->assertTableHasRow(User::class, name: 'Frieren');
$this->database->assertTableDoesNotHaveRow('users', name: 'Eisen');
$this->database->assertTableHasCount(User::class, count: 1);
$this->database->assertTableEmpty(User::class);
$this->database->assertTableNotEmpty(User::class);
```

**Migrate only specific migrations**

For specific use cases.
```php
$this->database->reset(migrate: false);
$this->database->migrate(CreateMigrationsTable::class, CreateUsersTable::class);

// ...
```

**Migrate everything**

What userland will do most of the time.
```php
$this->database->reset();

// ...
```