### PR TITLE
ci: use fixed phpunit and rector versions

### DIFF
--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -66,7 +66,7 @@ jobs:
         uses: supercharge/redis-github-action@1.7.0
 
       - name: Install PHPUnit
-        run: composer global require phpunit/phpunit:~12.1.0
+        run: composer global require phpunit/phpunit:12.4.0
 
       - name: Setup problem matchers
         run: |

--- a/packages/upgrade/composer.json
+++ b/packages/upgrade/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^8.4",
-        "rector/rector": "^2.1"
+        "rector/rector": "2.2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This is in order to deal with https://github.com/sebastianbergmann/phpunit/issues/6381