### PR TITLE
test(core): support paratest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ packages/database.sqlite
 packages/database/src/database.sqlite
 src/Tempest/database.sqlite
 tests/Fixtures/database.sqlite
+tests/Fixtures/database*.sqlite
 tests/Unit/Console/test-console.log
 src/Tempest/Database/src/database.sqlite
 .env

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,8 @@
         "tempest/blade": "dev-main",
         "thenetworg/oauth2-azure": "^2.2",
         "twig/twig": "^3.16",
-        "wohali/oauth2-discord-new": "^1.2"
+        "wohali/oauth2-discord-new": "^1.2",
+        "brianium/paratest": "^7.14"
     },
     "replace": {
         "tempest/auth": "self.version",

--- a/packages/container/src/HasInstance.php
+++ b/packages/container/src/HasInstance.php
@@ -6,14 +6,14 @@ namespace Tempest\Container;
 
 trait HasInstance
 {
-    private static self $instance;
+    private static ?self $instance = null;
 
     public static function instance(): ?self
     {
         return self::$instance ?? null;
     }
 
-    public static function setInstance(self $instance): void
+    public static function setInstance(?self $instance): void
     {
         self::$instance = $instance;
     }

--- a/tests/Fixtures/Config/database.sqlite.php
+++ b/tests/Fixtures/Config/database.sqlite.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Tempest\Database\Config\SQLiteConfig;
 
+use function Tempest\env;
+
 return new SQLiteConfig(
-    path: __DIR__ . '/../database.sqlite',
+    path: __DIR__ . '/../database' . env('TEST_TOKEN', 'default') . '.sqlite',
 );

--- a/tests/Integration/Console/Commands/MakeCommandCommandTest.php
+++ b/tests/Integration/Console/Commands/MakeCommandCommandTest.php
@@ -19,8 +19,8 @@ final class MakeCommandCommandTest extends FrameworkIntegrationTestCase
         parent::setUp();
 
         $this->installer->configure(
-            __DIR__ . '/install',
-            new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
         );
     }
 

--- a/tests/Integration/Console/Commands/MakeConfigCommandTest.php
+++ b/tests/Integration/Console/Commands/MakeConfigCommandTest.php
@@ -30,8 +30,8 @@ final class MakeConfigCommandTest extends FrameworkIntegrationTestCase
         parent::setUp();
 
         $this->installer->configure(
-            __DIR__ . '/install',
-            new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
         );
     }
 

--- a/tests/Integration/Console/Commands/MakeGeneratorCommandCommandTest.php
+++ b/tests/Integration/Console/Commands/MakeGeneratorCommandCommandTest.php
@@ -19,8 +19,8 @@ final class MakeGeneratorCommandCommandTest extends FrameworkIntegrationTestCase
         parent::setUp();
 
         $this->installer->configure(
-            __DIR__ . '/install',
-            new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
         );
     }
 

--- a/tests/Integration/Console/Commands/MakeMiddlewareCommandTest.php
+++ b/tests/Integration/Console/Commands/MakeMiddlewareCommandTest.php
@@ -22,8 +22,8 @@ final class MakeMiddlewareCommandTest extends FrameworkIntegrationTestCase
         parent::setUp();
 
         $this->installer->configure(
-            __DIR__ . '/install',
-            new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
         );
     }
 

--- a/tests/Integration/Console/Installer/ConsoleInstallerTest.php
+++ b/tests/Integration/Console/Installer/ConsoleInstallerTest.php
@@ -18,10 +18,10 @@ final class ConsoleInstallerTest extends FrameworkIntegrationTestCase
 
         $this->installer
             ->configure(
-                __DIR__ . '/install',
-                new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+                $this->internalStorage . '/install',
+                new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
             )
-            ->setRoot(__DIR__ . '/install');
+            ->setRoot($this->internalStorage . '/install');
     }
 
     protected function tearDown(): void

--- a/tests/Integration/Container/Commands/MakeInitializerCommandTest.php
+++ b/tests/Integration/Container/Commands/MakeInitializerCommandTest.php
@@ -19,8 +19,8 @@ class MakeInitializerCommandTest extends FrameworkIntegrationTestCase
         parent::setUp();
 
         $this->installer->configure(
-            __DIR__ . '/install',
-            new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
         );
     }
 

--- a/tests/Integration/Core/FrameworkInstallerTest.php
+++ b/tests/Integration/Core/FrameworkInstallerTest.php
@@ -18,10 +18,10 @@ final class FrameworkInstallerTest extends FrameworkIntegrationTestCase
 
         $this->installer
             ->configure(
-                __DIR__ . '/install',
-                new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+                $this->internalStorage . '/install',
+                new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
             )
-            ->setRoot(__DIR__ . '/install');
+            ->setRoot($this->internalStorage . '/install');
     }
 
     protected function tearDown(): void

--- a/tests/Integration/Core/InstallCommandTest.php
+++ b/tests/Integration/Core/InstallCommandTest.php
@@ -18,10 +18,10 @@ final class InstallCommandTest extends FrameworkIntegrationTestCase
 
         $this->installer
             ->configure(
-                __DIR__ . '/install',
-                new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+                $this->internalStorage . '/install',
+                new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
             )
-            ->setRoot(__DIR__ . '/install');
+            ->setRoot($this->internalStorage . '/install');
     }
 
     protected function tearDown(): void

--- a/tests/Integration/Core/PublishesFilesTest.php
+++ b/tests/Integration/Core/PublishesFilesTest.php
@@ -23,8 +23,8 @@ final class PublishesFilesTest extends FrameworkIntegrationTestCase
         parent::setUp();
 
         $this->installer->configure(
-            __DIR__ . '/install',
-            new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
         );
     }
 

--- a/tests/Integration/Core/ViewComponentsInstallerTest.php
+++ b/tests/Integration/Core/ViewComponentsInstallerTest.php
@@ -19,10 +19,10 @@ final class ViewComponentsInstallerTest extends FrameworkIntegrationTestCase
 
         $this->installer
             ->configure(
-                __DIR__ . '/install',
-                new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+                $this->internalStorage . '/install',
+                new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
             )
-            ->setRoot(__DIR__ . '/install');
+            ->setRoot($this->internalStorage . '/install');
 
         $this->registerViewComponent(
             name: 'x-vendor-a',

--- a/tests/Integration/Cryptography/GenerateSigningKeyCommandTest.php
+++ b/tests/Integration/Cryptography/GenerateSigningKeyCommandTest.php
@@ -21,9 +21,9 @@ final class GenerateSigningKeyCommandTest extends FrameworkIntegrationTestCase
 
     protected function tearDown(): void
     {
-        parent::tearDown();
-
         Filesystem\delete_file(root_path('.env'));
+
+        parent::tearDown();
     }
 
     public function test_creates_dot_env(): void

--- a/tests/Integration/Database/Commands/MakeMigrationCommandTest.php
+++ b/tests/Integration/Database/Commands/MakeMigrationCommandTest.php
@@ -20,7 +20,10 @@ final class MakeMigrationCommandTest extends FrameworkIntegrationTestCase
     #[PreCondition]
     protected function configure(): void
     {
-        $this->installer->configure(__DIR__ . '/install', new Psr4Namespace('App\\', __DIR__ . '/install/App'));
+        $this->installer->configure(
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
+        );
     }
 
     #[PostCondition]

--- a/tests/Integration/Database/Commands/MakeModelCommandTest.php
+++ b/tests/Integration/Database/Commands/MakeModelCommandTest.php
@@ -19,8 +19,8 @@ class MakeModelCommandTest extends FrameworkIntegrationTestCase
         parent::setUp();
 
         $this->installer->configure(
-            __DIR__ . '/install',
-            new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
         );
     }
 

--- a/tests/Integration/Database/DatabaseConfigTest.php
+++ b/tests/Integration/Database/DatabaseConfigTest.php
@@ -23,7 +23,7 @@ final class DatabaseConfigTest extends FrameworkIntegrationTestCase
     public function test_strategy_is_taken_into_account(string $strategy, string $expected): void
     {
         $this->container->config(new SQLiteConfig(
-            path: __DIR__ . '/../database.sqlite',
+            path: $this->internalStorage . '/../database.sqlite',
             namingStrategy: new $strategy(),
         ));
 

--- a/tests/Integration/Database/MultiDatabaseTest.php
+++ b/tests/Integration/Database/MultiDatabaseTest.php
@@ -42,8 +42,8 @@ final class MultiDatabaseTest extends FrameworkIntegrationTestCase
         }
 
         $files = [
-            __DIR__ . '/db-main.sqlite',
-            __DIR__ . '/db-backup.sqlite',
+            $this->internalStorage . '/db-main.sqlite',
+            $this->internalStorage . '/db-backup.sqlite',
         ];
 
         foreach ($files as $file) {
@@ -58,12 +58,12 @@ final class MultiDatabaseTest extends FrameworkIntegrationTestCase
         $this->container->addInitializer(DatabaseInitializer::class);
 
         $this->container->config(new SQLiteConfig(
-            path: __DIR__ . '/db-main.sqlite',
+            path: $this->internalStorage . '/db-main.sqlite',
             tag: 'main',
         ));
 
         $this->container->config(new SQLiteConfig(
-            path: __DIR__ . '/db-backup.sqlite',
+            path: $this->internalStorage . '/db-backup.sqlite',
             tag: 'backup',
         ));
     }

--- a/tests/Integration/Discovery/Commands/MakeDiscoveryCommandTest.php
+++ b/tests/Integration/Discovery/Commands/MakeDiscoveryCommandTest.php
@@ -19,8 +19,8 @@ class MakeDiscoveryCommandTest extends FrameworkIntegrationTestCase
         parent::setUp();
 
         $this->installer->configure(
-            __DIR__ . '/install',
-            new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
         );
     }
 

--- a/tests/Integration/Http/DatabaseSessionInstallerTest.php
+++ b/tests/Integration/Http/DatabaseSessionInstallerTest.php
@@ -19,8 +19,8 @@ final class DatabaseSessionInstallerTest extends FrameworkIntegrationTestCase
     protected function configure(): void
     {
         $this->installer
-            ->configure(__DIR__ . '/install', new Psr4Namespace('App\\', __DIR__ . '/install/App'))
-            ->setRoot(__DIR__ . '/install');
+            ->configure($this->internalStorage . '/install', new Psr4Namespace('App\\', $this->internalStorage . '/install/App'))
+            ->setRoot($this->internalStorage . '/install');
     }
 
     #[PostCondition]

--- a/tests/Integration/Http/MakeControllerCommandTest.php
+++ b/tests/Integration/Http/MakeControllerCommandTest.php
@@ -19,8 +19,8 @@ final class MakeControllerCommandTest extends FrameworkIntegrationTestCase
         parent::setUp();
 
         $this->installer->configure(
-            __DIR__ . '/install',
-            new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
         );
     }
 

--- a/tests/Integration/Http/MakeRequestCommandTest.php
+++ b/tests/Integration/Http/MakeRequestCommandTest.php
@@ -19,8 +19,8 @@ final class MakeRequestCommandTest extends FrameworkIntegrationTestCase
         parent::setUp();
 
         $this->installer->configure(
-            __DIR__ . '/install',
-            new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
         );
     }
 

--- a/tests/Integration/Http/MakeResponseCommandTest.php
+++ b/tests/Integration/Http/MakeResponseCommandTest.php
@@ -19,8 +19,8 @@ final class MakeResponseCommandTest extends FrameworkIntegrationTestCase
         parent::setUp();
 
         $this->installer->configure(
-            __DIR__ . '/install',
-            new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
         );
     }
 

--- a/tests/Integration/View/Commands/MakeViewCommandTest.php
+++ b/tests/Integration/View/Commands/MakeViewCommandTest.php
@@ -18,8 +18,8 @@ final class MakeViewCommandTest extends FrameworkIntegrationTestCase
         parent::setUp();
 
         $this->installer->configure(
-            __DIR__ . '/install',
-            new Psr4Namespace('App\\', __DIR__ . '/install/App'),
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/App'),
         );
     }
 

--- a/tests/Integration/Vite/ViteInstallerTest.php
+++ b/tests/Integration/Vite/ViteInstallerTest.php
@@ -14,12 +14,15 @@ final class ViteInstallerTest extends FrameworkIntegrationTestCase
     #[PreCondition]
     protected function configure(): void
     {
-        $this->installer->configure(__DIR__ . '/install', new Psr4Namespace('App\\', __DIR__ . '/install/app'));
+        $this->installer->configure(
+            $this->internalStorage . '/install',
+            new Psr4Namespace('App\\', $this->internalStorage . '/install/app'),
+        );
 
-        mkdir(__DIR__ . '/install/node_modules');
+        mkdir($this->internalStorage . '/install/node_modules');
 
         // force usage of npm because bun will mutate Tempest's root install otherwise
-        touch(__DIR__ . '/install/package-lock.json');
+        touch($this->internalStorage . '/install/package-lock.json');
     }
 
     #[After]

--- a/tests/Integration/Vite/ViteTest.php
+++ b/tests/Integration/Vite/ViteTest.php
@@ -23,7 +23,7 @@ final class ViteTest extends FrameworkIntegrationTestCase
     {
         parent::setUp();
 
-        $this->vite->setRootDirectory(__DIR__ . '/Fixtures/tmp');
+        $this->vite->setRootDirectory($this->internalStorage . '/Fixtures/tmp');
     }
 
     public function test_set_nonce(): void


### PR DESCRIPTION
Use with
`./vendor/bin/paratest` instead of `./vendor/bin/phpunit`
4min20s -> 50s

So now, tests have custom internalStorage set per worker. Paratest guarantees to set unique TEST_TOKEN.
Tests that modify files MUST use unique names for them (or use lock).

There were some kinda random errors due to container being statically set, so on tests `tearDown` I'm setting it to `null`.