### PR TITLE
fix(database): update generics on query builder

### DIFF
--- a/packages/database/src/Builder/QueryBuilders/HasWhereQueryBuilderMethods.php
+++ b/packages/database/src/Builder/QueryBuilders/HasWhereQueryBuilderMethods.php
@@ -11,7 +11,7 @@ use function Tempest\Support\str;
 /**
  * @template TModel of object
  * @phpstan-require-implements \Tempest\Database\Builder\QueryBuilders\BuildsQuery
- * @phpstan-require-implements \Tempest\Database\Builder\QueryBuilders\SupportsWhereConditions
+ * @phpstan-require-implements \Tempest\Database\Builder\QueryBuilders\SupportsWhereStatements
  * @use \Tempest\Database\Builder\QueryBuilders\HasConvenientWhereMethods<TModel>
  */
 trait HasWhereQueryBuilderMethods


### PR DESCRIPTION
Fixes the following error when using mago in [strict mode](https://mago.carthage.software/tools/analyzer/configuration-reference#strict-mode) in tempest projects:

```php
error[non-existent-class-like]: Class, Interface, or Trait `tempest\database\builder\querybuilders\supportswhereconditions` does not exist.
   ┌─ app/Repository/RecordRepository.php:50:16
   │
50 │           return query(Record::class)
   │ ╭────────────────^
51 │ │             ->select()
52 │ │             ->with('categories')
53 │ │             ->where('id = ?', $id)
   │ ╰──────────────────────────────────^ This expression refers to a non-existent class-like type
```