### PR TITLE
feat(reflection): resolve short class names in @var docblock annotations - PhpToken implementation

### DIFF
--- a/packages/reflection/src/PropertyReflector.php
+++ b/packages/reflection/src/PropertyReflector.php
@@ -254,12 +254,16 @@ final class PropertyReflector implements Reflector
         while ($i < $count && $tokens[$i]->text !== '}') {
             $this->skipWhitespaceTokens($tokens, $i, $count);
 
+            if ($i >= $count) {
+                break;
+            }
+
             if ($tokens[$i]->is([T_FUNCTION, T_CONST])) {
                 while ($i < $count && $tokens[$i]->text !== ',' && $tokens[$i]->text !== '}') {
                     $i++;
                 }
 
-                if ($tokens[$i]->text === ',') {
+                if ($i < $count && $tokens[$i]->text === ',') {
                     $i++;
                 }
 
@@ -275,17 +279,23 @@ final class PropertyReflector implements Reflector
 
             $this->skipWhitespaceTokens($tokens, $i, $count);
 
+            if ($i >= $count) {
+                break;
+            }
+
             $alias = $this->parseAlias($tokens, $i, $count) ?? $this->getShortName($name);
             $useStatements[$alias] = $prefix . '\\' . $name;
 
             $this->skipWhitespaceTokens($tokens, $i, $count);
 
-            if ($tokens[$i]->text === ',') {
+            if ($i < $count && $tokens[$i]->text === ',') {
                 $i++;
             }
         }
 
-        $i++;
+        if ($i < $count) {
+            $i++;
+        }
     }
 
     private function getShortName(string $fqcn): string

--- a/packages/reflection/src/PropertyReflector.php
+++ b/packages/reflection/src/PropertyReflector.php
@@ -5,11 +5,19 @@ declare(strict_types=1);
 namespace Tempest\Reflection;
 
 use Error;
+use PhpToken;
+use ReflectionClass;
 use ReflectionProperty as PHPReflectionProperty;
 
 final class PropertyReflector implements Reflector
 {
     use HasAttributes;
+
+    /** @var array<string, array<string, string>> */
+    private static array $useStatementCache = [];
+
+    /** @var array<string, string> */
+    private static array $resolvedTypeCache = [];
 
     public function __construct(
         private readonly PHPReflectionProperty $reflectionProperty,
@@ -94,17 +102,197 @@ final class PropertyReflector implements Reflector
     {
         $doc = $this->reflectionProperty->getDocComment();
 
-        if (! $doc) {
+        if (! $doc || ! preg_match('/@var\s+(?:(?:array|list)<([\\\\\w]+)>|([\\\\\w]+)\[\])/', $doc, $match)) {
             return null;
         }
 
-        preg_match('/@var ([\\\\\w]+)\[]/', $doc, $match);
+        $rawType = $match[1] !== '' ? $match[1] : $match[2];
+        $typeName = ltrim($rawType, '\\');
 
-        if (! isset($match[1])) {
+        return str_contains($rawType, '\\')
+            ? new TypeReflector($typeName)
+            : new TypeReflector($this->resolveShortClassName($typeName));
+    }
+
+    private function resolveShortClassName(string $shortName): string
+    {
+        $declaringClass = $this->reflectionProperty->getDeclaringClass();
+        $cacheKey = $declaringClass->getName() . '::' . $shortName;
+
+        return self::$resolvedTypeCache[$cacheKey] ??= $this->doResolveShortClassName($shortName, $declaringClass);
+    }
+
+    private function doResolveShortClassName(string $shortName, ReflectionClass $declaringClass): string
+    {
+        $fileName = $declaringClass->getFileName();
+
+        if ($fileName) {
+            self::$useStatementCache[$fileName] ??= $this->parseUseStatements($fileName);
+
+            if (isset(self::$useStatementCache[$fileName][$shortName])) {
+                return self::$useStatementCache[$fileName][$shortName];
+            }
+        }
+
+        $namespace = $declaringClass->getNamespaceName();
+
+        if ($namespace !== '') {
+            $fqcn = $namespace . '\\' . $shortName;
+
+            if (class_exists($fqcn)) {
+                return $fqcn;
+            }
+        }
+
+        return $shortName;
+    }
+
+    /** @return array<string, string> */
+    private function parseUseStatements(string $fileName): array
+    {
+        $content = file_get_contents($fileName);
+
+        if ($content === false) {
+            return [];
+        }
+
+        $tokens = PhpToken::tokenize($content);
+        $useStatements = [];
+        $count = count($tokens);
+
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            if ($token->is([T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM])) {
+                break;
+            }
+
+            if (! $token->is(T_USE)) {
+                continue;
+            }
+
+            $i++;
+            $this->skipWhitespaceTokens($tokens, $i, $count);
+
+            if ($tokens[$i]->is([T_FUNCTION, T_CONST])) {
+                continue;
+            }
+
+            $fqcn = $this->parseNamespacedName($tokens, $i, $count);
+            $this->skipWhitespaceTokens($tokens, $i, $count);
+
+            if ($tokens[$i]->text === '{') {
+                $this->parseGroupUse($tokens, $i, $count, $fqcn, $useStatements);
+                continue;
+            }
+
+            $alias = $this->parseAlias($tokens, $i, $count) ?? $this->getShortName($fqcn);
+            $useStatements[$alias] = $fqcn;
+
+            while ($i < $count && $tokens[$i]->text !== ';') {
+                $i++;
+            }
+        }
+
+        return $useStatements;
+    }
+
+    /** @param PhpToken[] $tokens */
+    private function skipWhitespaceTokens(array $tokens, int &$i, int $count): void
+    {
+        while ($i < $count && $tokens[$i]->is([T_WHITESPACE, T_COMMENT])) {
+            $i++;
+        }
+    }
+
+    /** @param PhpToken[] $tokens */
+    private function parseNamespacedName(array $tokens, int &$i, int $count): string
+    {
+        $name = '';
+
+        while ($i < $count) {
+            $token = $tokens[$i];
+
+            if ($token->is([T_STRING, T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED, T_NS_SEPARATOR])) {
+                $name .= $token->text;
+                $i++;
+            } elseif ($token->is(T_WHITESPACE)) {
+                $i++;
+            } else {
+                break;
+            }
+        }
+
+        return ltrim($name, '\\');
+    }
+
+    /** @param PhpToken[] $tokens */
+    private function parseAlias(array $tokens, int &$i, int $count): ?string
+    {
+        if (! $tokens[$i]->is(T_AS)) {
             return null;
         }
 
-        return new TypeReflector(ltrim($match[1], '\\'));
+        $i++;
+        $this->skipWhitespaceTokens($tokens, $i, $count);
+
+        if ($tokens[$i]->is(T_STRING)) {
+            return $tokens[$i++]->text;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param PhpToken[] $tokens
+     * @param array<string, string> $useStatements
+     */
+    private function parseGroupUse(array $tokens, int &$i, int $count, string $prefix, array &$useStatements): void
+    {
+        $i++;
+
+        while ($i < $count && $tokens[$i]->text !== '}') {
+            $this->skipWhitespaceTokens($tokens, $i, $count);
+
+            if ($tokens[$i]->is([T_FUNCTION, T_CONST])) {
+                while ($i < $count && $tokens[$i]->text !== ',' && $tokens[$i]->text !== '}') {
+                    $i++;
+                }
+
+                if ($tokens[$i]->text === ',') {
+                    $i++;
+                }
+
+                continue;
+            }
+
+            $name = $this->parseNamespacedName($tokens, $i, $count);
+
+            if ($name === '') {
+                $i++;
+                continue;
+            }
+
+            $this->skipWhitespaceTokens($tokens, $i, $count);
+
+            $alias = $this->parseAlias($tokens, $i, $count) ?? $this->getShortName($name);
+            $useStatements[$alias] = $prefix . '\\' . $name;
+
+            $this->skipWhitespaceTokens($tokens, $i, $count);
+
+            if ($tokens[$i]->text === ',') {
+                $i++;
+            }
+        }
+
+        $i++;
+    }
+
+    private function getShortName(string $fqcn): string
+    {
+        $pos = strrpos($fqcn, '\\');
+
+        return $pos === false ? $fqcn : substr($fqcn, $pos + 1);
     }
 
     public function isUninitialized(object $object): bool

--- a/packages/reflection/tests/Fixtures/IterableTypeResolution/Author.php
+++ b/packages/reflection/tests/Fixtures/IterableTypeResolution/Author.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Reflection\Tests\Fixtures\IterableTypeResolution;
+
+final class Author
+{
+    public string $name;
+}

--- a/packages/reflection/tests/Fixtures/IterableTypeResolution/Book.php
+++ b/packages/reflection/tests/Fixtures/IterableTypeResolution/Book.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Reflection\Tests\Fixtures\IterableTypeResolution;
+
+final class Book
+{
+    public string $title;
+}

--- a/packages/reflection/tests/Fixtures/IterableTypeResolution/Models/AliasedUseStatement.php
+++ b/packages/reflection/tests/Fixtures/IterableTypeResolution/Models/AliasedUseStatement.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Models;
+
+use Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Book as MyBook;
+
+final class AliasedUseStatement
+{
+    /** @var MyBook[] */
+    public array $books = [];
+}

--- a/packages/reflection/tests/Fixtures/IterableTypeResolution/Models/FullyQualifiedClassName.php
+++ b/packages/reflection/tests/Fixtures/IterableTypeResolution/Models/FullyQualifiedClassName.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Models;
+
+final class FullyQualifiedClassName
+{
+    /** @var \Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Book[] */
+    public array $books = [];
+}

--- a/packages/reflection/tests/Fixtures/IterableTypeResolution/Models/GroupUseStatement.php
+++ b/packages/reflection/tests/Fixtures/IterableTypeResolution/Models/GroupUseStatement.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Models;
+
+use Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Author;
+use Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Book;
+
+final class GroupUseStatement
+{
+    /** @var Book[] */
+    public array $books = [];
+
+    /** @var Author[] */
+    public array $authors = [];
+}

--- a/packages/reflection/tests/Fixtures/IterableTypeResolution/Models/RegularUseStatement.php
+++ b/packages/reflection/tests/Fixtures/IterableTypeResolution/Models/RegularUseStatement.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Models;
+
+use Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Book;
+
+final class RegularUseStatement
+{
+    /** @var Book[] */
+    public array $books = [];
+}

--- a/packages/reflection/tests/Fixtures/IterableTypeResolution/SameNamespace.php
+++ b/packages/reflection/tests/Fixtures/IterableTypeResolution/SameNamespace.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Reflection\Tests\Fixtures\IterableTypeResolution;
+
+final class SameNamespace
+{
+    /** @var Book[] */
+    public array $books = [];
+}

--- a/packages/reflection/tests/PropertyReflectorTest.php
+++ b/packages/reflection/tests/PropertyReflectorTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Reflection\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Reflection\PropertyReflector;
+use Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Author;
+use Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Book;
+use Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Models\AliasedUseStatement;
+use Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Models\FullyQualifiedClassName;
+use Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Models\GroupUseStatement;
+use Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\Models\RegularUseStatement;
+use Tempest\Reflection\Tests\Fixtures\IterableTypeResolution\SameNamespace;
+
+final class PropertyReflectorTest extends TestCase
+{
+    #[Test]
+    public function iterable_type_with_regular_use_statement(): void
+    {
+        $property = PropertyReflector::fromParts(RegularUseStatement::class, 'books');
+
+        $iterableType = $property->getIterableType();
+
+        $this->assertNotNull($iterableType);
+        $this->assertSame(Book::class, $iterableType->getName());
+    }
+
+    #[Test]
+    public function iterable_type_with_aliased_use_statement(): void
+    {
+        $property = PropertyReflector::fromParts(AliasedUseStatement::class, 'books');
+
+        $iterableType = $property->getIterableType();
+
+        $this->assertNotNull($iterableType);
+        $this->assertSame(Book::class, $iterableType->getName());
+    }
+
+    #[Test]
+    public function iterable_type_with_group_use_statement(): void
+    {
+        $booksProperty = PropertyReflector::fromParts(GroupUseStatement::class, 'books');
+        $authorsProperty = PropertyReflector::fromParts(GroupUseStatement::class, 'authors');
+
+        $booksType = $booksProperty->getIterableType();
+        $authorsType = $authorsProperty->getIterableType();
+
+        $this->assertNotNull($booksType);
+        $this->assertSame(Book::class, $booksType->getName());
+
+        $this->assertNotNull($authorsType);
+        $this->assertSame(Author::class, $authorsType->getName());
+    }
+
+    #[Test]
+    public function iterable_type_with_same_namespace(): void
+    {
+        $property = PropertyReflector::fromParts(SameNamespace::class, 'books');
+
+        $iterableType = $property->getIterableType();
+
+        $this->assertNotNull($iterableType);
+        $this->assertSame(Book::class, $iterableType->getName());
+    }
+
+    #[Test]
+    public function iterable_type_with_fully_qualified_class_name(): void
+    {
+        $property = PropertyReflector::fromParts(FullyQualifiedClassName::class, 'books');
+
+        $iterableType = $property->getIterableType();
+
+        $this->assertNotNull($iterableType);
+        $this->assertSame(Book::class, $iterableType->getName());
+    }
+}


### PR DESCRIPTION
Closes https://github.com/tempestphp/tempest-framework/issues/1749.

I've also managed to make a php-parser implementation, which is needless to say much more elegan.

PHP-Parser implementation here: https://github.com/tempestphp/tempest-framework/pull/1787

If someone could perhaps benchmark both implementations, I'd be grateful.