### PR TITLE
feat(event-bus)!: support enum events in `EventBus::listen()`

### DIFF
--- a/packages/event-bus/src/EventBus.php
+++ b/packages/event-bus/src/EventBus.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\EventBus;
 
 use Closure;
+use UnitEnum;
 
 interface EventBus
 {
@@ -16,5 +17,5 @@ interface EventBus
     /**
      * Adds a listener for the given event. The closure accepts the event object as its first parameter, so the `$event` parameter is optional.
      */
-    public function listen(Closure $handler, ?string $event = null): void;
+    public function listen(Closure $handler, string|UnitEnum|null $event = null): void;
 }

--- a/packages/event-bus/src/EventBusConfig.php
+++ b/packages/event-bus/src/EventBusConfig.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use Tempest\Core\Middleware;
 use Tempest\Reflection\FunctionReflector;
 use Tempest\Reflection\MethodReflector;
+use UnitEnum;
 
 final class EventBusConfig
 {
@@ -20,8 +21,12 @@ final class EventBusConfig
         public Middleware $middleware = new Middleware(),
     ) {}
 
-    public function addClosureHandler(Closure $handler, ?string $event = null): self
+    public function addClosureHandler(Closure $handler, string|UnitEnum|null $event = null): self
     {
+        if ($event instanceof UnitEnum) {
+            $event = $event::class . '::' . $event->name;
+        }
+
         $event ??= new FunctionReflector($handler)
             ->getParameter(key: 0)
             ?->getType()

--- a/packages/event-bus/src/GenericEventBus.php
+++ b/packages/event-bus/src/GenericEventBus.php
@@ -18,7 +18,7 @@ final readonly class GenericEventBus implements EventBus
         private(set) EventBusConfig $eventBusConfig,
     ) {}
 
-    public function listen(Closure $handler, ?string $event = null): void
+    public function listen(Closure $handler, string|UnitEnum|null $event = null): void
     {
         $this->eventBusConfig->addClosureHandler($handler, $event);
     }

--- a/packages/event-bus/src/Testing/FakeEventBus.php
+++ b/packages/event-bus/src/Testing/FakeEventBus.php
@@ -6,6 +6,7 @@ use Closure;
 use Tempest\EventBus\CallableEventHandler;
 use Tempest\EventBus\EventBus;
 use Tempest\EventBus\GenericEventBus;
+use UnitEnum;
 
 final class FakeEventBus implements EventBus
 {
@@ -31,7 +32,7 @@ final class FakeEventBus implements EventBus
         }
     }
 
-    public function listen(Closure $handler, ?string $event = null): void
+    public function listen(Closure $handler, string|UnitEnum|null $event = null): void
     {
         $this->genericEventBus->listen($handler, $event);
     }

--- a/packages/event-bus/tests/EventBusTest.php
+++ b/packages/event-bus/tests/EventBusTest.php
@@ -13,6 +13,7 @@ use Tempest\EventBus\EventBus;
 use Tempest\EventBus\EventBusConfig;
 use Tempest\EventBus\EventHandler;
 use Tempest\EventBus\GenericEventBus;
+use Tempest\EventBus\Tests\Fixtures\EventEnum;
 use Tempest\EventBus\Tests\Fixtures\EventInterface;
 use Tempest\EventBus\Tests\Fixtures\EventInterfaceHandler;
 use Tempest\EventBus\Tests\Fixtures\EventInterfaceImplementation;
@@ -189,5 +190,25 @@ final class EventBusTest extends TestCase
         $eventBus->dispatch(new EventInterfaceImplementation());
 
         $this->assertTrue(EventInterfaceHandler::$itHappened);
+    }
+
+    public function test_closure_based_handlers_using_listen_method_and_enums(): void
+    {
+        $container = new GenericContainer();
+        $config = new EventBusConfig();
+        $eventBus = new GenericEventBus($container, $config);
+        $hasHappened = false;
+
+        $eventBus->listen(function () use (&$hasHappened): void {
+            $hasHappened = true;
+        }, EventEnum::TWO);
+
+        $eventBus->dispatch(EventEnum::ONE);
+
+        $this->assertFalse($hasHappened);
+
+        $eventBus->dispatch(EventEnum::TWO);
+
+        $this->assertTrue($hasHappened);
     }
 }

--- a/packages/event-bus/tests/Fixtures/EventEnum.php
+++ b/packages/event-bus/tests/Fixtures/EventEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\EventBus\Tests\Fixtures;
+
+enum EventEnum
+{
+    case ONE;
+    case TWO;
+}


### PR DESCRIPTION
Currently when attempting to listen to a enum event, such as `KernelEvent` with an ad-hoc listener, one needs to manually construct the event key that is generated internally in `GenericEventBus::resolveHandlers()`, which is fragile:

    $bus->listen(…, KernelEvent::class . '::' . KernelEvent::SHUTDOWN->name);

Support taking a UnitEnum directly, which is already supported for the `EventHandler` attribute.
