### PR TITLE
feat(testing)!: remove deprecated testing utilities

### DIFF
--- a/src/Tempest/Framework/Testing/IntegrationTest.php
+++ b/src/Tempest/Framework/Testing/IntegrationTest.php
@@ -19,8 +19,6 @@ use Tempest\Container\GenericContainer;
 use Tempest\Core\ExceptionTester;
 use Tempest\Core\FrameworkKernel;
 use Tempest\Core\Kernel;
-use Tempest\Database\Migrations\CreateMigrationsTable;
-use Tempest\Database\Migrations\MigrationManager;
 use Tempest\Database\Testing\DatabaseTester;
 use Tempest\DateTime\DateTimeInterface;
 use Tempest\Discovery\DiscoveryLocation;
@@ -57,26 +55,59 @@ abstract class IntegrationTest extends TestCase
 
     protected ConsoleTester $console;
 
+    /**
+     * Provides utilities for testing HTTP routes.
+     */
     protected HttpRouterTester $http;
 
+    /**
+     * Provides utilities for testing installers.
+     */
     protected InstallerTester $installer;
 
+    /**
+     * Provides utilities for testing the Vite integration.
+     */
     protected ViteTester $vite;
 
+    /**
+     * Provides utilities for testing the event bus.
+     */
     protected EventBusTester $eventBus;
 
+    /**
+     * Provides utilities for testing storage management.
+     */
     protected StorageTester $storage;
 
+    /**
+     * Provides utilities for testing emails.
+     */
     protected MailTester $mailer;
 
+    /**
+     * Provides utilities for testing the cache.
+     */
     protected CacheTester $cache;
 
+    /**
+     * Provides utilities for testing exception reporting.
+     */
     protected ExceptionTester $exceptions;
 
+    /**
+     * Provides utilities for testing process execution.
+     */
     protected ProcessTester $process;
 
+    /**
+     * Provides utilities for testing OAuth flows.
+     */
     protected OAuthTester $oauth;
 
+    /**
+     * Provides utilities for testing the database.
+     */
     protected DatabaseTester $database;
 
     protected function setUp(): void
@@ -168,41 +199,6 @@ abstract class IntegrationTest extends TestCase
         $this->container->singleton(GenericRequest::class, fn () => $request);
 
         return $this;
-    }
-
-    /**
-     * Cleans up the database and migrates the migrations using `migrateDatabase`.
-     *
-     * @deprecated Use `$this->database->setup()` instead.
-     */
-    protected function setupDatabase(): self
-    {
-        $migrationManager = $this->container->get(MigrationManager::class);
-        $migrationManager->dropAll();
-
-        $this->migrateDatabase();
-
-        return $this;
-    }
-
-    /**
-     * Creates the migration table. You may override this method to provide more migrations to run for every tests in this file.
-     *
-     * @deprecated Use `$this->database->migrate()` instead.
-     */
-    protected function migrateDatabase(): void
-    {
-        $this->migrate(CreateMigrationsTable::class);
-    }
-
-    /**
-     * Migrates the specified migration classes.
-     *
-     * @deprecated Use `$this->database->migrate()` instead.
-     */
-    protected function migrate(string|object ...$migrationClasses): void
-    {
-        $this->database->migrate(...$migrationClasses);
     }
 
     protected function clock(DateTimeInterface|string $now = 'now'): MockClock

--- a/tests/Integration/Auth/Authentication/CurrentAuthenticatableTest.php
+++ b/tests/Integration/Auth/Authentication/CurrentAuthenticatableTest.php
@@ -22,7 +22,7 @@ final class CurrentAuthenticatableTest extends FrameworkIntegrationTestCase
     #[PreCondition]
     protected function configure(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateServiceAccountTableMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateServiceAccountTableMigration::class);
 
         $this->container->config(new AuthConfig(authenticatables: [ServiceAccount::class]));
     }

--- a/tests/Integration/Auth/Authentication/DatabaseAuthenticatableResolverTest.php
+++ b/tests/Integration/Auth/Authentication/DatabaseAuthenticatableResolverTest.php
@@ -21,7 +21,7 @@ final class DatabaseAuthenticatableResolverTest extends FrameworkIntegrationTest
     #[Test]
     public function can_resolve_custom_authenticatable_class(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateApiTokensTableMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateApiTokensTableMigration::class);
 
         $this->container->config(new AuthConfig(authenticatables: [ApiToken::class]));
 
@@ -37,7 +37,7 @@ final class DatabaseAuthenticatableResolverTest extends FrameworkIntegrationTest
     #[Test]
     public function can_resolve_id_from_custom_authenticatable_class(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateApiTokensTableMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateApiTokensTableMigration::class);
 
         $this->container->config(new AuthConfig(authenticatables: [ApiToken::class]));
 

--- a/tests/Integration/Auth/Authentication/SessionAuthenticatorTest.php
+++ b/tests/Integration/Auth/Authentication/SessionAuthenticatorTest.php
@@ -50,7 +50,7 @@ final class SessionAuthenticatorTest extends FrameworkIntegrationTestCase
             $this->container->get(SessionConfig::class),
         ));
 
-        $this->migrate(CreateMigrationsTable::class, CreateUsersTableMigration::class, CreateApiKeysTableMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUsersTableMigration::class, CreateApiKeysTableMigration::class);
     }
 
     #[PostCondition]

--- a/tests/Integration/Database/Builder/CountQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/CountQueryBuilderTest.php
@@ -138,7 +138,7 @@ final class CountQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_count(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
 
         query('authors')
             ->insert(

--- a/tests/Integration/Database/Builder/CustomPrimaryKeyTest.php
+++ b/tests/Integration/Database/Builder/CustomPrimaryKeyTest.php
@@ -15,7 +15,7 @@ final class CustomPrimaryKeyTest extends FrameworkIntegrationTestCase
 {
     public function test_model_with_custom_primary_key_name(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateCustomPrimaryKeyUserModelTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateCustomPrimaryKeyUserModelTable::class);
 
         $frieren = query(CustomPrimaryKeyUserModel::class)->create(name: 'Frieren', magic: 'Time Magic');
 
@@ -32,7 +32,7 @@ final class CustomPrimaryKeyTest extends FrameworkIntegrationTestCase
 
     public function test_update_or_create_with_custom_primary_key(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateCustomPrimaryKeyUserModelTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateCustomPrimaryKeyUserModelTable::class);
 
         $frieren = query(CustomPrimaryKeyUserModel::class)->create(name: 'Frieren', magic: 'Time Magic');
 
@@ -47,7 +47,7 @@ final class CustomPrimaryKeyTest extends FrameworkIntegrationTestCase
 
     public function test_model_without_id_property_still_works(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateModelWithoutIdMigration::class);
 
         $model = query(ModelWithoutId::class)->new(name: 'Test');
         $this->assertInstanceOf(ModelWithoutId::class, $model);

--- a/tests/Integration/Database/Builder/DeleteQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/DeleteQueryBuilderTest.php
@@ -93,7 +93,7 @@ final class DeleteQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_delete_with_non_object_model(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
 
         query('authors')
             ->insert(

--- a/tests/Integration/Database/Builder/InsertQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/InsertQueryBuilderTest.php
@@ -129,7 +129,7 @@ final class InsertQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_then_method(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
 
         $id = query(Book::class)
             ->insert(title: 'Timeline Taxi')
@@ -154,7 +154,7 @@ final class InsertQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_insert_with_non_object_model(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
 
         query('authors')
             ->insert(

--- a/tests/Integration/Database/Builder/InsertRelationsTest.php
+++ b/tests/Integration/Database/Builder/InsertRelationsTest.php
@@ -28,7 +28,7 @@ final class InsertRelationsTest extends FrameworkIntegrationTestCase
 {
     public function test_inserting_has_many_with_arrays(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
 
         $id = query(Book::class)
             ->insert(
@@ -50,7 +50,7 @@ final class InsertRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_inserting_has_one_with_array(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -75,7 +75,7 @@ final class InsertRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_inserting_has_many_with_objects(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
 
         $id = query(Book::class)
             ->insert(
@@ -97,7 +97,7 @@ final class InsertRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_inserting_has_one_with_object(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -122,7 +122,7 @@ final class InsertRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_inserting_mixed_relations(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -154,7 +154,7 @@ final class InsertRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_inserting_empty_has_many_relation(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
 
         $id = query(Book::class)
             ->insert(title: 'Empty Book', chapters: [])
@@ -170,7 +170,7 @@ final class InsertRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_inserting_large_batch_has_many(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
 
         $chapters = [];
         for ($i = 1; $i <= 10; $i++) {
@@ -191,7 +191,7 @@ final class InsertRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_inserting_has_many_preserves_additional_data(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
 
         $id = query(Book::class)
             ->insert(
@@ -233,7 +233,7 @@ final class InsertRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_relation_insertion_with_mixed_types(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
 
         $id = query(Book::class)
             ->insert(
@@ -257,7 +257,7 @@ final class InsertRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_insertion_with_custom_primary_key_names(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateMageTable::class, CreateSpellTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateMageTable::class, CreateSpellTable::class);
 
         $id = query(Mage::class)
             ->insert(
@@ -285,7 +285,7 @@ final class InsertRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_insertion_with_non_standard_relation_names(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePartyTable::class, CreateAdventurerTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePartyTable::class, CreateAdventurerTable::class);
 
         $id = query(Party::class)
             ->insert(
@@ -319,7 +319,7 @@ final class InsertRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_insertion_with_custom_foreign_key_names(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateMageTable::class, CreateSpellTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateMageTable::class, CreateSpellTable::class);
 
         $spellId = query(Spell::class)
             ->insert(

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -60,7 +60,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 {
     public function test_create_and_update_model(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             FooDatabaseMigration::class,
         );
@@ -88,7 +88,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_get_with_non_id_object(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             FooDatabaseMigration::class,
         );
@@ -104,7 +104,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_creating_many_and_saving_preserves_model_id(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             FooDatabaseMigration::class,
         );
@@ -123,7 +123,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_complex_query(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -152,7 +152,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_all_with_relations(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -185,7 +185,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_missing_relation_exception(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateATable::class,
             CreateBTable::class,
@@ -216,7 +216,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_nested_relations(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateATable::class,
             CreateBTable::class,
@@ -238,7 +238,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_load_belongs_to(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateATable::class,
             CreateBTable::class,
@@ -261,7 +261,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_has_many_relations(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -290,7 +290,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_has_many_through_relation(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateHasManyParentTable::class,
             CreateHasManyChildTable::class,
@@ -313,7 +313,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_empty_has_many_relation(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -329,7 +329,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_has_one_relation(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -349,7 +349,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_invalid_has_one_relation(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateHasManyParentTable::class,
             CreateHasManyChildTable::class,
@@ -372,7 +372,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_lazy_load(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateATable::class,
             CreateBTable::class,
@@ -397,7 +397,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_eager_load(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateATable::class,
             CreateBTable::class,
@@ -417,7 +417,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_no_result(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateATable::class,
             CreateBTable::class,
@@ -468,7 +468,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_select_virtual_property(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateATable::class,
             CreateBTable::class,
@@ -488,7 +488,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_update_with_virtual_property(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateATable::class,
             CreateBTable::class,
@@ -518,7 +518,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_update_or_create(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -565,7 +565,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_delete(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             FooDatabaseMigration::class,
         );
@@ -586,7 +586,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_delete_via_model_class_with_where_conditions(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             FooDatabaseMigration::class,
         );
@@ -607,7 +607,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_delete_via_model_instance_with_primary_key(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             FooDatabaseMigration::class,
         );
@@ -623,7 +623,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_delete_with_uninitialized_primary_key(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             FooDatabaseMigration::class,
         );
@@ -637,7 +637,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_delete_nonexistent_record(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             FooDatabaseMigration::class,
         );
@@ -656,7 +656,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_nullable_relations(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateBNullableTable::class,
             CreateANullableTable::class,
@@ -673,7 +673,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
     public function test_nullable_relation_save(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateBNullableTable::class,
             CreateANullableTable::class,

--- a/tests/Integration/Database/Builder/QueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/QueryBuilderTest.php
@@ -18,7 +18,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 {
     public function test_select(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
 
         query(TestUserModel::class)->create(name: 'Frieren');
         query(TestUserModel::class)->create(name: 'Fern');
@@ -53,7 +53,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_insert(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
 
         $builderWithId = query(TestUserModel::class)->insert(name: 'Frieren');
         $builderWithoutId = query(TestUserModelWithoutId::class)->insert(name: 'Stark');
@@ -77,7 +77,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_update(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
 
         $createdWithId = query(TestUserModel::class)->create(name: 'Frieren');
         query(TestUserModelWithoutId::class)->create(name: 'Stark');
@@ -102,7 +102,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_delete(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
 
         $createdWithId = query(TestUserModel::class)->create(name: 'Frieren');
         query(TestUserModel::class)->create(name: 'Fern');
@@ -129,7 +129,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_count(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
 
         query(TestUserModel::class)->create(name: 'Frieren');
         query(TestUserModel::class)->create(name: 'Fern');
@@ -170,7 +170,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_get_with_id_query(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class);
 
         $created = query(TestUserModel::class)->create(name: 'Himmel');
         $retrieved = query(TestUserModel::class)->get($created->id);
@@ -182,7 +182,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_get_throws_for_model_without_id(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWithoutIdMigration::class);
 
         $this->expectException(ModelDidNotHavePrimaryColumn::class);
         $this->expectExceptionMessage(
@@ -194,7 +194,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_all(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
 
         query(TestUserModel::class)->create(name: 'Fern');
         query(TestUserModel::class)->create(name: 'Stark');
@@ -216,7 +216,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_find(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
 
         query(TestUserModel::class)->create(name: 'Frieren');
         query(TestUserModel::class)->create(name: 'Fern');
@@ -242,7 +242,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_create(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
 
         $createdWithId = query(TestUserModel::class)->create(name: 'Ubel');
         $createdWithoutId = query(TestUserModelWithoutId::class)->create(name: 'Serie');
@@ -257,7 +257,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_find_or_new_finds_existing(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
 
         $existingWithId = query(TestUserModel::class)->create(name: 'Serie');
         $existingWithoutId = query(TestUserModelWithoutId::class)->create(name: 'Macht');
@@ -282,7 +282,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_find_or_new_creates_new(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class, TestModelWithoutIdMigration::class);
 
         $resultWithId = query(TestUserModel::class)->findOrNew(
             find: ['name' => 'NonExistent'],
@@ -304,7 +304,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_update_or_create_updates_existing(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class);
 
         $existingWithId = query(TestUserModel::class)->create(name: 'Qual');
 
@@ -320,7 +320,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_update_or_create_creates_new(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class);
 
         $resultWithId = query(TestUserModel::class)->updateOrCreate(
             find: ['name' => 'NonExistent'],
@@ -334,7 +334,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_get_with_string_id(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class);
 
         $created = query(TestUserModel::class)->create(name: 'Heiter');
         $retrieved = query(TestUserModel::class)->get((string) $created->id->value);
@@ -346,7 +346,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_get_with_int_id(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class);
 
         $created = query(TestUserModel::class)->create(name: 'Eisen');
         $retrieved = query(TestUserModel::class)->get($created->id->value);
@@ -358,7 +358,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_get_returns_null_for_non_existent_id(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWrapperMigration::class);
 
         $result = query(TestUserModel::class)->get(new PrimaryKey(999));
 
@@ -367,7 +367,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_find_by_id_throws_for_model_without_id(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWithoutIdMigration::class);
 
         $this->expectException(ModelDidNotHavePrimaryColumn::class);
         $this->expectExceptionMessage(
@@ -379,7 +379,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_update_or_create_throws_for_model_without_id(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWithoutIdMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWithoutIdMigration::class);
 
         $this->expectException(ModelDidNotHavePrimaryColumn::class);
         $this->expectExceptionMessage(
@@ -394,7 +394,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_custom_primary_key_name(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWithCustomPrimaryKeyMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWithCustomPrimaryKeyMigration::class);
 
         $created = query(TestUserModelWithCustomPrimaryKey::class)->create(name: 'Fern');
 
@@ -410,7 +410,7 @@ final class QueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_custom_primary_key_update_or_create(): void
     {
-        $this->migrate(CreateMigrationsTable::class, TestModelWithCustomPrimaryKeyMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, TestModelWithCustomPrimaryKeyMigration::class);
 
         $original = query(TestUserModelWithCustomPrimaryKey::class)->create(name: 'Stark');
 

--- a/tests/Integration/Database/Builder/SelectQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/SelectQueryBuilderTest.php
@@ -116,7 +116,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_where_statement(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -135,7 +135,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_join(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -158,7 +158,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_order_by(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -177,7 +177,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_order_by_with_field_and_direction(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -198,7 +198,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_order_by_with_field_defaults_to_asc(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -216,7 +216,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_order_by_raw_shorthand(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -252,7 +252,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_limit(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -273,7 +273,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_offset(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -297,7 +297,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_chunk(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -324,7 +324,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_chunk_with_relation(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -345,7 +345,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_raw(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -392,7 +392,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_select_first_with_non_object_model(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
 
         query('authors')
             ->insert(
@@ -411,7 +411,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_select_all_with_non_object_model(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
 
         query('authors')
             ->insert(

--- a/tests/Integration/Database/Builder/UpdateQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/UpdateQueryBuilderTest.php
@@ -227,7 +227,7 @@ final class UpdateQueryBuilderTest extends FrameworkIntegrationTestCase
 
     public function test_update_with_non_object_model(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
 
         query('authors')
             ->insert(

--- a/tests/Integration/Database/Builder/UpdateRelationsTest.php
+++ b/tests/Integration/Database/Builder/UpdateRelationsTest.php
@@ -28,7 +28,7 @@ final class UpdateRelationsTest extends FrameworkIntegrationTestCase
 {
     public function test_updating_has_many_with_arrays(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
 
         $bookId = query(Book::class)
             ->insert(
@@ -63,7 +63,7 @@ final class UpdateRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_updating_has_one_with_array(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -96,7 +96,7 @@ final class UpdateRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_updating_has_many_with_objects(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
 
         $bookId = query(Book::class)
             ->insert(
@@ -129,7 +129,7 @@ final class UpdateRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_updating_has_one_with_object(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -160,7 +160,7 @@ final class UpdateRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_updating_mixed_relations(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -204,7 +204,7 @@ final class UpdateRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_updating_empty_has_many_relation(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
 
         $bookId = query(Book::class)
             ->insert(
@@ -234,7 +234,7 @@ final class UpdateRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_updating_large_batch_has_many(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
 
         $bookId = query(Book::class)
             ->insert(
@@ -268,7 +268,7 @@ final class UpdateRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_updating_has_many_preserves_additional_data(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
 
         $bookId = query(Book::class)
             ->insert(
@@ -302,7 +302,7 @@ final class UpdateRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_updating_relation_with_mixed_types(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class, CreateBookTable::class, CreateChapterTable::class);
 
         $bookId = query(Book::class)
             ->insert(
@@ -336,7 +336,7 @@ final class UpdateRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_updating_with_custom_primary_key_names(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateUpdateMageTable::class, CreateUpdateSpellTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUpdateMageTable::class, CreateUpdateSpellTable::class);
 
         $mageId = query(UpdateMage::class)
             ->insert(
@@ -375,7 +375,7 @@ final class UpdateRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_updating_with_non_standard_relation_names(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateUpdatePartyTable::class, CreateUpdateAdventurerTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUpdatePartyTable::class, CreateUpdateAdventurerTable::class);
 
         $partyId = query(UpdateParty::class)
             ->insert(
@@ -421,7 +421,7 @@ final class UpdateRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_updating_with_custom_foreign_key_names(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateUpdateMageTable::class, CreateUpdateSpellTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUpdateMageTable::class, CreateUpdateSpellTable::class);
 
         $spellId = query(UpdateSpell::class)
             ->insert(
@@ -457,7 +457,7 @@ final class UpdateRelationsTest extends FrameworkIntegrationTestCase
 
     public function test_update_throws_exception_when_model_has_no_primary_key(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,

--- a/tests/Integration/Database/CircularEagerLoadingTest.php
+++ b/tests/Integration/Database/CircularEagerLoadingTest.php
@@ -41,7 +41,7 @@ final class CircularEagerLoadingTest extends FrameworkIntegrationTestCase
 
     public function test_it_saves_and_loads_relations_without_causing_infinite_loop(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateUserWithEagerTable::class,
             CreateProfileWithEagerTable::class,

--- a/tests/Integration/Database/ConvenientDateWhereMethodsTest.php
+++ b/tests/Integration/Database/ConvenientDateWhereMethodsTest.php
@@ -28,7 +28,7 @@ final class ConvenientDateWhereMethodsTest extends FrameworkIntegrationTestCase
 
         $this->clock = $this->clock('2025-08-02 12:00:00');
 
-        $this->migrate(CreateMigrationsTable::class, CreateEventTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateEventTable::class);
         $this->seedTestData();
     }
 

--- a/tests/Integration/Database/ConvenientWhereMethodsTest.php
+++ b/tests/Integration/Database/ConvenientWhereMethodsTest.php
@@ -24,7 +24,7 @@ final class ConvenientWhereMethodsTest extends FrameworkIntegrationTestCase
     {
         parent::setUp();
 
-        $this->migrate(CreateMigrationsTable::class, CreateUserTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUserTable::class);
         $this->seedTestData();
     }
 

--- a/tests/Integration/Database/CustomPrimaryKeyRelationshipLoadingTest.php
+++ b/tests/Integration/Database/CustomPrimaryKeyRelationshipLoadingTest.php
@@ -25,7 +25,7 @@ final class CustomPrimaryKeyRelationshipLoadingTest extends FrameworkIntegration
 {
     public function test_has_one_relationship_with_uuid_primary_keys(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateMageWithUuidMigration::class,
             CreateGrimoireWithUuidMigration::class,
@@ -57,7 +57,7 @@ final class CustomPrimaryKeyRelationshipLoadingTest extends FrameworkIntegration
 
     public function test_has_many_relationship_with_uuid_primary_keys(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateMageWithUuidMigration::class,
             CreateSpellWithUuidMigration::class,
@@ -100,7 +100,7 @@ final class CustomPrimaryKeyRelationshipLoadingTest extends FrameworkIntegration
 
     public function test_belongs_to_relationship_with_uuid_primary_keys(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateMageWithUuidMigration::class,
             CreateSpellWithUuidMigration::class,
@@ -129,7 +129,7 @@ final class CustomPrimaryKeyRelationshipLoadingTest extends FrameworkIntegration
 
     public function test_nested_relationship_loading_with_uuid_primary_keys(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateMageWithUuidMigration::class,
             CreateGrimoireWithUuidMigration::class,
@@ -174,7 +174,7 @@ final class CustomPrimaryKeyRelationshipLoadingTest extends FrameworkIntegration
 
     public function test_relationship_with_custom_foreign_key_naming(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateMageWithUuidMigration::class,
             CreateArtifactWithUuidMigration::class,
@@ -209,7 +209,7 @@ final class CustomPrimaryKeyRelationshipLoadingTest extends FrameworkIntegration
 
     public function test_relationship_loading_preserves_uuid_integrity(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateMageWithUuidMigration::class,
             CreateSpellWithUuidMigration::class,
@@ -253,7 +253,7 @@ final class CustomPrimaryKeyRelationshipLoadingTest extends FrameworkIntegration
 
     public function test_automatic_uuid_primary_key_detection(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateMageSimpleMigration::class,
             CreateSpellSimpleMigration::class,

--- a/tests/Integration/Database/EncryptedAttributeTest.php
+++ b/tests/Integration/Database/EncryptedAttributeTest.php
@@ -25,7 +25,7 @@ final class EncryptedAttributeTest extends FrameworkIntegrationTestCase
     #[Test]
     public function encrypts_value_on_insert(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateUserWithEncryptedDataTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUserWithEncryptedDataTable::class);
 
         $user = query(UserWithEncryptedData::class)->create(
             email: 'test@example.com',
@@ -42,7 +42,7 @@ final class EncryptedAttributeTest extends FrameworkIntegrationTestCase
     #[Test]
     public function encrypts_value_on_update(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateUserWithEncryptedDataTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUserWithEncryptedDataTable::class);
 
         $user = query(UserWithEncryptedData::class)->create(
             email: 'test@example.com',
@@ -62,7 +62,7 @@ final class EncryptedAttributeTest extends FrameworkIntegrationTestCase
     #[Test]
     public function does_not_re_encrypt_already_encrypted_values(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateUserWithEncryptedDataTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUserWithEncryptedDataTable::class);
 
         $user = query(UserWithEncryptedData::class)->create(
             email: 'test@example.com',
@@ -75,7 +75,7 @@ final class EncryptedAttributeTest extends FrameworkIntegrationTestCase
     #[Test]
     public function handles_null_values(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateUserWithNullableEncryptedDataTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUserWithNullableEncryptedDataTable::class);
 
         $user = query(UserWithNullableEncryptedData::class)->create(
             email: 'test@example.com',
@@ -88,7 +88,7 @@ final class EncryptedAttributeTest extends FrameworkIntegrationTestCase
     #[Test]
     public function handles_empty_strings(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateUserWithEncryptedDataTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUserWithEncryptedDataTable::class);
 
         $user = query(UserWithEncryptedData::class)->create(
             email: 'test@example.com',

--- a/tests/Integration/Database/GenericDatabaseTest.php
+++ b/tests/Integration/Database/GenericDatabaseTest.php
@@ -24,7 +24,7 @@ final class GenericDatabaseTest extends FrameworkIntegrationTestCase
 {
     public function test_transaction_manager_execute(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
 
         $db = $this->container->get(Database::class);
 
@@ -41,7 +41,7 @@ final class GenericDatabaseTest extends FrameworkIntegrationTestCase
 
     public function test_transaction_manager_fails(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
 
         $db = $this->container->get(Database::class);
 
@@ -60,7 +60,7 @@ final class GenericDatabaseTest extends FrameworkIntegrationTestCase
 
     public function test_query_with_semicolons(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class);
 
         $db = $this->container->get(Database::class);
         $db->execute(

--- a/tests/Integration/Database/GenericTransactionManagerTest.php
+++ b/tests/Integration/Database/GenericTransactionManagerTest.php
@@ -19,7 +19,7 @@ final class GenericTransactionManagerTest extends FrameworkIntegrationTestCase
 {
     public function test_transaction_manager(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
 
         $manager = $this->container->get(TransactionManager::class);
 
@@ -35,7 +35,7 @@ final class GenericTransactionManagerTest extends FrameworkIntegrationTestCase
 
     public function test_transaction_manager_commit(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
 
         $manager = $this->container->get(TransactionManager::class);
 
@@ -51,7 +51,7 @@ final class GenericTransactionManagerTest extends FrameworkIntegrationTestCase
 
     public function test_transaction_manager_commit_rollback(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
 
         $manager = $this->container->get(TransactionManager::class);
 

--- a/tests/Integration/Database/HashedAttributeTest.php
+++ b/tests/Integration/Database/HashedAttributeTest.php
@@ -23,7 +23,7 @@ final class HashedAttributeTest extends FrameworkIntegrationTestCase
     #[Test]
     public function hashes_value_on_insert(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateUserWithHashTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUserWithHashTable::class);
 
         $user = query(UserWithHash::class)->create(
             email: 'test@example.com',
@@ -43,7 +43,7 @@ final class HashedAttributeTest extends FrameworkIntegrationTestCase
     #[Test]
     public function hashes_value_on_update(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateUserWithHashTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUserWithHashTable::class);
 
         $user = query(UserWithHash::class)
             ->create(
@@ -66,7 +66,7 @@ final class HashedAttributeTest extends FrameworkIntegrationTestCase
     #[Test]
     public function does_not_rehash_already_hashed_values(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateUserWithHashTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUserWithHashTable::class);
 
         $user = query(UserWithHash::class)
             ->create(
@@ -82,7 +82,7 @@ final class HashedAttributeTest extends FrameworkIntegrationTestCase
     #[Test]
     public function handles_null_values(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateUserWithNullablePasswordTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateUserWithNullablePasswordTable::class);
 
         $user = query(UserWithNullablePassword::class)
             ->create(

--- a/tests/Integration/Database/ModelInspector/ModelWithDtoTest.php
+++ b/tests/Integration/Database/ModelInspector/ModelWithDtoTest.php
@@ -36,7 +36,7 @@ final class ModelWithDtoTest extends FrameworkIntegrationTestCase
             }
         };
 
-        $this->migrate(CreateMigrationsTable::class, $migration);
+        $this->database->migrate(CreateMigrationsTable::class, $migration);
 
         ModelWithDtoTestModelWithSerializedDto::new(dto: new ModelWithDtoTestDtoForModelWithSerializer('test'))->save();
 

--- a/tests/Integration/Database/ModelsWithoutIdTest.php
+++ b/tests/Integration/Database/ModelsWithoutIdTest.php
@@ -24,7 +24,7 @@ final class ModelsWithoutIdTest extends FrameworkIntegrationTestCase
 {
     public function test_update_model_without_id_with_specific_conditions(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateLogEntryMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateLogEntryMigration::class);
 
         query(LogEntry::class)->create(
             level: 'INFO',
@@ -47,7 +47,7 @@ final class ModelsWithoutIdTest extends FrameworkIntegrationTestCase
 
     public function test_delete_operations_on_models_without_id(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateLogEntryMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateLogEntryMigration::class);
 
         query(LogEntry::class)->create(
             level: 'TEMP',
@@ -75,7 +75,7 @@ final class ModelsWithoutIdTest extends FrameworkIntegrationTestCase
 
     public function test_model_without_id_with_unique_constraints(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateCacheEntryMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateCacheEntryMigration::class);
 
         query(CacheEntry::class)->create(
             cache_key: 'spell_fire',
@@ -97,7 +97,7 @@ final class ModelsWithoutIdTest extends FrameworkIntegrationTestCase
 
     public function test_relationship_methods_throw_for_models_without_id(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateLogEntryMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateLogEntryMigration::class);
 
         $this->expectException(ModelDidNotHavePrimaryColumn::class);
         $this->expectExceptionMessage('does not have a primary column defined, which is required for the `findById` method');
@@ -107,7 +107,7 @@ final class ModelsWithoutIdTest extends FrameworkIntegrationTestCase
 
     public function test_get_method_throws_for_models_without_id(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateLogEntryMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateLogEntryMigration::class);
 
         $this->expectException(ModelDidNotHavePrimaryColumn::class);
         $this->expectExceptionMessage('does not have a primary column defined, which is required for the `get` method');
@@ -117,7 +117,7 @@ final class ModelsWithoutIdTest extends FrameworkIntegrationTestCase
 
     public function test_update_or_create_throws_for_models_without_id(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateLogEntryMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateLogEntryMigration::class);
 
         $this->expectException(ModelDidNotHavePrimaryColumn::class);
         $this->expectExceptionMessage('does not have a primary column defined, which is required for the `updateOrCreate` method');
@@ -130,7 +130,7 @@ final class ModelsWithoutIdTest extends FrameworkIntegrationTestCase
 
     public function test_model_with_mixed_id_and_non_id_properties(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreateMixedModelMigration::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreateMixedModelMigration::class);
 
         $mixed = query(MixedModel::class)->create(
             regular_field: 'test',

--- a/tests/Integration/Database/QueryStatements/AlterTableStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/AlterTableStatementTest.php
@@ -27,7 +27,7 @@ final class AlterTableStatementTest extends FrameworkIntegrationTestCase
     {
         $migration = $this->getAlterTableMigration();
 
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreateUserDatabaseMigration::class,
         );
@@ -53,7 +53,7 @@ final class AlterTableStatementTest extends FrameworkIntegrationTestCase
             $this->assertStringContainsString($message, $queryWasInvalid->getMessage());
         }
 
-        $this->migrate($migration::class);
+        $this->database->migrate($migration::class);
         $this->assertCount(3, MigrationModel::all());
 
         $this->assertSame(

--- a/tests/Integration/Database/QueryStatements/BelongsToStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/BelongsToStatementTest.php
@@ -54,7 +54,7 @@ final class BelongsToStatementTest extends FrameworkIntegrationTestCase
             }
         };
 
-        $this->migrate(CreateMigrationsTable::class, $customersMigration, $belongsToMigration, $foreignKeyMigration);
+        $this->database->migrate(CreateMigrationsTable::class, $customersMigration, $belongsToMigration, $foreignKeyMigration);
 
         $this->expectNotToPerformAssertions();
     }
@@ -85,7 +85,7 @@ final class BelongsToStatementTest extends FrameworkIntegrationTestCase
             }
         };
 
-        $this->migrate(CreateMigrationsTable::class, $categoriesMigration, $productsMigration);
+        $this->database->migrate(CreateMigrationsTable::class, $categoriesMigration, $productsMigration);
 
         $this->expectNotToPerformAssertions();
     }

--- a/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
@@ -46,7 +46,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
             }
         };
 
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             $migration,
         );
@@ -74,7 +74,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
             DatabaseDialect::POSTGRESQL => $this->expectException(DialectWasNotSupported::class),
         };
 
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             $migration,
         );
@@ -92,7 +92,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
             }
         };
 
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             $migration,
         );
@@ -102,7 +102,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
 
     public function test_enum_statement(): void
     {
-        $this->migrate(CreateMigrationsTable::class);
+        $this->database->migrate(CreateMigrationsTable::class);
 
         if ($this->container->get(Database::class)->dialect === DatabaseDialect::POSTGRESQL) {
             $enumTypeMigration = new class() implements MigratesUp {
@@ -117,7 +117,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
                 }
             };
 
-            $this->migrate($enumTypeMigration);
+            $this->database->migrate($enumTypeMigration);
         }
 
         $tableMigration = new class() implements MigratesUp {
@@ -134,7 +134,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
             }
         };
 
-        $this->migrate($tableMigration);
+        $this->database->migrate($tableMigration);
 
         $this->expectNotToPerformAssertions();
     }
@@ -154,7 +154,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
         $this->expectException(DefaultValueWasInvalid::class);
         $this->expectExceptionMessage("Default value '{default: \"invalid json\"}' provided for json is not valid");
 
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             $migration,
         );
@@ -172,7 +172,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
             }
         };
 
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             $migration,
         );
@@ -195,7 +195,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
         $this->expectException(ValueWasInvalid::class);
         $this->expectExceptionMessage("Value '[]' provided for set is not valid");
 
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             $migration,
         );
@@ -215,7 +215,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
             }
         };
 
-        $this->migrate(CreateMigrationsTable::class, $migration);
+        $this->database->migrate(CreateMigrationsTable::class, $migration);
 
         $this->expectNotToPerformAssertions();
     }
@@ -247,7 +247,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
             }
         };
 
-        $this->migrate(CreateMigrationsTable::class, $migration);
+        $this->database->migrate(CreateMigrationsTable::class, $migration);
 
         $this->expectNotToPerformAssertions();
     }
@@ -264,7 +264,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
             }
         };
 
-        $this->migrate(CreateMigrationsTable::class, $migration);
+        $this->database->migrate(CreateMigrationsTable::class, $migration);
 
         $this->expectNotToPerformAssertions();
     }

--- a/tests/Integration/Database/QueryTest.php
+++ b/tests/Integration/Database/QueryTest.php
@@ -20,7 +20,7 @@ final class QueryTest extends FrameworkIntegrationTestCase
 {
     public function test_with_bindings(): void
     {
-        $this->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
+        $this->database->migrate(CreateMigrationsTable::class, CreatePublishersTable::class, CreateAuthorTable::class);
 
         new Author(name: 'A')->save();
         new Author(name: 'B')->save();

--- a/tests/Integration/Database/RefreshModelTest.php
+++ b/tests/Integration/Database/RefreshModelTest.php
@@ -17,7 +17,7 @@ final class RefreshModelTest extends FrameworkIntegrationTestCase
 {
     public function test_refresh_works_for_models_with_unloaded_relation(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -65,7 +65,7 @@ final class RefreshModelTest extends FrameworkIntegrationTestCase
 
     public function test_load_method_only_refreshes_relations_and_nothing_else(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,

--- a/tests/Integration/Database/ToRawSqlTest.php
+++ b/tests/Integration/Database/ToRawSqlTest.php
@@ -263,7 +263,7 @@ final class ToRawSqlTest extends FrameworkIntegrationTestCase
 
     public function test_raw_sql_with_model_queries(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -355,7 +355,7 @@ final class ToRawSqlTest extends FrameworkIntegrationTestCase
 
     public function test_raw_sql_with_enum_values(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,

--- a/tests/Integration/Framework/Commands/DatabaseSeedCommandTest.php
+++ b/tests/Integration/Framework/Commands/DatabaseSeedCommandTest.php
@@ -19,7 +19,7 @@ final class DatabaseSeedCommandTest extends FrameworkIntegrationTestCase
 {
     public function test_seed_with_selected_seeder(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -39,7 +39,7 @@ final class DatabaseSeedCommandTest extends FrameworkIntegrationTestCase
 
     public function test_seed_with_manually_selected_seeder(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -68,7 +68,7 @@ final class DatabaseSeedCommandTest extends FrameworkIntegrationTestCase
 
     public function test_seed_all(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -95,7 +95,7 @@ final class DatabaseSeedCommandTest extends FrameworkIntegrationTestCase
             TestDatabaseSeeder::class,
         ];
 
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,

--- a/tests/Integration/Http/ValidationResponseTest.php
+++ b/tests/Integration/Http/ValidationResponseTest.php
@@ -53,7 +53,7 @@ final class ValidationResponseTest extends FrameworkIntegrationTestCase
 
     public function test_update_book(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -81,7 +81,7 @@ final class ValidationResponseTest extends FrameworkIntegrationTestCase
 
     public function test_failing_post_request(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,

--- a/tests/Integration/Route/RequestTest.php
+++ b/tests/Integration/Route/RequestTest.php
@@ -123,7 +123,7 @@ final class RequestTest extends FrameworkIntegrationTestCase
 
     public function test_custom_request_test_with_validation(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,
@@ -151,7 +151,7 @@ final class RequestTest extends FrameworkIntegrationTestCase
 
     public function test_custom_request_test_with_nested_validation(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,

--- a/tests/Integration/Route/RouterTest.php
+++ b/tests/Integration/Route/RouterTest.php
@@ -83,7 +83,7 @@ final class RouterTest extends FrameworkIntegrationTestCase
 
     public function test_route_binding(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,

--- a/tests/Integration/Validator/ExistsRuleTest.php
+++ b/tests/Integration/Validator/ExistsRuleTest.php
@@ -22,7 +22,7 @@ final class ExistsRuleTest extends FrameworkIntegrationTestCase
     #[PreCondition]
     protected function configure(): void
     {
-        $this->migrate(
+        $this->database->migrate(
             CreateMigrationsTable::class,
             CreatePublishersTable::class,
             CreateAuthorTable::class,


### PR DESCRIPTION
Closes #1843

This pull request removes database testing utilities that were deprecated in `2.x`. Those utilities have moved to the `DatabaseTester`.

Additionally, I improved the testing documentation and added docblocks to all tester class properties in `IntegrationsTest`.