### PR TITLE
feat(mapper): support union types in docblocks

### DIFF
--- a/packages/mapper/src/CasterFactory.php
+++ b/packages/mapper/src/CasterFactory.php
@@ -7,6 +7,7 @@ namespace Tempest\Mapper;
 use Closure;
 use Tempest\Mapper\Casters\DtoCaster;
 use Tempest\Reflection\PropertyReflector;
+use Tempest\Reflection\TypeReflector;
 
 use function Tempest\get;
 
@@ -59,6 +60,17 @@ final class CasterFactory
                 return is_callable($casterClass)
                     ? $casterClass($property)
                     : get($casterClass);
+            }
+        }
+
+        return null;
+    }
+
+    public function forType(TypeReflector $type): ?Caster
+    {
+        foreach ($this->casters as [$for, $casterClass]) {
+            if (is_string($for) && $type->matches($for) && ! \is_callable($for)) {
+                return get($casterClass);
             }
         }
 

--- a/packages/mapper/src/CasterFactory.php
+++ b/packages/mapper/src/CasterFactory.php
@@ -69,7 +69,7 @@ final class CasterFactory
     public function forType(TypeReflector $type): ?Caster
     {
         foreach ($this->casters as [$for, $casterClass]) {
-            if (is_string($for) && $type->matches($for) && ! \is_callable($for)) {
+            if (is_string($for) && $type->matches($for) && is_string($casterClass)) {
                 return get($casterClass);
             }
         }

--- a/packages/mapper/src/Casters/ArrayToObjectCollectionCaster.php
+++ b/packages/mapper/src/Casters/ArrayToObjectCollectionCaster.php
@@ -23,6 +23,7 @@ final readonly class ArrayToObjectCollectionCaster implements Caster
 
         $caster = match (true) {
             $iterableType->isEnum() => new EnumCaster($iterableType->getName()),
+            $iterableType->getName() === 'mixed' => new MixedCaster(),
             $iterableType->isBuiltIn() => $this->casterFactory->forType($iterableType),
             default => new ObjectCaster($iterableType),
         };

--- a/packages/mapper/src/Casters/MixedCaster.php
+++ b/packages/mapper/src/Casters/MixedCaster.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Mapper\Casters;
+
+use Tempest\Mapper\Caster;
+
+class MixedCaster implements Caster
+{
+    public function cast(mixed $input): mixed
+    {
+        return $input;
+    }
+}

--- a/packages/mapper/src/Casters/StringCaster.php
+++ b/packages/mapper/src/Casters/StringCaster.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Mapper\Casters;
+
+use Tempest\Mapper\Caster;
+
+class StringCaster implements Caster
+{
+    public function cast(mixed $input): string
+    {
+        return (string) $input;
+    }
+}

--- a/packages/mapper/src/Casters/UnionCaster.php
+++ b/packages/mapper/src/Casters/UnionCaster.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Mapper\Casters;
+
+use Tempest\Mapper\Caster;
+use Tempest\Reflection\PropertyReflector;
+
+use function Tempest\map;
+
+class UnionCaster implements Caster
+{
+    public function __construct(
+        private PropertyReflector $property,
+    ) {}
+
+    public function cast(mixed $input): mixed
+    {
+        $propertyType = $this->property->getDocType() ?? $this->property->getType();
+
+        // for native types that already match, return early
+        foreach ($propertyType->split() as $type) {
+            if ($type->accepts($input)) {
+                return $input;
+            }
+        }
+
+        $lastException = null;
+
+        // as last resort, try to map to any of the union types
+        foreach ($propertyType->split() as $type) {
+            try {
+                return map($input)->to($type->getName());
+            } catch (\Throwable $e) {
+                $lastException = $e;
+            }
+        }
+
+        throw $lastException;
+    }
+}

--- a/packages/reflection/src/PropertyReflector.php
+++ b/packages/reflection/src/PropertyReflector.php
@@ -107,6 +107,23 @@ final class PropertyReflector implements Reflector
         return new TypeReflector(ltrim($match[1], '\\'));
     }
 
+    public function getDocType(): ?TypeReflector
+    {
+        $doc = $this->reflectionProperty->getDocComment();
+
+        if (! $doc) {
+            return null;
+        }
+
+        preg_match('/@var ([^\s]+)/', $doc, $match);
+
+        if (! isset($match[1])) {
+            return null;
+        }
+
+        return new TypeReflector($match[1]);
+    }
+
     public function isUninitialized(object $object): bool
     {
         return ! $this->reflectionProperty->isInitialized($object);

--- a/packages/reflection/src/TypeReflector.php
+++ b/packages/reflection/src/TypeReflector.php
@@ -81,10 +81,13 @@ final readonly class TypeReflector implements Reflector
             return true;
         }
 
+        if ($this->cleanDefinition === 'mixed') {
+            return true;
+        }
+
         if ($this->isBuiltIn()) {
             return match ($this->cleanDefinition) {
                 'false' => $input === false,
-                'mixed' => true,
                 'never' => false,
                 'true' => $input === true,
                 'void' => false,

--- a/packages/reflection/tests/Fixtures/ClassWithIterableProperty.php
+++ b/packages/reflection/tests/Fixtures/ClassWithIterableProperty.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Reflection\Tests\Fixtures;
+
+class ClassWithIterableProperty
+{
+    /**
+     * @var string[]
+     */
+    public array $items;
+}

--- a/packages/reflection/tests/Fixtures/ClassWithUnionOfStringAndArray.php
+++ b/packages/reflection/tests/Fixtures/ClassWithUnionOfStringAndArray.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Reflection\Tests\Fixtures;
+
+class ClassWithUnionOfStringAndArray
+{
+    /**
+     * @var string|string[]|null
+     */
+    public string|array|null $items;
+}

--- a/packages/reflection/tests/PropertyReflectorTest.php
+++ b/packages/reflection/tests/PropertyReflectorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tempest\Reflection\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Reflection\ClassReflector;
+use Tempest\Reflection\Tests\Fixtures\ClassWithIterableProperty;
+use Tempest\Reflection\Tests\Fixtures\ClassWithUnionOfStringAndArray;
+
+final class PropertyReflectorTest extends TestCase
+{
+    public function test_get_iterable_type(): void
+    {
+        $reflector = new ClassReflector(ClassWithIterableProperty::class)->getProperty('items');
+
+        $iterableType = $reflector->getIterableType();
+
+        $this->assertEquals('string', $iterableType->getName());
+    }
+
+    public function test_get_union_of_string_and_array(): void
+    {
+        $reflector = new ClassReflector(ClassWithUnionOfStringAndArray::class)->getProperty('items');
+
+        $unionType = $reflector->getDocType();
+
+        $this->assertTrue($unionType->isUnion());
+        $this->assertCount(3, $unionType->split());
+        $this->assertTrue($unionType->accepts('a'));
+        $this->assertTrue($unionType->accepts(['a', 'b', 'c']));
+        $this->assertTrue($unionType->accepts([]));
+        $this->assertTrue($unionType->accepts(null));
+
+        $this->assertFalse($unionType->accepts(123));
+        $this->assertFalse($unionType->accepts([123]));
+        $this->assertFalse($unionType->accepts([null]));
+    }
+}

--- a/packages/reflection/tests/TypeReflectorTest.php
+++ b/packages/reflection/tests/TypeReflectorTest.php
@@ -5,6 +5,7 @@ namespace Tempest\Reflection\Tests;
 use PHPUnit\Framework\TestCase;
 use Tempest\Reflection\ClassReflector;
 use Tempest\Reflection\Tests\Fixtures\TestClassA;
+use Tempest\Reflection\TypeReflector;
 
 final class TypeReflectorTest extends TestCase
 {
@@ -88,6 +89,13 @@ final class TypeReflectorTest extends TestCase
                 ->getParameter('other')
                 ->getType()
                 ->isUnitEnum(),
+        );
+    }
+
+    public function test_string_type_matches_string(): void
+    {
+        $this->assertTrue(
+            new TypeReflector('string')->matches('string'),
         );
     }
 }

--- a/tests/Integration/Mapper/Fixtures/ObjectWithMixedArray.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithMixedArray.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+class ObjectWithMixedArray
+{
+    /** @var mixed[] */
+    public array $items;
+}

--- a/tests/Integration/Mapper/Fixtures/ObjectWithStringOrMixedArray.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithStringOrMixedArray.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+class ObjectWithStringOrMixedArray
+{
+    /** @var string|mixed[] */
+    public string|array $items;
+}

--- a/tests/Integration/Mapper/Fixtures/ObjectWithStringOrObjectUnion.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithStringOrObjectUnion.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+class ObjectWithStringOrObjectUnion
+{
+    public string|ObjectA $item;
+}

--- a/tests/Integration/Mapper/Fixtures/ObjectWithStringsArray.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithStringsArray.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+final class ObjectWithStringsArray
+{
+    /** @var string[] */
+    public array $items;
+}

--- a/tests/Integration/Mapper/Fixtures/ObjectWithUnionArray.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithUnionArray.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+final class ObjectWithUnionArray
+{
+    /** @var string|string[]|null */
+    public string|array|null $items;
+}

--- a/tests/Integration/Mapper/Mappers/ArrayToObjectMapperTestCase.php
+++ b/tests/Integration/Mapper/Mappers/ArrayToObjectMapperTestCase.php
@@ -16,6 +16,9 @@ use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithDoubleStringCaster;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithEnum;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMagicGetter;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMyObject;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithStringOrObjectUnion;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithStringsArray;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithUnionArray;
 use Tests\Tempest\Integration\Mapper\Fixtures\ParentObject;
 use Tests\Tempest\Integration\Mapper\Fixtures\ParentWithChildrenObject;
 
@@ -164,6 +167,69 @@ final class ArrayToObjectMapperTestCase extends FrameworkIntegrationTestCase
 
         $this->assertCount(1, $object->roles);
         $this->assertSame(EnumToBeMappedToArray::ADMIN, $object->roles[0]);
+    }
+
+    public function test_map_array_with_string_array_property(): void
+    {
+        $object = map(['items' => ['a', 'b', 'c']])->to(ObjectWithStringsArray::class);
+
+        $this->assertCount(3, $object->items);
+        $this->assertSame(
+            [
+                'a',
+                'b',
+                'c',
+            ],
+            $object->items,
+        );
+    }
+
+    public function test_map_union_array_property_with_string(): void
+    {
+        $object = map(['items' => 'a'])->to(ObjectWithUnionArray::class);
+
+        $this->assertSame(
+            'a',
+            $object->items,
+        );
+    }
+
+    public function test_map_union_array_property_with_array(): void
+    {
+        $object = map(['items' => ['a', 'b', 'c']])->to(ObjectWithUnionArray::class);
+
+        $this->assertSame(
+            [
+                'a',
+                'b',
+                'c',
+            ],
+            $object->items,
+        );
+    }
+
+    public function test_map_union_array_property_with_null(): void
+    {
+        $object = map(['items' => null])->to(ObjectWithUnionArray::class);
+
+        $this->assertNull($object->items);
+    }
+
+    public function test_map_union_string_or_object_with_string(): void
+    {
+        $object = map(['item' => 'string'])->to(ObjectWithStringOrObjectUnion::class);
+
+        $this->assertIsString($object->item);
+        $this->assertSame('string', $object->item);
+    }
+
+    public function test_map_union_string_or_object_with_object(): void
+    {
+        $object = map(['item' => ['a' => '1', 'b' => '2']])->to(ObjectWithStringOrObjectUnion::class);
+
+        $this->assertInstanceOf(ObjectA::class, $object->item);
+        $this->assertSame('1', $object->item->a);
+        $this->assertSame('2', $object->item->b);
     }
 }
 

--- a/tests/Integration/Mapper/Mappers/ArrayToObjectMapperTestCase.php
+++ b/tests/Integration/Mapper/Mappers/ArrayToObjectMapperTestCase.php
@@ -15,7 +15,9 @@ use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithDefaultValues;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithDoubleStringCaster;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithEnum;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMagicGetter;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMixedArray;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMyObject;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithStringOrMixedArray;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithStringOrObjectUnion;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithStringsArray;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithUnionArray;
@@ -230,6 +232,47 @@ final class ArrayToObjectMapperTestCase extends FrameworkIntegrationTestCase
         $this->assertInstanceOf(ObjectA::class, $object->item);
         $this->assertSame('1', $object->item->a);
         $this->assertSame('2', $object->item->b);
+    }
+
+    public function test_map_array_with_mixed_array_property(): void
+    {
+        $object = map(['items' => ['a', 1, 2.5, true, null, ['key' => 'value']]])->to(ObjectWithMixedArray::class);
+
+        $this->assertSame(
+            [
+                'a',
+                1,
+                2.5,
+                true,
+                null,
+                ['key' => 'value'],
+            ],
+            $object->items,
+        );
+    }
+
+    public function test_map_union_string_or_mixed_array_with_string(): void
+    {
+        $object = map(['items' => 'string'])->to(ObjectWithStringOrMixedArray::class);
+
+        $this->assertIsString($object->items);
+        $this->assertSame('string', $object->items);
+    }
+
+    public function test_map_union_string_or_mixed_array_with_array(): void
+    {
+        $object = map(['items' => ['a', 1, true, ['b' => 2]]])->to(ObjectWithStringOrMixedArray::class);
+
+        $this->assertIsArray($object->items);
+        $this->assertSame(
+            [
+                'a',
+                1,
+                true,
+                ['b' => 2],
+            ],
+            $object->items,
+        );
     }
 }
 


### PR DESCRIPTION
This pull request adds support for union types along with partially-understanding types defined in docblock.

```php
class StoreRequest {
    /** @var string|string[] */
    public string|array $tags;
}
```

`mixed` type is also supported

```php
class StoreRequest {
    /** @var string|mixed[] */
    public string|array $tags;
}
```

This means that it is now also supported.

```php
class StoreRequest {
    /** $var string[] */
    public array $tags;
}
```

There are still a few edge cases to resolve, but I would say this is MVP.

