### PR TITLE
fix(console): properly normalize boolean flag names

### DIFF
--- a/packages/console/src/Input/ConsoleArgumentDefinition.php
+++ b/packages/console/src/Input/ConsoleArgumentDefinition.php
@@ -65,7 +65,7 @@ final readonly class ConsoleArgumentDefinition
         $normalizedName = str($name)->kebab();
 
         if ($boolean) {
-            $normalizedName->replaceStart('no-', '');
+            $normalizedName = $normalizedName->replaceStart('no-', '');
         }
 
         return $normalizedName->toString();


### PR DESCRIPTION
`$normalizedName` is immutable, without reassigning it, the value won't change. This PR fixes the issue.