### PR TITLE
fix(core): gracefully handle missing seeders when using `db:seed`

### DIFF
--- a/src/Tempest/Framework/Commands/DatabaseSeedCommand.php
+++ b/src/Tempest/Framework/Commands/DatabaseSeedCommand.php
@@ -36,6 +36,12 @@ final class DatabaseSeedCommand
             return;
         }
 
+        if ($this->seederConfig->seeders === []) {
+            $this->console->info('No seeders are configured.');
+
+            return;
+        }
+
         if (count($this->seederConfig->seeders) === 1) {
             $this->runSeeder($this->seederConfig->seeders[0], $database);
             return;


### PR DESCRIPTION
If you run `db:seed` when there are no configured seeders and you press enter on the empty list, the CLI crashes. This PR fixes that.