### PR TITLE
fix(console)!: allow `--force` to bypass `CautionMiddleware`

### DIFF
--- a/packages/console/src/Console.php
+++ b/packages/console/src/Console.php
@@ -157,4 +157,9 @@ interface Console
      * Forces the console to not be interactive.
      */
     public function disablePrompting(): self;
+
+    /**
+     * Whether the console is in forced mode (skipping confirmations).
+     */
+    public function isForced(): bool;
 }

--- a/packages/console/src/Console.php
+++ b/packages/console/src/Console.php
@@ -161,5 +161,7 @@ interface Console
     /**
      * Whether the console is in forced mode (skipping confirmations).
      */
-    public function isForced(): bool;
+    public bool $isForced {
+        get;
+    }
 }

--- a/packages/console/src/GenericConsole.php
+++ b/packages/console/src/GenericConsole.php
@@ -39,7 +39,7 @@ final class GenericConsole implements Console
 
     private ?string $label = null;
 
-    private bool $isForced = false;
+    public private(set) bool $isForced = false;
 
     private bool $supportsPrompting = true;
 
@@ -71,11 +71,6 @@ final class GenericConsole implements Console
         $this->isForced = true;
 
         return $this;
-    }
-
-    public function isForced(): bool
-    {
-        return $this->isForced;
     }
 
     public function disablePrompting(): self

--- a/packages/console/src/GenericConsole.php
+++ b/packages/console/src/GenericConsole.php
@@ -73,6 +73,11 @@ final class GenericConsole implements Console
         return $this;
     }
 
+    public function isForced(): bool
+    {
+        return $this->isForced;
+    }
+
     public function disablePrompting(): self
     {
         $this->supportsPrompting = false;

--- a/packages/console/src/GenericConsole.php
+++ b/packages/console/src/GenericConsole.php
@@ -39,7 +39,7 @@ final class GenericConsole implements Console
 
     private ?string $label = null;
 
-    public private(set) bool $isForced = false;
+    private(set) bool $isForced = false;
 
     private bool $supportsPrompting = true;
 

--- a/packages/console/src/Middleware/CautionMiddleware.php
+++ b/packages/console/src/Middleware/CautionMiddleware.php
@@ -25,6 +25,10 @@ final readonly class CautionMiddleware implements ConsoleMiddleware
         $environment = $this->appConfig->environment;
 
         if ($environment->isProduction() || $environment->isStaging()) {
+            if ($this->console->isForced()) {
+                return $next($invocation);
+            }
+
             $continue = $this->console->confirm('This command might be destructive. Do you wish to continue?');
 
             if (! $continue) {

--- a/packages/console/src/Middleware/CautionMiddleware.php
+++ b/packages/console/src/Middleware/CautionMiddleware.php
@@ -25,7 +25,7 @@ final readonly class CautionMiddleware implements ConsoleMiddleware
         $environment = $this->appConfig->environment;
 
         if ($environment->isProduction() || $environment->isStaging()) {
-            if ($this->console->isForced()) {
+            if ($this->console->isForced) {
                 return $next($invocation);
             }
 


### PR DESCRIPTION
Fixes `php tempest cache:clear --force` failing in production environment.