### PR TITLE
fix(view): handle boolean attribute followed by non space whitespace or self-closing tags

### DIFF
--- a/packages/view/src/Parser/TempestViewLexer.php
+++ b/packages/view/src/Parser/TempestViewLexer.php
@@ -117,7 +117,7 @@ final class TempestViewLexer
 
                 $attributeName = $this->consumeWhile(self::WHITESPACE);
 
-                $attributeName .= $this->consumeUntil('= >');
+                $attributeName .= $this->consumeUntil(self::WHITESPACE . '=/>');
 
                 $hasValue = $this->seek() === '=';
 

--- a/packages/view/tests/TempestViewLexerTest.php
+++ b/packages/view/tests/TempestViewLexerTest.php
@@ -96,6 +96,40 @@ final class TempestViewLexerTest extends TestCase
         );
     }
 
+    public function test_boolean_attribute_with_self_closing_tag(): void
+    {
+        $code = '<input disabled/>';
+
+        $tokens = new TempestViewLexer($code)->lex();
+
+        $this->assertTokens(
+            expected: [
+                new Token('<input', TokenType::OPEN_TAG_START),
+                new Token(' disabled', TokenType::ATTRIBUTE_NAME),
+                new Token('/>', TokenType::SELF_CLOSING_TAG_END),
+            ],
+            actual: $tokens,
+        );
+    }
+
+    public function test_boolean_attribute_with_newline(): void
+    {
+        $code = '<div hidden
+></div>';
+
+        $tokens = new TempestViewLexer($code)->lex();
+
+        $this->assertTokens(
+            expected: [
+                new Token('<div', TokenType::OPEN_TAG_START),
+                new Token(' hidden', TokenType::ATTRIBUTE_NAME),
+                new Token("\n>", TokenType::OPEN_TAG_END),
+                new Token('</div>', TokenType::CLOSING_TAG),
+            ],
+            actual: $tokens,
+        );
+    }
+
     #[TestWith(['</x-foo>'])]
     public function test_closing_tag(string $tag): void
     {
@@ -132,9 +166,9 @@ final class TempestViewLexerTest extends TestCase
     foo=', TokenType::ATTRIBUTE_NAME),
                 new Token('"bar"', TokenType::ATTRIBUTE_VALUE),
                 new Token('
-    x-foo
-', TokenType::ATTRIBUTE_NAME),
-                new Token('    :baz=', TokenType::ATTRIBUTE_NAME),
+    x-foo', TokenType::ATTRIBUTE_NAME),
+                new Token('
+    :baz=', TokenType::ATTRIBUTE_NAME),
                 new Token('"true"', TokenType::ATTRIBUTE_VALUE),
                 new Token("\n>", TokenType::OPEN_TAG_END),
                 new Token('


### PR DESCRIPTION
I encountered compilation issues with else control structure :

```php
<textarea :if="true"></textarea><input :else/>

<textarea :if="true"></textarea><div :else
></div>

// Both throws a ViewCompilationFailed exception with syntax error, unexpected token "??"
```

While debugging this I found that the lexer consumes more characters than expected in the ATTRIBUTE_NAME token when handling boolean attributes followed by a self-closing tag or a non space whitespace.

My fix is correct HTML-wise as far I as know but I've never worked on a lexer before and may not have thought about a possible regression.

One existing test failed, but the expected case was inconsistent with the others attributes. I updated it and all other view tests passed.