### PR TITLE
fix(database): revert broken mysql dsn changes

### DIFF
--- a/packages/database/src/Config/MysqlConfig.php
+++ b/packages/database/src/Config/MysqlConfig.php
@@ -13,7 +13,7 @@ final class MysqlConfig implements DatabaseConfig
 {
     public string $dsn {
         get => sprintf(
-            'mysql:host=%s;port=%s;dbname=%s',
+            'mysql:host=%s:%s;dbname=%s',
             $this->host,
             $this->port,
             $this->database,

--- a/packages/database/tests/Config/DatabaseConfigTest.php
+++ b/packages/database/tests/Config/DatabaseConfigTest.php
@@ -44,7 +44,7 @@ final class DatabaseConfigTest extends TestCase
                 password: 'secret', // @mago-expect lint:no-literal-password
                 database: 'tempest',
             ),
-            'mysql:host=localhost;port=3307;dbname=tempest',
+            'mysql:host=localhost:3307;dbname=tempest',
             'user',
             'secret',
         ];


### PR DESCRIPTION
The change in #1664 caused an error after updating. 

> SQLSTATE[HY000] [2002] No such file or directory

I'm not sure why this happens, but I'm reverting the change until properly tested and fixed.