### PR TITLE
feat(database): support uuids as primary columns

### DIFF
--- a/packages/database/src/Builder/ModelInspector.php
+++ b/packages/database/src/Builder/ModelInspector.php
@@ -11,6 +11,7 @@ use Tempest\Database\HasOne;
 use Tempest\Database\PrimaryKey;
 use Tempest\Database\Relation;
 use Tempest\Database\Table;
+use Tempest\Database\Uuid;
 use Tempest\Database\Virtual;
 use Tempest\Mapper\SerializeAs;
 use Tempest\Mapper\SerializeWith;
@@ -548,5 +549,15 @@ final class ModelInspector
         }
 
         return $primaryKeyProperty->getValue($this->instance);
+    }
+
+    public function hasUuidPrimaryKey(): bool
+    {
+        return $this->getPrimaryKeyProperty()?->hasAttribute(Uuid::class) ?? false;
+    }
+
+    public function isUuidPrimaryKey(PropertyReflector $property): bool
+    {
+        return $property->getType()->matches(PrimaryKey::class) && $property->hasAttribute(Uuid::class);
     }
 }

--- a/packages/database/src/Builder/QueryBuilders/InsertQueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/InsertQueryBuilder.php
@@ -442,6 +442,10 @@ final class InsertQueryBuilder implements BuildsQuery
 
             $column = $propertyName;
 
+            if ($property->getType()->getName() === PrimaryKey::class && $value === null) {
+                continue;
+            }
+
             if ($definition->isRelation($property)) {
                 [$column, $value] = $this->resolveRelationProperty($definition, $property, $value);
             } else {

--- a/packages/database/src/Builder/QueryBuilders/QueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/QueryBuilder.php
@@ -264,7 +264,10 @@ final readonly class QueryBuilder
 
         if ($id !== null && $primaryKeyProperty !== null) {
             $primaryKeyName = $primaryKeyProperty->getName();
-            $model->{$primaryKeyName} = new PrimaryKey($id);
+
+            if (! $inspector->hasUuidPrimaryKey() || $model->{$primaryKeyName} === null) {
+                $model->{$primaryKeyName} = new PrimaryKey($id);
+            }
         }
 
         return $model;

--- a/packages/database/src/IsDatabaseModel.php
+++ b/packages/database/src/IsDatabaseModel.php
@@ -248,7 +248,9 @@ trait IsDatabaseModel
                 ->insert($this)
                 ->execute();
 
-            $primaryKeyProperty->setValue($this, $id);
+            if (! $model->hasUuidPrimaryKey()) {
+                $primaryKeyProperty->setValue($this, $id);
+            }
 
             return $this;
         }

--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -33,11 +33,28 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
     }
 
     /**
-     * Adds a primary key column to the table. MySQL and SQLite use an auto-incrementing `INTEGER` column, and PostgreSQL uses `SERIAL`.
+     * Adds a primary key column to the table.
+     *
+     * By default, MySQL and SQLite use an auto-incrementing `INTEGER` column, and PostgreSQL uses `SERIAL`.
+     * When setting `uuid` to `true`, MySQL will use `VARCHAR(36)`, PostgreSQL will use `UUID`, and SQLite will use `TEXT`.
      */
-    public function primary(string $name = 'id'): self
+    public function primary(string $name = 'id', bool $uuid = false): self
     {
-        $this->statements[] = new PrimaryKeyStatement($name);
+        if ($uuid) {
+            $this->uuid($name);
+        } else {
+            $this->statements[] = new PrimaryKeyStatement($name);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Adds a UUID v7 primary key column to the table. Uses `VARCHAR(36)` for MySQL, `UUID` for PostgreSQL, and `TEXT` for SQLite.
+     */
+    public function uuid(string $name = 'id'): self
+    {
+        $this->statements[] = new UuidPrimaryKeyStatement($name);
 
         return $this;
     }

--- a/packages/database/src/QueryStatements/UuidPrimaryKeyStatement.php
+++ b/packages/database/src/QueryStatements/UuidPrimaryKeyStatement.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\QueryStatements;
+
+use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\QueryStatement;
+
+final readonly class UuidPrimaryKeyStatement implements QueryStatement
+{
+    public function __construct(
+        private string $name = 'id',
+    ) {}
+
+    public function compile(DatabaseDialect $dialect): string
+    {
+        return match ($dialect) {
+            DatabaseDialect::MYSQL => sprintf('`%s` VARCHAR(36) PRIMARY KEY', $this->name),
+            DatabaseDialect::POSTGRESQL => sprintf('`%s` UUID PRIMARY KEY', $this->name),
+            DatabaseDialect::SQLITE => sprintf('`%s` TEXT PRIMARY KEY', $this->name),
+        };
+    }
+}

--- a/packages/database/src/Uuid.php
+++ b/packages/database/src/Uuid.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database;
+
+use Attribute;
+
+/**
+ * Marks a primary key property to automatically generate UUID v7 values when the model is saved.
+ * This must be applied to `PrimaryKey` properties that would use UUIDs instead of auto-incrementing integers.
+ *
+ * **Example**
+ * ```php
+ * final class User
+ * {
+ *     #[Uuid]
+ *     public PrimaryKey $uuid;
+ *
+ *     public function __construct(
+ *         public string $name,
+ *     ) {}
+ * }
+ * ```
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final readonly class Uuid
+{
+}

--- a/packages/database/tests/QueryStatements/CreateTableStatementTest.php
+++ b/packages/database/tests/QueryStatements/CreateTableStatementTest.php
@@ -178,4 +178,59 @@ final class CreateTableStatementTest extends TestCase
             SQL,
         ];
     }
+
+    #[DataProvider('provide_uuid_primary_database_dialects')]
+    public function test_create_table_with_uuid_primary(DatabaseDialect $dialect, string $validSql): void
+    {
+        $uuid = new CreateTableStatement('users')
+            ->uuid('uuid')
+            ->text('name')
+            ->text('email')
+            ->compile($dialect);
+
+        $primary = new CreateTableStatement('users')
+            ->primary('uuid', uuid: true)
+            ->text('name')
+            ->text('email')
+            ->compile($dialect);
+
+        $this->assertSame($validSql, $uuid);
+        $this->assertSame($validSql, $primary);
+    }
+
+    public static function provide_uuid_primary_database_dialects(): iterable
+    {
+        yield 'mysql' => [
+            DatabaseDialect::MYSQL,
+            <<<SQL
+            CREATE TABLE `users` (
+                `uuid` VARCHAR(36) PRIMARY KEY, 
+                `name` TEXT NOT NULL, 
+                `email` TEXT NOT NULL
+            );
+            SQL,
+        ];
+
+        yield 'postgresql' => [
+            DatabaseDialect::POSTGRESQL,
+            <<<SQL
+            CREATE TABLE `users` (
+                `uuid` UUID PRIMARY KEY, 
+                `name` TEXT NOT NULL, 
+                `email` TEXT NOT NULL
+            );
+            SQL,
+        ];
+
+        yield 'sqlite' => [
+            DatabaseDialect::SQLITE,
+            <<<SQL
+            CREATE TABLE `users` (
+                `uuid` TEXT PRIMARY KEY, 
+                `name` TEXT NOT NULL, 
+                `email` TEXT NOT NULL
+            );
+            SQL,
+        ];
+    }
 }

--- a/packages/database/tests/QueryStatements/UuidPrimaryKeyStatementTest.php
+++ b/packages/database/tests/QueryStatements/UuidPrimaryKeyStatementTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Tests\QueryStatements;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\QueryStatements\UuidPrimaryKeyStatement;
+
+/**
+ * @internal
+ */
+final class UuidPrimaryKeyStatementTest extends TestCase
+{
+    #[Test]
+    public function mysql_compilation(): void
+    {
+        $statement = new UuidPrimaryKeyStatement('uuid');
+        $compiled = $statement->compile(DatabaseDialect::MYSQL);
+
+        $this->assertSame('`uuid` VARCHAR(36) PRIMARY KEY', $compiled);
+    }
+
+    #[Test]
+    public function postgresql_compilation(): void
+    {
+        $statement = new UuidPrimaryKeyStatement('uuid');
+        $compiled = $statement->compile(DatabaseDialect::POSTGRESQL);
+
+        $this->assertSame('`uuid` UUID PRIMARY KEY', $compiled);
+    }
+
+    #[Test]
+    public function sqlite_compilation(): void
+    {
+        $statement = new UuidPrimaryKeyStatement('uuid');
+        $compiled = $statement->compile(DatabaseDialect::SQLITE);
+
+        $this->assertSame('`uuid` TEXT PRIMARY KEY', $compiled);
+    }
+
+    #[Test]
+    public function default_column_name(): void
+    {
+        $statement = new UuidPrimaryKeyStatement();
+        $compiled = $statement->compile(DatabaseDialect::MYSQL);
+
+        $this->assertSame('`id` VARCHAR(36) PRIMARY KEY', $compiled);
+    }
+}

--- a/tests/Integration/Database/CustomPrimaryKeyRelationshipLoadingTest.php
+++ b/tests/Integration/Database/CustomPrimaryKeyRelationshipLoadingTest.php
@@ -289,7 +289,7 @@ final class MageWithUuid
 {
     use IsDatabaseModel;
 
-    public ?PrimaryKey $uuid = null;
+    public PrimaryKey $uuid;
 
     #[HasOne(ownerJoin: 'mage_uuid')]
     public ?GrimoireWithUuid $grimoire = null;
@@ -313,7 +313,7 @@ final class GrimoireWithUuid
 {
     use IsDatabaseModel;
 
-    public ?PrimaryKey $uuid = null;
+    public PrimaryKey $uuid;
 
     #[HasOne(ownerJoin: 'uuid', relationJoin: 'mage_uuid')]
     public ?MageWithUuid $mage = null;
@@ -330,7 +330,7 @@ final class SpellWithUuid
 {
     use IsDatabaseModel;
 
-    public ?PrimaryKey $uuid = null;
+    public PrimaryKey $uuid;
 
     #[HasOne(ownerJoin: 'uuid', relationJoin: 'mage_uuid')]
     public ?MageWithUuid $mage = null;
@@ -348,7 +348,7 @@ final class ArtifactWithUuid
 {
     use IsDatabaseModel;
 
-    public ?PrimaryKey $uuid = null;
+    public PrimaryKey $uuid;
 
     #[HasOne(ownerJoin: 'uuid', relationJoin: 'owner_uuid')]
     public ?MageWithUuid $owner = null;
@@ -423,7 +423,7 @@ final class MageSimple
 {
     use IsDatabaseModel;
 
-    public ?PrimaryKey $uuid = null;
+    public PrimaryKey $uuid;
 
     /** @var \Tests\Tempest\Integration\Database\SpellSimple[] */
     #[HasMany]
@@ -440,7 +440,7 @@ final class SpellSimple
 {
     use IsDatabaseModel;
 
-    public ?PrimaryKey $uuid = null;
+    public PrimaryKey $uuid;
 
     #[BelongsTo]
     public ?MageSimple $mage = null;

--- a/tests/Integration/Database/UuidPrimaryKeyTest.php
+++ b/tests/Integration/Database/UuidPrimaryKeyTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Database;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\MigratesUp;
+use Tempest\Database\Migrations\CreateMigrationsTable;
+use Tempest\Database\PrimaryKey;
+use Tempest\Database\QueryStatement;
+use Tempest\Database\QueryStatements\CreateTableStatement;
+use Tempest\Database\Table;
+use Tempest\Database\Uuid;
+use Tempest\Support\Random;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\Database\query;
+
+/**
+ * @internal
+ */
+final class UuidPrimaryKeyTest extends FrameworkIntegrationTestCase
+{
+    #[Test]
+    public function uuid_primary_key_auto_generation(): void
+    {
+        $this->database->migrate(CreateMigrationsTable::class, CreateModelWithUuidTableMigration::class);
+
+        $mage = query(DatabaseModelWithUuid::class)->create(
+            name: 'Frieren',
+            race: 'Human',
+        );
+
+        $this->assertInstanceOf(DatabaseModelWithUuid::class, $mage);
+        $this->assertInstanceOf(PrimaryKey::class, $mage->uuid);
+        $this->assertTrue(Random\is_uuid($mage->uuid->value));
+        $this->assertSame('Frieren', $mage->name);
+        $this->assertSame('Human', $mage->race);
+    }
+
+    #[Test]
+    public function uuid_primary_key_save_method(): void
+    {
+        $this->database->migrate(CreateMigrationsTable::class, CreateModelWithUuidTableMigration::class);
+
+        $mage = new DatabaseModelWithUuid(name: 'Fern', race: 'Human');
+        $savedMage = $mage->save();
+
+        $this->assertSame($mage, $savedMage);
+        $this->assertInstanceOf(PrimaryKey::class, $mage->uuid);
+        $this->assertTrue(Random\is_uuid($mage->uuid->value));
+        $this->assertSame('Fern', $mage->name);
+    }
+
+    #[Test]
+    public function uuid_primary_key_retrieval(): void
+    {
+        $this->database->migrate(CreateMigrationsTable::class, CreateModelWithUuidTableMigration::class);
+
+        $mage = query(DatabaseModelWithUuid::class)->create(
+            name: 'Frieren',
+            race: 'Elf',
+        );
+
+        $retrieved = query(DatabaseModelWithUuid::class)->get($mage->uuid);
+        $this->assertNotNull($retrieved);
+        $this->assertSame('Frieren', $retrieved->name);
+        $this->assertTrue($mage->uuid->equals($retrieved->uuid));
+    }
+
+    #[Test]
+    public function uuid_primary_key_update_or_create(): void
+    {
+        $this->database->migrate(CreateMigrationsTable::class, CreateModelWithUuidTableMigration::class);
+
+        $original = query(DatabaseModelWithUuid::class)->create(
+            name: 'Himmel',
+            race: 'Elf',
+        );
+
+        $updated = query(DatabaseModelWithUuid::class)->updateOrCreate(
+            find: ['name' => 'Himmel'],
+            update: ['race' => 'Human'],
+        );
+
+        $this->assertTrue($original->uuid->equals($updated->uuid));
+        $this->assertSame('Human', $updated->race);
+    }
+
+    #[Test]
+    public function uuid_primary_key_manual_assignment(): void
+    {
+        $this->database->migrate(CreateMigrationsTable::class, CreateModelWithUuidTableMigration::class);
+
+        $uuid = Random\uuid();
+
+        $mage = new DatabaseModelWithUuid(name: 'Stark', race: 'Human');
+        $mage->uuid = new PrimaryKey($uuid);
+        $mage->save();
+
+        $this->assertSame($uuid, $mage->uuid->value);
+    }
+
+    #[Test]
+    public function uuid_primary_key_without_is_database_model_trait(): void
+    {
+        $this->database->migrate(CreateMigrationsTable::class, CreateModelWithUuidTableMigration::class);
+
+        $mage = query(ModelWithUuid::class)->create(
+            name: 'Frieren',
+            race: 'Elf',
+        );
+
+        $this->assertInstanceOf(ModelWithUuid::class, $mage);
+        $this->assertInstanceOf(PrimaryKey::class, $mage->uuid);
+        $this->assertTrue(Random\is_uuid($mage->uuid->value));
+        $this->assertSame('Frieren', $mage->name);
+        $this->assertSame('Elf', $mage->race);
+
+        $retrieved = query(ModelWithUuid::class)->get($mage->uuid);
+
+        $this->assertNotNull($retrieved);
+        $this->assertTrue($mage->uuid->equals($retrieved->uuid));
+    }
+}
+
+#[Table('model')]
+final class DatabaseModelWithUuid
+{
+    use IsDatabaseModel;
+
+    #[Uuid]
+    public PrimaryKey $uuid;
+
+    public function __construct(
+        public string $name,
+        public string $race,
+    ) {}
+}
+
+#[Table('model')]
+final class ModelWithUuid
+{
+    #[Uuid]
+    public PrimaryKey $uuid;
+
+    public function __construct(
+        public string $name,
+        public string $race,
+    ) {}
+}
+
+final class CreateModelWithUuidTableMigration implements MigratesUp
+{
+    public string $name = '001_create_model_with_uuid';
+
+    public function up(): QueryStatement
+    {
+        return new CreateTableStatement('model')
+            ->uuid(name: 'uuid')
+            ->text('name')
+            ->text('race');
+    }
+}


### PR DESCRIPTION
Closes https://github.com/tempestphp/tempest-framework/issues/619

This pull request adds support for generating UUID v7 primary keys during insertion. Note that since `IsDatabaseModel` provides a `id` property, which cannot be extended to receive the `#[Uuid]` attribute, this feature is technically not compatible with `IsDatabaseModel`.

```php
final class User
{
    #[Uuid]
    public PrimaryKey $id;

    public function __construct(
        public string $name,
    ) {}
}
```