### PR TITLE
fix(view): php 8.5 null offset deprecation warning

### DIFF
--- a/packages/view/src/Parser/TempestViewParser.php
+++ b/packages/view/src/Parser/TempestViewParser.php
@@ -9,7 +9,7 @@ final class TempestViewParser
     private array $scope = [];
 
     private ?Token $currentScope {
-        get => $this->scope[array_key_last($this->scope)] ?? null;
+        get => $this->scope[array_key_last($this->scope) ?? ''] ?? null;
     }
 
     public function __construct(


### PR DESCRIPTION
```
Deprecated: Using null as an array offset is deprecated, use an empty string instead in .../app/vendor/tempest/framework/packages/view/src/Parser/TempestViewParser.php on line 12
```