### PR TITLE
feat(core): enable partial discovery by default during development

### DIFF
--- a/packages/core/src/Commands/DiscoveryGenerateCommand.php
+++ b/packages/core/src/Commands/DiscoveryGenerateCommand.php
@@ -17,8 +17,6 @@ use Tempest\Core\FrameworkKernel;
 use Tempest\Core\Kernel;
 use Tempest\Core\Kernel\LoadDiscoveryClasses;
 
-use function Tempest\env;
-
 if (class_exists(\Tempest\Console\ConsoleCommand::class)) {
     final readonly class DiscoveryGenerateCommand
     {
@@ -37,7 +35,7 @@ if (class_exists(\Tempest\Console\ConsoleCommand::class)) {
         )]
         public function __invoke(): void
         {
-            $strategy = DiscoveryCacheStrategy::make(env('DISCOVERY_CACHE', default: $this->environment->requiresCaution()));
+            $strategy = DiscoveryCacheStrategy::resolveFromEnvironment();
 
             if ($strategy === DiscoveryCacheStrategy::NONE) {
                 $this->info('Discovery cache disabled, nothing to generate.');

--- a/packages/core/src/DiscoveryCache.php
+++ b/packages/core/src/DiscoveryCache.php
@@ -10,6 +10,7 @@ use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
 use Tempest\Discovery\Discovery;
 use Tempest\Discovery\DiscoveryItems;
 use Tempest\Discovery\DiscoveryLocation;
+use Tempest\Support\Filesystem;
 use Throwable;
 
 use function Tempest\internal_storage_path;
@@ -86,13 +87,10 @@ final class DiscoveryCache
 
     public function storeStrategy(DiscoveryCacheStrategy $strategy): void
     {
-        $dir = dirname(self::getCurrentDiscoverStrategyCachePath());
+        $path = self::getCurrentDiscoverStrategyCachePath();
 
-        if (! is_dir($dir)) {
-            mkdir($dir, recursive: true);
-        }
-
-        file_put_contents(self::getCurrentDiscoverStrategyCachePath(), $strategy->value);
+        Filesystem\create_directory_for_file($path);
+        Filesystem\write_file($path, $strategy->value);
     }
 
     public static function getCurrentDiscoverStrategyCachePath(): string

--- a/packages/core/src/FrameworkKernel.php
+++ b/packages/core/src/FrameworkKernel.php
@@ -240,10 +240,8 @@ final class FrameworkKernel implements Kernel
 
     public function registerExceptionHandler(): self
     {
-        $environment = $this->container->get(Environment::class);
-
         // During tests, PHPUnit registers its own error handling.
-        if ($environment->isTesting()) {
+        if (Environment::guessFromEnvironment()->isTesting()) {
             return $this;
         }
 

--- a/tests/Integration/Core/DiscoveryCacheTest.php
+++ b/tests/Integration/Core/DiscoveryCacheTest.php
@@ -2,8 +2,11 @@
 
 namespace Tests\Tempest\Integration\Core;
 
+use PHPUnit\Framework\Attributes\PostCondition;
+use PHPUnit\Framework\Attributes\Test;
 use Tempest\Core\CouldNotStoreDiscoveryCache;
 use Tempest\Core\DiscoveryCache;
+use Tempest\Core\DiscoveryCacheStrategy;
 use Tempest\Discovery\DiscoveryLocation;
 use Tests\Tempest\Integration\Core\Fixtures\TestDiscovery;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -12,7 +15,15 @@ use function Tempest\reflect;
 
 final class DiscoveryCacheTest extends FrameworkIntegrationTestCase
 {
-    public function test_exception_with_unserializable_discovery_items(): void
+    #[PostCondition]
+    protected function cleanup(): void
+    {
+        putenv('ENVIRONMENT=testing');
+        putenv('DISCOVERY_CACHE=true');
+    }
+
+    #[Test]
+    public function exception_with_unserializable_discovery_items(): void
     {
         $this->assertException(CouldNotStoreDiscoveryCache::class, function (): void {
             $discoveryCache = $this->container->get(DiscoveryCache::class);
@@ -25,5 +36,50 @@ final class DiscoveryCacheTest extends FrameworkIntegrationTestCase
                 $discovery,
             ]);
         });
+    }
+
+    #[Test]
+    public function partial_locally(): void
+    {
+        putenv('ENVIRONMENT=local');
+        putenv('DISCOVERY_CACHE=null');
+
+        $this->assertSame(DiscoveryCacheStrategy::PARTIAL, DiscoveryCacheStrategy::resolveFromEnvironment());
+    }
+
+    #[Test]
+    public function overridable_locally(): void
+    {
+        putenv('ENVIRONMENT=local');
+        putenv('DISCOVERY_CACHE=false');
+
+        $this->assertSame(DiscoveryCacheStrategy::NONE, DiscoveryCacheStrategy::resolveFromEnvironment());
+    }
+
+    #[Test]
+    public function enabled_in_production(): void
+    {
+        putenv('ENVIRONMENT=production');
+        putenv('DISCOVERY_CACHE=null');
+
+        $this->assertSame(DiscoveryCacheStrategy::FULL, DiscoveryCacheStrategy::resolveFromEnvironment());
+    }
+
+    #[Test]
+    public function enabled_in_staging(): void
+    {
+        putenv('ENVIRONMENT=staging');
+        putenv('DISCOVERY_CACHE=null');
+
+        $this->assertSame(DiscoveryCacheStrategy::FULL, DiscoveryCacheStrategy::resolveFromEnvironment());
+    }
+
+    #[Test]
+    public function overridable_in_production(): void
+    {
+        putenv('ENVIRONMENT=production');
+        putenv('DISCOVERY_CACHE=partial');
+
+        $this->assertSame(DiscoveryCacheStrategy::PARTIAL, DiscoveryCacheStrategy::resolveFromEnvironment());
     }
 }


### PR DESCRIPTION
This pull request enables partial discovery by default during development, and updates the discovery documentation with more information and a troubleshooting section.

I think that with the default `post-package-update` script that we provide, and given that we recommend setting it in the documentation, this is a safe thing to do. I also documented that when working on packages in a local environment, the discovery cache should manually be disabled.

I also added tests for the strategy initialization and shared the logic between the discovery cache initializer and the `discovery:generate` command.

Closes #1845