### PR TITLE
fix(support): process error message after callback in box()

### DIFF
--- a/packages/support/src/functions.php
+++ b/packages/support/src/functions.php
@@ -67,12 +67,12 @@ namespace Tempest\Support {
             $lastMessage = $message;
         });
 
-        if (null !== $lastMessage && Str\contains($lastMessage, '): ')) {
-            $lastMessage = Str\after_first(Str\to_lower_case($lastMessage), '): ');
-        }
-
         try {
             $value = $callback();
+
+            if (null !== $lastMessage && Str\contains($lastMessage, '): ')) {
+                $lastMessage = Str\after_first(Str\to_lower_case($lastMessage), '): ');
+            }
 
             return [$value, $lastMessage];
         } finally {

--- a/packages/support/tests/Filesystem/UnixFunctionsTest.php
+++ b/packages/support/tests/Filesystem/UnixFunctionsTest.php
@@ -151,7 +151,7 @@ final class UnixFunctionsTest extends TestCase
     public function test_delete_directory_non_recursive(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageMatches('/.*Directory not empty.*/');
+        $this->expectExceptionMessageMatches('/.*directory not empty.*/');
 
         $dir = $this->fixtures . '/tmp';
 


### PR DESCRIPTION
The message string processing was running before the callback executed (when `$lastMessage` was still `null`), so error messages were never being cleaned up.