### PR TITLE
fix(view): support relative view paths on windows

### DIFF
--- a/packages/view/src/IsView.php
+++ b/packages/view/src/IsView.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\View;
 
 use function Tempest\Support\path;
+use function Tempest\Support\Path\normalize;
 
 /** @phpstan-require-implements \Tempest\View\View */
 trait IsView
@@ -24,7 +25,7 @@ trait IsView
 
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
-        if (str_ends_with($trace[0]['file'], 'view/src/functions.php')) {
+        if (str_ends_with(normalize($trace[0]['file']), 'view/src/functions.php')) {
             $this->relativeRootPath = path($trace[1]['file'])->dirname()->toString();
         } else {
             $this->relativeRootPath = path($trace[0]['file'])->dirname()->toString();

--- a/tests/Integration/View/TempestViewRendererTest.php
+++ b/tests/Integration/View/TempestViewRendererTest.php
@@ -53,10 +53,6 @@ final class TempestViewRendererTest extends FrameworkIntegrationTestCase
 
     public function test_relative_view_path_rendering(): void
     {
-        if (PHP_OS_FAMILY === 'Windows') {
-            $this->markTestSkipped('Relative paths not supported on Windows');
-        }
-
         $this->http
             ->get(uri([RelativeViewController::class, 'asFunction']))
             ->assertOk()


### PR DESCRIPTION
Fixes #954 by normalizing the trace path before the `str_ends_with()` check.