### PR TITLE
fix(reflection): return null for method return type if not defined

### DIFF
--- a/packages/reflection/src/MethodReflector.php
+++ b/packages/reflection/src/MethodReflector.php
@@ -53,8 +53,12 @@ final class MethodReflector implements Reflector
         return $this->reflectionMethod->invokeArgs($object, $args);
     }
 
-    public function getReturnType(): TypeReflector
+    public function getReturnType(): ?TypeReflector
     {
+        if ($this->reflectionMethod->getReturnType() === null) {
+            return null;
+        }
+
         return new TypeReflector($this->reflectionMethod->getReturnType());
     }
 

--- a/packages/reflection/tests/Fixtures/NoReturnType.php
+++ b/packages/reflection/tests/Fixtures/NoReturnType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Reflection\Tests\Fixtures;
+
+final class NoReturnType
+{
+    // @mago-expect lint:return-type
+    public function noReturnType()
+    {
+        return 2137;
+    }
+}

--- a/packages/reflection/tests/MethodReflectorTest.php
+++ b/packages/reflection/tests/MethodReflectorTest.php
@@ -5,6 +5,7 @@ namespace Tempest\Reflection\Tests;
 use PHPUnit\Framework\TestCase;
 use Tempest\Reflection\ClassReflector;
 use Tempest\Reflection\ParameterReflector;
+use Tempest\Reflection\Tests\Fixtures\NoReturnType;
 use Tempest\Reflection\Tests\Fixtures\TestClassA;
 
 final class MethodReflectorTest extends TestCase
@@ -22,6 +23,15 @@ final class MethodReflectorTest extends TestCase
             new ClassReflector(TestClassA::class)
                 ->getMethod('method')
                 ->getParameter('unknown'),
+        );
+    }
+
+    public function test_no_return_type_returns_null(): void
+    {
+        $this->assertNull(
+            new ClassReflector(NoReturnType::class)
+                ->getMethod('noReturnType')
+                ->getReturnType(),
         );
     }
 }


### PR DESCRIPTION
Without this change it results in
`
PHP Fatal error:  Uncaught TypeError: Tempest\Reflection\TypeReflector::__construct(): Argument #1 ($reflector) must be of type Reflector|ReflectionType|string, null given
`