### PR TITLE
feat(database): add ability to create a query builder from another one

### DIFF
--- a/packages/database/src/Builder/QueryBuilders/BuildsQuery.php
+++ b/packages/database/src/Builder/QueryBuilders/BuildsQuery.php
@@ -2,6 +2,7 @@
 
 namespace Tempest\Database\Builder\QueryBuilders;
 
+use Tempest\Database\Builder\ModelInspector;
 use Tempest\Database\Query;
 
 /**
@@ -9,8 +10,41 @@ use Tempest\Database\Query;
  */
 interface BuildsQuery
 {
+    /**
+     * The current bindings for this query builder.
+     *
+     * @return array<mixed>
+     */
+    public array $bindings {
+        get;
+    }
+
+    /**
+     * The model inspector for this query builder.
+     */
+    public ModelInspector $model {
+        get;
+    }
+
+    /**
+     * Creates a {@see Query} instance with the specified optional bindings.
+     *
+     * ### Example
+     * ```php
+     * $builder->build(id: $id);
+     * ```
+     */
     public function build(mixed ...$bindings): Query;
 
-    /** @return self<TModel> */
+    /**
+     * Registers the specified bindings for this query.
+     *
+     * ### Example
+     * ```php
+     * $builder->bind(id: $id);
+     * ```
+     *
+     * @return self<TModel>
+     */
     public function bind(mixed ...$bindings): self;
 }

--- a/packages/database/src/Builder/QueryBuilders/HasConvenientWhereMethods.php
+++ b/packages/database/src/Builder/QueryBuilders/HasConvenientWhereMethods.php
@@ -13,6 +13,7 @@ use UnitEnum;
 
 /**
  * @template TModel of object
+ * @phpstan-require-implements \Tempest\Database\Builder\QueryBuilders\SupportsWhereConditions
  *
  * Shared methods for building WHERE conditions and convenience WHERE methods.
  */

--- a/packages/database/src/Builder/QueryBuilders/InsertQueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/InsertQueryBuilder.php
@@ -36,9 +36,9 @@ final class InsertQueryBuilder implements BuildsQuery
 
     private array $after = [];
 
-    private array $bindings = [];
+    public array $bindings = [];
 
-    private ModelInspector $model;
+    public ModelInspector $model;
 
     /**
      * @param class-string<TModel>|string|TModel $model

--- a/packages/database/src/Builder/QueryBuilders/SupportsWhereStatements.php
+++ b/packages/database/src/Builder/QueryBuilders/SupportsWhereStatements.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tempest\Database\Builder\QueryBuilders;
+
+use Tempest\Database\Builder\WhereOperator;
+use Tempest\Support\Arr\ImmutableArray;
+
+/**
+ * @template TModel of object
+ */
+interface SupportsWhereStatements
+{
+    /**
+     * The current WHERE statements for this query builder.
+     *
+     * @var ImmutableArray<WhereStatement>
+     */
+    public ImmutableArray $wheres {
+        get;
+    }
+
+    /**
+     * Adds a WHERE condition to the query.
+     *
+     * @return self<TModel>
+     */
+    public function whereField(string $field, mixed $value, string|WhereOperator $operator = WhereOperator::EQUALS): self;
+
+    /**
+     * Adds an OR WHERE condition to the query.
+     *
+     * @return self<TModel>
+     */
+    public function orWhere(string $field, mixed $value, WhereOperator $operator = WhereOperator::EQUALS): self;
+}

--- a/packages/database/src/OnDatabase.php
+++ b/packages/database/src/OnDatabase.php
@@ -6,7 +6,7 @@ use UnitEnum;
 
 trait OnDatabase
 {
-    private null|string|UnitEnum $onDatabase = null;
+    private(set) null|string|UnitEnum $onDatabase = null;
 
     public function onDatabase(null|string|UnitEnum $databaseTag): self
     {

--- a/packages/database/src/QueryStatements/CountStatement.php
+++ b/packages/database/src/QueryStatements/CountStatement.php
@@ -11,12 +11,14 @@ use function Tempest\Support\arr;
 
 final class CountStatement implements QueryStatement, HasWhereStatements
 {
-    public bool $distinct = false;
-
+    /**
+     * @param ImmutableArray<WhereStatement> $where
+     */
     public function __construct(
         public readonly TableDefinition $table,
         public ?string $column = null,
         public ImmutableArray $where = new ImmutableArray(),
+        public bool $distinct = false,
     ) {}
 
     public function compile(DatabaseDialect $dialect): string

--- a/tests/Integration/Database/Builder/CountQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/CountQueryBuilderTest.php
@@ -10,6 +10,7 @@ use Tempest\Database\Migrations\CreateMigrationsTable;
 use Tests\Tempest\Fixtures\Migrations\CreateAuthorTable;
 use Tests\Tempest\Fixtures\Migrations\CreatePublishersTable;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
+use Tests\Tempest\Fixtures\Modules\Books\Models\Chapter;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 use function Tempest\Database\query;
@@ -526,6 +527,15 @@ final class CountQueryBuilderTest extends FrameworkIntegrationTestCase
 
         $this->assertSameWithoutBackticks($expected, $query->compile());
         $this->assertSame([true, 'featured', 4.5], $query->bindings);
+    }
+
+    public function test_count_query_builder_from_another_query_builder(): void
+    {
+        $query = query(Chapter::class)
+            ->select()
+            ->where('book_id', 1);
+
+        $this->assertCount(1, CountQueryBuilder::fromQueryBuilder($query)->wheres);
     }
 }
 

--- a/tests/Integration/Database/Builder/DeleteQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/DeleteQueryBuilderTest.php
@@ -8,6 +8,7 @@ use Tempest\Database\PrimaryKey;
 use Tests\Tempest\Fixtures\Migrations\CreateAuthorTable;
 use Tests\Tempest\Fixtures\Migrations\CreatePublishersTable;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
+use Tests\Tempest\Fixtures\Modules\Books\Models\Chapter;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 use function Tempest\Database\query;
@@ -152,5 +153,14 @@ final class DeleteQueryBuilderTest extends FrameworkIntegrationTestCase
 
         $this->assertSameWithoutBackticks($expected, $query->compile());
         $this->assertSame(['draft', '2022-01-01'], $query->bindings);
+    }
+
+    public function test_delete_query_builder_from_another_query_builder(): void
+    {
+        $query = query(Chapter::class)
+            ->select()
+            ->where('book_id', 1);
+
+        $this->assertCount(1, DeleteQueryBuilder::fromQueryBuilder($query)->wheres);
     }
 }

--- a/tests/Integration/Database/Builder/SelectQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/SelectQueryBuilderTest.php
@@ -561,6 +561,40 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
         $this->assertSame('Timeline Taxi Chapter 4', $page10->data[0]->title);
     }
 
+    public function test_paginate_with_where_condition(): void
+    {
+        $this->seed();
+
+        $page1 = query(Chapter::class)
+            ->select()
+            ->whereField('book_id', value: 1)
+            ->paginate(itemsPerPage: 2);
+
+        $this->assertSame(3, $page1->totalItems);
+        $this->assertSame(2, $page1->totalPages);
+        $this->assertSame(1, $page1->currentPage);
+        $this->assertCount(2, $page1->data);
+        $this->assertSame('LOTR 1.1', $page1->data[0]->title);
+        $this->assertSame('LOTR 1.2', $page1->data[1]->title);
+    }
+
+    public function test_select_query_builder_from_another_query_builder(): void
+    {
+        $this->seed();
+
+        $source = query(Chapter::class)
+            ->select()
+            ->where('book_id', 1);
+
+        $query = SelectQueryBuilder::fromQueryBuilder($source);
+        $results = $query->all();
+
+        $this->assertCount(3, $results);
+        $this->assertSame('LOTR 1.1', $results[0]->title);
+        $this->assertSame('LOTR 1.2', $results[1]->title);
+        $this->assertSame('LOTR 1.3', $results[2]->title);
+    }
+
     private function seed(): void
     {
         $this->migrate(

--- a/tests/Integration/Database/Builder/UpdateQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/UpdateQueryBuilderTest.php
@@ -18,6 +18,7 @@ use Tests\Tempest\Fixtures\Migrations\CreatePublishersTable;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Fixtures\Modules\Books\Models\AuthorType;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
+use Tests\Tempest\Fixtures\Modules\Books\Models\Chapter;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 use function Tempest\Database\query;
@@ -466,6 +467,15 @@ final class UpdateQueryBuilderTest extends FrameworkIntegrationTestCase
             ->update(items: [['name' => 'Test Item']])
             ->whereNot('id', 999)
             ->execute();
+    }
+
+    public function test_update_query_builder_from_another_query_builder(): void
+    {
+        $query = query(Chapter::class)
+            ->select()
+            ->where('book_id', 1);
+
+        $this->assertCount(1, UpdateQueryBuilder::fromQueryBuilder($query, ['title' => 'Updated Title'])->wheres);
     }
 }
 


### PR DESCRIPTION
This pull request adds the ability to create a query builder from another one, by adding a new static constructor to each of them.

I had to introduce a new `SupportsWhereStatements` interface as well to expose the bindings and model from `BuildsQuery`. For the bindings, it definitely makes sense—for the model however, it could feel out of place for such an interface. But given that all `BuildsQuery` implementations have one, I think it's fine?

This PR was required to fix https://github.com/tempestphp/tempest-framework/issues/1720