### PR TITLE
feat(http): support database-based sessions

### DIFF
--- a/docs/1-essentials/01-routing.md
+++ b/docs/1-essentials/01-routing.md
@@ -732,22 +732,48 @@ public function store(Todo $todo): Redirect
 
 ### Session configuration
 
-Currently, there's only a built-in file session driver. More drivers are to be added in the future. By default, the session will stay valid for 10 hours, which you can overwrite by creating a `session.config.php` file:
+Tempest supports file and database-based sessions, the former being the default option. Sessions can be configured by creating a `session.config.php` file, in which the expiration time and the session driver can be specified.
+
+#### File sessions
+
+When using file-based sessions, which is the default, session data will be stored in files within the specified directory, relative to `.tempest`. You may configure the path and expiration duration like so:
 
 ```php app/Config/session.config.php
-<?php
 use Tempest\Http\Session\Config\FileSessionConfig;
 use Tempest\DateTime\Duration;
 
 return new FileSessionConfig(
-    path: 'sessions', // The path is relative to the project's cache folder
+   expiration: Duration::days(30),
+   path: 'sessions',
+);
+```
+
+#### Database sessions
+
+Tempest provides a database-based session driver, particularly useful for applications that run on multiple servers, as the session data can be shared across all instances.
+
+Before using database sessions, a dedicated table is needed. Tempest provides a migration, which may be installed in your project using its installer:
+
+```sh
+./tempest install sessions:database
+```
+
+This installer will also suggest creating the configuration file that sets up database sessions, with a default expiration of 30 days:
+
+```php app/Sessions/session.config.php
+use Tempest\Http\Session\Config\DatabaseSessionConfig;
+use Tempest\DateTime\Duration;
+
+return new DatabaseSessionConfig(
     expiration: Duration::days(30),
 );
 ```
 
 ### Session cleaning
 
-Outdated sessions should occasionally be cleaned up. Tempest comes with a built-in command to do so: `tempest session:clean`. This command makes use of the [scheduler](/2.x/features/scheduling). If you have scheduling enabled, it will automatically run behind the scenes.
+Sessions expire based on the last activity time. This means that as long as a user is actively using your application, their session will remain valid.
+
+Outdated sessions must occasionally be cleaned up. Tempest comes with a built-in command to do so, `session:clean`. This command makes use of the [scheduler](/2.x/features/scheduling). If you have scheduling enabled, it will automatically run behind the scenes.
 
 ## Deferring tasks
 

--- a/packages/database/src/Builder/QueryBuilders/HasConvenientWhereMethods.php
+++ b/packages/database/src/Builder/QueryBuilders/HasConvenientWhereMethods.php
@@ -393,7 +393,7 @@ trait HasConvenientWhereMethods
     }
 
     /**
-     * Adds a `WHERE` condition for records created after a specific date.
+     * Adds a `WHERE` condition for records which specified field is after a specific date.
      *
      * @return self<TModel>
      */
@@ -403,7 +403,7 @@ trait HasConvenientWhereMethods
     }
 
     /**
-     * Adds a `WHERE` condition for records created before a specific date.
+     * Adds a `WHERE` condition for records which specified field is before a specific date.
      *
      * @return self<TModel>
      */

--- a/packages/http/src/Session/CleanupSessionsCommand.php
+++ b/packages/http/src/Session/CleanupSessionsCommand.php
@@ -10,8 +10,6 @@ use Tempest\Console\Schedule;
 use Tempest\Console\Scheduler\Every;
 use Tempest\EventBus\EventBus;
 
-use function Tempest\listen;
-
 final readonly class CleanupSessionsCommand
 {
     public function __construct(
@@ -20,10 +18,7 @@ final readonly class CleanupSessionsCommand
         private EventBus $eventBus,
     ) {}
 
-    #[ConsoleCommand(
-        name: 'session:clean',
-        description: 'Finds and removes all expired sessions',
-    )]
+    #[ConsoleCommand(name: 'session:clean', description: 'Finds and removes all expired sessions', aliases: ['session:cleanup'])]
     #[Schedule(Every::MINUTE)]
     public function __invoke(): void
     {

--- a/packages/http/src/Session/Config/DatabaseSessionConfig.php
+++ b/packages/http/src/Session/Config/DatabaseSessionConfig.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Session\Config;
+
+use Tempest\Container\Container;
+use Tempest\DateTime\Duration;
+use Tempest\Http\Session\Managers\DatabaseSessionManager;
+use Tempest\Http\Session\SessionConfig;
+
+final class DatabaseSessionConfig implements SessionConfig
+{
+    /**
+     * @param Duration $expiration Time required for a session to expire.
+     */
+    public function __construct(
+        private(set) Duration $expiration,
+    ) {}
+
+    public function createManager(Container $container): DatabaseSessionManager
+    {
+        return $container->get(DatabaseSessionManager::class);
+    }
+}

--- a/packages/http/src/Session/Config/FileSessionConfig.php
+++ b/packages/http/src/Session/Config/FileSessionConfig.php
@@ -5,18 +5,17 @@ namespace Tempest\Http\Session\Config;
 use Tempest\Container\Container;
 use Tempest\DateTime\Duration;
 use Tempest\Http\Session\Managers\FileSessionManager;
-use Tempest\Http\Session\Resolvers\CookieSessionIdResolver;
 use Tempest\Http\Session\SessionConfig;
 
 final class FileSessionConfig implements SessionConfig
 {
+    /**
+     * @param string $path Path to the sessions storage directory, relative to the internal storage.
+     * @param Duration $expiration Time required for a session to expire.
+     */
     public function __construct(
-        /**
-         * Path to the sessions storage directory, relative to the internal storage.
-         */
-        public string $path,
-
         public Duration $expiration,
+        public string $path = 'sessions',
     ) {}
 
     public function createManager(Container $container): FileSessionManager

--- a/packages/http/src/Session/Config/session.config.php
+++ b/packages/http/src/Session/Config/session.config.php
@@ -5,5 +5,5 @@ use Tempest\Http\Session\Config\FileSessionConfig;
 
 return new FileSessionConfig(
     path: 'sessions',
-    expiration: Duration::hours(10),
+    expiration: Duration::days(30),
 );

--- a/packages/http/src/Session/Installer/CreateSessionsTable.php
+++ b/packages/http/src/Session/Installer/CreateSessionsTable.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Session\Installer;
+
+use Tempest\Database\MigratesUp;
+use Tempest\Database\QueryStatement;
+use Tempest\Database\QueryStatements\CreateTableStatement;
+use Tempest\Discovery\SkipDiscovery;
+
+#[SkipDiscovery]
+final class CreateSessionsTable implements MigratesUp
+{
+    private(set) string $name = '0000-00-00_create_sessions_table';
+
+    public function up(): QueryStatement
+    {
+        return new CreateTableStatement('sessions')
+            ->primary('id')
+            ->string('session_id')
+            ->text('data')
+            ->datetime('created_at')
+            ->datetime('last_active_at')
+            ->index('session_id');
+    }
+}

--- a/packages/http/src/Session/Installer/DatabaseSessionInstaller.php
+++ b/packages/http/src/Session/Installer/DatabaseSessionInstaller.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Session\Installer;
+
+use Tempest\Console\Console;
+use Tempest\Console\Input\ConsoleArgumentBag;
+use Tempest\Container\Container;
+use Tempest\Core\Installer;
+use Tempest\Core\PublishesFiles;
+use Tempest\Database\Migrations\MigrationManager;
+
+use function Tempest\root_path;
+use function Tempest\src_path;
+use function Tempest\Support\Namespace\to_fqcn;
+
+final class DatabaseSessionInstaller implements Installer
+{
+    use PublishesFiles;
+
+    private(set) string $name = 'sessions:database';
+
+    public function __construct(
+        private readonly MigrationManager $migrationManager,
+        private readonly Container $container,
+        private readonly Console $console,
+        private readonly ConsoleArgumentBag $consoleArgumentBag,
+    ) {}
+
+    public function install(): void
+    {
+        $migration = $this->publish(
+            source: __DIR__ . '/CreateSessionsTable.stub.php',
+            destination: src_path('Sessions/CreateSessionsTable.php'),
+        );
+
+        $this->publish(
+            source: __DIR__ . '/session.config.stub.php',
+            destination: src_path('Sessions/session.config.php'),
+        );
+
+        $this->publishImports();
+
+        if ($migration && $this->shouldMigrate()) {
+            $this->migrationManager->executeUp(
+                migration: $this->container->get(to_fqcn($migration, root: root_path())),
+            );
+        }
+    }
+
+    private function shouldMigrate(): bool
+    {
+        $argument = $this->consoleArgumentBag->get('migrate');
+
+        if ($argument === null || ! is_bool($argument->value)) {
+            return $this->console->confirm('Do you want to execute migrations?', default: false);
+        }
+
+        return (bool) $argument->value;
+    }
+}

--- a/packages/http/src/Session/Installer/session.config.stub.php
+++ b/packages/http/src/Session/Installer/session.config.stub.php
@@ -1,0 +1,9 @@
+<?php
+
+use Tempest\DateTime\Duration;
+use Tempest\Http\Session\Config\DatabaseSessionConfig;
+use Tempest\Http\Session\Models\DatabaseSession;
+
+return new DatabaseSessionConfig(
+    expiration: Duration::days(30),
+);

--- a/packages/http/src/Session/Managers/DatabaseSession.php
+++ b/packages/http/src/Session/Managers/DatabaseSession.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Session\Managers;
+
+use Tempest\Database\PrimaryKey;
+use Tempest\Database\Table;
+use Tempest\DateTime\DateTime;
+
+#[Table('sessions')]
+final class DatabaseSession
+{
+    public PrimaryKey $id;
+
+    public string $session_id;
+
+    public string $data;
+
+    public DateTime $created_at;
+
+    public DateTime $last_active_at;
+}

--- a/packages/http/src/Session/Managers/DatabaseSessionManager.php
+++ b/packages/http/src/Session/Managers/DatabaseSessionManager.php
@@ -5,22 +5,24 @@ declare(strict_types=1);
 namespace Tempest\Http\Session\Managers;
 
 use Tempest\Clock\Clock;
+use Tempest\Database\Database;
 use Tempest\Http\Session\Session;
 use Tempest\Http\Session\SessionConfig;
 use Tempest\Http\Session\SessionDestroyed;
 use Tempest\Http\Session\SessionId;
 use Tempest\Http\Session\SessionManager;
-use Tempest\Support\Filesystem;
-use Throwable;
+use Tempest\Support\Arr;
+use Tempest\Support\Arr\ArrayInterface;
 
+use function Tempest\Database\query;
 use function Tempest\event;
-use function Tempest\internal_storage_path;
 
-final readonly class FileSessionManager implements SessionManager
+final readonly class DatabaseSessionManager implements SessionManager
 {
     public function __construct(
         private Clock $clock,
-        private SessionConfig $sessionConfig,
+        private SessionConfig $config,
+        private Database $database,
     ) {}
 
     public function create(SessionId $id): Session
@@ -35,21 +37,34 @@ final readonly class FileSessionManager implements SessionManager
 
     public function get(SessionId $id, string $key, mixed $default = null): mixed
     {
-        return $this->getData($id)[$key] ?? $default;
+        $value = Arr\get_by_key($this->getData($id), $key, $default);
+
+        if ($value instanceof ArrayInterface) {
+            return $value->toArray();
+        }
+
+        return $value;
+    }
+
+    public function all(SessionId $id): array
+    {
+        return $this->getData($id);
     }
 
     public function remove(SessionId $id, string $key): void
     {
         $data = $this->getData($id);
-
-        unset($data[$key]);
+        $data = Arr\remove_keys($data, $key);
 
         $this->persist($id, $data);
     }
 
     public function destroy(SessionId $id): void
     {
-        unlink($this->getPath($id));
+        query(DatabaseSession::class)
+            ->delete()
+            ->where('session_id', (string) $id)
+            ->execute();
 
         event(new SessionDestroyed($id));
     }
@@ -63,41 +78,39 @@ final readonly class FileSessionManager implements SessionManager
         }
 
         return $this->clock->now()->before(
-            other: $session->lastActiveAt->plus($this->sessionConfig->expiration),
+            other: $session->lastActiveAt->plus($this->config->expiration),
         );
     }
 
-    private function getPath(SessionId $id): string
+    public function cleanup(): void
     {
-        return internal_storage_path($this->sessionConfig->path, (string) $id);
+        $expired = $this->clock
+            ->now()
+            ->minus($this->config->expiration);
+
+        query(DatabaseSession::class)
+            ->delete()
+            ->whereBefore('last_active_at', $expired)
+            ->execute();
     }
 
     private function resolve(SessionId $id): ?Session
     {
-        $path = $this->getPath($id);
+        $session = query(DatabaseSession::class)
+            ->select()
+            ->where('session_id', (string) $id)
+            ->first();
 
-        try {
-            if (! Filesystem\is_file($path)) {
-                return null;
-            }
-
-            $file_pointer = fopen($path, 'rb');
-            flock($file_pointer, LOCK_SH);
-
-            $content = Filesystem\read_file($path);
-
-            flock($file_pointer, LOCK_UN);
-            fclose($file_pointer);
-
-            return unserialize($content, ['allowed_classes' => true]);
-        } catch (Throwable) {
+        if ($session === null) {
             return null;
         }
-    }
 
-    public function all(SessionId $id): array
-    {
-        return $this->getData($id);
+        return new Session(
+            id: $id,
+            createdAt: $session->created_at,
+            lastActiveAt: $session->last_active_at,
+            data: unserialize($session->data),
+        );
     }
 
     /**
@@ -120,35 +133,18 @@ final readonly class FileSessionManager implements SessionManager
             lastActiveAt: $now,
         );
 
-        $session->lastActiveAt = $now;
-
         if ($data !== null) {
             $session->data = $data;
         }
 
-        Filesystem\write_file($this->getPath($id), serialize($session), LOCK_EX);
+        query(DatabaseSession::class)->updateOrCreate([
+            'session_id' => (string) $id,
+        ], [
+            'data' => serialize($session->data),
+            'created_at' => $session->createdAt,
+            'last_active_at' => $now,
+        ]);
 
         return $session;
-    }
-
-    public function cleanup(): void
-    {
-        $sessionFiles = glob(internal_storage_path($this->sessionConfig->path, '/*'));
-
-        foreach ($sessionFiles as $sessionFile) {
-            $id = new SessionId(pathinfo($sessionFile, PATHINFO_FILENAME));
-
-            $session = $this->resolve($id);
-
-            if ($session === null) {
-                continue;
-            }
-
-            if ($this->isValid($session->id)) {
-                continue;
-            }
-
-            $session->destroy();
-        }
     }
 }

--- a/packages/http/src/Session/Session.php
+++ b/packages/http/src/Session/Session.php
@@ -41,6 +41,7 @@ final class Session
     public function __construct(
         public SessionId $id,
         public DateTimeInterface $createdAt,
+        public DateTimeInterface $lastActiveAt,
         /** @var array<array-key, mixed> */
         public array $data = [],
     ) {}

--- a/packages/http/src/Session/SessionConfig.php
+++ b/packages/http/src/Session/SessionConfig.php
@@ -4,12 +4,11 @@ namespace Tempest\Http\Session;
 
 use Tempest\Container\Container;
 use Tempest\DateTime\Duration;
-use Tempest\Http\Session\SessionIdResolver;
 
 interface SessionConfig
 {
     /**
-     * Time required for a session to expire. Defaults to 2 hours.
+     * Time required for a session to expire.
      */
     public Duration $expiration {
         get;

--- a/tests/Integration/Http/DatabaseSessionTest.php
+++ b/tests/Integration/Http/DatabaseSessionTest.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Http;
+
+use Google\Protobuf\UInt32Value;
+use PHPUnit\Framework\Attributes\PreCondition;
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Clock\Clock;
+use Tempest\Database\Database;
+use Tempest\Database\Migrations\CreateMigrationsTable;
+use Tempest\Database\Migrations\MigrationManager;
+use Tempest\DateTime\Duration;
+use Tempest\EventBus\EventBus;
+use Tempest\Http\Session\Config\DatabaseSessionConfig;
+use Tempest\Http\Session\Installer\CreateSessionsTable;
+use Tempest\Http\Session\Managers\DatabaseSession;
+use Tempest\Http\Session\Managers\DatabaseSessionManager;
+use Tempest\Http\Session\Session;
+use Tempest\Http\Session\SessionConfig;
+use Tempest\Http\Session\SessionDestroyed;
+use Tempest\Http\Session\SessionId;
+use Tempest\Http\Session\SessionManager;
+use Tempest\Support\Arr\ImmutableArray;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\Database\query;
+
+/**
+ * @internal
+ */
+final class DatabaseSessionTest extends FrameworkIntegrationTestCase
+{
+    public Session $session {
+        get => $this->container->get(Session::class);
+    }
+
+    #[PreCondition]
+    protected function configure(): void
+    {
+        $this->container->config(new DatabaseSessionConfig(expiration: Duration::hours(2)));
+
+        $this->container->singleton(SessionManager::class, fn () => new DatabaseSessionManager(
+            $this->container->get(Clock::class),
+            $this->container->get(SessionConfig::class),
+            $this->container->get(Database::class),
+        ));
+
+        $this->database->reset(migrate: false);
+        $this->database->migrate(CreateMigrationsTable::class, CreateSessionsTable::class);
+    }
+
+    #[Test]
+    public function create_session_from_container(): void
+    {
+        $this->assertInstanceOf(Session::class, $this->session);
+        $this->assertSessionExistsInDatabase($this->session->id);
+    }
+
+    #[Test]
+    public function put_get(): void
+    {
+        $this->session->set('frieren', 'elf_mage');
+
+        $this->assertEquals('elf_mage', $this->session->get('frieren'));
+        $this->assertSessionDataInDatabase($this->session->id, ['frieren' => 'elf_mage']);
+
+        $this->assertEquals('deceased_hero', $this->session->get('himmel', 'deceased_hero'));
+    }
+
+    #[Test]
+    public function put_nested_data(): void
+    {
+        $data = [
+            'members' => ['Frieren', 'Fern', 'Stark'],
+            'location' => 'Northern Plateau',
+            'quest' => [
+                'name' => 'Journey to Ende',
+                'progress' => 0.75,
+                'completed_tasks' => ['Find Himmel statue', 'Pass mage exam'],
+            ],
+        ];
+
+        $this->session->set('party', $data);
+
+        $this->assertEquals($data, $this->session->get('party'));
+        $this->assertSessionDataInDatabase($this->session->id, ['party' => $data]);
+    }
+
+    #[Test]
+    public function remove(): void
+    {
+        $this->session->set('spell', 'Zoltraak');
+        $this->session->set('caster', 'Frieren');
+
+        $this->assertEquals('Zoltraak', $this->session->get('spell'));
+
+        $this->session->remove('spell');
+
+        $this->assertNull($this->session->get('spell'));
+        $this->assertEquals('Frieren', $this->session->get('caster'));
+        $this->assertSessionDataInDatabase($this->session->id, ['caster' => 'Frieren']);
+    }
+
+    #[Test]
+    public function all(): void
+    {
+        $data = [
+            'mage' => 'Frieren',
+            'apprentice' => 'Fern',
+            'warrior' => 'Stark',
+        ];
+
+        foreach ($data as $key => $value) {
+            $this->session->set($key, $value);
+        }
+
+        $this->assertEquals($data, $this->session->all());
+    }
+
+    #[Test]
+    public function destroy(): void
+    {
+        $manager = $this->container->get(SessionManager::class);
+        $sessionId = new SessionId('test_session_destroy');
+
+        $session = $manager->create($sessionId);
+        $session->set('magic_type', 'offensive');
+
+        $this->assertSessionExistsInDatabase($sessionId);
+
+        $events = [];
+        $eventBus = $this->container->get(EventBus::class);
+        $eventBus->listen(function (SessionDestroyed $event) use (&$events): void {
+            $events[] = $event;
+        });
+
+        $session->destroy();
+
+        $this->assertSessionNotExistsInDatabase($sessionId);
+        $this->assertCount(1, $events);
+        $this->assertEquals((string) $sessionId, (string) $events[0]->id);
+    }
+
+    #[Test]
+    public function set_previous_url(): void
+    {
+        $session = $this->container->get(Session::class);
+        $session->setPreviousUrl('https://frieren.wiki/magic-academy');
+
+        $this->assertEquals('https://frieren.wiki/magic-academy', $session->getPreviousUrl());
+    }
+
+    #[Test]
+    public function is_valid(): void
+    {
+        $manager = $this->container->get(SessionManager::class);
+        $sessionId = new SessionId('new_session_validity');
+
+        $session = $manager->create($sessionId);
+
+        $this->assertTrue($session->isValid());
+        $this->assertTrue($manager->isValid($sessionId));
+    }
+
+    #[Test]
+    public function is_valid_for_unknown_session(): void
+    {
+        $manager = $this->container->get(SessionManager::class);
+
+        $this->assertFalse($manager->isValid(new SessionId('unknown_session')));
+    }
+
+    #[Test]
+    public function is_valid_for_expired_session(): void
+    {
+        $clock = $this->clock('2023-01-01 00:00:00');
+
+        $this->container->config(new DatabaseSessionConfig(expiration: Duration::second()));
+
+        $manager = $this->container->get(SessionManager::class);
+        $sessionId = new SessionId('expired_session');
+
+        $session = $manager->create($sessionId);
+
+        $this->assertTrue($session->isValid());
+
+        $clock->plus(2);
+
+        $this->assertFalse($session->isValid());
+        $this->assertFalse($manager->isValid($sessionId));
+    }
+
+    #[Test]
+    public function session_expires_based_on_last_activity(): void
+    {
+        $clock = $this->clock('2023-01-01 00:00:00');
+
+        $this->container->config(new DatabaseSessionConfig(expiration: Duration::minutes(30)));
+
+        $manager = $this->container->get(SessionManager::class);
+        $sessionId = new SessionId('last_activity_test');
+
+        // Create session
+        $session = $manager->create($sessionId);
+        $this->assertTrue($session->isValid());
+
+        $clock->plus(Duration::minutes(25));
+        $this->assertTrue($session->isValid());
+
+        // Perform activity
+        $session->set('activity', 'user_action');
+        $clock->plus(Duration::minutes(25));
+        $this->assertTrue($session->isValid());
+        $this->assertTrue($manager->isValid($sessionId));
+
+        // Move forward another 10 minutes, now 35 minutes from last activity
+        $clock->plus(Duration::minutes(10));
+        $this->assertFalse($session->isValid());
+        $this->assertFalse($manager->isValid($sessionId));
+    }
+
+    #[Test]
+    public function session_reflash(): void
+    {
+        $session = $this->container->get(Session::class);
+
+        $session->flash('success', 'Spell learned: Zoltraak');
+
+        $this->assertEquals('Spell learned: Zoltraak', $session->get('success'));
+
+        $session->reflash();
+        $session->cleanup();
+
+        $this->assertEquals('Spell learned: Zoltraak', $session->get('success'));
+    }
+
+    #[Test]
+    public function cleanup_removes_expired_sessions(): void
+    {
+        $clock = $this->clock('2023-01-01 00:00:00');
+
+        $this->container->config(new DatabaseSessionConfig(expiration: Duration::minutes(30)));
+
+        $manager = $this->container->get(SessionManager::class);
+
+        $activeSessionId = new SessionId('active_session');
+        $activeSession = $manager->create($activeSessionId);
+        $activeSession->set('status', 'active');
+
+        $clock->minus(Duration::hour());
+        $expiredSessionId = new SessionId('expired_session');
+        $expiredSession = $manager->create($expiredSessionId);
+        $expiredSession->set('status', 'expired');
+
+        $clock->plus(Duration::hour());
+
+        $this->assertSessionExistsInDatabase($activeSessionId);
+        $this->assertSessionExistsInDatabase($expiredSessionId);
+
+        $manager->cleanup();
+
+        $this->assertSessionExistsInDatabase($activeSessionId);
+        $this->assertSessionNotExistsInDatabase($expiredSessionId);
+    }
+
+    #[Test]
+    public function session_updates_last_active_timestamp(): void
+    {
+        $clock = $this->clock('2023-01-01 12:00:00');
+
+        $manager = $this->container->get(SessionManager::class);
+        $sessionId = new SessionId('timestamp_test');
+
+        $session = $manager->create($sessionId);
+        $originalTimestamp = $this->getSessionLastActiveTimestamp($sessionId);
+
+        $clock->plus(Duration::minutes(5));
+
+        $session->set('action', 'spell_cast');
+        $updatedTimestamp = $this->getSessionLastActiveTimestamp($sessionId);
+
+        $this->assertTrue($updatedTimestamp->after($originalTimestamp));
+    }
+
+    #[Test]
+    public function session_persists_csrf_token(): void
+    {
+        $session = $this->container->get(Session::class);
+        $token = $session->token;
+
+        $data = $this->getSessionDataFromDatabase($session->id);
+
+        $this->assertEquals($token, $data[Session::CSRF_TOKEN_KEY]);
+        $this->assertEquals($token, $session->token);
+    }
+
+    private function assertSessionExistsInDatabase(SessionId $sessionId): void
+    {
+        $session = query(DatabaseSession::class)
+            ->select()
+            ->where('session_id', (string) $sessionId)
+            ->first();
+
+        $this->assertNotNull($session, "Session {$sessionId} should exist in database");
+    }
+
+    private function assertSessionNotExistsInDatabase(SessionId $sessionId): void
+    {
+        $session = query(DatabaseSession::class)
+            ->select()
+            ->where('session_id', (string) $sessionId)
+            ->first();
+
+        $this->assertNull($session, "Session {$sessionId} should not exist in database");
+    }
+
+    private function assertSessionDataInDatabase(SessionId $sessionId, array $data): void
+    {
+        $session = query(DatabaseSession::class)
+            ->select()
+            ->where('session_id', (string) $sessionId)
+            ->first();
+
+        $this->assertNotNull($session, "Session {$sessionId} should exist in database");
+
+        $unserialized = unserialize($session->data);
+
+        foreach ($data as $key => $value) {
+            $this->assertEquals($value, $unserialized[$key], "Session data key '{$key}' should match expected value");
+        }
+    }
+
+    private function getSessionDataFromDatabase(SessionId $sessionId): array
+    {
+        $session = query(DatabaseSession::class)
+            ->select()
+            ->where('session_id', (string) $sessionId)
+            ->first();
+
+        return unserialize($session->data ?? '');
+    }
+
+    private function getSessionLastActiveTimestamp(SessionId $sessionId): \Tempest\DateTime\DateTime
+    {
+        $session = query(DatabaseSession::class)
+            ->select()
+            ->where('session_id', (string) $sessionId)
+            ->first();
+
+        $this->assertNotNull($session, "Session {$sessionId} should exist in database");
+
+        return $session->last_active_at;
+    }
+}


### PR DESCRIPTION
This pull request introduces support for database-based sessions. It works by providing a migration file through an installer, a new configuration file, and a built-in database session manager.

The installer publishes the migration file and a `session.config.php` with the following contents:
```php
use Tempest\Http\Session\Config\DatabaseSessionConfig;
use Tempest\DateTime\Duration;

return new DatabaseSessionConfig(
    expiration: Duration::days(30),
);
```

Note that even though the migration is published, it should not be modified, because the database session manager expects the exact columns defined on it. Unfortunately, I don't see a good way to publish the implementation itself without it feeling out of place.

I also fixed an issue with the existing file-based implementation: sessions always expired after the specified expiration based on the session *creation date*, not the last activity. In practice, this results in bad user experience, since users would _have_ to log in even if they're being active. Now, the last activity is tracked, and the expiration is based on that.