### PR TITLE
fix(discovery): handle the discovery test case corectlly

### DIFF
--- a/tests/Integration/Core/LoadDiscoveryClassesTest.php
+++ b/tests/Integration/Core/LoadDiscoveryClassesTest.php
@@ -31,7 +31,7 @@ final class LoadDiscoveryClassesTest extends FrameworkIntegrationTestCase
 
         $this->assertFalse(
             collect($migrations)
-                ->contains(fn($m) => $m instanceof HiddenDatabaseMigration)
+                ->contains(fn ($m) => $m instanceof HiddenDatabaseMigration),
         );
     }
 

--- a/tests/Integration/Core/LoadDiscoveryClassesTest.php
+++ b/tests/Integration/Core/LoadDiscoveryClassesTest.php
@@ -29,7 +29,10 @@ final class LoadDiscoveryClassesTest extends FrameworkIntegrationTestCase
     {
         $migrations = get(RunnableMigrations::class);
 
-        $this->assertNotContains(HiddenDatabaseMigration::class, $migrations);
+        $this->assertFalse(
+            collect($migrations)
+                ->contains(fn($m) => $m instanceof HiddenDatabaseMigration)
+        );
     }
 
     #[Test]

--- a/tests/Integration/Core/LoadDiscoveryClassesTest.php
+++ b/tests/Integration/Core/LoadDiscoveryClassesTest.php
@@ -9,6 +9,7 @@ use Tempest\Core\Kernel\LoadDiscoveryClasses;
 use Tempest\Database\MigratesUp;
 use Tempest\Database\Migrations\RunnableMigrations;
 use Tempest\Discovery\DiscoveryLocation;
+use Tempest\Support\Arr;
 use Tests\Tempest\Fixtures\Discovery\HiddenDatabaseMigration;
 use Tests\Tempest\Fixtures\Discovery\HiddenMigratableDatabaseMigration;
 use Tests\Tempest\Fixtures\GlobalHiddenDiscovery;
@@ -16,8 +17,6 @@ use Tests\Tempest\Fixtures\GlobalHiddenPathDiscovery;
 use Tests\Tempest\Integration\Core\Fixtures\ManualTestDiscovery;
 use Tests\Tempest\Integration\Core\Fixtures\ManualTestDiscoveryDependency;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
-
-use function Tempest\get;
 
 /**
  * @internal
@@ -27,12 +26,9 @@ final class LoadDiscoveryClassesTest extends FrameworkIntegrationTestCase
     #[Test]
     public function do_not_discover(): void
     {
-        $migrations = get(RunnableMigrations::class);
+        $migrations = $this->container->get(RunnableMigrations::class);
 
-        $this->assertFalse(
-            collect($migrations)
-                ->contains(fn ($m) => $m instanceof HiddenDatabaseMigration),
-        );
+        $this->assertFalse(Arr\contains($migrations, fn ($m) => $m instanceof HiddenDatabaseMigration));
     }
 
     #[Test]
@@ -50,11 +46,11 @@ final class LoadDiscoveryClassesTest extends FrameworkIntegrationTestCase
     #[Test]
     public function do_not_discover_except(): void
     {
-        $migrations = get(RunnableMigrations::class);
+        $migrations = $this->container->get(RunnableMigrations::class);
 
-        $foundMigrations = array_filter(
-            iterator_to_array($migrations),
-            static fn (MigratesUp $migration) => $migration instanceof HiddenMigratableDatabaseMigration,
+        $foundMigrations = Arr\filter(
+            array: iterator_to_array($migrations),
+            filter: static fn (MigratesUp $migration) => $migration instanceof HiddenMigratableDatabaseMigration,
         );
 
         $this->assertCount(1, $foundMigrations, 'Expected one hidden migration to be found');


### PR DESCRIPTION
as I was working on tests for another PR, I came across a specific test case that kept asserting as true. this happens because assertNotContains() checks for value equality, not type