### PR TITLE
fix(console): render nullable enum arguments

### DIFF
--- a/packages/console/src/Actions/RenderConsoleCommand.php
+++ b/packages/console/src/Actions/RenderConsoleCommand.php
@@ -63,13 +63,7 @@ final readonly class RenderConsoleCommand
             return $formattedArgumentName->wrap('<style="fg-gray dim"><</style>', '<style="fg-gray dim">></style>')->toString();
         }
 
-        $defaultValue = match (true) {
-            $argument->default === true => 'true',
-            $argument->default === false => 'false',
-            is_null($argument->default) => 'null',
-            is_array($argument->default) => 'array',
-            default => "{$argument->default}",
-        };
+        $defaultValue = $this->getArgumentDefaultValue($argument);
 
         return str()
             ->append(str('[')->wrap('<style="fg-gray dim">', '</style>'))
@@ -89,11 +83,24 @@ final readonly class RenderConsoleCommand
 
         $partsAsString = ' {<style="fg-blue">' . implode('|', $parts) . '</style>}';
         $line = "<style=\"fg-blue\">{$argument->name}</style>";
+        $defaultValue = $this->getArgumentDefaultValue($argument);
 
         if ($argument->hasDefault) {
-            return "[{$line}={$argument->default->value}{$partsAsString}]";
+            return "[{$line}={$defaultValue}{$partsAsString}]";
         }
 
         return "<{$line}{$partsAsString}>";
+    }
+
+    private function getArgumentDefaultValue(ConsoleArgumentDefinition $argument): string
+    {
+        return match (true) {
+            $argument->default === true => 'true',
+            $argument->default === false => 'false',
+            is_null($argument->default) => 'null',
+            is_array($argument->default) => 'array',
+            $argument->default instanceof BackedEnum => $argument->default->value,
+            default => "{$argument->default}",
+        };
     }
 }

--- a/tests/Integration/Console/Fixtures/MyConsole.php
+++ b/tests/Integration/Console/Fixtures/MyConsole.php
@@ -13,8 +13,10 @@ final class MyConsole
         string $path,
         TestStringEnum $type,
         TestStringEnum $fallback = TestStringEnum::A,
+        ?TestStringEnum $nullableEnum = null,
         int $times = 1,
         bool $force = false,
+        ?string $optional = null,
     ): void {
     }
 }


### PR DESCRIPTION
`RenderConsoleCommand` wasn't handling default null value for nullable enum argument well, because it assumed that default value is also an enum.

It was tempting to use `$this->console->call('test', ['--help'])->assertSomething()` in test case, but this would be testing `HelpMiddleware`, not a command itself.