### PR TITLE
feat(core)!: make `Environment` its own source of truth

### DIFF
--- a/docs/1-essentials/06-configuration.md
+++ b/docs/1-essentials/06-configuration.md
@@ -28,30 +28,30 @@ return new PostgresConfig(
 
 The configuration object above instructs Tempest to use PostgreSQL as its database, replacing the framework's default database, SQLite.
 
-## Accessing configuration objects
+### Accessing configuration objects
 
 To access a configuration object, you may inject it from the container like any other dependency.
 
 ```php
-use Tempest\Core\AppConfig;
+use Tempest\Core\Environment;
 
-final readonly class HomeController
+final readonly class AboutController
 {
     public function __construct(
-        private AppConfig $config,
+        private Environment $environment,
     ) {}
 
     #[Get('/')]
     public function __invoke(): View
     {
-        return view('home.view.php', environment: $this->config->environment);
+        return view('about.view.php', environment: $this->environment);
     }
 }
 ```
 
-## Updating configuration objects
+### Updating configuration objects
 
-To update a property in a configuration object, you may simply assign a new value. Due to the object being a singleton, the modification will be persisted throught the rest of the application's lifecycle.
+To update a property in a configuration object, you may simply assign a new value. Due to the object being a singleton, the modification will be persisted through the rest of the application's lifecycle.
 
 ```php
 use Tempest\Support\Random;
@@ -81,7 +81,7 @@ final class SlackConfig
         public string $token,
         public string $baseUrl,
         public string $applicationId,
-        public string $userAgent,
+        public ?string $userAgent = null,
     ) {}
 }
 ```
@@ -120,7 +120,7 @@ final class SlackConnector extends HttpConnector
 
 ## Per-environment configuration
 
-Whenever possible, you should have a single configuration file per feature. You may use the `Tempest\env()` function inside that file to reference credentials and environment-specific values.
+Whenever possible, you should have a single configuration file per feature. You may use the {b`Tempest\env()`} function inside that file to reference credentials and environment-specific values.
 
 However, it's sometimes needed to have completely different configurations in development and in production. For instance, you may use S3 for your [storage](../2-features/05-file-storage.md) in production, but use the local filesystem during development.
 
@@ -134,6 +134,13 @@ return new S3StorageConfig(
     secretAccessKey: env('S3_SECRET_ACCESS_KEY'),
 );
 ```
+
+The following suffixes are supported:
+
+- `.prd.config.php`, `.prod.config.php`, and `.production.config.php` for the production environment.
+- `.stg.config.php` and `.staging.config.php` for the staging environment.
+- `.dev.config.php` and `.local.config.php` for the development environment.
+- `.test.config.php` and `.testing.config.php` for the testing environment.
 
 ## Disabling the configuration cache
 

--- a/docs/1-essentials/07-testing.md
+++ b/docs/1-essentials/07-testing.md
@@ -125,6 +125,18 @@ $this->console
 
 And many, many more.
 
+## Spoofing the environment
+
+By default, Tempest provides a `phpunit.xml` that sets the `ENVIRONMENT` variable to `testing`. This is needed so that Tempest can adapt its boot process and load the proper configuration files for the testing environment.
+
+During tests, you may want to test different paths of your application depending on the environment. For instance, you may want to test that certain features are only available in production. To do this, you may override the {b`Tempest\Core\Environment`} singleton:
+
+```php
+use Tempest\Core\Environment;
+
+$this->container->singleton(Environment::class, Environment::PRODUCTION);
+```
+
 ## Changing the location of tests
 
 The `phpunit.xml` file contains a `{html}<testsuite>` element that configures the directory in which PHPUnit looks for test files. This may be changed to follow any rule of your convenience.

--- a/packages/cache/src/Commands/CacheStatusCommand.php
+++ b/packages/cache/src/Commands/CacheStatusCommand.php
@@ -12,9 +12,9 @@ use Tempest\Console\ConsoleCommand;
 use Tempest\Console\HasConsole;
 use Tempest\Container\Container;
 use Tempest\Container\GenericContainer;
-use Tempest\Core\AppConfig;
 use Tempest\Core\ConfigCache;
 use Tempest\Core\DiscoveryCache;
+use Tempest\Core\Environment;
 use Tempest\Icon\IconCache;
 use Tempest\Support\Str;
 use Tempest\View\ViewCache;
@@ -22,7 +22,7 @@ use UnitEnum;
 
 use function Tempest\Support\arr;
 
-if (class_exists(\Tempest\Console\ConsoleCommand::class)) {
+if (class_exists(ConsoleCommand::class)) {
     final readonly class CacheStatusCommand
     {
         use HasConsole;
@@ -30,7 +30,7 @@ if (class_exists(\Tempest\Console\ConsoleCommand::class)) {
         public function __construct(
             private Console $console,
             private Container $container,
-            private AppConfig $appConfig,
+            private Environment $environment,
             private DiscoveryCache $discoveryCache,
         ) {}
 
@@ -73,7 +73,7 @@ if (class_exists(\Tempest\Console\ConsoleCommand::class)) {
                     },
                 );
 
-                if ($this->appConfig->environment->isProduction() && ! $this->discoveryCache->enabled) {
+                if ($this->environment->requiresCaution() && ! $this->discoveryCache->enabled) {
                     $this->console->writeln();
                     $this->console->error('Discovery cache is disabled in production. This is not recommended.');
                 }

--- a/packages/console/src/Middleware/CautionMiddleware.php
+++ b/packages/console/src/Middleware/CautionMiddleware.php
@@ -9,7 +9,7 @@ use Tempest\Console\ConsoleMiddleware;
 use Tempest\Console\ConsoleMiddlewareCallable;
 use Tempest\Console\ExitCode;
 use Tempest\Console\Initializers\Invocation;
-use Tempest\Core\AppConfig;
+use Tempest\Core\Environment;
 use Tempest\Discovery\SkipDiscovery;
 
 #[SkipDiscovery]
@@ -17,14 +17,12 @@ final readonly class CautionMiddleware implements ConsoleMiddleware
 {
     public function __construct(
         private Console $console,
-        private AppConfig $appConfig,
+        private Environment $environment,
     ) {}
 
     public function __invoke(Invocation $invocation, ConsoleMiddlewareCallable $next): ExitCode|int
     {
-        $environment = $this->appConfig->environment;
-
-        if ($environment->isProduction() || $environment->isStaging()) {
+        if ($this->environment->requiresCaution()) {
             if ($this->console->isForced) {
                 return $next($invocation);
             }

--- a/packages/core/src/AppConfig.php
+++ b/packages/core/src/AppConfig.php
@@ -8,14 +8,10 @@ use function Tempest\env;
 
 final class AppConfig
 {
-    public Environment $environment;
-
     public string $baseUri;
 
     public function __construct(
         public ?string $name = null,
-
-        ?Environment $environment = null,
 
         ?string $baseUri = null,
 
@@ -27,7 +23,6 @@ final class AppConfig
          */
         public array $insightsProviders = [],
     ) {
-        $this->environment = $environment ?? Environment::guessFromEnvironment();
         $this->baseUri = $baseUri ?? env('BASE_URI') ?? '';
     }
 }

--- a/packages/core/src/AppConfig.php
+++ b/packages/core/src/AppConfig.php
@@ -27,7 +27,7 @@ final class AppConfig
          */
         public array $insightsProviders = [],
     ) {
-        $this->environment = $environment ?? Environment::fromEnv();
+        $this->environment = $environment ?? Environment::guessFromEnvironment();
         $this->baseUri = $baseUri ?? env('BASE_URI') ?? '';
     }
 }

--- a/packages/core/src/Commands/DiscoveryGenerateCommand.php
+++ b/packages/core/src/Commands/DiscoveryGenerateCommand.php
@@ -9,10 +9,10 @@ use Tempest\Console\ConsoleCommand;
 use Tempest\Console\HasConsole;
 use Tempest\Container\Container;
 use Tempest\Container\GenericContainer;
-use Tempest\Core\AppConfig;
 use Tempest\Core\DiscoveryCache;
 use Tempest\Core\DiscoveryCacheStrategy;
 use Tempest\Core\DiscoveryConfig;
+use Tempest\Core\Environment;
 use Tempest\Core\FrameworkKernel;
 use Tempest\Core\Kernel;
 use Tempest\Core\Kernel\LoadDiscoveryClasses;
@@ -27,7 +27,7 @@ if (class_exists(\Tempest\Console\ConsoleCommand::class)) {
         public function __construct(
             private Kernel $kernel,
             private DiscoveryCache $discoveryCache,
-            private AppConfig $appConfig,
+            private Environment $environment,
         ) {}
 
         #[ConsoleCommand(
@@ -37,7 +37,7 @@ if (class_exists(\Tempest\Console\ConsoleCommand::class)) {
         )]
         public function __invoke(): void
         {
-            $strategy = DiscoveryCacheStrategy::make(env('DISCOVERY_CACHE', default: $this->appConfig->environment->isProduction()));
+            $strategy = DiscoveryCacheStrategy::make(env('DISCOVERY_CACHE', default: $this->environment->requiresCaution()));
 
             if ($strategy === DiscoveryCacheStrategy::NONE) {
                 $this->info('Discovery cache disabled, nothing to generate.');

--- a/packages/core/src/ConfigCacheInitializer.php
+++ b/packages/core/src/ConfigCacheInitializer.php
@@ -14,18 +14,16 @@ final class ConfigCacheInitializer implements Initializer
     public function initialize(Container $container): ConfigCache
     {
         return new ConfigCache(
-            enabled: $this->shouldCacheBeEnabled(
-                $container->get(AppConfig::class)->environment->isProduction(),
-            ),
+            enabled: $this->shouldCacheBeEnabled(),
         );
     }
 
-    private function shouldCacheBeEnabled(bool $isProduction): bool
+    private function shouldCacheBeEnabled(): bool
     {
         if (env('INTERNAL_CACHES') === false) {
             return false;
         }
 
-        return (bool) env('CONFIG_CACHE', default: $isProduction);
+        return (bool) env('CONFIG_CACHE', default: Environment::guessFromEnvironment()->requiresCaution());
     }
 }

--- a/packages/core/src/DiscoveryCacheInitializer.php
+++ b/packages/core/src/DiscoveryCacheInitializer.php
@@ -14,19 +14,17 @@ final class DiscoveryCacheInitializer implements Initializer
     public function initialize(Container $container): DiscoveryCache
     {
         return new DiscoveryCache(
-            strategy: $this->resolveDiscoveryCacheStrategy(
-                $container->get(AppConfig::class)->environment->isProduction(),
-            ),
+            strategy: $this->resolveDiscoveryCacheStrategy(),
         );
     }
 
-    private function resolveDiscoveryCacheStrategy(bool $isProduction): DiscoveryCacheStrategy
+    private function resolveDiscoveryCacheStrategy(): DiscoveryCacheStrategy
     {
         if ($this->isDiscoveryGenerateCommand() || $this->isDiscoveryClearCommand()) {
             return DiscoveryCacheStrategy::NONE;
         }
 
-        $current = DiscoveryCacheStrategy::make(env('DISCOVERY_CACHE', default: $isProduction));
+        $current = DiscoveryCacheStrategy::make(env('DISCOVERY_CACHE', default: Environment::guessFromEnvironment()->requiresCaution()));
 
         if ($current === DiscoveryCacheStrategy::NONE) {
             return $current;

--- a/packages/core/src/Environment.php
+++ b/packages/core/src/Environment.php
@@ -17,6 +17,14 @@ enum Environment: string
     case CONTINUOUS_INTEGRATION = 'ci';
     case TESTING = 'testing';
 
+    /**
+     * Determines if this environment requires caution for destructive operations.
+     */
+    public function requiresCaution(): bool
+    {
+        return in_array($this, [self::PRODUCTION, self::STAGING], strict: true);
+    }
+
     public function isProduction(): bool
     {
         return $this === self::PRODUCTION;

--- a/packages/core/src/Environment.php
+++ b/packages/core/src/Environment.php
@@ -6,14 +6,16 @@ namespace Tempest\Core;
 
 use function Tempest\env;
 
+/**
+ * Represents the environment in which the application is running.
+ */
 enum Environment: string
 {
     case LOCAL = 'local';
     case STAGING = 'staging';
     case PRODUCTION = 'production';
-    case CI = 'ci';
+    case CONTINUOUS_INTEGRATION = 'ci';
     case TESTING = 'testing';
-    case OTHER = 'other';
 
     public function isProduction(): bool
     {
@@ -30,9 +32,9 @@ enum Environment: string
         return $this === self::LOCAL;
     }
 
-    public function isCI(): bool
+    public function isContinuousIntegration(): bool
     {
-        return $this === self::CI;
+        return $this === self::CONTINUOUS_INTEGRATION;
     }
 
     public function isTesting(): bool
@@ -40,14 +42,17 @@ enum Environment: string
         return $this === self::TESTING;
     }
 
-    public function isOther(): bool
+    /**
+     * Guesses the environment from the `ENVIRONMENT` environment variable.
+     */
+    public static function guessFromEnvironment(): self
     {
-        return $this === self::OTHER;
-    }
+        $value = env('ENVIRONMENT', default: 'local');
 
-    public static function fromEnv(): self
-    {
-        $value = env('ENVIRONMENT', 'local');
+        // Can be removed after https://github.com/tempestphp/tempest-framework/pull/1836
+        if (is_null($value)) {
+            $value = 'local';
+        }
 
         return self::tryFrom($value) ?? throw new EnvironmentValueWasInvalid($value);
     }

--- a/packages/core/src/EnvironmentInitalizer.php
+++ b/packages/core/src/EnvironmentInitalizer.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tempest\Core;
+
+use Tempest\Container\Container;
+use Tempest\Container\Initializer;
+
+final class EnvironmentInitalizer implements Initializer
+{
+    public function initialize(Container $container): Environment
+    {
+        return $container->get(AppConfig::class)->environment;
+    }
+}

--- a/packages/core/src/EnvironmentInitalizer.php
+++ b/packages/core/src/EnvironmentInitalizer.php
@@ -4,11 +4,13 @@ namespace Tempest\Core;
 
 use Tempest\Container\Container;
 use Tempest\Container\Initializer;
+use Tempest\Container\Singleton;
 
 final class EnvironmentInitalizer implements Initializer
 {
+    #[Singleton]
     public function initialize(Container $container): Environment
     {
-        return $container->get(AppConfig::class)->environment;
+        return Environment::guessFromEnvironment();
     }
 }

--- a/packages/core/src/EnvironmentInsightsProvider.php
+++ b/packages/core/src/EnvironmentInsightsProvider.php
@@ -10,6 +10,7 @@ final class EnvironmentInsightsProvider implements InsightsProvider
 
     public function __construct(
         private readonly AppConfig $appConfig,
+        private readonly Environment $environment,
     ) {}
 
     public function getInsights(): array
@@ -19,7 +20,7 @@ final class EnvironmentInsightsProvider implements InsightsProvider
             'PHP version' => PHP_VERSION,
             'Composer version' => $this->getComposerVersion(),
             'Operating system' => $this->getOperatingSystem(),
-            'Environment' => $this->appConfig->environment->value,
+            'Environment' => $this->environment->value,
             'Application URL' => $this->appConfig->baseUri ?: new Insight('Not set', Insight::ERROR),
         ];
     }

--- a/packages/core/src/EnvironmentValueWasInvalid.php
+++ b/packages/core/src/EnvironmentValueWasInvalid.php
@@ -12,8 +12,10 @@ final class EnvironmentValueWasInvalid extends Exception
 {
     public function __construct(string $value)
     {
-        $possibleValues = arr(Environment::cases())->map(fn (Environment $environment) => $environment->value)->implode(', ');
+        $possibleValues = arr(Environment::cases())
+            ->map(fn (Environment $environment) => $environment->value)
+            ->join();
 
-        parent::__construct("Invalid environment value `{$value}`, possible values are {$possibleValues}.");
+        parent::__construct("Invalid environment [{$value}]. Possible values are {$possibleValues}.");
     }
 }

--- a/packages/core/src/ExceptionHandlerInitializer.php
+++ b/packages/core/src/ExceptionHandlerInitializer.php
@@ -13,11 +13,11 @@ final class ExceptionHandlerInitializer implements Initializer
     #[Singleton]
     public function initialize(Container $container): ExceptionHandler
     {
-        $config = $container->get(AppConfig::class);
+        $environment = $container->get(Environment::class);
 
         return match (true) {
             PHP_SAPI === 'cli' => $container->get(ConsoleExceptionHandler::class),
-            $config->environment->isLocal() => $container->get(DevelopmentExceptionHandler::class),
+            $environment->isLocal() => $container->get(DevelopmentExceptionHandler::class),
             default => $container->get(HttpExceptionHandler::class),
         };
     }

--- a/packages/core/src/FrameworkKernel.php
+++ b/packages/core/src/FrameworkKernel.php
@@ -168,10 +168,7 @@ final class FrameworkKernel implements Kernel
     public function loadDiscovery(): self
     {
         $this->container->addInitializer(DiscoveryCacheInitializer::class);
-        $this->container->invoke(
-            LoadDiscoveryClasses::class,
-            discoveryLocations: $this->discoveryLocations,
-        );
+        $this->container->invoke(LoadDiscoveryClasses::class, discoveryLocations: $this->discoveryLocations);
 
         return $this;
     }
@@ -179,7 +176,9 @@ final class FrameworkKernel implements Kernel
     public function loadConfig(): self
     {
         $this->container->addInitializer(ConfigCacheInitializer::class);
-        $this->container->invoke(LoadConfig::class);
+
+        $loadConfig = $this->container->get(LoadConfig::class, environment: Environment::guessFromEnvironment());
+        $loadConfig();
 
         return $this;
     }
@@ -232,7 +231,7 @@ final class FrameworkKernel implements Kernel
 
         // In development, we want to register a developer-friendly error
         // handler as soon as possible to catch any kind of exception.
-        if (PHP_SAPI !== 'cli' && ! $environment->isProduction()) {
+        if (PHP_SAPI !== 'cli' && $environment->isLocal()) {
             new RegisterEmergencyExceptionHandler()->register();
         }
 
@@ -241,10 +240,10 @@ final class FrameworkKernel implements Kernel
 
     public function registerExceptionHandler(): self
     {
-        $appConfig = $this->container->get(AppConfig::class);
+        $environment = $this->container->get(Environment::class);
 
         // During tests, PHPUnit registers its own error handling.
-        if ($appConfig->environment->isTesting()) {
+        if ($environment->isTesting()) {
             return $this;
         }
 

--- a/packages/core/src/FrameworkKernel.php
+++ b/packages/core/src/FrameworkKernel.php
@@ -223,7 +223,7 @@ final class FrameworkKernel implements Kernel
 
     public function registerEmergencyExceptionHandler(): self
     {
-        $environment = Environment::fromEnv();
+        $environment = Environment::guessFromEnvironment();
 
         // During tests, PHPUnit registers its own error handling.
         if ($environment->isTesting()) {

--- a/packages/core/src/Kernel/LoadConfig.php
+++ b/packages/core/src/Kernel/LoadConfig.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tempest\Core\Kernel;
 
-use Tempest\Core\AppConfig;
 use Tempest\Core\ConfigCache;
+use Tempest\Core\Environment;
 use Tempest\Core\Kernel;
 use Tempest\Support\Arr\MutableArray;
 use Tempest\Support\Filesystem;
@@ -17,7 +17,7 @@ final readonly class LoadConfig
     public function __construct(
         private Kernel $kernel,
         private ConfigCache $cache,
-        private AppConfig $appConfig,
+        private Environment $environment,
     ) {}
 
     public function __invoke(): void
@@ -52,9 +52,9 @@ final readonly class LoadConfig
 
         return $configPaths
             ->filter(fn (string $path) => match (true) {
-                $this->appConfig->environment->isLocal() => ! Str\contains($path, [...$suffixes['production'], ...$suffixes['staging'], ...$suffixes['testing']]),
-                $this->appConfig->environment->isProduction() => ! Str\contains($path, [...$suffixes['staging'], ...$suffixes['testing'], ...$suffixes['development']]),
-                $this->appConfig->environment->isStaging() => ! Str\contains($path, [...$suffixes['testing'], ...$suffixes['development'], ...$suffixes['production']]),
+                $this->environment->isLocal() => ! Str\contains($path, [...$suffixes['production'], ...$suffixes['staging'], ...$suffixes['testing']]),
+                $this->environment->isProduction() => ! Str\contains($path, [...$suffixes['staging'], ...$suffixes['testing'], ...$suffixes['development']]),
+                $this->environment->isStaging() => ! Str\contains($path, [...$suffixes['testing'], ...$suffixes['development'], ...$suffixes['production']]),
                 default => true,
             })
             ->sortByCallback(function (string $path1, string $path2) use ($suffixes): int {

--- a/packages/core/tests/EnvironmentTest.php
+++ b/packages/core/tests/EnvironmentTest.php
@@ -38,8 +38,8 @@ final class EnvironmentTest extends TestCase
         putenv('ENVIRONMENT=staging');
         $this->assertSame(Environment::STAGING, $container->get(Environment::class));
 
-        // ensure it's not a singleton
+        // ensure it's a singleton
         putenv('ENVIRONMENT=production');
-        $this->assertSame(Environment::PRODUCTION, $container->get(Environment::class));
+        $this->assertSame(Environment::STAGING, $container->get(Environment::class));
     }
 }

--- a/packages/core/tests/EnvironmentTest.php
+++ b/packages/core/tests/EnvironmentTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tempest\Core\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Container\GenericContainer;
+use Tempest\Core\Environment;
+use Tempest\Core\EnvironmentInitalizer;
+use Tempest\Core\EnvironmentValueWasInvalid;
+
+final class EnvironmentTest extends TestCase
+{
+    #[Test]
+    public function default_is_local(): void
+    {
+        putenv('ENVIRONMENT=null');
+
+        $this->assertSame(Environment::LOCAL, Environment::guessFromEnvironment());
+    }
+
+    #[Test]
+    public function throws_on_unknown_value(): void
+    {
+        putenv('ENVIRONMENT=unknown');
+
+        $this->expectException(EnvironmentValueWasInvalid::class);
+
+        Environment::guessFromEnvironment();
+    }
+
+    #[Test]
+    public function can_be_resolved_from_container(): void
+    {
+        $container = new GenericContainer();
+        $container->addInitializer(EnvironmentInitalizer::class);
+
+        putenv('ENVIRONMENT=staging');
+        $this->assertSame(Environment::STAGING, $container->get(Environment::class));
+
+        // ensure it's not a singleton
+        putenv('ENVIRONMENT=production');
+        $this->assertSame(Environment::PRODUCTION, $container->get(Environment::class));
+    }
+}

--- a/packages/discovery/src/DiscoveryItems.php
+++ b/packages/discovery/src/DiscoveryItems.php
@@ -17,7 +17,7 @@ final class DiscoveryItems implements IteratorAggregate, Countable
         private array $items = [],
     ) {}
 
-    public function addForLocation(DiscoveryLocation $location, array $values): self
+    public function addForLocation(DiscoveryLocation $location, iterable $values): self
     {
         $existingValues = $this->items[$location->path] ?? [];
 

--- a/packages/http/src/Session/VerifyCsrfMiddleware.php
+++ b/packages/http/src/Session/VerifyCsrfMiddleware.php
@@ -6,6 +6,7 @@ namespace Tempest\Http\Session;
 
 use Tempest\Clock\Clock;
 use Tempest\Core\AppConfig;
+use Tempest\Core\Environment;
 use Tempest\Core\Priority;
 use Tempest\Cryptography\Encryption\Encrypter;
 use Tempest\Cryptography\Encryption\Exceptions\EncryptionException;
@@ -29,6 +30,7 @@ final readonly class VerifyCsrfMiddleware implements HttpMiddleware
     public function __construct(
         private Session $session,
         private AppConfig $appConfig,
+        private Environment $environment,
         private SessionConfig $sessionConfig,
         private CookieManager $cookies,
         private Clock $clock,
@@ -60,7 +62,7 @@ final readonly class VerifyCsrfMiddleware implements HttpMiddleware
             return true;
         }
 
-        if ($this->appConfig->environment->isTesting()) {
+        if ($this->environment->isTesting()) {
             return true;
         }
 

--- a/packages/log/src/GenericLogger.php
+++ b/packages/log/src/GenericLogger.php
@@ -8,7 +8,7 @@ use Monolog\Level as MonologLogLevel;
 use Monolog\Logger as Monolog;
 use Psr\Log\LogLevel as PsrLogLevel;
 use Stringable;
-use Tempest\Core\AppConfig;
+use Tempest\Core\Environment;
 use Tempest\EventBus\EventBus;
 
 final class GenericLogger implements Logger
@@ -18,7 +18,7 @@ final class GenericLogger implements Logger
 
     public function __construct(
         private readonly LogConfig $logConfig,
-        private readonly AppConfig $appConfig,
+        private readonly Environment $environment,
         private readonly EventBus $eventBus,
     ) {}
 
@@ -97,7 +97,7 @@ final class GenericLogger implements Logger
 
         if (! isset($this->drivers[$key])) {
             $this->drivers[$key] = new Monolog(
-                name: $this->logConfig->prefix ?? $this->appConfig->environment->value,
+                name: $this->logConfig->prefix ?? $this->environment->value,
                 handlers: $channel->getHandlers($level),
                 processors: $channel->getProcessors(),
             );

--- a/packages/log/src/LoggerInitializer.php
+++ b/packages/log/src/LoggerInitializer.php
@@ -8,7 +8,7 @@ use Psr\Log\LoggerInterface;
 use Tempest\Container\Container;
 use Tempest\Container\DynamicInitializer;
 use Tempest\Container\Singleton;
-use Tempest\Core\AppConfig;
+use Tempest\Core\Environment;
 use Tempest\EventBus\EventBus;
 use Tempest\Reflection\ClassReflector;
 use UnitEnum;
@@ -25,7 +25,7 @@ final readonly class LoggerInitializer implements DynamicInitializer
     {
         return new GenericLogger(
             logConfig: $container->get(LogConfig::class, $tag),
-            appConfig: $container->get(AppConfig::class),
+            environment: $container->get(Environment::class),
             eventBus: $container->get(EventBus::class),
         );
     }

--- a/packages/view/src/Components/x-icon.view.php
+++ b/packages/view/src/Components/x-icon.view.php
@@ -4,7 +4,7 @@
  * @var string|null $class
  */
 
-use Tempest\Core\AppConfig;
+use Tempest\Core\Environment;
 use Tempest\Icon\Icon;
 
 use function Tempest\get;
@@ -12,7 +12,7 @@ use function Tempest\Support\str;
 
 $class ??= null;
 $name ??= null;
-$appConfig = get(AppConfig::class);
+$environment = get(Environment::class);
 
 if ($name) {
     $svg = get(Icon::class)->render($name);
@@ -20,7 +20,7 @@ if ($name) {
     $svg = null;
 }
 
-if ($svg === null && $appConfig->environment->isLocal()) {
+if ($svg === null && $environment->isLocal()) {
     $svg = '<!-- unknown-icon: ' . $name . ' -->';
 }
 

--- a/packages/view/src/Elements/ViewComponentElement.php
+++ b/packages/view/src/Elements/ViewComponentElement.php
@@ -183,7 +183,7 @@ final class ViewComponentElement implements Element, WithToken
 
                     // A slot doesn't have any content, so we'll comment it out.
                     // This is to prevent DOM parsing errors (slots in <head> tags is one example, see #937)
-                    return $this->environment->isProduction() ? '' : '<!--' . $matches[0] . '-->';
+                    return $this->environment->isLocal() ? '<!--' . $matches[0] . '-->' : '';
                 }
 
                 $slotElement = $this->getSlotElement($slot->name);

--- a/packages/view/src/Initializers/ElementFactoryInitializer.php
+++ b/packages/view/src/Initializers/ElementFactoryInitializer.php
@@ -5,7 +5,7 @@ namespace Tempest\View\Initializers;
 use Tempest\Container\Container;
 use Tempest\Container\Initializer;
 use Tempest\Container\Singleton;
-use Tempest\Core\AppConfig;
+use Tempest\Core\Environment;
 use Tempest\View\Elements\ElementFactory;
 use Tempest\View\ViewConfig;
 
@@ -15,8 +15,8 @@ final class ElementFactoryInitializer implements Initializer
     public function initialize(Container $container): ElementFactory
     {
         return new ElementFactory(
-            $container->get(ViewConfig::class),
-            $container->get(AppConfig::class)->environment,
+            viewConfig: $container->get(ViewConfig::class),
+            environment: $container->get(Environment::class),
         );
     }
 }

--- a/packages/view/src/Initializers/ViewCacheInitializer.php
+++ b/packages/view/src/Initializers/ViewCacheInitializer.php
@@ -5,7 +5,7 @@ namespace Tempest\View\Initializers;
 use Tempest\Container\Container;
 use Tempest\Container\Initializer;
 use Tempest\Container\Singleton;
-use Tempest\Core\AppConfig;
+use Tempest\Core\Environment;
 use Tempest\View\ViewCache;
 
 use function Tempest\env;
@@ -16,20 +16,18 @@ final class ViewCacheInitializer implements Initializer
     public function initialize(Container $container): ViewCache
     {
         $viewCache = new ViewCache(
-            enabled: $this->shouldCacheBeEnabled(
-                $container->get(AppConfig::class)->environment->isProduction(),
-            ),
+            enabled: $this->shouldCacheBeEnabled(),
         );
 
         return $viewCache;
     }
 
-    private function shouldCacheBeEnabled(bool $isProduction): bool
+    private function shouldCacheBeEnabled(): bool
     {
         if (env('INTERNAL_CACHES') === false) {
             return false;
         }
 
-        return (bool) env('VIEW_CACHE', default: $isProduction);
+        return (bool) env('VIEW_CACHE', default: Environment::guessFromEnvironment());
     }
 }

--- a/packages/vite/src/Vite.php
+++ b/packages/vite/src/Vite.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Vite;
 
 use Tempest\Container\Container;
-use Tempest\Core\AppConfig;
+use Tempest\Core\Environment;
 use Tempest\Support\Filesystem;
 use Tempest\Support\Json;
 use Tempest\Vite\Exceptions\DevelopmentServerWasNotRunning;
@@ -28,7 +28,7 @@ final class Vite
     private static ?Manifest $manifest = null;
 
     public function __construct(
-        private readonly AppConfig $appConfig,
+        private readonly Environment $environment,
         private readonly ViteConfig $viteConfig,
         private readonly Container $container,
         private readonly TagCompiler $tagCompiler,
@@ -109,7 +109,7 @@ final class Vite
 
     private function shouldUseManifest(): bool
     {
-        if ($this->appConfig->environment->isTesting() && ! $this->viteConfig->useManifestDuringTesting) {
+        if ($this->environment->isTesting() && ! $this->viteConfig->useManifestDuringTesting) {
             return false;
         }
 

--- a/tests/Integration/Console/Middleware/CautionMiddlewareTest.php
+++ b/tests/Integration/Console/Middleware/CautionMiddlewareTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Console\Middleware;
 
-use Tempest\Core\AppConfig;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
 use Tempest\Core\Environment;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
@@ -13,17 +14,22 @@ use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
  */
 final class CautionMiddlewareTest extends FrameworkIntegrationTestCase
 {
-    public function test_in_local(): void
+    #[Test]
+    public function in_local(): void
     {
+        $this->container->singleton(Environment::class, Environment::LOCAL);
+
         $this->console
             ->call('caution')
             ->assertContains('CAUTION confirmed');
     }
 
-    public function test_in_production(): void
+    #[Test]
+    #[TestWith([Environment::PRODUCTION])]
+    #[TestWith([Environment::STAGING])]
+    public function in_caution_environments(Environment $environment): void
     {
-        $appConfig = $this->container->get(AppConfig::class);
-        $appConfig->environment = Environment::PRODUCTION;
+        $this->container->singleton(Environment::class, $environment);
 
         $this->console
             ->call('caution')

--- a/tests/Integration/Core/AppConfigTest.php
+++ b/tests/Integration/Core/AppConfigTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Core;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tempest\Core\AppConfig;
-use Tempest\Core\Environment;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 /**
@@ -13,11 +13,12 @@ use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
  */
 final class AppConfigTest extends FrameworkIntegrationTestCase
 {
-    public function test_defaults(): void
+    #[Test]
+    public function defaults(): void
     {
         $appConfig = $this->container->get(AppConfig::class);
 
-        $this->assertSame(Environment::TESTING, $appConfig->environment);
         $this->assertSame('', $appConfig->baseUri);
+        $this->assertSame(null, $appConfig->name);
     }
 }

--- a/tests/Integration/Core/Config/LoadConfigTest.php
+++ b/tests/Integration/Core/Config/LoadConfigTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Tempest\Integration\Core\Config;
 
-use Tempest\Core\AppConfig;
 use Tempest\Core\ConfigCache;
 use Tempest\Core\Environment;
 use Tempest\Core\Kernel\LoadConfig;
@@ -64,7 +63,8 @@ final class LoadConfigTest extends FrameworkIntegrationTestCase
             'db.config.php',
         ]);
 
-        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+        $this->container->singleton(Environment::class, Environment::PRODUCTION);
+
         $config = $this->container->get(LoadConfig::class)->find();
 
         $this->assertCount(2, $config);
@@ -82,7 +82,8 @@ final class LoadConfigTest extends FrameworkIntegrationTestCase
             'db.config.php',
         ]);
 
-        $this->container->get(AppConfig::class)->environment = Environment::STAGING;
+        $this->container->singleton(Environment::class, Environment::STAGING);
+
         $config = $this->container->get(LoadConfig::class)->find();
 
         $this->assertCount(2, $config);
@@ -100,7 +101,8 @@ final class LoadConfigTest extends FrameworkIntegrationTestCase
             'db.config.php',
         ]);
 
-        $this->container->get(AppConfig::class)->environment = Environment::LOCAL;
+        $this->container->singleton(Environment::class, Environment::LOCAL);
+
         $config = $this->container->get(LoadConfig::class)->find();
 
         $this->assertCount(3, $config);

--- a/tests/Integration/Framework/Commands/DatabaseSeedCommandTest.php
+++ b/tests/Integration/Framework/Commands/DatabaseSeedCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Tempest\Integration\Framework\Commands;
 
-use Tempest\Core\AppConfig;
 use Tempest\Core\Environment;
 use Tempest\Database\Config\SeederConfig;
 use Tempest\Database\Migrations\CreateMigrationsTable;
@@ -129,8 +128,7 @@ final class DatabaseSeedCommandTest extends FrameworkIntegrationTestCase
 
     public function test_db_seed_caution(): void
     {
-        $appConfig = $this->container->get(AppConfig::class);
-        $appConfig->environment = Environment::PRODUCTION;
+        $this->container->singleton(Environment::class, Environment::PRODUCTION);
 
         $this->console
             ->call('migrate:fresh --seed --all')

--- a/tests/Integration/Http/CsrfTest.php
+++ b/tests/Integration/Http/CsrfTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Tempest\Integration\Http;
 
 use PHPUnit\Framework\Attributes\TestWith;
-use Tempest\Core\AppConfig;
 use Tempest\Core\Environment;
 use Tempest\Cryptography\Encryption\Encrypter;
 use Tempest\Http\GenericRequest;
@@ -20,7 +19,7 @@ final class CsrfTest extends FrameworkIntegrationTestCase
 {
     public function test_csrf_is_sent_as_cookie(): void
     {
-        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+        $this->container->singleton(Environment::class, Environment::PRODUCTION);
 
         $token = $this->container->get(Session::class)->get(Session::CSRF_TOKEN_KEY);
 
@@ -37,7 +36,7 @@ final class CsrfTest extends FrameworkIntegrationTestCase
     {
         $this->expectException(CsrfTokenDidNotMatch::class);
 
-        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+        $this->container->singleton(Environment::class, Environment::PRODUCTION);
         $this->http->sendRequest(new GenericRequest($method, uri: '/test'));
     }
 
@@ -46,7 +45,7 @@ final class CsrfTest extends FrameworkIntegrationTestCase
     #[TestWith([Method::HEAD])]
     public function test_allows_missing_in_read_verbs(Method $method): void
     {
-        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+        $this->container->singleton(Environment::class, Environment::PRODUCTION);
 
         $this->http
             ->sendRequest(new GenericRequest($method, uri: '/test'))
@@ -57,7 +56,7 @@ final class CsrfTest extends FrameworkIntegrationTestCase
     {
         $this->expectException(CsrfTokenDidNotMatch::class);
 
-        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+        $this->container->singleton(Environment::class, Environment::PRODUCTION);
         $this->container->get(Session::class)->set(Session::CSRF_TOKEN_KEY, 'abc');
 
         $this->http->post('/test', [Session::CSRF_TOKEN_KEY => 'def']);
@@ -67,7 +66,7 @@ final class CsrfTest extends FrameworkIntegrationTestCase
     {
         $this->expectException(CsrfTokenDidNotMatch::class);
 
-        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+        $this->container->singleton(Environment::class, Environment::PRODUCTION);
         $this->container->get(Session::class)->set(Session::CSRF_TOKEN_KEY, 'abc');
 
         $this->http->post('/test', [Session::CSRF_TOKEN_KEY => 'def']);
@@ -75,7 +74,7 @@ final class CsrfTest extends FrameworkIntegrationTestCase
 
     public function test_matches_from_body(): void
     {
-        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+        $this->container->singleton(Environment::class, Environment::PRODUCTION);
 
         $session = $this->container->get(Session::class);
 
@@ -86,7 +85,7 @@ final class CsrfTest extends FrameworkIntegrationTestCase
 
     public function test_matches_from_header_when_encrypted(): void
     {
-        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+        $this->container->singleton(Environment::class, Environment::PRODUCTION);
         $session = $this->container->get(Session::class);
 
         // Encrypt the token as it would be in a real request
@@ -103,7 +102,7 @@ final class CsrfTest extends FrameworkIntegrationTestCase
     public function test_throws_csrf_exception_when_header_is_non_serialized_hash(): void
     {
         $this->expectException(CsrfTokenDidNotMatch::class);
-        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+        $this->container->singleton(Environment::class, Environment::PRODUCTION);
         $session = $this->container->get(Session::class);
 
         // simulate a non-serialized hash

--- a/tests/Integration/Log/GenericLoggerTest.php
+++ b/tests/Integration/Log/GenericLoggerTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\Attributes\PreCondition;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\LogLevel as PsrLogLevel;
 use ReflectionClass;
-use Tempest\Core\AppConfig;
+use Tempest\Core\Environment;
 use Tempest\DateTime\Duration;
 use Tempest\EventBus\EventBus;
 use Tempest\Log\Channels\AppendLogChannel;
@@ -35,8 +35,8 @@ final class GenericLoggerTest extends FrameworkIntegrationTestCase
         get => $this->container->get(EventBus::class);
     }
 
-    private AppConfig $appConfig {
-        get => $this->container->get(AppConfig::class);
+    private Environment $environment {
+        get => $this->container->get(Environment::class);
     }
 
     #[PreCondition]
@@ -58,7 +58,7 @@ final class GenericLoggerTest extends FrameworkIntegrationTestCase
 
         $config = new SimpleLogConfig($filePath, prefix: 'tempest');
 
-        $logger = new GenericLogger($config, $this->appConfig, $this->bus);
+        $logger = new GenericLogger($config, $this->environment, $this->bus);
         $logger->info('test');
 
         $this->assertFileExists($filePath);
@@ -72,18 +72,18 @@ final class GenericLoggerTest extends FrameworkIntegrationTestCase
         $filePath = __DIR__ . '/logs/tempest-' . date('Y-m-d') . '.log';
         $config = new DailyLogConfig(__DIR__ . '/logs/tempest.log', prefix: 'tempest');
 
-        $logger = new GenericLogger($config, $this->appConfig, $this->bus);
+        $logger = new GenericLogger($config, $this->environment, $this->bus);
         $logger->info('test');
 
         $this->assertFileExists($filePath);
         $this->assertStringContainsString('test', Filesystem\read_file($filePath));
 
         $clock->plus(Duration::day());
-        $logger = new GenericLogger($config, $this->appConfig, $this->bus);
+        $logger = new GenericLogger($config, $this->environment, $this->bus);
         $logger->info('test');
 
         $clock->plus(Duration::days(2));
-        $logger = new GenericLogger($config, $this->appConfig, $this->bus);
+        $logger = new GenericLogger($config, $this->environment, $this->bus);
         $logger->info('test');
     }
 
@@ -93,7 +93,7 @@ final class GenericLoggerTest extends FrameworkIntegrationTestCase
         $filePath = __DIR__ . '/logs/tempest-' . date('Y-W') . '.log';
         $config = new WeeklyLogConfig(__DIR__ . '/logs/tempest.log', prefix: 'tempest');
 
-        $logger = new GenericLogger($config, $this->appConfig, $this->bus);
+        $logger = new GenericLogger($config, $this->environment, $this->bus);
         $logger->info('test');
 
         $this->assertFileExists($filePath);
@@ -114,7 +114,7 @@ final class GenericLoggerTest extends FrameworkIntegrationTestCase
             prefix: 'tempest',
         );
 
-        $logger = new GenericLogger($config, $this->appConfig, $this->bus);
+        $logger = new GenericLogger($config, $this->environment, $this->bus);
         $logger->info('test');
 
         $this->assertFileExists($filePath);
@@ -136,7 +136,7 @@ final class GenericLoggerTest extends FrameworkIntegrationTestCase
             prefix: 'tempest',
         );
 
-        $logger = new GenericLogger($config, $this->appConfig, $this->bus);
+        $logger = new GenericLogger($config, $this->environment, $this->bus);
         $logger->log($level, 'test');
 
         $this->assertFileExists($filePath);
@@ -155,7 +155,7 @@ final class GenericLoggerTest extends FrameworkIntegrationTestCase
             $this->assertSame(['foo' => 'bar'], $event->context);
         });
 
-        $logger = new GenericLogger(new NullLogConfig(), $this->appConfig, $this->bus);
+        $logger = new GenericLogger(new NullLogConfig(), $this->environment, $this->bus);
         $logger->log($level, 'This is a log message of level: ' . $level->value, context: ['foo' => 'bar']);
     }
 
@@ -168,7 +168,7 @@ final class GenericLoggerTest extends FrameworkIntegrationTestCase
             prefix: 'tempest',
         );
 
-        $logger = new GenericLogger($config, $this->appConfig, $this->bus);
+        $logger = new GenericLogger($config, $this->environment, $this->bus);
         $logger->critical('critical');
         $logger->debug('debug');
 

--- a/tests/Integration/View/Components/IconComponentTest.php
+++ b/tests/Integration/View/Components/IconComponentTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\View\Components;
 
-use Tempest\Core\AppConfig;
 use Tempest\Core\ConfigCache;
 use Tempest\Core\Environment;
 use Tempest\DateTime\Duration;
@@ -127,7 +126,7 @@ final class IconComponentTest extends FrameworkIntegrationTestCase
             ->willReturn(new GenericResponse(status: Status::NOT_FOUND, body: ''));
 
         $this->container->register(HttpClient::class, fn () => $mockHttpClient);
-        $this->container->singleton(AppConfig::class, fn () => new AppConfig(environment: Environment::LOCAL));
+        $this->container->singleton(Environment::class, Environment::LOCAL);
 
         $this->assertSame(
             '<!-- unknown-icon: ph:eye -->',
@@ -145,7 +144,7 @@ final class IconComponentTest extends FrameworkIntegrationTestCase
             ->willReturn(new GenericResponse(status: Status::NOT_FOUND, body: ''));
 
         $this->container->register(HttpClient::class, fn () => $mockHttpClient);
-        $this->container->singleton(AppConfig::class, fn () => new AppConfig(environment: Environment::PRODUCTION));
+        $this->container->singleton(Environment::class, Environment::PRODUCTION);
 
         $this->assertSame(
             '',

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -6,7 +6,6 @@ namespace Tests\Tempest\Integration\View;
 
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use Tempest\Core\AppConfig;
 use Tempest\Core\Environment;
 use Tempest\Http\Session\Session;
 use Tempest\Validation\Rules\IsAlphaNumeric;
@@ -497,6 +496,8 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
 
     public function test_empty_slots_are_commented_out(): void
     {
+        $this->container->singleton(Environment::class, Environment::LOCAL);
+
         $this->registerViewComponent('x-layout', <<<'HTML'
         <html lang="en">
         <head>
@@ -519,7 +520,7 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
 
     public function test_empty_slots_are_removed_in_production(): void
     {
-        $this->container->get(AppConfig::class)->environment = Environment::PRODUCTION;
+        $this->container->singleton(Environment::class, Environment::PRODUCTION);
 
         $this->registerViewComponent('x-layout', <<<'HTML'
         <html lang="en">
@@ -886,9 +887,9 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         $this->registerViewComponent('x-b', <<<'HTML'
         <?php 
         use function \Tempest\get;
-        use \Tempest\Core\AppConfig;
+        use \Tempest\Core\Environment;
         ?>
-        {{ get(AppConfig::class)->environment->value }}
+        {{ get(Environment::class)->value }}
         HTML);
 
         $html = $this->render(<<<'HTML'


### PR DESCRIPTION
Because injecting `Environment` is more discoverable and a better DX than injecting `AppConfig`. 

```php
public function __construct(
    private readonly Environment $environment,
) {}
```

**EDIT**: so actually, as specified in my comment below, I completely dissociated `AppConfig` from `Environment`:
- The booting process uses `Environment::fromEnv` indirectly through `AppConfig`'s constructor when resolved from the container
- Specifying the `environment` property of the `AppConfig` in userland will not behave as expected due to that
- It makes sense that `Environment` is its own source of truth in the container, it's even easier to spoof in tests