### PR TITLE
refactor: use `Str\parse` to convert enums to string

### DIFF
--- a/packages/auth/src/AccessControl/PolicyBasedAccessControl.php
+++ b/packages/auth/src/AccessControl/PolicyBasedAccessControl.php
@@ -2,7 +2,6 @@
 
 namespace Tempest\Auth\AccessControl;
 
-use BackedEnum;
 use Closure;
 use Tempest\Auth\AuthConfig;
 use Tempest\Auth\Authentication\Authenticator;
@@ -13,6 +12,7 @@ use Tempest\Container\Container;
 use Tempest\Reflection\MethodReflector;
 use Tempest\Reflection\ParameterReflector;
 use Tempest\Support\Arr\ImmutableArray;
+use Tempest\Support\Str;
 use UnitEnum;
 
 /**
@@ -82,11 +82,7 @@ final readonly class PolicyBasedAccessControl implements AccessControl
             ? $resource::class
             : $resource;
 
-        $actionBeingEvaluated = match (true) {
-            $action instanceof BackedEnum => $action->value,
-            $action instanceof UnitEnum => $action->name,
-            default => $action,
-        };
+        $actionBeingEvaluated = Str\parse($action);
 
         return new ImmutableArray($this->authConfig->policies[$resource] ?? [])
             ->filter(fn ($_, string $action) => $action === $actionBeingEvaluated)

--- a/packages/auth/src/AuthConfig.php
+++ b/packages/auth/src/AuthConfig.php
@@ -7,7 +7,6 @@ namespace Tempest\Auth;
 use BackedEnum;
 use Tempest\Auth\AccessControl\Policy;
 use Tempest\Auth\Authentication\Authenticatable;
-use Tempest\Auth\Exceptions\PolicyMethodWasInvalid;
 use Tempest\Auth\Exceptions\PolicyWasInvalid;
 use Tempest\Reflection\MethodReflector;
 use Tempest\Support\Arr;
@@ -44,11 +43,7 @@ final class AuthConfig
         }
 
         foreach (Arr\wrap($policy->action) as $action) {
-            $action = match (true) {
-                $action instanceof BackedEnum => $action->value,
-                $action instanceof UnitEnum => $action->name,
-                default => $action,
-            };
+            $action = Str\parse($action);
 
             $this->policies[$policy->resource][$action] ??= [];
             $this->policies[$policy->resource][$action][] = $handler;

--- a/packages/auth/src/Exceptions/OAuthWasNotConfigured.php
+++ b/packages/auth/src/Exceptions/OAuthWasNotConfigured.php
@@ -5,17 +5,14 @@ declare(strict_types=1);
 namespace Tempest\Auth\Exceptions;
 
 use Exception;
+use Tempest\Support\Str;
 use UnitEnum;
 
 final class OAuthWasNotConfigured extends Exception implements AuthenticationException
 {
     public static function configurationWasMissing(null|string|UnitEnum $tag): self
     {
-        $tag = match (true) {
-            is_string($tag) => $tag,
-            $tag instanceof UnitEnum => $tag->name,
-            default => null,
-        };
+        $tag = Str\parse($tag, default: null);
 
         return new self(
             $tag

--- a/packages/cache/src/Testing/CacheTester.php
+++ b/packages/cache/src/Testing/CacheTester.php
@@ -7,9 +7,8 @@ use Tempest\Cache\CacheInitializer;
 use Tempest\Clock\Clock;
 use Tempest\Container\Container;
 use Tempest\Container\GenericContainer;
+use Tempest\Support\Str;
 use UnitEnum;
-
-use function Tempest\Support\Str\to_kebab_case;
 
 final readonly class CacheTester
 {
@@ -23,11 +22,7 @@ final readonly class CacheTester
     public function fake(null|string|UnitEnum $tag = null): TestingCache
     {
         $cache = new TestingCache(
-            tag: match (true) {
-                is_string($tag) => to_kebab_case($tag),
-                $tag instanceof UnitEnum => to_kebab_case($tag->name),
-                default => 'default',
-            },
+            tag: Str\to_kebab_case(Str\parse($tag, default: 'default')),
             clock: $this->container->get(Clock::class)->toPsrClock(),
         );
 

--- a/packages/database/src/Builder/QueryBuilders/HasConvenientWhereMethods.php
+++ b/packages/database/src/Builder/QueryBuilders/HasConvenientWhereMethods.php
@@ -47,15 +47,12 @@ trait HasConvenientWhereMethods
                     throw new \InvalidArgumentException("{$operator->value} operator requires an array of values");
                 }
 
-                $value = array_map(
-                    fn (mixed $value) => match (true) {
-                        $value instanceof BackedEnum => $value->value,
-                        $value instanceof UnitEnum => $value->name,
-                        $value instanceof ArrayAccess => (array) $value,
-                        default => $value,
-                    },
-                    $value,
-                );
+                $value = array_map(fn (mixed $value) => match (true) {
+                    $value instanceof BackedEnum => $value->value,
+                    $value instanceof UnitEnum => $value->name,
+                    $value instanceof ArrayAccess => (array) $value,
+                    default => $value,
+                }, $value);
 
                 $placeholders = str_repeat('?,', times: count($value) - 1) . '?';
                 $sql .= " {$operator->value} ({$placeholders})";

--- a/packages/event-bus/src/EventBusDiscovery.php
+++ b/packages/event-bus/src/EventBusDiscovery.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Tempest\EventBus;
 
-use BackedEnum;
 use Tempest\Discovery\Discovery;
 use Tempest\Discovery\DiscoveryLocation;
 use Tempest\Discovery\IsDiscovery;
 use Tempest\Reflection\ClassReflector;
 use Tempest\Reflection\TypeReflector;
-use UnitEnum;
+use Tempest\Support\Str;
 
 final class EventBusDiscovery implements Discovery
 {
@@ -29,12 +28,7 @@ final class EventBusDiscovery implements Discovery
                 continue;
             }
 
-            $eventName = match (true) {
-                $eventHandler->event instanceof BackedEnum => $eventHandler->event->value,
-                $eventHandler->event instanceof UnitEnum => $eventHandler->event->name,
-                is_string($eventHandler->event) => $eventHandler->event,
-                default => null,
-            };
+            $eventName = Str\parse($eventHandler->event, default: null);
 
             if ($eventName === null) {
                 $parameters = iterator_to_array($method->getParameters());

--- a/packages/event-bus/src/GenericEventBus.php
+++ b/packages/event-bus/src/GenericEventBus.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Tempest\EventBus;
 
-use BackedEnum;
 use Closure;
 use Tempest\Container\Container;
-use UnitEnum;
+use Tempest\Support\Str;
 
 final readonly class GenericEventBus implements EventBus
 {
@@ -33,13 +32,7 @@ final readonly class GenericEventBus implements EventBus
     /** @return \Tempest\EventBus\CallableEventHandler[] */
     private function resolveHandlers(string|object $event): array
     {
-        $eventName = match (true) {
-            $event instanceof BackedEnum => $event->value,
-            $event instanceof UnitEnum => $event->name,
-            is_string($event) => $event,
-            default => $event::class,
-        };
-
+        $eventName = Str\parse($event) ?: $event::class;
         $handlers = $this->eventBusConfig->handlers[$eventName] ?? [];
 
         if (is_object($event)) {

--- a/packages/event-bus/src/Testing/EventBusTester.php
+++ b/packages/event-bus/src/Testing/EventBusTester.php
@@ -2,15 +2,12 @@
 
 namespace Tempest\EventBus\Testing;
 
-use BackedEnum;
 use Closure;
 use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\GeneratorNotSupportedException;
 use Tempest\Container\Container;
 use Tempest\EventBus\EventBus;
 use Tempest\EventBus\EventBusConfig;
-use UnitEnum;
+use Tempest\Support\Str;
 
 final class EventBusTester
 {
@@ -110,12 +107,7 @@ final class EventBusTester
     /** @return array<\Tempest\EventBus\CallableEventHandler> */
     private function findHandlersFor(string|object $event): array
     {
-        $eventName = match (true) {
-            $event instanceof BackedEnum => $event->value,
-            $event instanceof UnitEnum => $event->name,
-            is_string($event) => $event,
-            default => $event::class,
-        };
+        $eventName = Str\parse($event) ?: $event::class;
 
         return $this->fakeEventBus->eventBusConfig->handlers[$eventName] ?? [];
     }

--- a/packages/storage/src/Testing/StorageTester.php
+++ b/packages/storage/src/Testing/StorageTester.php
@@ -6,10 +6,8 @@ use Tempest\Container\Container;
 use Tempest\Container\GenericContainer;
 use Tempest\Storage\Storage;
 use Tempest\Storage\StorageInitializer;
-use Tempest\Support\Arr;
+use Tempest\Support\Str;
 use UnitEnum;
-
-use function Tempest\Support\Str\to_kebab_case;
 
 final readonly class StorageTester
 {
@@ -22,11 +20,9 @@ final readonly class StorageTester
      */
     public function fake(null|string|UnitEnum $tag = null, bool $persist = false): TestingStorage
     {
-        $storage = new TestingStorage(match (true) {
-            is_string($tag) => to_kebab_case($tag),
-            $tag instanceof UnitEnum => to_kebab_case($tag->name),
-            default => 'default',
-        });
+        $storage = new TestingStorage(
+            path: Str\to_kebab_case(Str\parse($tag, default: 'default')),
+        );
 
         $this->container->singleton(Storage::class, $storage, $tag);
 

--- a/packages/support/src/Str/functions.php
+++ b/packages/support/src/Str/functions.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 namespace Tempest\Support\Str {
+    use BackedEnum;
     use Stringable;
     use Tempest\Support\Arr;
+    use UnitEnum;
     use voku\helper\ASCII;
 
     use function levenshtein as php_levenshtein;
@@ -887,7 +889,7 @@ namespace Tempest\Support\Str {
     /**
      * Parses the given value to a string, returning the default value if it is not a string or `Stringable`.
      */
-    function parse(mixed $string, string $default = ''): string
+    function parse(mixed $string, ?string $default = ''): ?string
     {
         if (is_string($string)) {
             return $string;
@@ -899,6 +901,14 @@ namespace Tempest\Support\Str {
 
         if ($string instanceof Stringable) {
             return (string) $string;
+        }
+
+        if ($string instanceof BackedEnum) {
+            return (string) $string->value;
+        }
+
+        if ($string instanceof UnitEnum) {
+            return $string->name;
         }
 
         if (is_object($string) && method_exists($string, '__toString')) {

--- a/packages/support/tests/Str/FunctionsTest.php
+++ b/packages/support/tests/Str/FunctionsTest.php
@@ -16,6 +16,7 @@ final class FunctionsTest extends TestCase
         $this->assertSame('1', Str\parse('1'));
         $this->assertSame('1', Str\parse(1));
         $this->assertSame('', Str\parse(new stdClass()));
+        $this->assertSame(null, Str\parse(new stdClass(), default: null));
         $this->assertSame('', Str\parse(new stdClass(), default: ''));
         $this->assertSame('foo', Str\parse(new stdClass(), default: 'foo'));
         $this->assertSame('foo', Str\parse(new MutableString('foo')));

--- a/tests/Integration/TestingDatabaseInitializer.php
+++ b/tests/Integration/TestingDatabaseInitializer.php
@@ -15,6 +15,7 @@ use Tempest\Database\GenericDatabase;
 use Tempest\Database\Transactions\GenericTransactionManager;
 use Tempest\Mapper\SerializerFactory;
 use Tempest\Reflection\ClassReflector;
+use Tempest\Support\Str;
 use UnitEnum;
 
 final class TestingDatabaseInitializer implements DynamicInitializer
@@ -30,11 +31,7 @@ final class TestingDatabaseInitializer implements DynamicInitializer
     #[Singleton]
     public function initialize(ClassReflector $class, null|string|UnitEnum $tag, Container $container): Database
     {
-        $tag = match (true) {
-            $tag instanceof UnitEnum => $tag->name,
-            is_string($tag) => $tag,
-            default => '',
-        };
+        $tag = Str\parse($tag);
 
         /** @var PDOConnection|null $connection */
         $connection = self::$connections[$tag] ?? null;


### PR DESCRIPTION
This pull request refactors a bunch of:
```php
$result = match (true) {
    $value instanceof BackedEnum => $value->value,
    $value instanceof UnitEnum => $value->name,
    default => $value,
};
```

to:

```php
$result = Str\parse($value);
```