### PR TITLE
feat(database): add foreign key support for sqlite dialect

### DIFF
--- a/packages/database/src/QueryStatements/BelongsToStatement.php
+++ b/packages/database/src/QueryStatements/BelongsToStatement.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tempest\Database\QueryStatements;
 
 use Tempest\Database\Config\DatabaseDialect;
-use Tempest\Database\DialectWasNotSupported;
 use Tempest\Database\QueryStatement;
 
 final readonly class BelongsToStatement implements QueryStatement
@@ -44,7 +43,7 @@ final readonly class BelongsToStatement implements QueryStatement
                     'ON UPDATE ' . $this->onUpdate->value,
                 )),
             ),
-            DatabaseDialect::POSTGRESQL => new ConstraintStatement(
+            DatabaseDialect::POSTGRESQL, DatabaseDialect::SQLITE => new ConstraintStatement(
                 $constraintName,
                 new RawStatement(sprintf(
                     'FOREIGN KEY(%s) REFERENCES %s(%s) %s %s',
@@ -55,7 +54,6 @@ final readonly class BelongsToStatement implements QueryStatement
                     'ON UPDATE ' . $this->onUpdate->value,
                 )),
             ),
-            DatabaseDialect::SQLITE => throw new DialectWasNotSupported(),
         };
 
         return $statement->compile($dialect);

--- a/packages/database/src/QueryStatements/ConstraintNameStatement.php
+++ b/packages/database/src/QueryStatements/ConstraintNameStatement.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tempest\Database\QueryStatements;
 
 use Tempest\Database\Config\DatabaseDialect;
-use Tempest\Database\DialectWasNotSupported;
 use Tempest\Database\QueryStatement;
 
 final readonly class ConstraintNameStatement implements QueryStatement
@@ -21,9 +20,6 @@ final readonly class ConstraintNameStatement implements QueryStatement
 
     public function compile(DatabaseDialect $dialect): string
     {
-        return match ($dialect) {
-            DatabaseDialect::MYSQL, DatabaseDialect::POSTGRESQL => sprintf('CONSTRAINT %s', $this->name->compile($dialect)),
-            default => throw new DialectWasNotSupported(),
-        };
+        return sprintf('CONSTRAINT %s', $this->name->compile($dialect));
     }
 }

--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -395,8 +395,14 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
             'CREATE TABLE %s (%s);',
             new TableDefinition($this->tableName),
             arr($this->statements)
-                // Remove BelongsTo for sqlLite as it does not support those queries
-                ->filter(fn (QueryStatement $queryStatement) => ! ($dialect === DatabaseDialect::SQLITE && $queryStatement instanceof BelongsToStatement))
+                ->sortByCallback(function (QueryStatement $a, QueryStatement $b) {
+                    // Foreign keys must be defined last in SQLite
+                    if ($a instanceof BelongsToStatement && $b instanceof BelongsToStatement) {
+                        return 0;
+                    }
+
+                    return $a instanceof BelongsToStatement ? 1 : -1;
+                })
                 ->map(fn (QueryStatement $queryStatement) => str($queryStatement->compile($dialect))->trim()->replace('  ', ' '))
                 ->filter(fn (ImmutableString $str) => $str->isNotEmpty())
                 ->implode(', ' . PHP_EOL . '    ')

--- a/packages/database/tests/QueryStatements/AlterTableStatementTest.php
+++ b/packages/database/tests/QueryStatements/AlterTableStatementTest.php
@@ -59,6 +59,7 @@ final class AlterTableStatementTest extends TestCase
     }
 
     #[TestWith([DatabaseDialect::POSTGRESQL])]
+    #[TestWith([DatabaseDialect::SQLITE])]
     public function test_alter_add_belongs_to_postgresql(DatabaseDialect $dialect): void
     {
         $expected = 'ALTER TABLE `table` ADD CONSTRAINT `fk_parent_table_foo` FOREIGN KEY(foo) REFERENCES parent(bar) ON DELETE RESTRICT ON UPDATE NO ACTION ;';
@@ -69,16 +70,6 @@ final class AlterTableStatementTest extends TestCase
         $normalized = self::removeDuplicateWhitespace($statement);
 
         $this->assertEqualsIgnoringCase($expected, $normalized);
-    }
-
-    #[TestWith([DatabaseDialect::SQLITE])]
-    public function test_alter_add_belongs_to_unsupported(DatabaseDialect $dialect): void
-    {
-        $this->expectException(DialectWasNotSupported::class);
-
-        new AlterTableStatement('table')
-            ->add(new BelongsToStatement('table.foo', 'parent.bar'))
-            ->compile($dialect);
     }
 
     #[TestWith([DatabaseDialect::MYSQL])]
@@ -98,6 +89,7 @@ final class AlterTableStatementTest extends TestCase
 
     #[TestWith([DatabaseDialect::MYSQL, 'ALTER TABLE `table` DROP CONSTRAINT `foo` ;'])]
     #[TestWith([DatabaseDialect::POSTGRESQL, 'ALTER TABLE `table` DROP CONSTRAINT `foo` ;'])]
+    #[TestWith([DatabaseDialect::SQLITE, 'ALTER TABLE `table` DROP CONSTRAINT `foo` ;'])]
     public function test_alter_table_drop_constraint(DatabaseDialect $dialect, string $expected): void
     {
         $statement = new AlterTableStatement('table')
@@ -107,15 +99,6 @@ final class AlterTableStatementTest extends TestCase
         $normalized = self::removeDuplicateWhitespace($statement);
 
         $this->assertEqualsIgnoringCase($expected, $normalized);
-    }
-
-    #[TestWith([DatabaseDialect::SQLITE])]
-    public function test_alter_table_drop_constraint_unsupported_dialects(DatabaseDialect $dialect): void
-    {
-        $this->expectException(DialectWasNotSupported::class);
-        new AlterTableStatement('table')
-            ->dropConstraint('foo')
-            ->compile($dialect);
     }
 
     #[TestWith([DatabaseDialect::MYSQL, 'ALTER TABLE `table` ADD `foo` VARCHAR(42) DEFAULT \'bar\' NOT NULL ;'])]

--- a/packages/database/tests/QueryStatements/CreateTableStatementTest.php
+++ b/packages/database/tests/QueryStatements/CreateTableStatementTest.php
@@ -98,8 +98,8 @@ final class CreateTableStatementTest extends TestCase
             CREATE TABLE `books` (
                 `id` INTEGER PRIMARY KEY AUTO_INCREMENT, 
                 `author_id` INTEGER  NOT NULL, 
-                CONSTRAINT `fk_authors_books_author_id` FOREIGN KEY books(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION, 
-                `name` VARCHAR(255) NOT NULL
+                `name` VARCHAR(255) NOT NULL, 
+                CONSTRAINT `fk_authors_books_author_id` FOREIGN KEY books(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION
             );
             SQL,
         ];
@@ -110,8 +110,8 @@ final class CreateTableStatementTest extends TestCase
             CREATE TABLE `books` (
                 `id` SERIAL PRIMARY KEY, 
                 `author_id` INTEGER  NOT NULL, 
-                CONSTRAINT `fk_authors_books_author_id` FOREIGN KEY(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION, 
-                `name` VARCHAR(255) NOT NULL
+                `name` VARCHAR(255) NOT NULL, 
+                CONSTRAINT `fk_authors_books_author_id` FOREIGN KEY(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION
             );
             SQL,
         ];
@@ -122,7 +122,8 @@ final class CreateTableStatementTest extends TestCase
             CREATE TABLE `books` (
                 `id` INTEGER PRIMARY KEY AUTOINCREMENT, 
                 `author_id` INTEGER  NOT NULL, 
-                `name` VARCHAR(255) NOT NULL
+                `name` VARCHAR(255) NOT NULL, 
+                CONSTRAINT `fk_authors_books_author_id` FOREIGN KEY(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION
             );
             SQL,
         ];
@@ -149,8 +150,8 @@ final class CreateTableStatementTest extends TestCase
             CREATE TABLE `books` (
                 `id` INTEGER PRIMARY KEY AUTO_INCREMENT, 
                 `author_id` INTEGER  NOT NULL, 
-                CONSTRAINT `fk_authors_books_author_id` FOREIGN KEY books(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION, 
-                `name` VARCHAR(255) NOT NULL
+                `name` VARCHAR(255) NOT NULL, 
+                CONSTRAINT `fk_authors_books_author_id` FOREIGN KEY books(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION
             );
             SQL,
         ];
@@ -161,8 +162,8 @@ final class CreateTableStatementTest extends TestCase
             CREATE TABLE `books` (
                 `id` SERIAL PRIMARY KEY, 
                 `author_id` INTEGER  NOT NULL, 
-                CONSTRAINT `fk_authors_books_author_id` FOREIGN KEY(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION, 
-                `name` VARCHAR(255) NOT NULL
+                `name` VARCHAR(255) NOT NULL, 
+                CONSTRAINT `fk_authors_books_author_id` FOREIGN KEY(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION
             );
             SQL,
         ];
@@ -173,7 +174,8 @@ final class CreateTableStatementTest extends TestCase
             CREATE TABLE `books` (
                 `id` INTEGER PRIMARY KEY AUTOINCREMENT, 
                 `author_id` INTEGER  NOT NULL, 
-                `name` VARCHAR(255) NOT NULL
+                `name` VARCHAR(255) NOT NULL, 
+                CONSTRAINT `fk_authors_books_author_id` FOREIGN KEY(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION
             );
             SQL,
         ];


### PR DESCRIPTION
Fixes #1830

This PR adds foreign key support for SQLite dialect (cf. https://sqlite.org/foreignkeys.html for specification).

## Changes

The following code now successfully creates a foreign key with sqlite:

```php
return new CreateTableStatement('books')
    ->primary()
    ->belongsTo('books.author_id', 'authors.id', OnDelete::CASCADE)
    ->text('title');
```

At first, it didn't work because in SQLite, foreign keys must be defined after table columns.

So I used the `sortByCallback` function on the statements array in order to make sure that foreign keys are always defined at the end of the create table statement.

## Limitations

The following code fails (QueryWasInvalid exception): 

```php
public function up(): QueryStatement
{
    return new AlterTableStatement('authors')
        ->add(new BelongsToStatement('books.author_id', 'authors.id', OnDelete::CASCADE));
}
```

This is perfectly normal because it is not possible to add a foreign key on an existing table in sqlite.

It would be better if tempest threw a DialectWasNotSupported exception, but I'm not sure if it's possible to implement easily, because the BelongsToStatement is wrapped inside a AlterAddColumnStatement object.

## Warning

I updated the unit tests but I didn't do a lot of real world testing.
I only tested a migration with a create statement and an alter statement.