### PR TITLE
feat(session): add redis session manager

### DIFF
--- a/packages/http/src/Session/Config/RedisSessionConfig.php
+++ b/packages/http/src/Session/Config/RedisSessionConfig.php
@@ -16,7 +16,7 @@ final class RedisSessionConfig implements SessionConfig
      */
     public function __construct(
         private(set) Duration $expiration,
-        private(set) string $prefix = 'session',
+        private(set) string $prefix = 'session:',
     ) {}
 
     public function createManager(Container $container): RedisSessionManager

--- a/packages/http/src/Session/Config/RedisSessionConfig.php
+++ b/packages/http/src/Session/Config/RedisSessionConfig.php
@@ -16,7 +16,7 @@ final class RedisSessionConfig implements SessionConfig
      */
     public function __construct(
         private(set) Duration $expiration,
-        private(set) string $prefix = 'session:',
+        readonly string $prefix = 'session:',
     ) {}
 
     public function createManager(Container $container): RedisSessionManager

--- a/packages/http/src/Session/Config/RedisSessionConfig.php
+++ b/packages/http/src/Session/Config/RedisSessionConfig.php
@@ -23,5 +23,4 @@ final class RedisSessionConfig implements SessionConfig
     {
         return $container->get(RedisSessionManager::class);
     }
-
 }

--- a/packages/http/src/Session/Config/RedisSessionConfig.php
+++ b/packages/http/src/Session/Config/RedisSessionConfig.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Session\Config;
+
+use Tempest\Container\Container;
+use Tempest\DateTime\Duration;
+use Tempest\Http\Session\Managers\RedisSessionManager;
+use Tempest\Http\Session\SessionConfig;
+
+final class RedisSessionConfig implements SessionConfig
+{
+    /**
+     * @param Duration $expiration Time required for a session to expire.
+     */
+    public function __construct(
+        private(set) Duration $expiration,
+        private(set) string $prefix = 'session',
+    ) {}
+
+    public function createManager(Container $container): RedisSessionManager
+    {
+        return $container->get(RedisSessionManager::class);
+    }
+
+}

--- a/packages/http/src/Session/Managers/RedisSessionManager.php
+++ b/packages/http/src/Session/Managers/RedisSessionManager.php
@@ -139,7 +139,6 @@ final readonly class RedisSessionManager implements SessionManager
         do {
             $result = $this->redis->command('SCAN', $cursor, 'MATCH', $this->getKey(new SessionId('*')), 'COUNT', '100');
             $cursor = $result[0];
-            ld($result);
             foreach ($result[1] as $key) {
                 $sessionId = $this->getSessionIdFromKey($key);
 

--- a/packages/http/src/Session/Managers/RedisSessionManager.php
+++ b/packages/http/src/Session/Managers/RedisSessionManager.php
@@ -77,7 +77,7 @@ final readonly class RedisSessionManager implements SessionManager
         try {
             $content = $this->redis->get($this->getKey($id));
             return unserialize($content, ['allowed_classes' => true]);
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             return null;
         }
     }

--- a/packages/http/src/Session/Managers/RedisSessionManager.php
+++ b/packages/http/src/Session/Managers/RedisSessionManager.php
@@ -11,8 +11,8 @@ use Tempest\Http\Session\SessionDestroyed;
 use Tempest\Http\Session\SessionId;
 use Tempest\Http\Session\SessionManager;
 use Tempest\KeyValue\Redis\Redis;
-use Tempest\Support\Filesystem;
 use Throwable;
+
 use function Tempest\event;
 
 final readonly class RedisSessionManager implements SessionManager

--- a/packages/http/src/Session/Managers/RedisSessionManager.php
+++ b/packages/http/src/Session/Managers/RedisSessionManager.php
@@ -49,7 +49,7 @@ final readonly class RedisSessionManager implements SessionManager
 
     public function destroy(SessionId $id): void
     {
-        $this->redis->getClient()->del($this->getKey($id));
+        $this->redis->command('UNLINK', $this->getKey($id));
 
         event(new SessionDestroyed($id));
     }

--- a/packages/http/src/Session/Managers/RedisSessionManager.php
+++ b/packages/http/src/Session/Managers/RedisSessionManager.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Session\Managers;
+
+use Tempest\Clock\Clock;
+use Tempest\Http\Session\Session;
+use Tempest\Http\Session\SessionConfig;
+use Tempest\Http\Session\SessionDestroyed;
+use Tempest\Http\Session\SessionId;
+use Tempest\Http\Session\SessionManager;
+use Tempest\KeyValue\Redis\Redis;
+use Tempest\Support\Filesystem;
+use Throwable;
+use function Tempest\event;
+
+final readonly class RedisSessionManager implements SessionManager
+{
+    public function __construct(
+        private Clock $clock,
+        private Redis $redis,
+        private SessionConfig $sessionConfig,
+    ) {}
+
+    public function create(SessionId $id): Session
+    {
+        return $this->persist($id);
+    }
+
+    public function set(SessionId $id, string $key, mixed $value): void
+    {
+        $this->persist($id, [...$this->getData($id), ...[$key => $value]]);
+    }
+
+    public function get(SessionId $id, string $key, mixed $default = null): mixed
+    {
+        return $this->getData($id)[$key] ?? $default;
+    }
+
+    public function remove(SessionId $id, string $key): void
+    {
+        $data = $this->getData($id);
+
+        unset($data[$key]);
+
+        $this->persist($id, $data);
+    }
+
+    public function destroy(SessionId $id): void
+    {
+        $this->redis->getClient()->del($this->getKey($id));
+
+        event(new SessionDestroyed($id));
+    }
+
+    public function isValid(SessionId $id): bool
+    {
+        $session = $this->resolve($id);
+
+        if ($session === null) {
+            return false;
+        }
+
+        if (! ($session->lastActiveAt ?? null)) {
+            return false;
+        }
+
+        return $this->clock->now()->before(
+            other: $session->lastActiveAt->plus($this->sessionConfig->expiration),
+        );
+    }
+
+    private function resolve(SessionId $id): ?Session
+    {
+        try {
+            $content = $this->redis->get($this->getKey($id));
+            return unserialize($content, ['allowed_classes' => true]);
+        } catch (Throwable $e) {
+            return null;
+        }
+    }
+
+    public function all(SessionId $id): array
+    {
+        return $this->getData($id);
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function getData(SessionId $id): array
+    {
+        return $this->resolve($id)->data ?? [];
+    }
+
+    /**
+     * @param array<mixed>|null $data
+     */
+    private function persist(SessionId $id, ?array $data = null): Session
+    {
+        $now = $this->clock->now();
+        $session = $this->resolve($id) ?? new Session(
+            id: $id,
+            createdAt: $now,
+            lastActiveAt: $now,
+        );
+
+        $session->lastActiveAt = $now;
+
+        if ($data !== null) {
+            $session->data = $data;
+        }
+
+        $this->redis->set($this->getKey($id), serialize($session), $this->sessionConfig->expiration);
+
+        return $session;
+    }
+
+    private function getKey(SessionId $id): string
+    {
+        return sprintf('%s_%s', $this->sessionConfig->prefix, $id);
+    }
+
+    public function cleanup(): void
+    {
+        // what should we do here?
+        // on persist we set the expiration (ttl) for the session in the redis store
+        // in theory all session data should be expire by itself
+    }
+}

--- a/tests/Integration/Http/RedisSessionTest.php
+++ b/tests/Integration/Http/RedisSessionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Integration\Http;
+namespace Tests\Tempest\Integration\Http;
 
 use PHPUnit\Framework\Attributes\Test;
 use Tempest\Clock\Clock;

--- a/tests/Integration/Http/RedisSessionTest.php
+++ b/tests/Integration/Http/RedisSessionTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Integration\Http;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Clock\Clock;
+use Tempest\DateTime\Duration;
+use Tempest\EventBus\EventBus;
+use Tempest\Http\Session\Config\RedisSessionConfig;
+use Tempest\Http\Session\Managers\RedisSessionManager;
+use Tempest\Http\Session\Session;
+use Tempest\Http\Session\SessionConfig;
+use Tempest\Http\Session\SessionDestroyed;
+use Tempest\Http\Session\SessionId;
+use Tempest\Http\Session\SessionManager;
+use Tempest\KeyValue\Redis\Redis;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+/**
+ * @internal
+ */
+final class RedisSessionTest extends FrameworkIntegrationTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container->config(new RedisSessionConfig(expiration: Duration::hours(2)));
+        $this->container->singleton(
+            SessionManager::class,
+            fn () => new RedisSessionManager(
+                $this->container->get(Clock::class),
+                $this->container->get(Redis::class),
+                $this->container->get(SessionConfig::class),
+            ),
+        );
+    }
+
+    #[Test]
+    public function create_session_from_container(): void
+    {
+        $session = $this->container->get(Session::class);
+
+        $this->assertInstanceOf(Session::class, $session);
+    }
+
+    #[Test]
+    public function put_get(): void
+    {
+        $session = $this->container->get(Session::class);
+
+        $session->set('test', 'value');
+
+        $value = $session->get('test');
+        $this->assertEquals('value', $value);
+    }
+
+    #[Test]
+    public function remove(): void
+    {
+        $session = $this->container->get(Session::class);
+
+        $session->set('test', 'value');
+        $session->remove('test');
+
+        $value = $session->get('test');
+        $this->assertNull($value);
+    }
+
+    #[Test]
+    public function destroy(): void
+    {
+        $manager = $this->container->get(SessionManager::class);
+        $sessionId = new SessionId('test_session_destroy');
+
+        $session = $manager->create($sessionId);
+        $session->set('magic_type', 'offensive');
+
+        $this->assertTrue($manager->isValid($sessionId));
+
+        $events = [];
+        $eventBus = $this->container->get(EventBus::class);
+        $eventBus->listen(function (SessionDestroyed $event) use (&$events): void {
+            $events[] = $event;
+        });
+
+        $session->destroy();
+
+        $this->assertFalse($manager->isValid($sessionId));
+        $this->assertCount(1, $events);
+        $this->assertEquals((string) $sessionId, (string) $events[0]->id);
+    }
+
+    #[Test]
+    public function set_previous_url(): void
+    {
+        $session = $this->container->get(Session::class);
+        $session->setPreviousUrl('http://localhost/previous');
+
+        $this->assertEquals('http://localhost/previous', $session->getPreviousUrl());
+    }
+
+    #[Test]
+    public function is_valid(): void
+    {
+        $clock = $this->clock('2023-01-01 00:00:00');
+
+        $this->container->config(new RedisSessionConfig(
+            expiration: Duration::second(),
+        ));
+
+        $sessionManager = $this->container->get(SessionManager::class);
+
+        $this->assertFalse($sessionManager->isValid(new SessionId('unknown')));
+
+        $session = $sessionManager->create(new SessionId('new'));
+
+        $this->assertTrue($session->isValid());
+
+        $clock->plus(1);
+
+        $this->assertFalse($session->isValid());
+    }
+
+    #[Test]
+    public function session_reflash(): void
+    {
+        $session = $this->container->get(Session::class);
+
+        $session->flash('test', 'value');
+        $session->flash('test2', ['key' => 'value']);
+
+        $this->assertEquals('value', $session->get('test'));
+
+        $session->reflash();
+        $session->cleanup();
+
+        $this->assertEquals('value', $session->get('test'));
+        $this->assertEquals(['key' => 'value'], $session->get('test2'));
+    }
+
+    #[Test]
+    public function session_expires_based_on_last_activity(): void
+    {
+        $clock = $this->clock('2023-01-01 00:00:00');
+
+        $this->container->config(new RedisSessionConfig(
+            expiration: Duration::minutes(30),
+        ));
+
+        $manager = $this->container->get(SessionManager::class);
+        $sessionId = new SessionId('last_activity_test');
+
+        // Create session
+        $session = $manager->create($sessionId);
+        $this->assertTrue($session->isValid());
+
+        $clock->plus(Duration::minutes(25));
+        $this->assertTrue($session->isValid());
+
+        // Perform activity
+        $session->set('activity', 'user_action');
+        $clock->plus(Duration::minutes(25));
+        $this->assertTrue($session->isValid());
+        $this->assertTrue($manager->isValid($sessionId));
+
+        // Move forward another 10 minutes, now 35 minutes from last activity
+        $clock->plus(Duration::minutes(10));
+        $this->assertFalse($session->isValid());
+        $this->assertFalse($manager->isValid($sessionId));
+    }
+}

--- a/tests/Integration/Http/RedisSessionTest.php
+++ b/tests/Integration/Http/RedisSessionTest.php
@@ -116,6 +116,7 @@ final class RedisSessionTest extends FrameworkIntegrationTestCase
 
         $this->container->config(new RedisSessionConfig(
             expiration: Duration::second(),
+            prefix: 'test_session:',
         ));
 
         $sessionManager = $this->container->get(SessionManager::class);
@@ -155,6 +156,7 @@ final class RedisSessionTest extends FrameworkIntegrationTestCase
 
         $this->container->config(new RedisSessionConfig(
             expiration: Duration::minutes(30),
+            prefix: 'test_session:',
         ));
 
         $manager = $this->container->get(SessionManager::class);
@@ -184,7 +186,7 @@ final class RedisSessionTest extends FrameworkIntegrationTestCase
     {
         $clock = $this->clock('2023-01-01 00:00:00');
 
-        $this->container->config(new RedisSessionConfig(expiration: Duration::minutes(30)));
+        $this->container->config(new RedisSessionConfig(expiration: Duration::minutes(30), prefix: 'test_session:'));
 
         $manager = $this->container->get(SessionManager::class);
 
@@ -267,7 +269,7 @@ final class RedisSessionTest extends FrameworkIntegrationTestCase
         $redis = $this->container->get(Redis::class);
 
         try {
-            $content = $redis->get(sprintf('%s%s',  'test_session:', $id));
+            $content = $redis->get(sprintf('%s%s', 'test_session:', $id));
             return unserialize($content, ['allowed_classes' => true]);
         } catch (Throwable) {
             return null;

--- a/tests/Integration/Http/RedisSessionTest.php
+++ b/tests/Integration/Http/RedisSessionTest.php
@@ -31,7 +31,7 @@ final class RedisSessionTest extends FrameworkIntegrationTestCase
         $this->container->config(new RedisSessionConfig(expiration: Duration::hours(2)));
         $this->container->singleton(
             SessionManager::class,
-            fn() => new RedisSessionManager(
+            fn () => new RedisSessionManager(
                 $this->container->get(Clock::class),
                 $this->container->get(Redis::class),
                 $this->container->get(SessionConfig::class),
@@ -242,7 +242,7 @@ final class RedisSessionTest extends FrameworkIntegrationTestCase
     {
         $session = $this->getSessionFromDatabase($sessionId);
 
-        $this->assertNotNull($session, "Session {$sessionId} should not exist in database");
+        $this->assertNotNull($session, "Session {$sessionId} should exist in database");
     }
 
     private function assertSessionNotExistsInDatabase(SessionId $sessionId): void
@@ -250,17 +250,6 @@ final class RedisSessionTest extends FrameworkIntegrationTestCase
         $session = $this->getSessionFromDatabase($sessionId);
 
         $this->assertNull($session, "Session {$sessionId} should not exist in database");
-    }
-
-    private function assertSessionDataInDatabase(SessionId $sessionId, array $data): void
-    {
-        $session = $this->getSessionFromDatabase($sessionId);
-
-        $this->assertNotNull($session, "Session {$sessionId} should exist in database");
-
-        foreach ($data as $key => $value) {
-            $this->assertEquals($value, $session->data[$key], "Session data key '{$key}' should match expected value");
-        }
     }
 
     private function getSessionLastActiveTimestamp(SessionId $sessionId): \Tempest\DateTime\DateTime
@@ -272,16 +261,15 @@ final class RedisSessionTest extends FrameworkIntegrationTestCase
         return $session->lastActiveAt;
     }
 
-
     private function getSessionFromDatabase(SessionId $id): ?Session
     {
         $config = $this->container->get(SessionConfig::class);
         $redis = $this->container->get(Redis::class);
 
         try {
-            $content = $redis->get(sprintf('%s_%s', $config->prefix, $id));
+            $content = $redis->get(sprintf('%s%s', $config->prefix, $id));
             return unserialize($content, ['allowed_classes' => true]);
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             return null;
         }
     }


### PR DESCRIPTION
Close #1700 

Questions:
- Do we need actions in cleanup function when we set the expiration on the redis stored data?
- Is the RedisSessionConfig the right way to set a prefix for session keys? 
- Do we need multiple tagged Redis setups?
- How can we setup the Redis client to a different database for sessions in this scenario? If we want to

Laravel uses multiple configuration an treat redis as database, to separate cache from other things they configure multiple connections to different databases. 
The Redis Client itself allows to set the prefix for the client as a whole. From my understanding to support that we need a tagged(`'session'`) redis client. I dont understand how to do that without touchung the kv-store.

For example `RedisCacheConfig`:
The cache uses the same RedisConfig as the RedisSessionConfig and the data will be written in the same database.
