### PR TITLE
refactor!: use consistent namespaces for functions

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -18,11 +18,10 @@ use Composer\Semver\VersionParser;
 use Tempest\Console\Console;
 use Tempest\Console\ConsoleApplication;
 use Tempest\Console\Exceptions\InterruptException;
-use Tempest\Http\Response;
 use Tempest\HttpClient\HttpClient;
 use Tempest\Support\Json;
+use Tempest\Container;
 
-use function Tempest\get;
 use function Tempest\Support\arr;
 use function Tempest\Support\str;
 
@@ -178,7 +177,7 @@ function updateBranchProtection(bool $enabled): void
     $token = Tempest\env('RELEASE_GITHUB_TOKEN');
     $uri = "https://api.github.com/repos/tempestphp/tempest-framework/rulesets/{$ruleset}";
 
-    $httpClient = Tempest\get(HttpClient::class);
+    $httpClient = Container\get(HttpClient::class);
     $response = $httpClient->put(
         uri: $uri,
         headers: ['Authorization' => "Bearer {$token}"],
@@ -196,7 +195,7 @@ function triggerSubsplit(): void
     $token = Tempest\env('RELEASE_GITHUB_TOKEN');
     $uri = 'https://api.github.com/repos/tempestphp/tempest-framework/actions/workflows/subsplit-packages.yml/dispatches';
 
-    $httpClient = Tempest\get(HttpClient::class);
+    $httpClient = Container\get(HttpClient::class);
 
     $response = $httpClient->post(
         uri: $uri,
@@ -346,7 +345,7 @@ try {
 
     performPreReleaseChecks('origin', 'main');
 
-    $console = get(Console::class);
+    $console = Container\get(Console::class);
     $console->writeln();
     $console->info(sprintf('Current version is <em>%s</em>.', $current = getCurrentVersion()));
 

--- a/docs/1-essentials/05-container.md
+++ b/docs/1-essentials/05-container.md
@@ -47,10 +47,10 @@ The `{php}\Tempest\invoke()` function serves the same purpose when the container
 
 ### Locating a dependency
 
-There are situations where it may not be possible to inject a dependency on a constructor. To work around this, Tempest provides the `{php}\Tempest\get()` function, which can resolve an object from the container.
+There are situations where it may not be possible to inject a dependency on a constructor. To work around this, Tempest provides the `{php}\Tempest\Container\get()` function, which can resolve an object from the container.
 
 ```php
-use function Tempest\get;
+use function Tempest\Container\get;
 
 $config = get(AppConfig::class);
 ```

--- a/packages/clock/src/functions.php
+++ b/packages/clock/src/functions.php
@@ -4,7 +4,7 @@ namespace Tempest\Clock;
 
 use Tempest\DateTime\DateTimeInterface;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 /**
  * Get the current date and time as a {@see \Tempest\DateTime\DateTimeInterface} object.

--- a/packages/command-bus/src/functions.php
+++ b/packages/command-bus/src/functions.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Tempest\CommandBus;
 
 use Tempest\CommandBus\CommandBus;
+use Tempest\Container;
 
 /**
  * Dispatches the given `$command` to the {@see CommandBus}, triggering all associated command handlers.
  */
 function command(object $command): void
 {
-    $commandBus = get(CommandBus::class);
+    $commandBus = Container\get(CommandBus::class);
 
     $commandBus->dispatch($command);
 }

--- a/packages/command-bus/src/functions.php
+++ b/packages/command-bus/src/functions.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Tempest {
-    use Tempest\CommandBus\CommandBus;
+namespace Tempest\CommandBus;
 
-    /**
-     * Dispatches the given `$command` to the {@see CommandBus}, triggering all associated command handlers.
-     */
-    function command(object $command): void
-    {
-        $commandBus = get(CommandBus::class);
+use Tempest\CommandBus\CommandBus;
 
-        $commandBus->dispatch($command);
-    }
+/**
+ * Dispatches the given `$command` to the {@see CommandBus}, triggering all associated command handlers.
+ */
+function command(object $command): void
+{
+    $commandBus = get(CommandBus::class);
+
+    $commandBus->dispatch($command);
 }

--- a/packages/console/src/Scheduler/GenericScheduler.php
+++ b/packages/console/src/Scheduler/GenericScheduler.php
@@ -10,7 +10,7 @@ use Tempest\Console\Scheduler;
 use Tempest\Process\ProcessExecutor;
 use Tempest\Support\Filesystem;
 
-use function Tempest\event;
+use function Tempest\EventBus\event;
 use function Tempest\internal_storage_path;
 
 final readonly class GenericScheduler implements Scheduler

--- a/packages/container/src/functions.php
+++ b/packages/container/src/functions.php
@@ -2,42 +2,42 @@
 
 declare(strict_types=1);
 
-namespace Tempest {
-    use Tempest\Container\GenericContainer;
-    use Tempest\Reflection\FunctionReflector;
-    use Tempest\Reflection\MethodReflector;
+namespace Tempest\Container;
 
-    /**
-     * Retrieves an instance of the specified `$className` from the container.
-     *
-     * @template TClassName of object
-     * @param class-string<TClassName> $className
-     * @return TClassName
-     */
-    function get(string $className, ?string $tag = null, mixed ...$params): object
-    {
-        $container = GenericContainer::instance();
+use Tempest\Container\GenericContainer;
+use Tempest\Reflection\FunctionReflector;
+use Tempest\Reflection\MethodReflector;
 
-        return $container->get($className, $tag, ...$params);
-    }
+/**
+ * Retrieves an instance of the specified `$className` from the container.
+ *
+ * @template TClassName of object
+ * @param class-string<TClassName> $className
+ * @return TClassName
+ */
+function get(string $className, ?string $tag = null, mixed ...$params): object
+{
+    $container = GenericContainer::instance();
 
-    /**
-     * Invokes the given method, function, callable or invokable class from the container. If no named parameters are specified, they will be resolved from the container.
-     *
-     * #### Examples
-     * ```php
-     * \Tempest\invoke(function (MyService $service) {
-     *   $service->execute();
-     * });
-     * ```
-     * ```php
-     * \Tempest\invoke(MyService::class, key: $apiKey);
-     * ```
-     */
-    function invoke(MethodReflector|FunctionReflector|callable|string $callable, mixed ...$params): mixed
-    {
-        $container = GenericContainer::instance();
+    return $container->get($className, $tag, ...$params);
+}
 
-        return $container->invoke($callable, ...$params);
-    }
+/**
+ * Invokes the given method, function, callable or invokable class from the container. If no named parameters are specified, they will be resolved from the container.
+ *
+ * #### Examples
+ * ```php
+ * \Tempest\invoke(function (MyService $service) {
+ *   $service->execute();
+ * });
+ * ```
+ * ```php
+ * \Tempest\invoke(MyService::class, key: $apiKey);
+ * ```
+ */
+function invoke(MethodReflector|FunctionReflector|callable|string $callable, mixed ...$params): mixed
+{
+    $container = GenericContainer::instance();
+
+    return $container->invoke($callable, ...$params);
 }

--- a/packages/container/tests/ContainerTest.php
+++ b/packages/container/tests/ContainerTest.php
@@ -6,6 +6,7 @@ namespace Tempest\Container\Tests;
 
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Tempest\Container;
 use Tempest\Container\Exceptions\CircularDependencyEncountered;
 use Tempest\Container\Exceptions\DecoratorDidNotImplementInterface;
 use Tempest\Container\Exceptions\DependencyCouldNotBeAutowired;
@@ -65,7 +66,7 @@ use Tempest\Container\Tests\Fixtures\UnionInterfaceB;
 use Tempest\Container\Tests\Fixtures\UnionTypesClass;
 use Tempest\Reflection\ClassReflector;
 
-use function Tempest\reflect;
+use function Tempest\Reflection\reflect;
 
 /**
  * @internal
@@ -411,7 +412,7 @@ final class ContainerTest extends TestCase
         GenericContainer::setInstance($container = new GenericContainer());
         $container->singleton(SingletonClass::class, fn () => new SingletonClass());
 
-        $result = \Tempest\invoke(fn (SingletonClass $class) => $class::class);
+        $result = Container\invoke(fn (SingletonClass $class) => $class::class);
 
         $this->assertEquals(SingletonClass::class, $result);
     }

--- a/packages/core/src/functions.php
+++ b/packages/core/src/functions.php
@@ -2,104 +2,104 @@
 
 declare(strict_types=1);
 
-namespace Tempest {
-    use Closure;
-    use Stringable;
-    use Tempest\Core\Composer;
-    use Tempest\Core\DeferredTasks;
-    use Tempest\Core\EnvironmentVariableValidationFailed;
-    use Tempest\Core\Kernel;
-    use Tempest\Intl\Translator;
-    use Tempest\Support\Namespace\PathCouldNotBeMappedToNamespace;
-    use Tempest\Validation\Rule;
-    use Tempest\Validation\Validator;
+namespace Tempest;
 
-    use function Tempest\Support\Namespace\to_psr4_namespace;
-    use function Tempest\Support\Path\to_absolute_path;
+use Closure;
+use Stringable;
+use Tempest\Core\Composer;
+use Tempest\Core\DeferredTasks;
+use Tempest\Core\EnvironmentVariableValidationFailed;
+use Tempest\Core\Kernel;
+use Tempest\Intl\Translator;
+use Tempest\Support\Namespace\PathCouldNotBeMappedToNamespace;
+use Tempest\Validation\Rule;
+use Tempest\Validation\Validator;
 
-    /**
-     * Creates an absolute path scoped to the root of the project.
-     */
-    function root_path(Stringable|string ...$parts): string
-    {
-        return to_absolute_path(get(Kernel::class)->root, ...$parts);
+use function Tempest\Support\Namespace\to_psr4_namespace;
+use function Tempest\Support\Path\to_absolute_path;
+
+/**
+ * Creates an absolute path scoped to the root of the project.
+ */
+function root_path(Stringable|string ...$parts): string
+{
+    return to_absolute_path(get(Kernel::class)->root, ...$parts);
+}
+
+/**
+ * Creates an absolute path scoped to the main directory of the project.
+ */
+function src_path(Stringable|string ...$parts): string
+{
+    return root_path(get(Composer::class)->mainNamespace->path, ...$parts);
+}
+
+/**
+ * Creates an absolute path scoped to the framework's internal storage directory.
+ */
+function internal_storage_path(Stringable|string ...$parts): string
+{
+    return to_absolute_path(get(Kernel::class)->internalStorage, ...$parts);
+}
+
+/**
+ * Converts the given path to a registered namespace. The path is expected to be absolute, or relative to the root of the project.
+ *
+ * @throws PathCouldNotBeMappedToNamespace If the path cannot be mapped to registered namespace
+ */
+function registered_namespace(Stringable|string ...$parts): string
+{
+    return to_psr4_namespace(get(Composer::class)->namespaces, root_path(...$parts), root: root_path());
+}
+
+/**
+ * Converts the given path to the main namespace. The path is expected to be absolute, or relative to the root of the project.
+ *
+ * @throws PathCouldNotBeMappedToNamespace If the path cannot be mapped to the main namespace
+ */
+function src_namespace(Stringable|string ...$parts): string
+{
+    return to_psr4_namespace(get(Composer::class)->mainNamespace, root_path(...$parts), root: root_path());
+}
+
+/**
+ * Retrieves the given `$key` from the environment variables. If `$key` is not defined, `$default` is returned instead.
+ *
+ * @param Rule[] $rules Optional validation rules for the value of this environment variable. If one of the rules don't pass, an exception is thrown, preventing the application from booting.
+ */
+function env(string $key, mixed $default = null, array $rules = []): mixed
+{
+    $value = getenv($key);
+    $value = match (is_string($value) ? mb_strtolower($value) : $value) {
+        'true' => true,
+        'false' => false,
+        false, 'null', '' => $default,
+        default => $value,
+    };
+
+    if ($rules === [] || ! class_exists(Validator::class) || ! interface_exists(Translator::class)) {
+        return $value;
     }
 
-    /**
-     * Creates an absolute path scoped to the main directory of the project.
-     */
-    function src_path(Stringable|string ...$parts): string
-    {
-        return root_path(get(Composer::class)->mainNamespace->path, ...$parts);
+    $validator = get(Validator::class);
+    $failures = $validator->validateValue($value, $rules);
+
+    if ($failures === []) {
+        return $value;
     }
 
-    /**
-     * Creates an absolute path scoped to the framework's internal storage directory.
-     */
-    function internal_storage_path(Stringable|string ...$parts): string
-    {
-        return to_absolute_path(get(Kernel::class)->internalStorage, ...$parts);
-    }
+    throw new EnvironmentVariableValidationFailed(
+        name: $key,
+        value: $value,
+        failingRules: $failures,
+        validator: $validator,
+    );
+}
 
-    /**
-     * Converts the given path to a registered namespace. The path is expected to be absolute, or relative to the root of the project.
-     *
-     * @throws PathCouldNotBeMappedToNamespace If the path cannot be mapped to registered namespace
-     */
-    function registered_namespace(Stringable|string ...$parts): string
-    {
-        return to_psr4_namespace(get(Composer::class)->namespaces, root_path(...$parts), root: root_path());
-    }
-
-    /**
-     * Converts the given path to the main namespace. The path is expected to be absolute, or relative to the root of the project.
-     *
-     * @throws PathCouldNotBeMappedToNamespace If the path cannot be mapped to the main namespace
-     */
-    function src_namespace(Stringable|string ...$parts): string
-    {
-        return to_psr4_namespace(get(Composer::class)->mainNamespace, root_path(...$parts), root: root_path());
-    }
-
-    /**
-     * Retrieves the given `$key` from the environment variables. If `$key` is not defined, `$default` is returned instead.
-     *
-     * @param Rule[] $rules Optional validation rules for the value of this environment variable. If one of the rules don't pass, an exception is thrown, preventing the application from booting.
-     */
-    function env(string $key, mixed $default = null, array $rules = []): mixed
-    {
-        $value = getenv($key);
-        $value = match (is_string($value) ? mb_strtolower($value) : $value) {
-            'true' => true,
-            'false' => false,
-            false, 'null', '' => $default,
-            default => $value,
-        };
-
-        if ($rules === [] || ! class_exists(Validator::class) || ! interface_exists(Translator::class)) {
-            return $value;
-        }
-
-        $validator = get(Validator::class);
-        $failures = $validator->validateValue($value, $rules);
-
-        if ($failures === []) {
-            return $value;
-        }
-
-        throw new EnvironmentVariableValidationFailed(
-            name: $key,
-            value: $value,
-            failingRules: $failures,
-            validator: $validator,
-        );
-    }
-
-    /**
-     * Defer a task, will be run after a request has been sent or a command has executed
-     */
-    function defer(Closure $closure): void
-    {
-        get(DeferredTasks::class)->add($closure);
-    }
+/**
+ * Defer a task, will be run after a request has been sent or a command has executed
+ */
+function defer(Closure $closure): void
+{
+    get(DeferredTasks::class)->add($closure);
 }

--- a/packages/core/src/functions.php
+++ b/packages/core/src/functions.php
@@ -6,6 +6,7 @@ namespace Tempest;
 
 use Closure;
 use Stringable;
+use Tempest\Container;
 use Tempest\Core\Composer;
 use Tempest\Core\DeferredTasks;
 use Tempest\Core\EnvironmentVariableValidationFailed;
@@ -23,7 +24,7 @@ use function Tempest\Support\Path\to_absolute_path;
  */
 function root_path(Stringable|string ...$parts): string
 {
-    return to_absolute_path(get(Kernel::class)->root, ...$parts);
+    return to_absolute_path(Container\get(Kernel::class)->root, ...$parts);
 }
 
 /**
@@ -31,7 +32,7 @@ function root_path(Stringable|string ...$parts): string
  */
 function src_path(Stringable|string ...$parts): string
 {
-    return root_path(get(Composer::class)->mainNamespace->path, ...$parts);
+    return root_path(Container\get(Composer::class)->mainNamespace->path, ...$parts);
 }
 
 /**
@@ -39,7 +40,7 @@ function src_path(Stringable|string ...$parts): string
  */
 function internal_storage_path(Stringable|string ...$parts): string
 {
-    return to_absolute_path(get(Kernel::class)->internalStorage, ...$parts);
+    return to_absolute_path(Container\get(Kernel::class)->internalStorage, ...$parts);
 }
 
 /**
@@ -49,7 +50,7 @@ function internal_storage_path(Stringable|string ...$parts): string
  */
 function registered_namespace(Stringable|string ...$parts): string
 {
-    return to_psr4_namespace(get(Composer::class)->namespaces, root_path(...$parts), root: root_path());
+    return to_psr4_namespace(Container\get(Composer::class)->namespaces, root_path(...$parts), root: root_path());
 }
 
 /**
@@ -59,7 +60,7 @@ function registered_namespace(Stringable|string ...$parts): string
  */
 function src_namespace(Stringable|string ...$parts): string
 {
-    return to_psr4_namespace(get(Composer::class)->mainNamespace, root_path(...$parts), root: root_path());
+    return to_psr4_namespace(Container\get(Composer::class)->mainNamespace, root_path(...$parts), root: root_path());
 }
 
 /**
@@ -81,7 +82,7 @@ function env(string $key, mixed $default = null, array $rules = []): mixed
         return $value;
     }
 
-    $validator = get(Validator::class);
+    $validator = Container\get(Validator::class);
     $failures = $validator->validateValue($value, $rules);
 
     if ($failures === []) {
@@ -101,5 +102,5 @@ function env(string $key, mixed $default = null, array $rules = []): mixed
  */
 function defer(Closure $closure): void
 {
-    get(DeferredTasks::class)->add($closure);
+    Container\get(DeferredTasks::class)->add($closure);
 }

--- a/packages/database/src/Builder/ModelInspector.php
+++ b/packages/database/src/Builder/ModelInspector.php
@@ -23,8 +23,8 @@ use Tempest\Validation\Exceptions\ValidationFailed;
 use Tempest\Validation\SkipValidation;
 use Tempest\Validation\Validator;
 
+use function Tempest\Container\get;
 use function Tempest\Database\inspect;
-use function Tempest\get;
 use function Tempest\Support\arr;
 use function Tempest\Support\str;
 

--- a/packages/database/src/Builder/QueryBuilders/InsertQueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/InsertQueryBuilder.php
@@ -24,8 +24,8 @@ use Tempest\Support\Conditions\HasConditions;
 use Tempest\Support\Random;
 use Tempest\Support\Str\ImmutableString;
 
+use function Tempest\Container\get;
 use function Tempest\Database\inspect;
-use function Tempest\get;
 use function Tempest\Support\str;
 
 /**

--- a/packages/database/src/Builder/QueryBuilders/QueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/QueryBuilder.php
@@ -6,9 +6,9 @@ use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\PrimaryKey;
 use Tempest\Mapper\SerializerFactory;
 
+use function Tempest\Container\get;
 use function Tempest\Database\inspect;
 use function Tempest\Database\query;
-use function Tempest\get;
 use function Tempest\Mapper\make;
 use function Tempest\Support\arr;
 

--- a/packages/database/src/Builder/QueryBuilders/SelectQueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/SelectQueryBuilder.php
@@ -29,8 +29,8 @@ use Tempest\Support\Paginator\PaginatedData;
 use Tempest\Support\Paginator\Paginator;
 use Tempest\Support\Str\ImmutableString;
 
+use function Tempest\Container\get;
 use function Tempest\Database\inspect;
-use function Tempest\get;
 use function Tempest\Mapper\map;
 
 /**

--- a/packages/database/src/Builder/QueryBuilders/UpdateQueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/UpdateQueryBuilder.php
@@ -24,8 +24,8 @@ use Tempest\Support\Arr\ImmutableArray;
 use Tempest\Support\Conditions\HasConditions;
 use Tempest\Support\Str\ImmutableString;
 
+use function Tempest\Container\get;
 use function Tempest\Database\inspect;
-use function Tempest\get;
 
 /**
  * @template TModel of object

--- a/packages/database/src/Migrations/MigrationManager.php
+++ b/packages/database/src/Migrations/MigrationManager.php
@@ -24,7 +24,7 @@ use Throwable;
 
 use function Tempest\Database\inspect;
 use function Tempest\Database\query;
-use function Tempest\event;
+use function Tempest\EventBus\event;
 
 final class MigrationManager
 {

--- a/packages/database/src/Query.php
+++ b/packages/database/src/Query.php
@@ -7,7 +7,7 @@ namespace Tempest\Database;
 use Tempest\Database\Config\DatabaseDialect;
 use Tempest\Support\Str\ImmutableString;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 /**
  * A database query that can be executed.

--- a/packages/database/src/functions.php
+++ b/packages/database/src/functions.php
@@ -1,31 +1,31 @@
 <?php
 
-namespace Tempest\Database {
-    use Tempest\Database\Builder\ModelInspector;
-    use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
+namespace Tempest\Database;
 
-    /**
-     * Creates a new query builder instance for the given model or table name.
-     *
-     * @template TModel of object
-     * @param class-string<TModel>|string|TModel $model
-     * @return QueryBuilder<TModel>
-     */
-    function query(string|object $model): QueryBuilder
-    {
-        return new QueryBuilder($model);
-    }
+use Tempest\Database\Builder\ModelInspector;
+use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
 
-    /**
-     * Inspects the given model or table name to provide database insights.
-     *
-     * @template TModel of object
-     * @param class-string<TModel>|string|TModel $model
-     * @return ModelInspector<TModel>
-     * @internal
-     */
-    function inspect(string|object $model): ModelInspector
-    {
-        return ModelInspector::forModel($model);
-    }
+/**
+ * Creates a new query builder instance for the given model or table name.
+ *
+ * @template TModel of object
+ * @param class-string<TModel>|string|TModel $model
+ * @return QueryBuilder<TModel>
+ */
+function query(string|object $model): QueryBuilder
+{
+    return new QueryBuilder($model);
+}
+
+/**
+ * Inspects the given model or table name to provide database insights.
+ *
+ * @template TModel of object
+ * @param class-string<TModel>|string|TModel $model
+ * @return ModelInspector<TModel>
+ * @internal
+ */
+function inspect(string|object $model): ModelInspector
+{
+    return ModelInspector::forModel($model);
 }

--- a/packages/datetime/src/functions.php
+++ b/packages/datetime/src/functions.php
@@ -1,293 +1,293 @@
 <?php
 
-namespace Tempest\DateTime {
-    use IntlCalendar;
-    use IntlDateFormatter;
-    use IntlTimeZone;
-    use RuntimeException;
-    use Tempest\DateTime\DateStyle;
-    use Tempest\DateTime\Exception\ParserException;
-    use Tempest\DateTime\FormatPattern;
-    use Tempest\DateTime\SecondsStyle;
-    use Tempest\DateTime\Timestamp;
-    use Tempest\DateTime\TimeStyle;
-    use Tempest\DateTime\Timezone;
-    use Tempest\Intl\Locale;
+namespace Tempest\DateTime;
 
-    use function hrtime;
-    use function microtime;
-    use function Tempest\Intl\current_locale;
+use IntlCalendar;
+use IntlDateFormatter;
+use IntlTimeZone;
+use RuntimeException;
+use Tempest\DateTime\DateStyle;
+use Tempest\DateTime\Exception\ParserException;
+use Tempest\DateTime\FormatPattern;
+use Tempest\DateTime\SecondsStyle;
+use Tempest\DateTime\Timestamp;
+use Tempest\DateTime\TimeStyle;
+use Tempest\DateTime\Timezone;
+use Tempest\Intl\Locale;
 
-    use const Tempest\DateTime\NANOSECONDS_PER_SECOND;
+use function hrtime;
+use function microtime;
+use function Tempest\Intl\current_locale;
 
-    /**
-     * Get the current date and time as a {@see \Tempest\DateTime\DateTime} object.
-     */
-    function now(): DateTime
-    {
-        return DateTime::now();
+use const Tempest\DateTime\NANOSECONDS_PER_SECOND;
+
+/**
+ * Get the current date and time as a {@see \Tempest\DateTime\DateTime} object.
+ */
+function now(): DateTime
+{
+    return DateTime::now();
+}
+
+/**
+ * Check if the given year is a leap year.
+ *
+ * Returns true if the specified year is a leap year according to the Gregorian
+ * calendar; otherwise, returns false.
+ *
+ * @return bool True if the year is a leap year, false otherwise.
+ */
+function is_leap_year(int $year): bool
+{
+    return ($year % 4) === 0 && (($year % 100) !== 0 || ($year % 400) === 0);
+}
+
+/**
+ * @internal
+ */
+function format_rfc3339(Timestamp $timestamp, ?SecondsStyle $secondsStyle = null, bool $useZ = false, ?Timezone $timezone = null): string
+{
+    $secondsStyle ??= SecondsStyle::fromTimestamp($timestamp);
+
+    if (null === $timezone) {
+        $timezone = Timezone::UTC;
+    } elseif ($useZ) {
+        $useZ = Timezone::UTC === $timezone;
     }
 
+    $seconds = $timestamp->getSeconds();
+    $nanoseconds = $timestamp->getNanoseconds();
+
+    // Intl formatter cannot handle nanoseconds and microseconds, do it manually instead.
+    $fraction = substr((string) $nanoseconds, 0, $secondsStyle->value);
+
+    if ($fraction !== '') {
+        $fraction = '.' . $fraction;
+    }
+
+    $pattern = match ($useZ) {
+        true => "yyyy-MM-dd'T'HH:mm:ss@ZZZZZ",
+        false => "yyyy-MM-dd'T'HH:mm:ss@xxx",
+    };
+
+    $formatter = namespace\create_intl_date_formatter(
+        pattern: $pattern,
+        timezone: $timezone,
+    );
+
+    $rfcString = $formatter->format($seconds);
+
+    return str_replace('@', $fraction, $rfcString);
+}
+
+/**
+ * @internal
+ */
+function create_intl_date_formatter(
+    ?DateStyle $dateStyle = null,
+    ?TimeStyle $timeStyle = null,
+    null|FormatPattern|string $pattern = null,
+    ?Timezone $timezone = null,
+    ?Locale $locale = null,
+): IntlDateFormatter {
+    if ($pattern instanceof FormatPattern) {
+        $pattern = $pattern->value;
+    }
+
+    $dateStyle ??= DateStyle::default();
+    $timeStyle ??= TimeStyle::default();
+    $locale ??= current_locale();
+    $timezone ??= Timezone::default();
+
+    return new IntlDateFormatter(
+        locale: $locale->value,
+        dateType: match ($dateStyle) {
+            DateStyle::NONE => IntlDateFormatter::NONE,
+            DateStyle::SHORT => IntlDateFormatter::SHORT,
+            DateStyle::MEDIUM => IntlDateFormatter::MEDIUM,
+            DateStyle::LONG => IntlDateFormatter::LONG,
+            DateStyle::FULL => IntlDateFormatter::FULL,
+            DateStyle::RELATIVE_SHORT => IntlDateFormatter::RELATIVE_SHORT,
+            DateStyle::RELATIVE_MEDIUM => IntlDateFormatter::RELATIVE_MEDIUM,
+            DateStyle::RELATIVE_LONG => IntlDateFormatter::RELATIVE_LONG,
+            DateStyle::RELATIVE_FULL => IntlDateFormatter::RELATIVE_FULL,
+        },
+        timeType: match ($timeStyle) {
+            TimeStyle::NONE => IntlDateFormatter::NONE,
+            TimeStyle::SHORT => IntlDateFormatter::SHORT,
+            TimeStyle::MEDIUM => IntlDateFormatter::MEDIUM,
+            TimeStyle::LONG => IntlDateFormatter::LONG,
+            TimeStyle::FULL => IntlDateFormatter::FULL,
+        },
+        timezone: namespace\to_intl_timezone($timezone),
+        calendar: IntlDateFormatter::GREGORIAN,
+        pattern: $pattern,
+    );
+}
+
+/**
+ * @internal
+ */
+function default_timezone(): Timezone
+{
     /**
-     * Check if the given year is a leap year.
+     * `date_default_timezone_get` function might return any of the "Others" timezones
+     * mentioned in PHP doc: https://www.php.net/manual/en/timezones.others.php.
      *
-     * Returns true if the specified year is a leap year according to the Gregorian
-     * calendar; otherwise, returns false.
-     *
-     * @return bool True if the year is a leap year, false otherwise.
+     * Those timezones are not supported by Tempest (aside from UTC), as they are considered "legacy".
      */
-    function is_leap_year(int $year): bool
-    {
-        return ($year % 4) === 0 && (($year % 100) !== 0 || ($year % 400) === 0);
-    }
+    $timezoneId = date_default_timezone_get();
 
+    return Timezone::tryFrom($timezoneId) ?? Timezone::UTC;
+}
+
+/**
+ * @return array{int, int}
+ *
+ * @internal
+ */
+function high_resolution_time(): array
+{
     /**
-     * @internal
+     * @var null|array{int, int} $offset
      */
-    function format_rfc3339(Timestamp $timestamp, ?SecondsStyle $secondsStyle = null, bool $useZ = false, ?Timezone $timezone = null): string
-    {
-        $secondsStyle ??= SecondsStyle::fromTimestamp($timestamp);
+    static $offset = null;
 
-        if (null === $timezone) {
-            $timezone = Timezone::UTC;
-        } elseif ($useZ) {
-            $useZ = Timezone::UTC === $timezone;
+    if ($offset === null) {
+        $offset = hrtime();
+
+        if ($offset === false) { // @phpstan-ignore-line identical.alwaysFalse
+            throw new \RuntimeException('The system does not provide a monotonic timer.');
         }
 
-        $seconds = $timestamp->getSeconds();
-        $nanoseconds = $timestamp->getNanoseconds();
+        $time = system_time();
 
-        // Intl formatter cannot handle nanoseconds and microseconds, do it manually instead.
-        $fraction = substr((string) $nanoseconds, 0, $secondsStyle->value);
-
-        if ($fraction !== '') {
-            $fraction = '.' . $fraction;
-        }
-
-        $pattern = match ($useZ) {
-            true => "yyyy-MM-dd'T'HH:mm:ss@ZZZZZ",
-            false => "yyyy-MM-dd'T'HH:mm:ss@xxx",
-        };
-
-        $formatter = namespace\create_intl_date_formatter(
-            pattern: $pattern,
-            timezone: $timezone,
-        );
-
-        $rfcString = $formatter->format($seconds);
-
-        return str_replace('@', $fraction, $rfcString);
+        $offset = [
+            $time[0] - $offset[0],
+            $time[1] - $offset[1],
+        ];
     }
 
-    /**
-     * @internal
-     */
-    function create_intl_date_formatter(
-        ?DateStyle $dateStyle = null,
-        ?TimeStyle $timeStyle = null,
-        null|FormatPattern|string $pattern = null,
-        ?Timezone $timezone = null,
-        ?Locale $locale = null,
-    ): IntlDateFormatter {
-        if ($pattern instanceof FormatPattern) {
-            $pattern = $pattern->value;
-        }
+    [$secondsOffset, $nanosecondsOffset] = $offset;
+    [$seconds, $nanoseconds] = hrtime();
 
-        $dateStyle ??= DateStyle::default();
-        $timeStyle ??= TimeStyle::default();
-        $locale ??= current_locale();
-        $timezone ??= Timezone::default();
+    $nanosecondsAdjusted = $nanoseconds + $nanosecondsOffset;
 
-        return new IntlDateFormatter(
-            locale: $locale->value,
-            dateType: match ($dateStyle) {
-                DateStyle::NONE => IntlDateFormatter::NONE,
-                DateStyle::SHORT => IntlDateFormatter::SHORT,
-                DateStyle::MEDIUM => IntlDateFormatter::MEDIUM,
-                DateStyle::LONG => IntlDateFormatter::LONG,
-                DateStyle::FULL => IntlDateFormatter::FULL,
-                DateStyle::RELATIVE_SHORT => IntlDateFormatter::RELATIVE_SHORT,
-                DateStyle::RELATIVE_MEDIUM => IntlDateFormatter::RELATIVE_MEDIUM,
-                DateStyle::RELATIVE_LONG => IntlDateFormatter::RELATIVE_LONG,
-                DateStyle::RELATIVE_FULL => IntlDateFormatter::RELATIVE_FULL,
-            },
-            timeType: match ($timeStyle) {
-                TimeStyle::NONE => IntlDateFormatter::NONE,
-                TimeStyle::SHORT => IntlDateFormatter::SHORT,
-                TimeStyle::MEDIUM => IntlDateFormatter::MEDIUM,
-                TimeStyle::LONG => IntlDateFormatter::LONG,
-                TimeStyle::FULL => IntlDateFormatter::FULL,
-            },
-            timezone: namespace\to_intl_timezone($timezone),
-            calendar: IntlDateFormatter::GREGORIAN,
-            pattern: $pattern,
-        );
+    if ($nanosecondsAdjusted >= NANOSECONDS_PER_SECOND) {
+        ++$seconds;
+        $nanosecondsAdjusted -= NANOSECONDS_PER_SECOND;
+    } elseif ($nanosecondsAdjusted < 0) {
+        --$seconds;
+        $nanosecondsAdjusted += NANOSECONDS_PER_SECOND;
     }
 
-    /**
-     * @internal
-     */
-    function default_timezone(): Timezone
-    {
-        /**
-         * `date_default_timezone_get` function might return any of the "Others" timezones
-         * mentioned in PHP doc: https://www.php.net/manual/en/timezones.others.php.
-         *
-         * Those timezones are not supported by Tempest (aside from UTC), as they are considered "legacy".
-         */
-        $timezoneId = date_default_timezone_get();
+    $seconds += $secondsOffset;
+    $nanoseconds = $nanosecondsAdjusted;
 
-        return Timezone::tryFrom($timezoneId) ?? Timezone::UTC;
-    }
+    return [$seconds, $nanoseconds];
+}
 
-    /**
-     * @return array{int, int}
-     *
-     * @internal
-     */
-    function high_resolution_time(): array
-    {
-        /**
-         * @var null|array{int, int} $offset
-         */
-        static $offset = null;
+/**
+ * @internal
+ */
+function intl_parse(
+    string $rawString,
+    ?DateStyle $dateStyle = null,
+    ?TimeStyle $timeStyle = null,
+    null|FormatPattern|string $pattern = null,
+    ?Timezone $timezone = null,
+    ?Locale $locale = null,
+): int {
+    $formatter = namespace\create_intl_date_formatter($dateStyle, $timeStyle, $pattern, $timezone, $locale);
 
-        if ($offset === null) {
-            $offset = hrtime();
+    $timestamp = $formatter->parse($rawString);
 
-            if ($offset === false) { // @phpstan-ignore-line identical.alwaysFalse
-                throw new \RuntimeException('The system does not provide a monotonic timer.');
-            }
+    if ($timestamp === false) {
+        // Only show pattern in the exception if it was provided.
+        if (null !== $pattern) {
+            $formatter_pattern = $pattern instanceof FormatPattern ? $pattern->value : $pattern;
 
-            $time = system_time();
-
-            $offset = [
-                $time[0] - $offset[0],
-                $time[1] - $offset[1],
-            ];
-        }
-
-        [$secondsOffset, $nanosecondsOffset] = $offset;
-        [$seconds, $nanoseconds] = hrtime();
-
-        $nanosecondsAdjusted = $nanoseconds + $nanosecondsOffset;
-
-        if ($nanosecondsAdjusted >= NANOSECONDS_PER_SECOND) {
-            ++$seconds;
-            $nanosecondsAdjusted -= NANOSECONDS_PER_SECOND;
-        } elseif ($nanosecondsAdjusted < 0) {
-            --$seconds;
-            $nanosecondsAdjusted += NANOSECONDS_PER_SECOND;
-        }
-
-        $seconds += $secondsOffset;
-        $nanoseconds = $nanosecondsAdjusted;
-
-        return [$seconds, $nanoseconds];
-    }
-
-    /**
-     * @internal
-     */
-    function intl_parse(
-        string $rawString,
-        ?DateStyle $dateStyle = null,
-        ?TimeStyle $timeStyle = null,
-        null|FormatPattern|string $pattern = null,
-        ?Timezone $timezone = null,
-        ?Locale $locale = null,
-    ): int {
-        $formatter = namespace\create_intl_date_formatter($dateStyle, $timeStyle, $pattern, $timezone, $locale);
-
-        $timestamp = $formatter->parse($rawString);
-
-        if ($timestamp === false) {
-            // Only show pattern in the exception if it was provided.
-            if (null !== $pattern) {
-                $formatter_pattern = $pattern instanceof FormatPattern ? $pattern->value : $pattern;
-
-                throw new ParserException(sprintf(
-                    "Unable to interpret '%s' as a valid date/time using pattern '%s'.",
-                    $rawString,
-                    $formatter_pattern,
-                ));
-            }
-
-            throw new ParserException("Unable to interpret '{$rawString}' as a valid date/time.");
-        }
-
-        return (int) $timestamp;
-    }
-
-    /**
-     * @return array{int, int}
-     *
-     * @internal
-     */
-    function system_time(): array
-    {
-        $time = microtime();
-
-        $parts = explode(' ', $time);
-        $seconds = (int) $parts[1];
-        $nanoseconds = (int) ((float) $parts[0] * (float) NANOSECONDS_PER_SECOND);
-
-        return [$seconds, $nanoseconds];
-    }
-
-    /**
-     * @internal
-     */
-    function to_intl_timezone(Timezone $timezone): IntlTimeZone
-    {
-        $value = $timezone->value;
-
-        if (str_starts_with($value, '+') || str_starts_with($value, '-')) {
-            $value = 'GMT' . $value;
-        }
-
-        $tz = IntlTimeZone::createTimeZone($value);
-
-        if ($tz === null) { // @phpstan-ignore-line identical.alwaysFalse
-            throw new \RuntimeException(sprintf(
-                'Failed to create intl timezone from timezone "%s" ("%s" / "%s").',
-                $timezone->name,
-                $timezone->value,
-                $value,
+            throw new ParserException(sprintf(
+                "Unable to interpret '%s' as a valid date/time using pattern '%s'.",
+                $rawString,
+                $formatter_pattern,
             ));
         }
 
-        if ($tz->getID() === 'Etc/Unknown' && $tz->getRawOffset() === 0) {
-            throw new \RuntimeException(sprintf(
-                'Failed to create a valid intl timezone, unknown timezone "%s" ("%s" / "%s") given.',
-                $timezone->name,
-                $timezone->value,
-                $value,
-            ));
-        }
-
-        return $tz;
+        throw new ParserException("Unable to interpret '{$rawString}' as a valid date/time.");
     }
 
+    return (int) $timestamp;
+}
+
+/**
+ * @return array{int, int}
+ *
+ * @internal
+ */
+function system_time(): array
+{
+    $time = microtime();
+
+    $parts = explode(' ', $time);
+    $seconds = (int) $parts[1];
+    $nanoseconds = (int) ((float) $parts[0] * (float) NANOSECONDS_PER_SECOND);
+
+    return [$seconds, $nanoseconds];
+}
+
+/**
+ * @internal
+ */
+function to_intl_timezone(Timezone $timezone): IntlTimeZone
+{
+    $value = $timezone->value;
+
+    if (str_starts_with($value, '+') || str_starts_with($value, '-')) {
+        $value = 'GMT' . $value;
+    }
+
+    $tz = IntlTimeZone::createTimeZone($value);
+
+    if ($tz === null) { // @phpstan-ignore-line identical.alwaysFalse
+        throw new \RuntimeException(sprintf(
+            'Failed to create intl timezone from timezone "%s" ("%s" / "%s").',
+            $timezone->name,
+            $timezone->value,
+            $value,
+        ));
+    }
+
+    if ($tz->getID() === 'Etc/Unknown' && $tz->getRawOffset() === 0) {
+        throw new \RuntimeException(sprintf(
+            'Failed to create a valid intl timezone, unknown timezone "%s" ("%s" / "%s") given.',
+            $timezone->name,
+            $timezone->value,
+            $value,
+        ));
+    }
+
+    return $tz;
+}
+
+/**
+ * @internal
+ */
+function create_intl_calendar_from_date_time(
+    Timezone $timezone,
+    int $year,
+    int $month,
+    int $day,
+    int $hours,
+    int $minutes,
+    int $seconds,
+): IntlCalendar {
     /**
-     * @internal
+     * @var IntlCalendar $calendar
      */
-    function create_intl_calendar_from_date_time(
-        Timezone $timezone,
-        int $year,
-        int $month,
-        int $day,
-        int $hours,
-        int $minutes,
-        int $seconds,
-    ): IntlCalendar {
-        /**
-         * @var IntlCalendar $calendar
-         */
-        $calendar = IntlCalendar::createInstance(to_intl_timezone($timezone));
+    $calendar = IntlCalendar::createInstance(to_intl_timezone($timezone));
 
-        $calendar->setDateTime($year, $month - 1, $day, $hours, $minutes, $seconds);
+    $calendar->setDateTime($year, $month - 1, $day, $hours, $minutes, $seconds);
 
-        return $calendar;
-    }
+    return $calendar;
 }

--- a/packages/debug/src/functions.php
+++ b/packages/debug/src/functions.php
@@ -2,75 +2,73 @@
 
 declare(strict_types=1);
 
-namespace {
-    use Tempest\Debug\Debug;
+use Tempest\Debug\Debug;
 
-    if (! function_exists('lw')) {
-        /**
-         * Writes the given `$input` to the logs, and dumps it.
-         * @see \Tempest\Debug\Debug::log()
-         */
-        function lw(mixed ...$input): void
-        {
-            Debug::resolve()->log($input);
-        }
+if (! function_exists('lw')) {
+    /**
+     * Writes the given `$input` to the logs, and dumps it.
+     * @see \Tempest\Debug\Debug::log()
+     */
+    function lw(mixed ...$input): void
+    {
+        Debug::resolve()->log($input);
     }
+}
 
-    if (! function_exists('ld')) {
-        /**
-         * Writes the given `$input` to the logs, dumps it, and stops the execution of the script.
-         * @see \Tempest\Debug\Debug::log()
-         */
-        function ld(mixed ...$input): never
-        {
-            Debug::resolve()->log($input);
-            die();
-        }
+if (! function_exists('ld')) {
+    /**
+     * Writes the given `$input` to the logs, dumps it, and stops the execution of the script.
+     * @see \Tempest\Debug\Debug::log()
+     */
+    function ld(mixed ...$input): never
+    {
+        Debug::resolve()->log($input);
+        die();
     }
+}
 
-    if (! function_exists('ll')) {
-        /**
-         * Writes the given `$input` to the logs.
-         * @see \Tempest\Debug\Debug::log()
-         */
-        function ll(mixed ...$input): void
-        {
-            Debug::resolve()->log($input, writeToOut: false);
-        }
+if (! function_exists('ll')) {
+    /**
+     * Writes the given `$input` to the logs.
+     * @see \Tempest\Debug\Debug::log()
+     */
+    function ll(mixed ...$input): void
+    {
+        Debug::resolve()->log($input, writeToOut: false);
     }
+}
 
-    if (! function_exists('le')) {
-        /**
-         * Emits a `ItemsDebugged` event.
-         * @see \Tempest\Debug\Debug::log()
-         */
-        function le(mixed ...$input): void
-        {
-            Debug::resolve()->log($input, writeToOut: false, writeToLog: false);
-        }
+if (! function_exists('le')) {
+    /**
+     * Emits a `ItemsDebugged` event.
+     * @see \Tempest\Debug\Debug::log()
+     */
+    function le(mixed ...$input): void
+    {
+        Debug::resolve()->log($input, writeToOut: false, writeToLog: false);
     }
+}
 
-    if (! function_exists('dd')) {
-        /**
-         * Writes the given `$input` to the logs, dumps it, and stops the execution of the script.
-         * @see ld()
-         * @see \Tempest\Debug\Debug::log()
-         */
-        function dd(mixed ...$input): never
-        {
-            ld(...$input);
-        }
+if (! function_exists('dd')) {
+    /**
+     * Writes the given `$input` to the logs, dumps it, and stops the execution of the script.
+     * @see ld()
+     * @see \Tempest\Debug\Debug::log()
+     */
+    function dd(mixed ...$input): never
+    {
+        ld(...$input);
     }
+}
 
-    if (! function_exists('dump')) {
-        /**
-         * Writes the given `$input` to the logs, and dumps it.
-         * @see lw()
-         * @see \Tempest\Debug\Debug::log()
-         */
-        function dump(mixed ...$input): void
-        {
-            lw(...$input);
-        }
+if (! function_exists('dump')) {
+    /**
+     * Writes the given `$input` to the logs, and dumps it.
+     * @see lw()
+     * @see \Tempest\Debug\Debug::log()
+     */
+    function dump(mixed ...$input): void
+    {
+        lw(...$input);
     }
 }

--- a/packages/event-bus/src/GenericEventBus.php
+++ b/packages/event-bus/src/GenericEventBus.php
@@ -9,7 +9,7 @@ use Tempest\Container\Container;
 use Tempest\Support\Str;
 use UnitEnum;
 
-use function Tempest\reflect;
+use function Tempest\Reflection\reflect;
 
 final readonly class GenericEventBus implements EventBus
 {

--- a/packages/event-bus/src/functions.php
+++ b/packages/event-bus/src/functions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\EventBus;
 
 use Closure;
+use Tempest\Container;
 use Tempest\EventBus\EventBus;
 use Tempest\EventBus\EventBusConfig;
 
@@ -13,7 +14,7 @@ use Tempest\EventBus\EventBusConfig;
  */
 function event(string|object $event): void
 {
-    $eventBus = get(EventBus::class);
+    $eventBus = Container\get(EventBus::class);
 
     $eventBus->dispatch($event);
 }
@@ -23,7 +24,7 @@ function event(string|object $event): void
  */
 function listen(Closure $handler, ?string $event = null): void
 {
-    $config = get(EventBusConfig::class);
+    $config = Container\get(EventBusConfig::class);
 
     $config->addClosureHandler($handler, $event);
 }

--- a/packages/event-bus/src/functions.php
+++ b/packages/event-bus/src/functions.php
@@ -2,28 +2,28 @@
 
 declare(strict_types=1);
 
-namespace Tempest {
-    use Closure;
-    use Tempest\EventBus\EventBus;
-    use Tempest\EventBus\EventBusConfig;
+namespace Tempest\EventBus;
 
-    /**
-     * Dispatches the given `$event`, triggering all associated event listeners.
-     */
-    function event(string|object $event): void
-    {
-        $eventBus = get(EventBus::class);
+use Closure;
+use Tempest\EventBus\EventBus;
+use Tempest\EventBus\EventBusConfig;
 
-        $eventBus->dispatch($event);
-    }
+/**
+ * Dispatches the given `$event`, triggering all associated event listeners.
+ */
+function event(string|object $event): void
+{
+    $eventBus = get(EventBus::class);
 
-    /**
-     * Registers a closure-based event listener for the given `$event`.
-     */
-    function listen(Closure $handler, ?string $event = null): void
-    {
-        $config = get(EventBusConfig::class);
+    $eventBus->dispatch($event);
+}
 
-        $config->addClosureHandler($handler, $event);
-    }
+/**
+ * Registers a closure-based event listener for the given `$event`.
+ */
+function listen(Closure $handler, ?string $event = null): void
+{
+    $config = get(EventBusConfig::class);
+
+    $config->addClosureHandler($handler, $event);
 }

--- a/packages/event-bus/tests/EventBusTest.php
+++ b/packages/event-bus/tests/EventBusTest.php
@@ -22,8 +22,8 @@ use Tempest\EventBus\Tests\Fixtures\MyEventHandler;
 use Tempest\EventBus\Tests\Fixtures\MyService;
 use Tempest\Reflection\MethodReflector;
 
-use function Tempest\get;
-use function Tempest\listen;
+use function Tempest\Container\get;
+use function Tempest\EventBus\listen;
 
 /**
  * @internal

--- a/packages/http/src/IsRequest.php
+++ b/packages/http/src/IsRequest.php
@@ -8,7 +8,7 @@ use Tempest\Http\Cookie\Cookie;
 use Tempest\Http\Session\Session;
 use Tempest\Validation\SkipValidation;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 use function Tempest\Support\Arr\get_by_key;
 use function Tempest\Support\Arr\has_key;
 use function Tempest\Support\str;

--- a/packages/http/src/IsResponse.php
+++ b/packages/http/src/IsResponse.php
@@ -12,7 +12,7 @@ use Tempest\Http\Session\Session;
 use Tempest\View\View;
 use UnitEnum;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 /** @phpstan-require-implements \Tempest\Http\Response */
 trait IsResponse

--- a/packages/http/src/Responses/Back.php
+++ b/packages/http/src/Responses/Back.php
@@ -10,7 +10,7 @@ use Tempest\Http\Response;
 use Tempest\Http\Session\PreviousUrl;
 use Tempest\Http\Status;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 /**
  * This response is not fit for stateless requests.

--- a/packages/http/src/Session/Managers/DatabaseSessionManager.php
+++ b/packages/http/src/Session/Managers/DatabaseSessionManager.php
@@ -14,7 +14,7 @@ use Tempest\Http\Session\SessionId;
 use Tempest\Http\Session\SessionManager;
 
 use function Tempest\Database\query;
-use function Tempest\event;
+use function Tempest\EventBus\event;
 
 final readonly class DatabaseSessionManager implements SessionManager
 {

--- a/packages/http/src/Session/Managers/FileSessionManager.php
+++ b/packages/http/src/Session/Managers/FileSessionManager.php
@@ -14,7 +14,7 @@ use Tempest\Http\Session\SessionManager;
 use Tempest\Support\Filesystem;
 use Throwable;
 
-use function Tempest\event;
+use function Tempest\EventBus\event;
 use function Tempest\internal_storage_path;
 
 final readonly class FileSessionManager implements SessionManager

--- a/packages/http/src/Session/Managers/RedisSessionManager.php
+++ b/packages/http/src/Session/Managers/RedisSessionManager.php
@@ -15,7 +15,7 @@ use Tempest\KeyValue\Redis\Redis;
 use Tempest\Support\Str;
 use Throwable;
 
-use function Tempest\event;
+use function Tempest\EventBus\event;
 
 final readonly class RedisSessionManager implements SessionManager
 {

--- a/packages/icon/src/functions.php
+++ b/packages/icon/src/functions.php
@@ -2,7 +2,7 @@
 
 namespace Tempest\Icon;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 /**
  * Renders an icon as an SVG snippet. If the icon is not cached, it will be

--- a/packages/intl/bin/plural-rules.php
+++ b/packages/intl/bin/plural-rules.php
@@ -13,7 +13,7 @@ use Tempest\Console\ConsoleApplication;
 use Tempest\Support\Filesystem;
 use Tempest\Support\Json;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 final class PluralRulesMatcherGenerator
 {

--- a/packages/intl/src/functions.php
+++ b/packages/intl/src/functions.php
@@ -9,7 +9,7 @@ use Tempest\Intl\Locale;
 use Tempest\Intl\Pluralizer\Pluralizer;
 use Tempest\Intl\Translator;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 /**
  * Translates the given key with optional arguments.

--- a/packages/mail/src/Testing/TestingMailer.php
+++ b/packages/mail/src/Testing/TestingMailer.php
@@ -7,7 +7,7 @@ use Tempest\Mail\Email;
 use Tempest\Mail\EmailWasSent;
 use Tempest\Mail\Mailer;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 final class TestingMailer implements Mailer
 {

--- a/packages/mapper/src/functions.php
+++ b/packages/mapper/src/functions.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Mapper;
 
-use Tempest;
+use Tempest\Container;
 use Tempest\Mapper\ObjectFactory;
 
 /**
@@ -24,7 +24,7 @@ use Tempest\Mapper\ObjectFactory;
  */
 function make(object|string $objectOrClass): ObjectFactory
 {
-    return Tempest\get(ObjectFactory::class)->forClass($objectOrClass);
+    return Container\get(ObjectFactory::class)->forClass($objectOrClass);
 }
 
 /**
@@ -40,5 +40,5 @@ function make(object|string $objectOrClass): ObjectFactory
  */
 function map(mixed $data): ObjectFactory
 {
-    return Tempest\get(ObjectFactory::class)->withData($data);
+    return Container\get(ObjectFactory::class)->withData($data);
 }

--- a/packages/reflection/src/functions.php
+++ b/packages/reflection/src/functions.php
@@ -2,29 +2,29 @@
 
 declare(strict_types=1);
 
-namespace Tempest {
-    use ReflectionClass as PHPReflectionClass;
-    use ReflectionProperty as PHPReflectionProperty;
-    use Tempest\Reflection\ClassReflector;
-    use Tempest\Reflection\PropertyReflector;
+namespace Tempest\Reflection;
 
-    /**
-     * Creates a new {@see Reflector} instance based on the given `$classOrProperty`.
-     */
-    function reflect(mixed $classOrProperty, ?string $propertyName = null): ClassReflector|PropertyReflector
-    {
-        if ($classOrProperty instanceof PHPReflectionClass) {
-            return new ClassReflector($classOrProperty);
-        }
+use ReflectionClass as PHPReflectionClass;
+use ReflectionProperty as PHPReflectionProperty;
+use Tempest\Reflection\ClassReflector;
+use Tempest\Reflection\PropertyReflector;
 
-        if ($classOrProperty instanceof PHPReflectionProperty) {
-            return new PropertyReflector($classOrProperty);
-        }
-
-        if ($propertyName !== null) {
-            return new PropertyReflector(new PHPReflectionProperty($classOrProperty, $propertyName));
-        }
-
+/**
+ * Creates a new {@see Reflector} instance based on the given `$classOrProperty`.
+ */
+function reflect(mixed $classOrProperty, ?string $propertyName = null): ClassReflector|PropertyReflector
+{
+    if ($classOrProperty instanceof PHPReflectionClass) {
         return new ClassReflector($classOrProperty);
     }
+
+    if ($classOrProperty instanceof PHPReflectionProperty) {
+        return new PropertyReflector($classOrProperty);
+    }
+
+    if ($propertyName !== null) {
+        return new PropertyReflector(new PHPReflectionProperty($classOrProperty, $propertyName));
+    }
+
+    return new ClassReflector($classOrProperty);
 }

--- a/packages/router/src/functions.php
+++ b/packages/router/src/functions.php
@@ -9,7 +9,7 @@ use Tempest\DateTime\Duration;
 use Tempest\Reflection\MethodReflector;
 use Tempest\Router\UriGenerator;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 /**
  * Creates a valid URI to the given `$action`.

--- a/packages/storage/src/Config/CustomStorageConfig.php
+++ b/packages/storage/src/Config/CustomStorageConfig.php
@@ -5,7 +5,7 @@ namespace Tempest\Storage\Config;
 use League\Flysystem\FilesystemAdapter;
 use UnitEnum;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 final class CustomStorageConfig implements StorageConfig
 {

--- a/packages/support/src/Arr/functions.php
+++ b/packages/support/src/Arr/functions.php
@@ -2,1284 +2,1263 @@
 
 declare(strict_types=1);
 
-namespace Tempest\Support\Arr {
-    use Closure;
-    use Countable;
-    use Generator;
-    use InvalidArgumentException;
-    use LogicException;
-    use Random\Randomizer;
-    use Tempest\Mapper;
-    use Tempest\Support\Str\ImmutableString;
-    use Traversable;
+namespace Tempest\Support\Arr;
 
-    use function sort as php_sort;
+use Closure;
+use Countable;
+use Generator;
+use InvalidArgumentException;
+use LogicException;
+use Random\Randomizer;
+use Tempest\Mapper;
+use Tempest\Support\Str\ImmutableString;
+use Traversable;
 
-    /**
-     * Finds a value in the array and return the corresponding key if successful.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param (Closure(TValue, TKey): bool)|mixed $value The value to search for, a {@see Closure} will find the first item that returns true.
-     * @param bool $strict Whether to use strict comparison.
-     *
-     * @return array-key|null The key for `$value` if found, `null` otherwise.
-     */
-    function find_key(iterable $array, mixed $value, bool $strict = false): int|string|null
-    {
-        $array = to_array($array);
+use function sort as php_sort;
 
-        if (! $value instanceof Closure) {
-            $search = array_search($value, $array, $strict);
+/**
+ * Finds a value in the array and return the corresponding key if successful.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param (Closure(TValue, TKey): bool)|mixed $value The value to search for, a {@see Closure} will find the first item that returns true.
+ * @param bool $strict Whether to use strict comparison.
+ *
+ * @return array-key|null The key for `$value` if found, `null` otherwise.
+ */
+function find_key(iterable $array, mixed $value, bool $strict = false): int|string|null
+{
+    $array = to_array($array);
 
-            return $search === false ? null : $search; // Keep empty values but convert false to null
-        }
+    if (! $value instanceof Closure) {
+        $search = array_search($value, $array, $strict);
 
-        return array_find_key($array, static fn ($item, $key) => $value($item, $key) === true);
+        return $search === false ? null : $search; // Keep empty values but convert false to null
     }
 
-    /**
-     * Chunks the array into chunks of the given size.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param int $size The size of each chunk.
-     * @param bool $preserveKeys Whether to preserve the keys of the original array.
-     *
-     * @return array<int,array<TKey, TValue>>
-     */
-    function chunk(iterable $array, int $size, bool $preserveKeys = true): array
-    {
-        $array = to_array($array);
+    return array_find_key($array, static fn ($item, $key) => $value($item, $key) === true);
+}
 
-        if ($size <= 0) {
-            return [];
-        }
+/**
+ * Chunks the array into chunks of the given size.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param int $size The size of each chunk.
+ * @param bool $preserveKeys Whether to preserve the keys of the original array.
+ *
+ * @return array<int,array<TKey, TValue>>
+ */
+function chunk(iterable $array, int $size, bool $preserveKeys = true): array
+{
+    $array = to_array($array);
 
-        $chunks = [];
-        foreach (array_chunk($array, $size, $preserveKeys) as $chunk) {
-            $chunks[] = $chunk;
-        }
-
-        return $chunks;
+    if ($size <= 0) {
+        return [];
     }
 
-    /**
-     * Reduces the array to a single value using a callback.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @template TReduceInitial
-     * @template TReduceReturnType
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param callable(TReduceInitial|TReduceReturnType, TValue, TKey): TReduceReturnType $callback
-     * @param TReduceInitial $initial
-     *
-     * @return TReduceReturnType
-     */
-    function reduce(iterable $array, callable $callback, mixed $initial = null): mixed
-    {
-        $array = to_array($array);
-
-        $result = $initial;
-
-        foreach ($array as $key => $value) {
-            $result = $callback($result, $value, $key);
-        }
-
-        return $result;
+    $chunks = [];
+    foreach (array_chunk($array, $size, $preserveKeys) as $chunk) {
+        $chunks[] = $chunk;
     }
 
-    /**
-     * Gets a value by its key from the array and remove it. Mutates the array.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param array<TKey,TValue> $array
-     * @param array-key $key
-     */
-    function pull(array &$array, string|int $key, mixed $default = null): mixed
-    {
-        $value = get_by_key($array, $key, $default);
-        $array = namespace\forget_keys($array, $key);
+    return $chunks;
+}
 
-        return $value;
+/**
+ * Reduces the array to a single value using a callback.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @template TReduceInitial
+ * @template TReduceReturnType
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param callable(TReduceInitial|TReduceReturnType, TValue, TKey): TReduceReturnType $callback
+ * @param TReduceInitial $initial
+ *
+ * @return TReduceReturnType
+ */
+function reduce(iterable $array, callable $callback, mixed $initial = null): mixed
+{
+    $array = to_array($array);
+
+    $result = $initial;
+
+    foreach ($array as $key => $value) {
+        $result = $callback($result, $value, $key);
     }
 
-    /**
-     * Shuffles the array.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @return array<TKey, TValue>
-     */
-    function shuffle(iterable $array): array
-    {
-        return new Randomizer()->shuffleArray(to_array($array));
+    return $result;
+}
+
+/**
+ * Gets a value by its key from the array and remove it. Mutates the array.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param array<TKey,TValue> $array
+ * @param array-key $key
+ */
+function pull(array &$array, string|int $key, mixed $default = null): mixed
+{
+    $value = get_by_key($array, $key, $default);
+    $array = namespace\forget_keys($array, $key);
+
+    return $value;
+}
+
+/**
+ * Shuffles the array.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @return array<TKey, TValue>
+ */
+function shuffle(iterable $array): array
+{
+    return new Randomizer()->shuffleArray(to_array($array));
+}
+
+/**
+ * Removes the specified keys from the array. The array is not mutated.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param array<TKey,TValue> $array
+ * @param array-key|array<array-key> $keys The keys of the items to remove.
+ * @return array<TKey,TValue>
+ */
+function remove_keys(iterable $array, string|int|array $keys): array
+{
+    $array = to_array($array);
+
+    return namespace\forget_keys($array, $keys);
+}
+
+/**
+ * Removes the specified values from the array. The array is not mutated.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param array<TKey,TValue> $array
+ * @param TValue|array<TValue> $values The values to remove.
+ * @return array<TKey,TValue>
+ */
+function remove_values(array $array, string|int|array $values): array
+{
+    $array = to_array($array);
+
+    return namespace\forget_values($array, $values);
+}
+
+/**
+ * Removes the specified keys from the array. The array is mutated.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param array<TKey,TValue> $array
+ * @param array-key|array<array-key> $keys The keys of the items to remove.
+ * @return array<TKey,TValue>
+ */
+function forget_keys(array &$array, string|int|array $keys): array
+{
+    $keys = is_array($keys) ? $keys : [$keys];
+
+    foreach ($keys as $key) {
+        unset($array[$key]);
     }
 
-    /**
-     * Removes the specified keys from the array. The array is not mutated.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param array<TKey,TValue> $array
-     * @param array-key|array<array-key> $keys The keys of the items to remove.
-     * @return array<TKey,TValue>
-     */
-    function remove_keys(iterable $array, string|int|array $keys): array
-    {
-        $array = to_array($array);
+    return $array;
+}
 
-        return namespace\forget_keys($array, $keys);
-    }
+/**
+ * Removes the specified values from the array. The array is mutated.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param array<TKey,TValue> $array
+ * @param TValue|array<TValue> $values The values to remove.
+ * @return array<TKey,TValue>
+ */
+function forget_values(array &$array, string|int|array $values): array
+{
+    $values = is_array($values) ? $values : [$values];
 
-    /**
-     * Removes the specified values from the array. The array is not mutated.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param array<TKey,TValue> $array
-     * @param TValue|array<TValue> $values The values to remove.
-     * @return array<TKey,TValue>
-     */
-    function remove_values(array $array, string|int|array $values): array
-    {
-        $array = to_array($array);
-
-        return namespace\forget_values($array, $values);
-    }
-
-    /**
-     * Removes the specified keys from the array. The array is mutated.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param array<TKey,TValue> $array
-     * @param array-key|array<array-key> $keys The keys of the items to remove.
-     * @return array<TKey,TValue>
-     */
-    function forget_keys(array &$array, string|int|array $keys): array
-    {
-        $keys = is_array($keys) ? $keys : [$keys];
-
-        foreach ($keys as $key) {
+    foreach ($values as $value) {
+        if (! is_null($key = array_find_key($array, fn (mixed $match) => $value === $match))) {
             unset($array[$key]);
         }
-
-        return $array;
     }
 
-    /**
-     * Removes the specified values from the array. The array is mutated.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param array<TKey,TValue> $array
-     * @param TValue|array<TValue> $values The values to remove.
-     * @return array<TKey,TValue>
-     */
-    function forget_values(array &$array, string|int|array $values): array
-    {
-        $values = is_array($values) ? $values : [$values];
+    return $array;
+}
 
-        foreach ($values as $value) {
-            if (! is_null($key = array_find_key($array, fn (mixed $match) => $value === $match))) {
-                unset($array[$key]);
-            }
+/**
+ * Asserts whether the array is a list.
+ * An array is a list if its keys consist of consecutive numbers.
+ */
+function is_list(iterable $array): bool
+{
+    return array_is_list(to_array($array));
+}
+
+/**
+ * Asserts whether the array is a associative.
+ * An array is associative if its keys do not consist of consecutive numbers.
+ */
+function is_associative(iterable $array): bool
+{
+    return ! is_list(to_array($array));
+}
+
+/**
+ * Gets one or a specified number of random values from the array.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param int $number The number of random values to get.
+ * @param bool $preserveKey Whether to include the keys of the original array.
+ *
+ * @return array<TKey, TValue>|mixed The random values, or a single value if `$number` is 1.
+ */
+function random(iterable $array, int $number = 1, bool $preserveKey = false): mixed
+{
+    $array = to_array($array);
+
+    $count = count($array);
+
+    if ($number > $count) {
+        throw new InvalidArgumentException("Cannot retrieve {$number} items from an array of {$count} items.");
+    }
+
+    if ($number < 1) {
+        throw new InvalidArgumentException("Random value only accepts positive integers, {$number} requested.");
+    }
+
+    $keys = new Randomizer()->pickArrayKeys($array, $number);
+
+    $randomValues = [];
+    foreach ($keys as $key) {
+        $preserveKey
+            ? ($randomValues[$key] = $array[$key])
+            : ($randomValues[] = $array[$key]);
+    }
+
+    if ($preserveKey === false) {
+        shuffle($randomValues);
+    }
+
+    return count($randomValues) > 1
+        ? new ImmutableArray($randomValues)
+        : $randomValues[0];
+}
+
+/**
+ * Retrieves values from a given key in each sub-array of the current array.
+ * Optionally, you can pass a second parameter to also get the keys following the same pattern.
+ *
+ * @param string $value The key to assign the values from, support dot notation.
+ * @param string|null $key The key to assign the keys from, support dot notation.
+ */
+function pluck(iterable $array, string $value, ?string $key = null): array
+{
+    $array = to_array($array);
+
+    $results = [];
+
+    foreach ($array as $item) {
+        if (! is_array($item)) {
+            continue;
         }
 
-        return $array;
+        $itemValue = get_by_key($item, $value);
+
+        /**
+         * Perform basic pluck if no key is given.
+         * Otherwise, also pluck the key as well.
+         */
+        if (is_null($key)) {
+            $results[] = $itemValue;
+        } else {
+            $itemKey = get_by_key($item, $key);
+            $results[$itemKey] = $itemValue;
+        }
     }
 
-    /**
-     * Asserts whether the array is a list.
-     * An array is a list if its keys consist of consecutive numbers.
-     */
-    function is_list(iterable $array): bool
-    {
-        return array_is_list(to_array($array));
+    return $results;
+}
+
+/**
+ * Returns a new array with the specified values prepended.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param TValue $values
+ */
+function prepend(iterable $array, mixed ...$values): array
+{
+    $array = to_array($array);
+
+    foreach (array_reverse($values) as $value) {
+        $array = [$value, ...$array];
     }
 
-    /**
-     * Asserts whether the array is a associative.
-     * An array is associative if its keys do not consist of consecutive numbers.
-     */
-    function is_associative(iterable $array): bool
-    {
-        return ! is_list(to_array($array));
+    return $array;
+}
+
+/**
+ * Appends the specified values to the array.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param TValue $values
+ */
+function append(iterable $array, mixed ...$values): array
+{
+    $array = to_array($array);
+
+    foreach ($values as $value) {
+        $array = [...$array, $value];
     }
 
-    /**
-     * Gets one or a specified number of random values from the array.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param int $number The number of random values to get.
-     * @param bool $preserveKey Whether to include the keys of the original array.
-     *
-     * @return array<TKey, TValue>|mixed The random values, or a single value if `$number` is 1.
-     */
-    function random(iterable $array, int $number = 1, bool $preserveKey = false): mixed
-    {
-        $array = to_array($array);
+    return $array;
+}
 
-        $count = count($array);
+/**
+ * Appends the specified value to the array.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param TValue $value
+ */
+function push(iterable $array, mixed $value): array
+{
+    $array = to_array($array);
+    $array[] = $value;
 
-        if ($number > $count) {
-            throw new InvalidArgumentException("Cannot retrieve {$number} items from an array of {$count} items.");
+    return $array;
+}
+
+/**
+ * Pads the array to the specified size with a value.
+ */
+function pad(iterable $array, int $size, mixed $value): array
+{
+    $array = to_array($array);
+
+    return array_pad($array, $size, $value);
+}
+
+/**
+ * Reverses the keys and values of the array.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @return array<TValue&array-key, TKey>
+ */
+function flip(iterable $array): array
+{
+    $array = to_array($array);
+
+    return array_flip($array);
+}
+
+/**
+ * Returns a new array with only unique items from the original array.
+ *
+ * @param string|null|Closure $key The key to use as the uniqueness criteria in nested arrays.
+ * @param bool $shouldBeStrict Whether the comparison should be strict, only used when giving a key parameter.
+ */
+function unique(iterable $array, null|Closure|string $key = null, bool $shouldBeStrict = false): array
+{
+    $array = to_array($array);
+
+    if (is_null($key) && $shouldBeStrict === false) {
+        return array_unique($array, flags: SORT_REGULAR);
+    }
+
+    $uniqueItems = [];
+    $uniqueFilteredValues = [];
+
+    foreach ($array as $item) {
+        // Ensure we don't check raw values with key filter
+        if (! is_null($key) && ! is_array($item) && ! $key instanceof Closure) {
+            continue;
         }
 
-        if ($number < 1) {
-            throw new InvalidArgumentException("Random value only accepts positive integers, {$number} requested.");
+        $filterValue = match ($key instanceof Closure) {
+            true => $key($item, $array),
+            false => is_array($item)
+                ? get_by_key($item, $key)
+                : $item,
+        };
+
+        if (is_null($filterValue)) {
+            continue;
         }
 
-        $keys = new Randomizer()->pickArrayKeys($array, $number);
-
-        $randomValues = [];
-        foreach ($keys as $key) {
-            $preserveKey
-                ? ($randomValues[$key] = $array[$key])
-                : ($randomValues[] = $array[$key]);
+        if (in_array($filterValue, $uniqueFilteredValues, strict: $shouldBeStrict)) {
+            continue;
         }
 
-        if ($preserveKey === false) {
-            shuffle($randomValues);
+        $uniqueItems[] = $item;
+        $uniqueFilteredValues[] = $filterValue;
+    }
+
+    return $uniqueItems;
+}
+
+/**
+ * Returns a copy of the given array with only the items that are not present in any of the given arrays.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param array<TKey, TValue> ...$arrays
+ */
+function diff(iterable $array, array ...$arrays): array
+{
+    return array_diff(to_array($array), ...$arrays);
+}
+
+/**
+ * Returns a new array with only the items whose keys are not present in any of the given arrays.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param array<TKey, TValue> ...$arrays
+ */
+function diff_keys(iterable $array, array ...$arrays): array
+{
+    return array_diff_key(to_array($array), ...$arrays);
+}
+
+/**
+ * Returns a copy of the given array with only the items that are present in all of the given arrays.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param array<TKey, TValue> ...$arrays
+ */
+function intersect(iterable $array, array ...$arrays): array
+{
+    return array_intersect(to_array($array), ...$arrays);
+}
+
+/**
+ * Returns a copy of the given array with only the items whose keys are present in all of the given arrays.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param array<TKey, TValue> ...$arrays
+ */
+function intersect_keys(iterable $array, array ...$arrays): array
+{
+    return array_intersect_key(to_array($array), ...$arrays);
+}
+
+/**
+ * Merges the array with the given arrays.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param array<TKey, TValue> ...$arrays The arrays to merge.
+ */
+function merge(iterable $array, iterable ...$arrays): array
+{
+    return array_merge(to_array($array), ...array_map(to_array(...), $arrays));
+}
+
+/**
+ * Creates a new array with this current array values as keys and the given values as values.
+ *
+ * @template TCombineValue
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param iterable<array-key, TCombineValue> $values
+ *
+ * @return array<array-key, TCombineValue>
+ */
+function combine(iterable $array, iterable $values): array
+{
+    $array = to_array($array);
+    $values = to_array($values);
+
+    if (count($array) !== count($values)) {
+        throw new InvalidArgumentException(
+            sprintf('Cannot combine arrays of different lengths (%d keys vs %d values)', count($array), count($values)),
+        );
+    }
+
+    return array_combine($array, $values);
+}
+
+/**
+ * Asserts whether the given `$array` is equal to `$other` array.
+ */
+function equals(iterable $array, iterable $other): bool
+{
+    $array = to_array($array);
+    $other = to_array($other);
+
+    return $array === $other;
+}
+
+/**
+ * Returns the first item in the array that matches the given `$filter`.
+ * If `$filter` is `null`, returns the first item.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param null|Closure(TValue $value, TKey $key): bool $filter
+ *
+ * @return TValue
+ */
+function first(iterable $array, ?Closure $filter = null, mixed $default = null): mixed
+{
+    $array = to_array($array);
+
+    if ($array === []) {
+        return $default;
+    }
+
+    if ($filter === null) {
+        return $array[array_key_first($array)] ?? $default;
+    }
+
+    return array_find($array, static fn ($value, $key) => $filter($value, $key)) ?? $default;
+}
+
+/**
+ * Returns the item at the given index in the specified array.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ *
+ * @return TValue
+ */
+function at(iterable $array, int $index, mixed $default = null): mixed
+{
+    $array = to_array($array);
+
+    if ($index < 0) {
+        $index = abs($index) - 1;
+        $array = namespace\reverse($array);
+    }
+
+    return namespace\get_by_key(array_values($array), key: $index, default: $default);
+}
+
+/**
+ * Returns the last item in the array that matches the given `$filter`.
+ * If `$filter` is `null`, returns the last item.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param null|Closure(TValue $value, TKey $key): bool $filter
+ *
+ * @return TValue
+ */
+function last(iterable $array, ?Closure $filter = null, mixed $default = null): mixed
+{
+    $array = to_array($array);
+
+    if ($array === []) {
+        return $default;
+    }
+
+    if ($filter === null) {
+        return $array[array_key_last($array)] ?? $default;
+    }
+
+    return array_find(namespace\reverse($array), static fn ($value, $key) => $filter($value, $key)) ?? $default;
+}
+
+/**
+ * Returns a copy of the given array without the last value.
+ *
+ * @param mixed $value The popped value will be stored in this variable.
+ */
+function pop(iterable $array, mixed &$value = null): array
+{
+    $array = to_array($array);
+    $value = namespace\last($array);
+
+    return array_slice($array, 0, -1);
+}
+
+/**
+ * Returns a copy of the given array without the first value.
+ *
+ * @param mixed $value The unshifted value will be stored in this variable
+ */
+function unshift(iterable $array, mixed &$value = null): array
+{
+    $array = to_array($array);
+    $value = namespace\first($array);
+
+    return array_slice($array, 1);
+}
+
+/**
+ * Returns a copy of the given array in reverse order.
+ */
+function reverse(iterable $array): array
+{
+    return array_reverse(to_array($array));
+}
+
+/**
+ * Asserts whether the array is empty.
+ */
+function is_empty(iterable $array): bool
+{
+    return to_array($array) === [];
+}
+
+/**
+ * Returns an instance of {@see \Tempest\Support\Str\ImmutableString} with the values of the array joined with the given `$glue`.
+ */
+function implode(iterable $array, string $glue): ImmutableString
+{
+    return new ImmutableString(\implode($glue, to_array($array)));
+}
+
+/**
+ * Returns a copy of the given array with the keys of this array as values.
+ */
+function keys(iterable $array): array
+{
+    return array_keys(to_array($array));
+}
+
+/**
+ * Returns a copy of the given array without its keys.
+ */
+function values(iterable $array): array
+{
+    return array_values(to_array($array));
+}
+
+/**
+ * Returns a copy of the given array with only the items that pass the given `$filter`.
+ * If `$filter` is `null`, the new array will contain only values that are not `false` or `null`.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param null|Closure(TValue $value, TKey $key): bool $filter
+ */
+function filter(iterable $array, ?Closure $filter = null): array
+{
+    $result = [];
+    $filter ??= static fn (mixed $value, mixed $_) => ! in_array($value, [false, null], strict: true);
+
+    foreach (to_array($array) as $key => $value) {
+        if ($filter($value, $key)) {
+            $result[$key] = $value;
+        }
+    }
+
+    return $result;
+}
+
+/**
+ * Applies the given callback to all items of the array.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param Closure(TKey $value, TValue $key): void $each
+ */
+function each(iterable $array, Closure $each): array
+{
+    $array = to_array($array);
+
+    foreach ($array as $key => $value) {
+        $each($value, $key);
+    }
+
+    return $array;
+}
+
+/**
+ * Returns a copy of the given array with each item transformed by the given callback.
+ *
+ * @template TMapValue
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param Closure(TValue, TKey): TMapValue $map
+ *
+ * @return array<TKey, TMapValue>
+ */
+function map_iterable(iterable $array, Closure $map): array
+{
+    $result = [];
+
+    foreach (to_array($array) as $key => $value) {
+        $result[$key] = $map($value, $key);
+    }
+
+    return $result;
+}
+
+/**
+ * Returns a copy of the given array with each item transformed by the given callback.
+ * The callback must return a generator, associating a key and a value.
+ *
+ * ### Example
+ * ```php
+ * map_with_keys(['a', 'b'], fn (mixed $value, mixed $key) => yield $key => $value);
+ * ```
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param Closure(TValue $value, TKey $key): Generator $map
+ */
+function map_with_keys(iterable $array, Closure $map): array
+{
+    $result = [];
+
+    foreach (to_array($array) as $key => $value) {
+        $generator = $map($value, $key);
+
+        // @phpstan-ignore instanceof.alwaysTrue
+        if (! $generator instanceof Generator) {
+            throw new MapWithKeysDidNotUseAGenerator();
         }
 
-        return count($randomValues) > 1
-            ? new ImmutableArray($randomValues)
-            : $randomValues[0];
+        $result[$generator->key()] = $generator->current();
     }
 
-    /**
-     * Retrieves values from a given key in each sub-array of the current array.
-     * Optionally, you can pass a second parameter to also get the keys following the same pattern.
-     *
-     * @param string $value The key to assign the values from, support dot notation.
-     * @param string|null $key The key to assign the keys from, support dot notation.
-     */
-    function pluck(iterable $array, string $value, ?string $key = null): array
-    {
-        $array = to_array($array);
+    return $result;
+}
 
-        $results = [];
+/**
+ * Gets the value identified by the specified `$key`, or `$default` if no such value exists.
+ * @return mixed|ImmutableArray
+ */
+function get_by_key(iterable $array, int|string $key, mixed $default = null): mixed
+{
+    $value = to_array($array);
 
-        foreach ($array as $item) {
-            if (! is_array($item)) {
-                continue;
-            }
-
-            $itemValue = get_by_key($item, $value);
-
-            /**
-             * Perform basic pluck if no key is given.
-             * Otherwise, also pluck the key as well.
-             */
-            if (is_null($key)) {
-                $results[] = $itemValue;
-            } else {
-                $itemKey = get_by_key($item, $key);
-                $results[$itemKey] = $itemValue;
-            }
-        }
-
-        return $results;
+    if (isset($value[$key])) {
+        return is_array($value[$key])
+            ? new ImmutableArray($value[$key])
+            : $value[$key];
     }
 
-    /**
-     * Returns a new array with the specified values prepended.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param TValue $values
-     */
-    function prepend(iterable $array, mixed ...$values): array
-    {
-        $array = to_array($array);
+    $keys = is_int($key)
+        ? [$key]
+        : explode('.', $key);
 
-        foreach (array_reverse($values) as $value) {
-            $array = [$value, ...$array];
-        }
-
-        return $array;
-    }
-
-    /**
-     * Appends the specified values to the array.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param TValue $values
-     */
-    function append(iterable $array, mixed ...$values): array
-    {
-        $array = to_array($array);
-
-        foreach ($values as $value) {
-            $array = [...$array, $value];
-        }
-
-        return $array;
-    }
-
-    /**
-     * Appends the specified value to the array.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param TValue $value
-     */
-    function push(iterable $array, mixed $value): array
-    {
-        $array = to_array($array);
-        $array[] = $value;
-
-        return $array;
-    }
-
-    /**
-     * Pads the array to the specified size with a value.
-     */
-    function pad(iterable $array, int $size, mixed $value): array
-    {
-        $array = to_array($array);
-
-        return array_pad($array, $size, $value);
-    }
-
-    /**
-     * Reverses the keys and values of the array.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @return array<TValue&array-key, TKey>
-     */
-    function flip(iterable $array): array
-    {
-        $array = to_array($array);
-
-        return array_flip($array);
-    }
-
-    /**
-     * Returns a new array with only unique items from the original array.
-     *
-     * @param string|null|Closure $key The key to use as the uniqueness criteria in nested arrays.
-     * @param bool $shouldBeStrict Whether the comparison should be strict, only used when giving a key parameter.
-     */
-    function unique(iterable $array, null|Closure|string $key = null, bool $shouldBeStrict = false): array
-    {
-        $array = to_array($array);
-
-        if (is_null($key) && $shouldBeStrict === false) {
-            return array_unique($array, flags: SORT_REGULAR);
-        }
-
-        $uniqueItems = [];
-        $uniqueFilteredValues = [];
-
-        foreach ($array as $item) {
-            // Ensure we don't check raw values with key filter
-            if (! is_null($key) && ! is_array($item) && ! $key instanceof Closure) {
-                continue;
-            }
-
-            $filterValue = match ($key instanceof Closure) {
-                true => $key($item, $array),
-                false => is_array($item)
-                    ? get_by_key($item, $key)
-                    : $item,
-            };
-
-            if (is_null($filterValue)) {
-                continue;
-            }
-
-            if (in_array($filterValue, $uniqueFilteredValues, strict: $shouldBeStrict)) {
-                continue;
-            }
-
-            $uniqueItems[] = $item;
-            $uniqueFilteredValues[] = $filterValue;
-        }
-
-        return $uniqueItems;
-    }
-
-    /**
-     * Returns a copy of the given array with only the items that are not present in any of the given arrays.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param array<TKey, TValue> ...$arrays
-     */
-    function diff(iterable $array, array ...$arrays): array
-    {
-        return array_diff(to_array($array), ...$arrays);
-    }
-
-    /**
-     * Returns a new array with only the items whose keys are not present in any of the given arrays.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param array<TKey, TValue> ...$arrays
-     */
-    function diff_keys(iterable $array, array ...$arrays): array
-    {
-        return array_diff_key(to_array($array), ...$arrays);
-    }
-
-    /**
-     * Returns a copy of the given array with only the items that are present in all of the given arrays.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param array<TKey, TValue> ...$arrays
-     */
-    function intersect(iterable $array, array ...$arrays): array
-    {
-        return array_intersect(to_array($array), ...$arrays);
-    }
-
-    /**
-     * Returns a copy of the given array with only the items whose keys are present in all of the given arrays.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param array<TKey, TValue> ...$arrays
-     */
-    function intersect_keys(iterable $array, array ...$arrays): array
-    {
-        return array_intersect_key(to_array($array), ...$arrays);
-    }
-
-    /**
-     * Merges the array with the given arrays.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param array<TKey, TValue> ...$arrays The arrays to merge.
-     */
-    function merge(iterable $array, iterable ...$arrays): array
-    {
-        return array_merge(to_array($array), ...array_map(to_array(...), $arrays));
-    }
-
-    /**
-     * Creates a new array with this current array values as keys and the given values as values.
-     *
-     * @template TCombineValue
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param iterable<array-key, TCombineValue> $values
-     *
-     * @return array<array-key, TCombineValue>
-     */
-    function combine(iterable $array, iterable $values): array
-    {
-        $array = to_array($array);
-        $values = to_array($values);
-
-        if (count($array) !== count($values)) {
-            throw new InvalidArgumentException(
-                sprintf('Cannot combine arrays of different lengths (%d keys vs %d values)', count($array), count($values)),
-            );
-        }
-
-        return array_combine($array, $values);
-    }
-
-    /**
-     * Asserts whether the given `$array` is equal to `$other` array.
-     */
-    function equals(iterable $array, iterable $other): bool
-    {
-        $array = to_array($array);
-        $other = to_array($other);
-
-        return $array === $other;
-    }
-
-    /**
-     * Returns the first item in the array that matches the given `$filter`.
-     * If `$filter` is `null`, returns the first item.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param null|Closure(TValue $value, TKey $key): bool $filter
-     *
-     * @return TValue
-     */
-    function first(iterable $array, ?Closure $filter = null, mixed $default = null): mixed
-    {
-        $array = to_array($array);
-
-        if ($array === []) {
+    foreach ($keys as $key) {
+        if (! is_array($value) && ! $value instanceof \ArrayAccess) {
             return $default;
         }
 
-        if ($filter === null) {
-            return $array[array_key_first($array)] ?? $default;
-        }
-
-        return array_find($array, static fn ($value, $key) => $filter($value, $key)) ?? $default;
-    }
-
-    /**
-     * Returns the item at the given index in the specified array.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     *
-     * @return TValue
-     */
-    function at(iterable $array, int $index, mixed $default = null): mixed
-    {
-        $array = to_array($array);
-
-        if ($index < 0) {
-            $index = abs($index) - 1;
-            $array = namespace\reverse($array);
-        }
-
-        return namespace\get_by_key(array_values($array), key: $index, default: $default);
-    }
-
-    /**
-     * Returns the last item in the array that matches the given `$filter`.
-     * If `$filter` is `null`, returns the last item.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param null|Closure(TValue $value, TKey $key): bool $filter
-     *
-     * @return TValue
-     */
-    function last(iterable $array, ?Closure $filter = null, mixed $default = null): mixed
-    {
-        $array = to_array($array);
-
-        if ($array === []) {
+        if (! isset($value[$key])) {
             return $default;
         }
 
-        if ($filter === null) {
-            return $array[array_key_last($array)] ?? $default;
-        }
-
-        return array_find(namespace\reverse($array), static fn ($value, $key) => $filter($value, $key)) ?? $default;
+        $value = $value[$key];
     }
 
-    /**
-     * Returns a copy of the given array without the last value.
-     *
-     * @param mixed $value The popped value will be stored in this variable.
-     */
-    function pop(iterable $array, mixed &$value = null): array
-    {
-        $array = to_array($array);
-        $value = namespace\last($array);
-
-        return array_slice($array, 0, -1);
+    if (is_array($value)) {
+        return new ImmutableArray($value);
     }
 
-    /**
-     * Returns a copy of the given array without the first value.
-     *
-     * @param mixed $value The unshifted value will be stored in this variable
-     */
-    function unshift(iterable $array, mixed &$value = null): array
-    {
-        $array = to_array($array);
-        $value = namespace\first($array);
+    return $value;
+}
 
-        return array_slice($array, 1);
-    }
+/**
+ * Asserts whether a value identified by the specified `$key` exists. Dot notation is supported.
+ */
+function has_key(iterable $array, int|string $key): bool
+{
+    $array = to_array($array);
 
-    /**
-     * Returns a copy of the given array in reverse order.
-     */
-    function reverse(iterable $array): array
-    {
-        return array_reverse(to_array($array));
-    }
-
-    /**
-     * Asserts whether the array is empty.
-     */
-    function is_empty(iterable $array): bool
-    {
-        return to_array($array) === [];
-    }
-
-    /**
-     * Returns an instance of {@see \Tempest\Support\Str\ImmutableString} with the values of the array joined with the given `$glue`.
-     */
-    function implode(iterable $array, string $glue): ImmutableString
-    {
-        return new ImmutableString(\implode($glue, to_array($array)));
-    }
-
-    /**
-     * Returns a copy of the given array with the keys of this array as values.
-     */
-    function keys(iterable $array): array
-    {
-        return array_keys(to_array($array));
-    }
-
-    /**
-     * Returns a copy of the given array without its keys.
-     */
-    function values(iterable $array): array
-    {
-        return array_values(to_array($array));
-    }
-
-    /**
-     * Returns a copy of the given array with only the items that pass the given `$filter`.
-     * If `$filter` is `null`, the new array will contain only values that are not `false` or `null`.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param null|Closure(TValue $value, TKey $key): bool $filter
-     */
-    function filter(iterable $array, ?Closure $filter = null): array
-    {
-        $result = [];
-        $filter ??= static fn (mixed $value, mixed $_) => ! in_array($value, [false, null], strict: true);
-
-        foreach (to_array($array) as $key => $value) {
-            if ($filter($value, $key)) {
-                $result[$key] = $value;
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * Applies the given callback to all items of the array.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param Closure(TKey $value, TValue $key): void $each
-     */
-    function each(iterable $array, Closure $each): array
-    {
-        $array = to_array($array);
-
-        foreach ($array as $key => $value) {
-            $each($value, $key);
-        }
-
-        return $array;
-    }
-
-    /**
-     * Returns a copy of the given array with each item transformed by the given callback.
-     *
-     * @template TMapValue
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param Closure(TValue, TKey): TMapValue $map
-     *
-     * @return array<TKey, TMapValue>
-     */
-    function map_iterable(iterable $array, Closure $map): array
-    {
-        $result = [];
-
-        foreach (to_array($array) as $key => $value) {
-            $result[$key] = $map($value, $key);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Returns a copy of the given array with each item transformed by the given callback.
-     * The callback must return a generator, associating a key and a value.
-     *
-     * ### Example
-     * ```php
-     * map_with_keys(['a', 'b'], fn (mixed $value, mixed $key) => yield $key => $value);
-     * ```
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param Closure(TValue $value, TKey $key): Generator $map
-     */
-    function map_with_keys(iterable $array, Closure $map): array
-    {
-        $result = [];
-
-        foreach (to_array($array) as $key => $value) {
-            $generator = $map($value, $key);
-
-            // @phpstan-ignore instanceof.alwaysTrue
-            if (! $generator instanceof Generator) {
-                throw new MapWithKeysDidNotUseAGenerator();
-            }
-
-            $result[$generator->key()] = $generator->current();
-        }
-
-        return $result;
-    }
-
-    /**
-     * Gets the value identified by the specified `$key`, or `$default` if no such value exists.
-     * @return mixed|ImmutableArray
-     */
-    function get_by_key(iterable $array, int|string $key, mixed $default = null): mixed
-    {
-        $value = to_array($array);
-
-        if (isset($value[$key])) {
-            return is_array($value[$key])
-                ? new ImmutableArray($value[$key])
-                : $value[$key];
-        }
-
-        $keys = is_int($key)
-            ? [$key]
-            : explode('.', $key);
-
-        foreach ($keys as $key) {
-            if (! is_array($value) && ! $value instanceof \ArrayAccess) {
-                return $default;
-            }
-
-            if (! isset($value[$key])) {
-                return $default;
-            }
-
-            $value = $value[$key];
-        }
-
-        if (is_array($value)) {
-            return new ImmutableArray($value);
-        }
-
-        return $value;
-    }
-
-    /**
-     * Asserts whether a value identified by the specified `$key` exists. Dot notation is supported.
-     */
-    function has_key(iterable $array, int|string $key): bool
-    {
-        $array = to_array($array);
-
-        if (isset($array[$key])) {
-            return true;
-        }
-
-        $keys = is_int($key)
-            ? [$key]
-            : explode('.', $key);
-
-        foreach ($keys as $key) {
-            if (! isset($array[$key])) {
-                return false;
-            }
-
-            $array = &$array[$key];
-        }
-
+    if (isset($array[$key])) {
         return true;
     }
 
-    /**
-     * Asserts whether the given array contains a value that can be identified by `$search`.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param TValue|Closure(TValue, TKey): bool $search
-     */
-    function contains(iterable $array, mixed $search): bool
-    {
-        $array = to_array($array);
-        $search = $search instanceof Closure
-            ? $search
-            : static fn (mixed $value) => $value === $search;
+    $keys = is_int($key)
+        ? [$key]
+        : explode('.', $key);
 
-        return array_any($array, static fn ($value, $key) => $search($value, $key));
+    foreach ($keys as $key) {
+        if (! isset($array[$key])) {
+            return false;
+        }
+
+        $array = &$array[$key];
     }
 
-    /**
-     * Asserts whether all items in the given array pass the given `$callback`.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param Closure(TValue, TKey): bool $callback
-     *
-     * @return bool If the collection is empty, returns `true`.
-     */
-    function every(iterable $array, ?Closure $callback = null): bool
-    {
-        $array = to_array($array);
-        $callback ??= static fn (mixed $value) => ! is_null($value);
+    return true;
+}
 
-        return array_all($array, static fn (mixed $value, int|string $key) => $callback($value, $key));
+/**
+ * Asserts whether the given array contains a value that can be identified by `$search`.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param TValue|Closure(TValue, TKey): bool $search
+ */
+function contains(iterable $array, mixed $search): bool
+{
+    $array = to_array($array);
+    $search = $search instanceof Closure
+        ? $search
+        : static fn (mixed $value) => $value === $search;
+
+    return array_any($array, static fn ($value, $key) => $search($value, $key));
+}
+
+/**
+ * Asserts whether all items in the given array pass the given `$callback`.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param Closure(TValue, TKey): bool $callback
+ *
+ * @return bool If the collection is empty, returns `true`.
+ */
+function every(iterable $array, ?Closure $callback = null): bool
+{
+    $array = to_array($array);
+    $callback ??= static fn (mixed $value) => ! is_null($value);
+
+    return array_all($array, static fn (mixed $value, int|string $key) => $callback($value, $key));
+}
+
+/**
+ * Returns a copy of the array with the given `$value` associated to the given `$key`.
+ */
+function set_by_key(iterable $array, string $key, mixed $value): array
+{
+    $array = to_array($array);
+    $current = &$array;
+    $keys = explode('.', $key);
+
+    foreach ($keys as $i => $key) {
+        // If this is the last key in dot notation, we don't
+        // need to go through the next steps.
+        if (count($keys) === 1) {
+            break;
+        }
+
+        // Remove the current key from our keys array
+        // so that later we can use the first value
+        // from that array as our key.
+        unset($keys[$i]);
+
+        // If we know this key is not an array, make it one.
+        if (! isset($current[$key]) || ! is_array($current[$key])) {
+            $current[$key] = [];
+        }
+
+        // Set the context to this key.
+        $current = &$current[$key];
     }
 
-    /**
-     * Returns a copy of the array with the given `$value` associated to the given `$key`.
-     */
-    function set_by_key(iterable $array, string $key, mixed $value): array
-    {
-        $array = to_array($array);
-        $current = &$array;
+    // Pull the first key out of the array
+    // and use it to set the value.
+    $current[array_shift($keys)] = $value;
+
+    return $array;
+}
+
+/**
+ * Returns a copy of the array that converts the dot-notated keys to a set of nested arrays.
+ */
+function undot(iterable $array): array
+{
+    $array = to_array($array);
+
+    $unwrapValue = function (string|int $key, mixed $value) {
+        if (is_int($key)) {
+            return [$key => $value];
+        }
+
         $keys = explode('.', $key);
 
-        foreach ($keys as $i => $key) {
-            // If this is the last key in dot notation, we don't
-            // need to go through the next steps.
-            if (count($keys) === 1) {
-                break;
-            }
+        for ($i = array_key_last($keys); $i >= 0; $i--) {
+            $currentKey = $keys[$i];
 
-            // Remove the current key from our keys array
-            // so that later we can use the first value
-            // from that array as our key.
-            unset($keys[$i]);
-
-            // If we know this key is not an array, make it one.
-            if (! isset($current[$key]) || ! is_array($current[$key])) {
-                $current[$key] = [];
-            }
-
-            // Set the context to this key.
-            $current = &$current[$key];
+            $value = [$currentKey => $value];
         }
 
-        // Pull the first key out of the array
-        // and use it to set the value.
-        $current[array_shift($keys)] = $value;
+        return $value;
+    };
 
-        return $array;
+    $unwrapped = [];
+
+    foreach ($array as $key => $value) {
+        $unwrapped[] = $unwrapValue($key, $value);
     }
 
-    /**
-     * Returns a copy of the array that converts the dot-notated keys to a set of nested arrays.
-     */
-    function undot(iterable $array): array
-    {
-        $array = to_array($array);
+    return array_merge_recursive(...$unwrapped);
+}
 
-        $unwrapValue = function (string|int $key, mixed $value) {
-            if (is_int($key)) {
-                return [$key => $value];
-            }
+/**
+ * Returns a copy of the array that converts nested arrays to a single-dimension dot-notation array.
+ */
+function dot(iterable $array, string $prefix = ''): array
+{
+    $array = to_array($array);
 
-            $keys = explode('.', $key);
+    $result = [];
 
-            for ($i = array_key_last($keys); $i >= 0; $i--) {
-                $currentKey = $keys[$i];
-
-                $value = [$currentKey => $value];
-            }
-
-            return $value;
-        };
-
-        $unwrapped = [];
-
-        foreach ($array as $key => $value) {
-            $unwrapped[] = $unwrapValue($key, $value);
-        }
-
-        return array_merge_recursive(...$unwrapped);
-    }
-
-    /**
-     * Returns a copy of the array that converts nested arrays to a single-dimension dot-notation array.
-     */
-    function dot(iterable $array, string $prefix = ''): array
-    {
-        $array = to_array($array);
-
-        $result = [];
-
-        foreach ($array as $key => $value) {
-            if (is_array($value)) {
-                $result = [...$result, ...dot($value, $prefix . $key . '.')];
-            } else {
-                $result[$prefix . $key] = $value;
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * Joins all values using the specified `$glue`. The last item of the string is separated by `$finalGlue`.
-     */
-    function join(iterable $array, string $glue = ', ', ?string $finalGlue = ' and '): ImmutableString
-    {
-        $array = to_array($array);
-
-        if ($finalGlue === '' || is_null($finalGlue)) {
-            return namespace\implode($array, $glue);
-        }
-
-        if (namespace\is_empty($array)) {
-            return new ImmutableString('');
-        }
-
-        $parts = namespace\pop($array, $last);
-
-        if (! namespace\is_empty($parts)) {
-            return namespace\implode($parts, $glue)->append($finalGlue, $last);
-        }
-
-        return new ImmutableString($last);
-    }
-
-    /**
-     * Returns a copy of the array flattened to a single level, or until the specified `$depth` is reached.
-     *
-     * ### Example
-     * ```php
-     * flatten(['foo', ['bar', 'baz']]); // ['foo', 'bar', 'baz']
-     * ```
-     */
-    function flatten(iterable $array, int|float $depth = INF): array
-    {
-        $array = to_array($array);
-        $result = [];
-
-        foreach ($array as $item) {
-            if (! is_array($item)) {
-                $result[] = $item;
-
-                continue;
-            }
-
-            $values = $depth === 1
-                ? namespace\values($item)
-                : namespace\flatten($item, $depth - 1);
-
-            foreach ($values as $value) {
-                $result[] = $value;
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * Returns a copy of the array grouped by the result of the given `$keyExtractor`.
-     * The keys of the resulting array are the values returned by the `$keyExtractor`.
-     *
-     * ### Example
-     * ```php
-     * group_by(
-     * [
-     * ['country' => 'france', 'continent' => 'europe'],
-     * ['country' => 'Sweden', 'continent' => 'europe'],
-     * ['country' => 'USA', 'continent' => 'america']
-     * ],
-     * fn($item) => $item['continent']
-     * );
-     * // [
-     * //     'europe' => [
-     * //         ['country' => 'france', 'continent' => 'europe'],
-     * //         ['country' => 'Sweden', 'continent' => 'europe']
-     * //     ],
-     * //     'america' => [
-     * //         ['country' => 'USA', 'continent' => 'america']
-     * //     ]
-     * // ]
-     * ```
-     *
-     * @template TKey of array-key
-     * @template TValue
-     * @param iterable<TKey,TValue> $array
-     * @param Closure(TValue, TKey): array-key $keyExtracor
-     */
-    function group_by(iterable $array, Closure $keyExtracor): array
-    {
-        $array = to_array($array);
-
-        $result = [];
-
-        foreach ($array as $key => $item) {
-            $key = $keyExtracor($item, $key);
-
-            $result[$key][] = $item;
-        }
-
-        return $result;
-    }
-
-    /**
-     * Returns a copy of the given array, with each item transformed by the given callback, then flattens it by the specified depth.
-     *
-     * @template TMapValue
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param Closure(TValue,TKey): TMapValue[] $map
-     *
-     * @return array<TKey,TMapValue>
-     */
-    function flat_map(iterable $array, Closure $map, int|float $depth = 1): array
-    {
-        return namespace\flatten(namespace\map_iterable(to_array($array), $map), $depth);
-    }
-
-    /**
-     * Returns a new array with the value of the given array mapped to the given object.
-     *
-     * @see Tempest\Mapper\map()
-     *
-     * @template T
-     * @param class-string<T> $to
-     */
-    function map_to(iterable $array, string $to): array
-    {
-        return Mapper\map(to_array($array))->collection()->to($to);
-    }
-
-    /**
-     * Returns a copy of the given array sorted by its values.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param bool $desc Sorts in descending order if `true`; defaults to `false` (ascending).
-     * @param bool|null $preserveKeys Preserves array keys if `true`; reindexes numerically if `false`.
-     *                                Defaults to `null`, which auto-detects preservation based on array type  (associative or list).
-     * @param int $flags Sorting flags to define comparison behavior, defaulting to `SORT_REGULAR`.
-     * @return array<array-key, TValue> Key type depends on whether array keys are preserved or not.
-     */
-    function sort(iterable $array, bool $desc = false, ?bool $preserveKeys = null, int $flags = SORT_REGULAR): array
-    {
-        $array = to_array($array);
-
-        if ($preserveKeys === null) {
-            $preserveKeys = is_associative($array);
-        }
-
-        if ($preserveKeys) {
-            $desc ? arsort($array, $flags) : asort($array, $flags);
+    foreach ($array as $key => $value) {
+        if (is_array($value)) {
+            $result = [...$result, ...dot($value, $prefix . $key . '.')];
         } else {
-            $desc ? rsort($array, $flags) : php_sort($array, $flags);
+            $result[$prefix . $key] = $value;
+        }
+    }
+
+    return $result;
+}
+
+/**
+ * Joins all values using the specified `$glue`. The last item of the string is separated by `$finalGlue`.
+ */
+function join(iterable $array, string $glue = ', ', ?string $finalGlue = ' and '): ImmutableString
+{
+    $array = to_array($array);
+
+    if ($finalGlue === '' || is_null($finalGlue)) {
+        return namespace\implode($array, $glue);
+    }
+
+    if (namespace\is_empty($array)) {
+        return new ImmutableString('');
+    }
+
+    $parts = namespace\pop($array, $last);
+
+    if (! namespace\is_empty($parts)) {
+        return namespace\implode($parts, $glue)->append($finalGlue, $last);
+    }
+
+    return new ImmutableString($last);
+}
+
+/**
+ * Returns a copy of the array flattened to a single level, or until the specified `$depth` is reached.
+ *
+ * ### Example
+ * ```php
+ * flatten(['foo', ['bar', 'baz']]); // ['foo', 'bar', 'baz']
+ * ```
+ */
+function flatten(iterable $array, int|float $depth = INF): array
+{
+    $array = to_array($array);
+    $result = [];
+
+    foreach ($array as $item) {
+        if (! is_array($item)) {
+            $result[] = $item;
+
+            continue;
         }
 
-        return $array;
-    }
+        $values = $depth === 1
+            ? namespace\values($item)
+            : namespace\flatten($item, $depth - 1);
 
-    /**
-     * Returns a copy of the given array sorted by its values using a callback function.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param \Closure(TValue $a, TValue $b) $callback The function to use for comparing values. It should accept two parameters and return an integer less than, equal to, or greater than zero if the first argument is considered to be respectively less than, equal to, or greater than the second.
-     * @param bool|null $preserveKeys Preserves array keys if `true`; reindexes numerically if `false`. Defaults to `null`, which auto-detects preservation based on array type (associative or list).
-     * @return array<array-key, TValue> Key type depends on whether array keys are preserved or not.
-     */
-    function sort_by_callback(iterable $array, callable $callback, ?bool $preserveKeys = null): array
-    {
-        $array = to_array($array);
-
-        if ($preserveKeys === null) {
-            $preserveKeys = is_associative($array);
+        foreach ($values as $value) {
+            $result[] = $value;
         }
-
-        $preserveKeys ? uasort($array, $callback) : usort($array, $callback);
-
-        return $array;
     }
 
-    /**
-     * Returns a copy of the given array sorted by its keys.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param bool $desc Sorts in descending order if `true`; defaults to `false` (ascending).
-     * @param int $flags Sorting flags to define comparison behavior, defaulting to `SORT_REGULAR`.
-     * @return array<TKey, TValue>
-     */
-    function sort_keys(iterable $array, bool $desc = false, int $flags = SORT_REGULAR): array
-    {
-        $array = to_array($array);
+    return $result;
+}
 
-        $desc ? krsort($array, $flags) : ksort($array, $flags);
+/**
+ * Returns a copy of the array grouped by the result of the given `$keyExtractor`.
+ * The keys of the resulting array are the values returned by the `$keyExtractor`.
+ *
+ * ### Example
+ * ```php
+ * group_by(
+ * [
+ * ['country' => 'france', 'continent' => 'europe'],
+ * ['country' => 'Sweden', 'continent' => 'europe'],
+ * ['country' => 'USA', 'continent' => 'america']
+ * ],
+ * fn($item) => $item['continent']
+ * );
+ * // [
+ * //     'europe' => [
+ * //         ['country' => 'france', 'continent' => 'europe'],
+ * //         ['country' => 'Sweden', 'continent' => 'europe']
+ * //     ],
+ * //     'america' => [
+ * //         ['country' => 'USA', 'continent' => 'america']
+ * //     ]
+ * // ]
+ * ```
+ *
+ * @template TKey of array-key
+ * @template TValue
+ * @param iterable<TKey,TValue> $array
+ * @param Closure(TValue, TKey): array-key $keyExtracor
+ */
+function group_by(iterable $array, Closure $keyExtracor): array
+{
+    $array = to_array($array);
 
-        return $array;
+    $result = [];
+
+    foreach ($array as $key => $item) {
+        $key = $keyExtracor($item, $key);
+
+        $result[$key][] = $item;
     }
 
-    /**
-     * Returns a copy of the given array sorted by its keys using a callback function.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $array
-     * @param callable $callback The function to use for comparing keys. It should accept two parameters
-     *                           and return an integer less than, equal to, or greater than zero if the
-     *                           first argument is considered to be respectively less than, equal to, or
-     *                           greater than the second.
-     * @return array<TKey, TValue>
-     */
-    function sort_keys_by_callback(iterable $array, callable $callback): array
-    {
-        $array = to_array($array);
+    return $result;
+}
 
-        uksort($array, $callback);
+/**
+ * Returns a copy of the given array, with each item transformed by the given callback, then flattens it by the specified depth.
+ *
+ * @template TMapValue
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param Closure(TValue,TKey): TMapValue[] $map
+ *
+ * @return array<TKey,TMapValue>
+ */
+function flat_map(iterable $array, Closure $map, int|float $depth = 1): array
+{
+    return namespace\flatten(namespace\map_iterable(to_array($array), $map), $depth);
+}
 
-        return $array;
+/**
+ * Returns a new array with the value of the given array mapped to the given object.
+ *
+ * @see Tempest\Mapper\map()
+ *
+ * @template T
+ * @param class-string<T> $to
+ */
+function map_to(iterable $array, string $to): array
+{
+    return Mapper\map(to_array($array))->collection()->to($to);
+}
+
+/**
+ * Returns a copy of the given array sorted by its values.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param bool $desc Sorts in descending order if `true`; defaults to `false` (ascending).
+ * @param bool|null $preserveKeys Preserves array keys if `true`; reindexes numerically if `false`.
+ *                                Defaults to `null`, which auto-detects preservation based on array type  (associative or list).
+ * @param int $flags Sorting flags to define comparison behavior, defaulting to `SORT_REGULAR`.
+ * @return array<array-key, TValue> Key type depends on whether array keys are preserved or not.
+ */
+function sort(iterable $array, bool $desc = false, ?bool $preserveKeys = null, int $flags = SORT_REGULAR): array
+{
+    $array = to_array($array);
+
+    if ($preserveKeys === null) {
+        $preserveKeys = is_associative($array);
     }
 
-    /**
-     * Extracts a part of the array.
-     *
-     * ### Example
-     * ```php
-     * slice([1, 2, 3, 4, 5], 2); // [3, 4, 5]
-     * ```
-     */
-    function slice(iterable $array, int $offset, ?int $length = null): array
-    {
-        $array = to_array($array);
-        $length ??= count($array) - $offset;
-
-        return array_slice($array, $offset, $length);
+    if ($preserveKeys) {
+        $desc ? arsort($array, $flags) : asort($array, $flags);
+    } else {
+        $desc ? rsort($array, $flags) : php_sort($array, $flags);
     }
 
-    /**
-     * Returns a new list containing the range of numbers from `$start` to `$end`
-     * inclusive, with the step between elements being `$step` if provided, or 1 by
-     * default.
-     *
-     * If `$start > $end`, it returns a descending range instead of an empty one.
-     *
-     * Examples:
-     *
-     *     range(0, 5)
-     *     => array(0, 1, 2, 3, 4, 5)
-     *
-     *     range(5, 0)
-     *     => array(5, 4, 3, 2, 1, 0)
-     *
-     *     range(0.0, 3.0, 0.5)
-     *     => array(0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0)
-     *
-     *     range(3.0, 0.0, -0.5)
-     *     => array(3.0, 2.5, 2.0, 1.5, 1.0, 0.5, 0.0)
-     *
-     * @template T of int|float
-     *
-     * @param T $start
-     * @param T $end
-     * @param T|null $step
-     *
-     * @throws LogicException If $start < $end, and $step is negative.
-     *
-     * @return non-empty-list<T>
-     */
-    function range(int|float $start, int|float $end, int|float|null $step = null): array
-    {
-        if ((float) $start === (float) $end) {
-            return [$start];
-        }
+    return $array;
+}
 
-        if ($start < $end) {
-            if (null === $step) {
-                /** @var T $step */
-                $step = 1;
-            }
+/**
+ * Returns a copy of the given array sorted by its values using a callback function.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param \Closure(TValue $a, TValue $b) $callback The function to use for comparing values. It should accept two parameters and return an integer less than, equal to, or greater than zero if the first argument is considered to be respectively less than, equal to, or greater than the second.
+ * @param bool|null $preserveKeys Preserves array keys if `true`; reindexes numerically if `false`. Defaults to `null`, which auto-detects preservation based on array type (associative or list).
+ * @return array<array-key, TValue> Key type depends on whether array keys are preserved or not.
+ */
+function sort_by_callback(iterable $array, callable $callback, ?bool $preserveKeys = null): array
+{
+    $array = to_array($array);
 
-            if ($step < 0) {
-                throw new LogicException('If $end is greater than $start, then $step must be positive or null.');
-            }
+    if ($preserveKeys === null) {
+        $preserveKeys = is_associative($array);
+    }
 
-            $result = [];
+    $preserveKeys ? uasort($array, $callback) : usort($array, $callback);
 
-            /**
-             * @var int|float $start
-             * @var int|float $step
-             */
-            for ($i = $start; $i <= $end; $i += $step) {
-                $result[] = $i;
-            }
+    return $array;
+}
 
-            return $result;
-        }
+/**
+ * Returns a copy of the given array sorted by its keys.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param bool $desc Sorts in descending order if `true`; defaults to `false` (ascending).
+ * @param int $flags Sorting flags to define comparison behavior, defaulting to `SORT_REGULAR`.
+ * @return array<TKey, TValue>
+ */
+function sort_keys(iterable $array, bool $desc = false, int $flags = SORT_REGULAR): array
+{
+    $array = to_array($array);
 
+    $desc ? krsort($array, $flags) : ksort($array, $flags);
+
+    return $array;
+}
+
+/**
+ * Returns a copy of the given array sorted by its keys using a callback function.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param iterable<TKey,TValue> $array
+ * @param callable $callback The function to use for comparing keys. It should accept two parameters
+ *                           and return an integer less than, equal to, or greater than zero if the
+ *                           first argument is considered to be respectively less than, equal to, or
+ *                           greater than the second.
+ * @return array<TKey, TValue>
+ */
+function sort_keys_by_callback(iterable $array, callable $callback): array
+{
+    $array = to_array($array);
+
+    uksort($array, $callback);
+
+    return $array;
+}
+
+/**
+ * Extracts a part of the array.
+ *
+ * ### Example
+ * ```php
+ * slice([1, 2, 3, 4, 5], 2); // [3, 4, 5]
+ * ```
+ */
+function slice(iterable $array, int $offset, ?int $length = null): array
+{
+    $array = to_array($array);
+    $length ??= count($array) - $offset;
+
+    return array_slice($array, $offset, $length);
+}
+
+/**
+ * Returns a new list containing the range of numbers from `$start` to `$end`
+ * inclusive, with the step between elements being `$step` if provided, or 1 by
+ * default.
+ *
+ * If `$start > $end`, it returns a descending range instead of an empty one.
+ *
+ * Examples:
+ *
+ *     range(0, 5)
+ *     => array(0, 1, 2, 3, 4, 5)
+ *
+ *     range(5, 0)
+ *     => array(5, 4, 3, 2, 1, 0)
+ *
+ *     range(0.0, 3.0, 0.5)
+ *     => array(0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0)
+ *
+ *     range(3.0, 0.0, -0.5)
+ *     => array(3.0, 2.5, 2.0, 1.5, 1.0, 0.5, 0.0)
+ *
+ * @template T of int|float
+ *
+ * @param T $start
+ * @param T $end
+ * @param T|null $step
+ *
+ * @throws LogicException If $start < $end, and $step is negative.
+ *
+ * @return non-empty-list<T>
+ */
+function range(int|float $start, int|float $end, int|float|null $step = null): array
+{
+    if ((float) $start === (float) $end) {
+        return [$start];
+    }
+
+    if ($start < $end) {
         if (null === $step) {
             /** @var T $step */
-            $step = -1;
+            $step = 1;
         }
 
-        if ($step > 0) {
-            throw new LogicException('If $start is greater than $end, then $step must be negative or null.');
+        if ($step < 0) {
+            throw new LogicException('If $end is greater than $start, then $step must be positive or null.');
         }
 
         $result = [];
@@ -1288,109 +1267,130 @@ namespace Tempest\Support\Arr {
          * @var int|float $start
          * @var int|float $step
          */
-        for ($i = $start; $i >= $end; $i += $step) {
+        for ($i = $start; $i <= $end; $i += $step) {
             $result[] = $i;
         }
 
         return $result;
     }
 
-    /**
-     * Returns a pair containing lists for which the given predicate returned `true` and `false`, respectively.
-     *
-     * @template T
-     *
-     * @param iterable<T> $iterable
-     * @param (Closure(T): bool) $predicate
-     *
-     * @return array{0: array<T>, 1: array<T>}
-     */
-    function partition(iterable $iterable, Closure $predicate): array
-    {
-        $success = [];
-        $failure = [];
-
-        foreach ($iterable as $value) {
-            if ($predicate($value)) {
-                $success[] = $value;
-                continue;
-            }
-
-            $failure[] = $value;
-        }
-
-        return [$success, $failure];
+    if (null === $step) {
+        /** @var T $step */
+        $step = -1;
     }
 
+    if ($step > 0) {
+        throw new LogicException('If $start is greater than $end, then $step must be negative or null.');
+    }
+
+    $result = [];
+
     /**
-     * Wraps the specified `$input` into an array. If the `$input` is already an array, it is returned.
-     * As opposed to {@see \Tempest\Support\Arr\to_array}, this function does not convert {@see Traversable} and {@see Countable} instances to arrays.
-     *
-     * @template TKey of array-key
-     * @template TValue
-     * @param null|array<TKey,TValue>|ArrayInterface<TKey,TValue>|TValue $input
-     * @return array<TKey,TValue>
+     * @var int|float $start
+     * @var int|float $step
      */
-    function wrap(mixed $input = []): array
-    {
-        if (is_array($input)) {
-            return $input;
+    for ($i = $start; $i >= $end; $i += $step) {
+        $result[] = $i;
+    }
+
+    return $result;
+}
+
+/**
+ * Returns a pair containing lists for which the given predicate returned `true` and `false`, respectively.
+ *
+ * @template T
+ *
+ * @param iterable<T> $iterable
+ * @param (Closure(T): bool) $predicate
+ *
+ * @return array{0: array<T>, 1: array<T>}
+ */
+function partition(iterable $iterable, Closure $predicate): array
+{
+    $success = [];
+    $failure = [];
+
+    foreach ($iterable as $value) {
+        if ($predicate($value)) {
+            $success[] = $value;
+            continue;
         }
 
-        if ($input instanceof ArrayInterface) {
-            return $input->toArray();
+        $failure[] = $value;
+    }
+
+    return [$success, $failure];
+}
+
+/**
+ * Wraps the specified `$input` into an array. If the `$input` is already an array, it is returned.
+ * As opposed to {@see \Tempest\Support\Arr\to_array}, this function does not convert {@see Traversable} and {@see Countable} instances to arrays.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ * @param null|array<TKey,TValue>|ArrayInterface<TKey,TValue>|TValue $input
+ * @return array<TKey,TValue>
+ */
+function wrap(mixed $input = []): array
+{
+    if (is_array($input)) {
+        return $input;
+    }
+
+    if ($input instanceof ArrayInterface) {
+        return $input->toArray();
+    }
+
+    if ($input === null) {
+        return [];
+    }
+
+    return [$input];
+}
+
+/**
+ * Converts various data structures to a PHP array.
+ * As opposed to `{@see \Tempest\Support\Arr\wrap}`, this function converts {@see Traversable} and {@see Countable} instances to arrays.
+ *
+ * @param mixed $input Any value that can be converted to an array:
+ *                     - Arrays are returned as-is
+ *                     - Scalar values are wrapped in an array
+ *                     - Traversable objects are converted using `{@see iterator_to_array}`
+ *                     - {@see Countable} objects are converted to arrays
+ *                     - {@see null} becomes an empty array
+ */
+function to_array(mixed $input): array
+{
+    if (is_array($input)) {
+        return $input;
+    }
+
+    if ($input instanceof ArrayInterface) {
+        return $input->toArray();
+    }
+
+    if ($input instanceof Traversable) {
+        return iterator_to_array($input);
+    }
+
+    if ($input instanceof Countable) {
+        $count = count($input);
+        $result = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            if (isset($input[$i])) {
+                $result[$i] = $input[$i];
+            }
         }
 
-        if ($input === null) {
-            return [];
-        }
+        return $result;
+    }
 
+    // Scalar values (string, int, float, bool) and objects are wrapped
+    if (is_scalar($input) || is_object($input)) {
         return [$input];
     }
 
-    /**
-     * Converts various data structures to a PHP array.
-     * As opposed to `{@see \Tempest\Support\Arr\wrap}`, this function converts {@see Traversable} and {@see Countable} instances to arrays.
-     *
-     * @param mixed $input Any value that can be converted to an array:
-     *                     - Arrays are returned as-is
-     *                     - Scalar values are wrapped in an array
-     *                     - Traversable objects are converted using `{@see iterator_to_array}`
-     *                     - {@see Countable} objects are converted to arrays
-     *                     - {@see null} becomes an empty array
-     */
-    function to_array(mixed $input): array
-    {
-        if (is_array($input)) {
-            return $input;
-        }
-
-        if ($input instanceof ArrayInterface) {
-            return $input->toArray();
-        }
-
-        if ($input instanceof Traversable) {
-            return iterator_to_array($input);
-        }
-
-        if ($input instanceof Countable) {
-            $count = count($input);
-            $result = [];
-
-            for ($i = 0; $i < $count; $i++) {
-                if (isset($input[$i])) {
-                    $result[$i] = $input[$i];
-                }
-            }
-
-            return $result;
-        }
-
-        // Scalar values (string, int, float, bool) and objects are wrapped
-        if (is_scalar($input) || is_object($input)) {
-            return [$input];
-        }
-
-        return [];
-    }
+    return [];
 }

--- a/packages/support/src/Comparison/functions.php
+++ b/packages/support/src/Comparison/functions.php
@@ -1,109 +1,109 @@
 <?php
 
-namespace Tempest\Support\Comparison {
-    /**
-     * @template T
-     *
-     * @param T $a
-     * @param T $b
-     *
-     * This method can be used as a sorter callback function for Comparable items.
-     *
-     * Vec\sort($list, Comparable\sort(...))
-     */
-    function sort(mixed $a, mixed $b): int
-    {
-        return compare($a, $b)->value;
+namespace Tempest\Support\Comparison;
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ *
+ * This method can be used as a sorter callback function for Comparable items.
+ *
+ * Vec\sort($list, Comparable\sort(...))
+ */
+function sort(mixed $a, mixed $b): int
+{
+    return compare($a, $b)->value;
+}
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ */
+function not_equal(mixed $a, mixed $b): bool
+{
+    return compare($a, $b) !== Order::EQUAL;
+}
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ */
+function less(mixed $a, mixed $b): bool
+{
+    return compare($a, $b) === Order::LESS;
+}
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ */
+function less_or_equal(mixed $a, mixed $b): bool
+{
+    $order = compare($a, $b);
+
+    return $order === Order::EQUAL || $order === Order::LESS;
+}
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ */
+function greater(mixed $a, mixed $b): bool
+{
+    return compare($a, $b) === Order::GREATER;
+}
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ */
+function greater_or_equal(mixed $a, mixed $b): bool
+{
+    $order = compare($a, $b);
+
+    return $order === Order::EQUAL || $order === Order::GREATER;
+}
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ */
+function equal(mixed $a, mixed $b): bool
+{
+    return compare($a, $b) === Order::EQUAL;
+}
+
+/**
+ * @template T
+ *
+ * @param T $a
+ * @param T $b
+ *
+ * This function can compare 2 values of a similar type.
+ * When the type happens to be mixed or never, it will fall back to PHP's internal comparison rules:
+ *
+ * @link https://www.php.net/manual/en/language.operators.comparison.php
+ * @link https://www.php.net/manual/en/types.comparisons.php
+ */
+function compare(mixed $a, mixed $b): Order
+{
+    if ($a instanceof Comparable) {
+        return $a->compare($b);
     }
 
-    /**
-     * @template T
-     *
-     * @param T $a
-     * @param T $b
-     */
-    function not_equal(mixed $a, mixed $b): bool
-    {
-        return compare($a, $b) !== Order::EQUAL;
-    }
-
-    /**
-     * @template T
-     *
-     * @param T $a
-     * @param T $b
-     */
-    function less(mixed $a, mixed $b): bool
-    {
-        return compare($a, $b) === Order::LESS;
-    }
-
-    /**
-     * @template T
-     *
-     * @param T $a
-     * @param T $b
-     */
-    function less_or_equal(mixed $a, mixed $b): bool
-    {
-        $order = compare($a, $b);
-
-        return $order === Order::EQUAL || $order === Order::LESS;
-    }
-
-    /**
-     * @template T
-     *
-     * @param T $a
-     * @param T $b
-     */
-    function greater(mixed $a, mixed $b): bool
-    {
-        return compare($a, $b) === Order::GREATER;
-    }
-
-    /**
-     * @template T
-     *
-     * @param T $a
-     * @param T $b
-     */
-    function greater_or_equal(mixed $a, mixed $b): bool
-    {
-        $order = compare($a, $b);
-
-        return $order === Order::EQUAL || $order === Order::GREATER;
-    }
-
-    /**
-     * @template T
-     *
-     * @param T $a
-     * @param T $b
-     */
-    function equal(mixed $a, mixed $b): bool
-    {
-        return compare($a, $b) === Order::EQUAL;
-    }
-
-    /**
-     * @template T
-     *
-     * @param T $a
-     * @param T $b
-     *
-     * This function can compare 2 values of a similar type.
-     * When the type happens to be mixed or never, it will fall back to PHP's internal comparison rules:
-     *
-     * @link https://www.php.net/manual/en/language.operators.comparison.php
-     * @link https://www.php.net/manual/en/types.comparisons.php
-     */
-    function compare(mixed $a, mixed $b): Order
-    {
-        if ($a instanceof Comparable) {
-            return $a->compare($b);
-        }
-
-        return Order::from($a <=> $b);
-    }
+    return Order::from($a <=> $b);
 }

--- a/packages/support/src/Html/functions.php
+++ b/packages/support/src/Html/functions.php
@@ -2,206 +2,206 @@
 
 declare(strict_types=1);
 
-namespace Tempest\Support\Html {
-    use Stringable;
+namespace Tempest\Support\Html;
 
-    use function Tempest\Support\arr;
+use Stringable;
 
-    /**
-     * Determines whether the specified HTML tag is a void tag.
-     * @see https://developer.mozilla.org/en-US/docs/Glossary/Void_element
-     */
-    function is_void_tag(Stringable|string $tag): bool
-    {
-        return in_array(
+use function Tempest\Support\arr;
+
+/**
+ * Determines whether the specified HTML tag is a void tag.
+ * @see https://developer.mozilla.org/en-US/docs/Glossary/Void_element
+ */
+function is_void_tag(Stringable|string $tag): bool
+{
+    return in_array(
+        (string) $tag,
+        [
+            'area',
+            'base',
+            'br',
+            'col',
+            'embed',
+            'hr',
+            'img',
+            'input',
+            'link',
+            'meta',
+            'param',
+            'source',
+            'track',
+            'wbr',
+        ],
+        strict: true,
+    );
+}
+
+/**
+ * Determines whether the specified HTML tag is known HTML tag.
+ * @see https://developer.mozilla.org/en-US/docs/Glossary/Tag
+ */
+function is_html_tag(Stringable|string $tag): bool
+{
+    return (
+        is_void_tag($tag)
+        || in_array(
             (string) $tag,
             [
+                'a',
+                'abbr',
+                'acronym',
+                'address',
+                'applet',
                 'area',
+                'article',
+                'aside',
+                'audio',
+                'b',
                 'base',
+                'basefont',
+                'bdi',
+                'bdo',
+                'big',
+                'blockquote',
+                'body',
                 'br',
+                'button',
+                'canvas',
+                'caption',
+                'center',
+                'cite',
+                'code',
                 'col',
+                'colgroup',
+                'data',
+                'datalist',
+                'dd',
+                'del',
+                'details',
+                'dfn',
+                'dialog',
+                'dir',
+                'div',
+                'dl',
+                'dt',
+                'em',
                 'embed',
+                'fieldset',
+                'figcaption',
+                'figure',
+                'font',
+                'footer',
+                'form',
+                'frame',
+                'frameset',
+                'h1',
+                'h2',
+                'h3',
+                'h4',
+                'h5',
+                'h6',
+                'head',
+                'header',
+                'hgroup',
                 'hr',
+                'html',
+                'i',
+                'iframe',
                 'img',
                 'input',
+                'ins',
+                'kbd',
+                'label',
+                'legend',
+                'li',
                 'link',
+                'main',
+                'map',
+                'mark',
+                'menu',
                 'meta',
+                'meter',
+                'nav',
+                'noframes',
+                'noscript',
+                'object',
+                'ol',
+                'optgroup',
+                'option',
+                'output',
+                'p',
                 'param',
+                'picture',
+                'pre',
+                'progress',
+                'q',
+                'rp',
+                'rt',
+                'ruby',
+                's',
+                'samp',
+                'script',
+                'search',
+                'section',
+                'select',
+                'small',
                 'source',
+                'span',
+                'strike',
+                'strong',
+                'style',
+                'sub',
+                'summary',
+                'sup',
+                'svg',
+                'table',
+                'tbody',
+                'td',
+                'template',
+                'textarea',
+                'tfoot',
+                'th',
+                'thead',
+                'time',
+                'title',
+                'tr',
                 'track',
+                'tt',
+                'u',
+                'ul',
+                'var',
+                'video',
                 'wbr',
             ],
             strict: true,
-        );
+        )
+    );
+}
+
+function format_attributes(array $attributes = []): string
+{
+    return $attributes = arr($attributes)
+        ->filter(fn (mixed $value) => ! in_array($value, [false, null], strict: true))
+        ->map(fn (mixed $value, int|string $key) => $value === true ? $key : $key . '="' . $value . '"')
+        ->values()
+        ->implode(' ')
+        ->when(
+            condition: fn ($string) => $string->length() !== 0,
+            callback: fn ($string) => $string->prepend(' '),
+        )
+        ->toString();
+}
+
+/**
+ * Creates an HTML tag with the specified optional attributes and content.
+ */
+function create_tag(string $tag, array $attributes = [], ?string $content = null): HtmlString
+{
+    $attributes = namespace\format_attributes($attributes);
+
+    if ($content || ! is_void_tag($tag)) {
+        return new HtmlString(sprintf('<%s%s>%s</%s>', $tag, $attributes, $content ?? '', $tag));
     }
 
-    /**
-     * Determines whether the specified HTML tag is known HTML tag.
-     * @see https://developer.mozilla.org/en-US/docs/Glossary/Tag
-     */
-    function is_html_tag(Stringable|string $tag): bool
-    {
-        return (
-            is_void_tag($tag)
-            || in_array(
-                (string) $tag,
-                [
-                    'a',
-                    'abbr',
-                    'acronym',
-                    'address',
-                    'applet',
-                    'area',
-                    'article',
-                    'aside',
-                    'audio',
-                    'b',
-                    'base',
-                    'basefont',
-                    'bdi',
-                    'bdo',
-                    'big',
-                    'blockquote',
-                    'body',
-                    'br',
-                    'button',
-                    'canvas',
-                    'caption',
-                    'center',
-                    'cite',
-                    'code',
-                    'col',
-                    'colgroup',
-                    'data',
-                    'datalist',
-                    'dd',
-                    'del',
-                    'details',
-                    'dfn',
-                    'dialog',
-                    'dir',
-                    'div',
-                    'dl',
-                    'dt',
-                    'em',
-                    'embed',
-                    'fieldset',
-                    'figcaption',
-                    'figure',
-                    'font',
-                    'footer',
-                    'form',
-                    'frame',
-                    'frameset',
-                    'h1',
-                    'h2',
-                    'h3',
-                    'h4',
-                    'h5',
-                    'h6',
-                    'head',
-                    'header',
-                    'hgroup',
-                    'hr',
-                    'html',
-                    'i',
-                    'iframe',
-                    'img',
-                    'input',
-                    'ins',
-                    'kbd',
-                    'label',
-                    'legend',
-                    'li',
-                    'link',
-                    'main',
-                    'map',
-                    'mark',
-                    'menu',
-                    'meta',
-                    'meter',
-                    'nav',
-                    'noframes',
-                    'noscript',
-                    'object',
-                    'ol',
-                    'optgroup',
-                    'option',
-                    'output',
-                    'p',
-                    'param',
-                    'picture',
-                    'pre',
-                    'progress',
-                    'q',
-                    'rp',
-                    'rt',
-                    'ruby',
-                    's',
-                    'samp',
-                    'script',
-                    'search',
-                    'section',
-                    'select',
-                    'small',
-                    'source',
-                    'span',
-                    'strike',
-                    'strong',
-                    'style',
-                    'sub',
-                    'summary',
-                    'sup',
-                    'svg',
-                    'table',
-                    'tbody',
-                    'td',
-                    'template',
-                    'textarea',
-                    'tfoot',
-                    'th',
-                    'thead',
-                    'time',
-                    'title',
-                    'tr',
-                    'track',
-                    'tt',
-                    'u',
-                    'ul',
-                    'var',
-                    'video',
-                    'wbr',
-                ],
-                strict: true,
-            )
-        );
-    }
-
-    function format_attributes(array $attributes = []): string
-    {
-        return $attributes = arr($attributes)
-            ->filter(fn (mixed $value) => ! in_array($value, [false, null], strict: true))
-            ->map(fn (mixed $value, int|string $key) => $value === true ? $key : $key . '="' . $value . '"')
-            ->values()
-            ->implode(' ')
-            ->when(
-                condition: fn ($string) => $string->length() !== 0,
-                callback: fn ($string) => $string->prepend(' '),
-            )
-            ->toString();
-    }
-
-    /**
-     * Creates an HTML tag with the specified optional attributes and content.
-     */
-    function create_tag(string $tag, array $attributes = [], ?string $content = null): HtmlString
-    {
-        $attributes = namespace\format_attributes($attributes);
-
-        if ($content || ! is_void_tag($tag)) {
-            return new HtmlString(sprintf('<%s%s>%s</%s>', $tag, $attributes, $content ?? '', $tag));
-        }
-
-        return new HtmlString(sprintf('<%s%s />', $tag, $attributes));
-    }
+    return new HtmlString(sprintf('<%s%s />', $tag, $attributes));
 }

--- a/packages/support/src/Math/functions.php
+++ b/packages/support/src/Math/functions.php
@@ -1,578 +1,578 @@
 <?php
 
-namespace Tempest\Support\Math {
-    use ArithmeticError;
-    use Closure;
-    use DivisionByZeroError;
-    use Tempest\Support\Str;
+namespace Tempest\Support\Math;
 
-    use function acos as php_acos;
-    use function asin as php_asin;
-    use function atan as php_atan;
-    use function atan2 as php_atan2;
-    use function bcadd;
-    use function bccomp;
-    use function bcdiv;
-    use function bcmod;
-    use function bcmul;
-    use function bcpow;
-    use function ceil as php_ceil;
-    use function cos as php_cos;
-    use function count;
-    use function exp as php_exp;
-    use function floor as php_floor;
-    use function intdiv;
-    use function log as php_log;
-    use function round as php_round;
-    use function sin as php_sin;
-    use function sort;
-    use function sqrt as php_sqrt;
-    use function tan as php_tan;
+use ArithmeticError;
+use Closure;
+use DivisionByZeroError;
+use Tempest\Support\Str;
 
-    /**
-     * Returns the square root of the given number.
-     *
-     * @throws Exception\InvalidArgumentException If $number is negative.
-     */
-    function sqrt(float $number): float
-    {
-        if ($number < 0) {
-            throw new Exception\InvalidArgumentException('$number must be a non-negative number.');
+use function acos as php_acos;
+use function asin as php_asin;
+use function atan as php_atan;
+use function atan2 as php_atan2;
+use function bcadd;
+use function bccomp;
+use function bcdiv;
+use function bcmod;
+use function bcmul;
+use function bcpow;
+use function ceil as php_ceil;
+use function cos as php_cos;
+use function count;
+use function exp as php_exp;
+use function floor as php_floor;
+use function intdiv;
+use function log as php_log;
+use function round as php_round;
+use function sin as php_sin;
+use function sort;
+use function sqrt as php_sqrt;
+use function tan as php_tan;
+
+/**
+ * Returns the square root of the given number.
+ *
+ * @throws Exception\InvalidArgumentException If $number is negative.
+ */
+function sqrt(float $number): float
+{
+    if ($number < 0) {
+        throw new Exception\InvalidArgumentException('$number must be a non-negative number.');
+    }
+
+    return php_sqrt($number);
+}
+
+/**
+ * Returns the absolute value of the given number.
+ *
+ * @template T of int|float
+ *
+ * @param T $number
+ *
+ * @return T
+ */
+function abs(int|float $number): int|float
+{
+    return $number < 0 ? -$number : $number;
+}
+
+/**
+ * Returns the arc cosine of the given number.
+ */
+function acos(float $number): float
+{
+    return php_acos($number);
+}
+
+/**
+ * Returns the arc sine of the given number.
+ */
+function asin(float $number): float
+{
+    return php_asin($number);
+}
+
+/**
+ * Returns the tangent of the given number.
+ */
+function tan(float $number): float
+{
+    return php_tan($number);
+}
+
+/**
+ * Returns the arc tangent of the given number.
+ */
+function atan(float $number): float
+{
+    return php_atan($number);
+}
+
+/**
+ * Returns the arc tangent of the given coordinates.
+ */
+function atan2(float $y, float $x): float
+{
+    return php_atan2($y, $x);
+}
+
+/**
+ * Converts the given string in base `$from_base` to base `$to_base`, assuming
+ * letters a-z are used for digits for bases greater than 10. The conversion is
+ * done to arbitrary precision.
+ *
+ * @param non-empty-string $value
+ * @param int<2, 36> $fromBase
+ * @param int<2, 36> $toBase
+ *
+ * @throws Exception\InvalidArgumentException If the given value is invalid.
+ */
+function base_convert(string $value, int $fromBase, int $toBase): string
+{
+    $fromAlphabet = mb_substr(Str\ALPHABET_ALPHANUMERIC, 0, $fromBase);
+    $resultDecimal = '0';
+    $placeValue = bcpow((string) $fromBase, (string) (strlen($value) - 1));
+
+    foreach (str_split($value) as $digit) {
+        $digitNumeric = stripos($fromAlphabet, $digit);
+
+        if (false === $digitNumeric) {
+            throw new Exception\InvalidArgumentException(sprintf('Invalid digit %s in base %d', $digit, $fromBase));
         }
 
-        return php_sqrt($number);
+        $resultDecimal = bcadd($resultDecimal, bcmul((string) $digitNumeric, $placeValue));
+        $placeValue = bcdiv($placeValue, (string) $fromBase);
     }
 
-    /**
-     * Returns the absolute value of the given number.
-     *
-     * @template T of int|float
-     *
-     * @param T $number
-     *
-     * @return T
-     */
-    function abs(int|float $number): int|float
-    {
-        return $number < 0 ? -$number : $number;
+    if (10 === $toBase) {
+        return $resultDecimal;
     }
 
-    /**
-     * Returns the arc cosine of the given number.
-     */
-    function acos(float $number): float
-    {
-        return php_acos($number);
+    $toAlphabet = mb_substr(Str\ALPHABET_ALPHANUMERIC, 0, $toBase);
+    $result = '';
+
+    do {
+        $result = $toAlphabet[(int) bcmod($resultDecimal, (string) $toBase)] . $result;
+        $resultDecimal = bcdiv($resultDecimal, (string) $toBase);
+    } while (bccomp($resultDecimal, '0') > 0);
+
+    return $result;
+}
+
+/**
+ * Return the smallest integer value greater than or equal to the given number.
+ */
+function ceil(float $number): float
+{
+    return php_ceil($number);
+}
+
+/**
+ * Returns the given number clamped to the given range.
+ *
+ * @template T of float|int
+ *
+ * @param T $number
+ * @param T $min
+ * @param T $max
+ *
+ * @throws Exception\InvalidArgumentException If $min is bigger than $max
+ *
+ * @return T
+ */
+function clamp(int|float $number, int|float $min, int|float $max): int|float
+{
+    if ($max < $min) {
+        throw new Exception\InvalidArgumentException('Expected $min to be lower or equal to $max.');
     }
 
-    /**
-     * Returns the arc sine of the given number.
-     */
-    function asin(float $number): float
-    {
-        return php_asin($number);
+    if ($number < $min) {
+        return $min;
     }
 
-    /**
-     * Returns the tangent of the given number.
-     */
-    function tan(float $number): float
-    {
-        return php_tan($number);
+    if ($number > $max) {
+        return $max;
     }
 
-    /**
-     * Returns the arc tangent of the given number.
-     */
-    function atan(float $number): float
-    {
-        return php_atan($number);
+    return $number;
+}
+
+/**
+ * Return the cosine of the given number.
+ */
+function cos(float $number): float
+{
+    return php_cos($number);
+}
+
+/**
+ * Returns the result of integer division of the given numerator by the given denominator.
+ *
+ * @throws Exception\ArithmeticException If the $numerator is Math\INT64_MIN and the $denominator is -1.
+ * @throws Exception\DivisionByZeroException If the $denominator is 0.
+ */
+function div(int $numerator, int $denominator): int
+{
+    try {
+        return intdiv($numerator, $denominator);
+    } catch (DivisionByZeroError $error) {
+        throw new Exception\DivisionByZeroException(sprintf('%s.', $error->getMessage()), $error->getCode(), $error);
+    } catch (ArithmeticError $error) {
+        throw new Exception\ArithmeticException(
+            'Division of Math\INT64_MIN by -1 is not an integer.',
+            $error->getCode(),
+            $error,
+        );
     }
+}
 
-    /**
-     * Returns the arc tangent of the given coordinates.
-     */
-    function atan2(float $y, float $x): float
-    {
-        return php_atan2($y, $x);
-    }
+/**
+ * Returns the exponential of the given number.
+ */
+function exp(float $number): float
+{
+    return php_exp($number);
+}
 
-    /**
-     * Converts the given string in base `$from_base` to base `$to_base`, assuming
-     * letters a-z are used for digits for bases greater than 10. The conversion is
-     * done to arbitrary precision.
-     *
-     * @param non-empty-string $value
-     * @param int<2, 36> $fromBase
-     * @param int<2, 36> $toBase
-     *
-     * @throws Exception\InvalidArgumentException If the given value is invalid.
-     */
-    function base_convert(string $value, int $fromBase, int $toBase): string
-    {
-        $fromAlphabet = mb_substr(Str\ALPHABET_ALPHANUMERIC, 0, $fromBase);
-        $resultDecimal = '0';
-        $placeValue = bcpow((string) $fromBase, (string) (strlen($value) - 1));
+/**
+ * Return the largest integer value less then or equal to the given number.
+ */
+function floor(float $number): float
+{
+    return php_floor($number);
+}
 
-        foreach (str_split($value) as $digit) {
-            $digitNumeric = stripos($fromAlphabet, $digit);
+/**
+ * Converts the given string in base `$from_base` to an integer, assuming letters a-z
+ * are used for digits when `$from_base` > 10.
+ *
+ * @param non-empty-string $number
+ * @param int<2, 36> $fromBase
+ *
+ * @throws Exception\InvalidArgumentException If $number contains an invalid digit in base $from_base
+ * @throws Exception\OverflowException In case of an integer overflow
+ */
+function from_base(string $number, int $fromBase): int
+{
+    $limit = div(INT64_MAX, $fromBase);
+    $result = 0;
 
-            if (false === $digitNumeric) {
-                throw new Exception\InvalidArgumentException(sprintf('Invalid digit %s in base %d', $digit, $fromBase));
-            }
+    foreach (str_split($number) as $digit) {
+        $oval = ord($digit);
 
-            $resultDecimal = bcadd($resultDecimal, bcmul((string) $digitNumeric, $placeValue));
-            $placeValue = bcdiv($placeValue, (string) $fromBase);
+        // Branches sorted by guesstimated frequency of use. */
+        if (/* '0' - '9' */ $oval <= 57 && $oval >= 48) {
+            $dval = $oval - 48;
+        } elseif (/* 'a' - 'z' */ $oval >= 97 && $oval <= 122) {
+            $dval = $oval - 87;
+        } elseif (/* 'A' - 'Z' */ $oval >= 65 && $oval <= 90) {
+            $dval = $oval - 55;
+        } else {
+            $dval = 99;
         }
 
-        if (10 === $toBase) {
-            return $resultDecimal;
+        if ($fromBase < $dval) {
+            throw new Exception\InvalidArgumentException(sprintf('Invalid digit %s in base %d', $digit, $fromBase));
         }
 
-        $toAlphabet = mb_substr(Str\ALPHABET_ALPHANUMERIC, 0, $toBase);
-        $result = '';
-
-        do {
-            $result = $toAlphabet[(int) bcmod($resultDecimal, (string) $toBase)] . $result;
-            $resultDecimal = bcdiv($resultDecimal, (string) $toBase);
-        } while (bccomp($resultDecimal, '0') > 0);
-
-        return $result;
+        $oldval = $result;
+        $result = ($fromBase * $result) + $dval;
+        if ($oldval > $limit || $oldval > $result) {
+            throw new Exception\OverflowException(sprintf('Unexpected integer overflow parsing %s from base %d', $number, $fromBase));
+        }
     }
 
-    /**
-     * Return the smallest integer value greater than or equal to the given number.
-     */
-    function ceil(float $number): float
-    {
-        return php_ceil($number);
+    return $result;
+}
+
+/**
+ * Converts the given non-negative number into the given base, using letters a-z
+ * for digits when then given base is > 10.
+ *
+ * @param int<0, max> $number
+ * @param int<2, 36> $base
+ *
+ * @return non-empty-string
+ */
+function to_base(int $number, int $base): string
+{
+    $result = '';
+
+    do {
+        $quotient = div($number, $base);
+        $result = Str\ALPHABET_ALPHANUMERIC[$number - ($quotient * $base)] . $result;
+        $number = $quotient;
+    } while (0 !== $number);
+
+    return $result;
+}
+
+/**
+ * Returns the logarithm of the given number.
+ *
+ * @throws Exception\InvalidArgumentException If $number or $base are negative, or $base is equal to 1.0.
+ */
+function log(float $number, ?float $base = null): float
+{
+    if ($number <= 0) {
+        throw new Exception\InvalidArgumentException('$number must be positive.');
     }
 
-    /**
-     * Returns the given number clamped to the given range.
-     *
-     * @template T of float|int
-     *
-     * @param T $number
-     * @param T $min
-     * @param T $max
-     *
-     * @throws Exception\InvalidArgumentException If $min is bigger than $max
-     *
-     * @return T
-     */
-    function clamp(int|float $number, int|float $min, int|float $max): int|float
-    {
-        if ($max < $min) {
-            throw new Exception\InvalidArgumentException('Expected $min to be lower or equal to $max.');
-        }
+    if (null === $base) {
+        return php_log($number);
+    }
 
-        if ($number < $min) {
-            return $min;
-        }
+    if ($base <= 0) {
+        throw new Exception\InvalidArgumentException('$base must be positive.');
+    }
 
+    if ($base === 1.0) {
+        throw new Exception\InvalidArgumentException('Logarithm undefined for $base of 1.0.');
+    }
+
+    return php_log($number, $base);
+}
+
+/**
+ * Returns the largest element of the given iterable, or null if the
+ * iterable is empty.
+ *
+ * The value for comparison is determined by the given function.
+ *
+ * In the case of duplicate values, later values overwrite previous ones.
+ *
+ * @template T
+ *
+ * @param iterable<T> $numbers
+ * @param (Closure(T): numeric) $numericFunction
+ *
+ * @return T|null
+ */
+function max_by(iterable $numbers, Closure $numericFunction): mixed
+{
+    $max = null;
+    $maxNum = null;
+
+    foreach ($numbers as $value) {
+        $valueNum = $numericFunction($value);
+        if (null === $maxNum || $valueNum >= $maxNum) {
+            $max = $value;
+            $maxNum = $valueNum;
+        }
+    }
+
+    return $max;
+}
+
+/**
+ * Returns the largest element of the given list, or null if the array is empty.
+ *
+ * @template T of int|float
+ *
+ * @param array<T> $numbers
+ *
+ * @return ($numbers is non-empty-list<T> ? T : null)
+ */
+function max(array $numbers): null|int|float
+{
+    $max = null;
+
+    foreach ($numbers as $number) {
+        if (null === $max || $number > $max) {
+            $max = $number;
+        }
+    }
+
+    return $max;
+}
+
+/**
+ * Returns the largest number of all the given numbers.
+ *
+ * @template T of int|float
+ *
+ * @param T $first
+ * @param T $second
+ * @param T ...$rest
+ *
+ * @return T
+ */
+function maxva(int|float $first, int|float $second, int|float ...$rest): int|float
+{
+    $max = \max($first, $second);
+
+    foreach ($rest as $number) {
         if ($number > $max) {
-            return $max;
-        }
-
-        return $number;
-    }
-
-    /**
-     * Return the cosine of the given number.
-     */
-    function cos(float $number): float
-    {
-        return php_cos($number);
-    }
-
-    /**
-     * Returns the result of integer division of the given numerator by the given denominator.
-     *
-     * @throws Exception\ArithmeticException If the $numerator is Math\INT64_MIN and the $denominator is -1.
-     * @throws Exception\DivisionByZeroException If the $denominator is 0.
-     */
-    function div(int $numerator, int $denominator): int
-    {
-        try {
-            return intdiv($numerator, $denominator);
-        } catch (DivisionByZeroError $error) {
-            throw new Exception\DivisionByZeroException(sprintf('%s.', $error->getMessage()), $error->getCode(), $error);
-        } catch (ArithmeticError $error) {
-            throw new Exception\ArithmeticException(
-                'Division of Math\INT64_MIN by -1 is not an integer.',
-                $error->getCode(),
-                $error,
-            );
+            $max = $number;
         }
     }
 
-    /**
-     * Returns the exponential of the given number.
-     */
-    function exp(float $number): float
-    {
-        return php_exp($number);
+    return $max;
+}
+
+/**
+ * Returns the arithmetic mean of the given numbers in the list.
+ *
+ * Return null if the given list is empty.
+ *
+ * @param array<int|float> $numbers
+ *
+ * @return ($numbers is non-empty-list ? float : null)
+ */
+function mean(array $numbers): ?float
+{
+    $count = (float) count($numbers);
+
+    if (0.0 === $count) {
+        return null;
     }
 
-    /**
-     * Return the largest integer value less then or equal to the given number.
-     */
-    function floor(float $number): float
-    {
-        return php_floor($number);
+    $mean = 0.0;
+
+    foreach ($numbers as $number) {
+        $mean += (float) $number / $count;
     }
 
-    /**
-     * Converts the given string in base `$from_base` to an integer, assuming letters a-z
-     * are used for digits when `$from_base` > 10.
-     *
-     * @param non-empty-string $number
-     * @param int<2, 36> $fromBase
-     *
-     * @throws Exception\InvalidArgumentException If $number contains an invalid digit in base $from_base
-     * @throws Exception\OverflowException In case of an integer overflow
-     */
-    function from_base(string $number, int $fromBase): int
-    {
-        $limit = div(INT64_MAX, $fromBase);
-        $result = 0;
+    return $mean;
+}
 
-        foreach (str_split($number) as $digit) {
-            $oval = ord($digit);
+/**
+ * Returns the median of the given numbers in the list.
+ *
+ * Returns null if the given iterable is empty.
+ *
+ * @param array<int|float> $numbers
+ *
+ * @return ($numbers is non-empty-list ? float : null)
+ */
+function median(array $numbers): ?float
+{
+    sort($numbers);
+    $count = count($numbers);
 
-            // Branches sorted by guesstimated frequency of use. */
-            if (/* '0' - '9' */ $oval <= 57 && $oval >= 48) {
-                $dval = $oval - 48;
-            } elseif (/* 'a' - 'z' */ $oval >= 97 && $oval <= 122) {
-                $dval = $oval - 87;
-            } elseif (/* 'A' - 'Z' */ $oval >= 65 && $oval <= 90) {
-                $dval = $oval - 55;
-            } else {
-                $dval = 99;
-            }
-
-            if ($fromBase < $dval) {
-                throw new Exception\InvalidArgumentException(sprintf('Invalid digit %s in base %d', $digit, $fromBase));
-            }
-
-            $oldval = $result;
-            $result = ($fromBase * $result) + $dval;
-            if ($oldval > $limit || $oldval > $result) {
-                throw new Exception\OverflowException(sprintf('Unexpected integer overflow parsing %s from base %d', $number, $fromBase));
-            }
-        }
-
-        return $result;
+    if (0 === $count) {
+        return null;
     }
 
-    /**
-     * Converts the given non-negative number into the given base, using letters a-z
-     * for digits when then given base is > 10.
-     *
-     * @param int<0, max> $number
-     * @param int<2, 36> $base
-     *
-     * @return non-empty-string
-     */
-    function to_base(int $number, int $base): string
-    {
-        $result = '';
+    $middleIndex = div($count, 2);
 
-        do {
-            $quotient = div($number, $base);
-            $result = Str\ALPHABET_ALPHANUMERIC[$number - ($quotient * $base)] . $result;
-            $number = $quotient;
-        } while (0 !== $number);
-
-        return $result;
+    if (0 === ($count % 2)) {
+        return mean([$numbers[$middleIndex], $numbers[$middleIndex - 1]]);
     }
 
-    /**
-     * Returns the logarithm of the given number.
-     *
-     * @throws Exception\InvalidArgumentException If $number or $base are negative, or $base is equal to 1.0.
-     */
-    function log(float $number, ?float $base = null): float
-    {
-        if ($number <= 0) {
-            throw new Exception\InvalidArgumentException('$number must be positive.');
-        }
+    return (float) $numbers[$middleIndex];
+}
 
-        if (null === $base) {
-            return php_log($number);
-        }
+/**
+ * Returns the smallest element of the given iterable, or null if the
+ * iterable is empty.
+ *
+ * The value for comparison is determined by the given function.
+ *
+ * In the case of duplicate values, later values overwrite previous ones.
+ *
+ * @template T
+ *
+ * @param iterable<T> $numbers
+ * @param (Closure(T): numeric) $numericFunction
+ *
+ * @return T|null
+ */
+function min_by(iterable $numbers, Closure $numericFunction): mixed
+{
+    $min = null;
+    $minNum = null;
 
-        if ($base <= 0) {
-            throw new Exception\InvalidArgumentException('$base must be positive.');
-        }
+    foreach ($numbers as $value) {
+        $valueNum = $numericFunction($value);
 
-        if ($base === 1.0) {
-            throw new Exception\InvalidArgumentException('Logarithm undefined for $base of 1.0.');
+        if (null === $minNum || $valueNum <= $minNum) {
+            $min = $value;
+            $minNum = $valueNum;
         }
-
-        return php_log($number, $base);
     }
 
-    /**
-     * Returns the largest element of the given iterable, or null if the
-     * iterable is empty.
-     *
-     * The value for comparison is determined by the given function.
-     *
-     * In the case of duplicate values, later values overwrite previous ones.
-     *
-     * @template T
-     *
-     * @param iterable<T> $numbers
-     * @param (Closure(T): numeric) $numericFunction
-     *
-     * @return T|null
-     */
-    function max_by(iterable $numbers, Closure $numericFunction): mixed
-    {
-        $max = null;
-        $maxNum = null;
+    return $min;
+}
 
-        foreach ($numbers as $value) {
-            $valueNum = $numericFunction($value);
-            if (null === $maxNum || $valueNum >= $maxNum) {
-                $max = $value;
-                $maxNum = $valueNum;
-            }
+/**
+ * Returns the smallest element of the given list, or null if the
+ * list is empty.
+ *
+ * @template T of int|float
+ *
+ * @param array<T> $numbers
+ *
+ * @return ($numbers is non-empty-list<T> ? T : null)
+ */
+function min(array $numbers): null|float|int
+{
+    $min = null;
+
+    foreach ($numbers as $number) {
+        if (null === $min || $number < $min) {
+            $min = $number;
         }
-
-        return $max;
     }
 
-    /**
-     * Returns the largest element of the given list, or null if the array is empty.
-     *
-     * @template T of int|float
-     *
-     * @param array<T> $numbers
-     *
-     * @return ($numbers is non-empty-list<T> ? T : null)
-     */
-    function max(array $numbers): null|int|float
-    {
-        $max = null;
+    return $min;
+}
 
-        foreach ($numbers as $number) {
-            if (null === $max || $number > $max) {
-                $max = $number;
-            }
+/**
+ * Returns the smallest number of all the given numbers.
+ *
+ * @template T of int|float
+ *
+ * @param T $first
+ * @param T $second
+ * @param T ...$rest
+ *
+ * @return T
+ */
+function minva(int|float $first, int|float $second, int|float ...$rest): int|float
+{
+    $min = \min($first, $second);
+
+    foreach ($rest as $number) {
+        if ($number < $min) {
+            $min = $number;
         }
-
-        return $max;
     }
 
-    /**
-     * Returns the largest number of all the given numbers.
-     *
-     * @template T of int|float
-     *
-     * @param T $first
-     * @param T $second
-     * @param T ...$rest
-     *
-     * @return T
-     */
-    function maxva(int|float $first, int|float $second, int|float ...$rest): int|float
-    {
-        $max = \max($first, $second);
+    return $min;
+}
 
-        foreach ($rest as $number) {
-            if ($number > $max) {
-                $max = $number;
-            }
-        }
+/**
+ * Returns the given number rounded to the specified precision.
+ *
+ * A positive precision rounds to the nearest decimal place whereas a negative precision
+ * rounds to the nearest power of ten.
+ *
+ * For example, a precision of 1 rounds to the nearest tenth whereas a precision of -1 rounds to the nearst nearest.
+ */
+function round(float $number, int $precision = 0): float
+{
+    return php_round($number, $precision);
+}
 
-        return $max;
+/**
+ * Returns the sine of the given number.
+ */
+function sin(float $number): float
+{
+    return php_sin($number);
+}
+
+/**
+ * Returns the sum of all the given numbers.
+ *
+ * @param array<int|float> $numbers
+ */
+function sum_floats(array $numbers): float
+{
+    $result = 0.0;
+
+    foreach ($numbers as $number) {
+        $result += (float) $number;
     }
 
-    /**
-     * Returns the arithmetic mean of the given numbers in the list.
-     *
-     * Return null if the given list is empty.
-     *
-     * @param array<int|float> $numbers
-     *
-     * @return ($numbers is non-empty-list ? float : null)
-     */
-    function mean(array $numbers): ?float
-    {
-        $count = (float) count($numbers);
+    return $result;
+}
 
-        if (0.0 === $count) {
-            return null;
-        }
+/**
+ * Returns the sum of all the given numbers.
+ *
+ * @param array<int> $numbers
+ */
+function sum(array $numbers): int
+{
+    $result = 0;
 
-        $mean = 0.0;
-
-        foreach ($numbers as $number) {
-            $mean += (float) $number / $count;
-        }
-
-        return $mean;
+    foreach ($numbers as $number) {
+        $result += $number;
     }
 
-    /**
-     * Returns the median of the given numbers in the list.
-     *
-     * Returns null if the given iterable is empty.
-     *
-     * @param array<int|float> $numbers
-     *
-     * @return ($numbers is non-empty-list ? float : null)
-     */
-    function median(array $numbers): ?float
-    {
-        sort($numbers);
-        $count = count($numbers);
-
-        if (0 === $count) {
-            return null;
-        }
-
-        $middleIndex = div($count, 2);
-
-        if (0 === ($count % 2)) {
-            return mean([$numbers[$middleIndex], $numbers[$middleIndex - 1]]);
-        }
-
-        return (float) $numbers[$middleIndex];
-    }
-
-    /**
-     * Returns the smallest element of the given iterable, or null if the
-     * iterable is empty.
-     *
-     * The value for comparison is determined by the given function.
-     *
-     * In the case of duplicate values, later values overwrite previous ones.
-     *
-     * @template T
-     *
-     * @param iterable<T> $numbers
-     * @param (Closure(T): numeric) $numericFunction
-     *
-     * @return T|null
-     */
-    function min_by(iterable $numbers, Closure $numericFunction): mixed
-    {
-        $min = null;
-        $minNum = null;
-
-        foreach ($numbers as $value) {
-            $valueNum = $numericFunction($value);
-
-            if (null === $minNum || $valueNum <= $minNum) {
-                $min = $value;
-                $minNum = $valueNum;
-            }
-        }
-
-        return $min;
-    }
-
-    /**
-     * Returns the smallest element of the given list, or null if the
-     * list is empty.
-     *
-     * @template T of int|float
-     *
-     * @param array<T> $numbers
-     *
-     * @return ($numbers is non-empty-list<T> ? T : null)
-     */
-    function min(array $numbers): null|float|int
-    {
-        $min = null;
-
-        foreach ($numbers as $number) {
-            if (null === $min || $number < $min) {
-                $min = $number;
-            }
-        }
-
-        return $min;
-    }
-
-    /**
-     * Returns the smallest number of all the given numbers.
-     *
-     * @template T of int|float
-     *
-     * @param T $first
-     * @param T $second
-     * @param T ...$rest
-     *
-     * @return T
-     */
-    function minva(int|float $first, int|float $second, int|float ...$rest): int|float
-    {
-        $min = \min($first, $second);
-
-        foreach ($rest as $number) {
-            if ($number < $min) {
-                $min = $number;
-            }
-        }
-
-        return $min;
-    }
-
-    /**
-     * Returns the given number rounded to the specified precision.
-     *
-     * A positive precision rounds to the nearest decimal place whereas a negative precision
-     * rounds to the nearest power of ten.
-     *
-     * For example, a precision of 1 rounds to the nearest tenth whereas a precision of -1 rounds to the nearst nearest.
-     */
-    function round(float $number, int $precision = 0): float
-    {
-        return php_round($number, $precision);
-    }
-
-    /**
-     * Returns the sine of the given number.
-     */
-    function sin(float $number): float
-    {
-        return php_sin($number);
-    }
-
-    /**
-     * Returns the sum of all the given numbers.
-     *
-     * @param array<int|float> $numbers
-     */
-    function sum_floats(array $numbers): float
-    {
-        $result = 0.0;
-
-        foreach ($numbers as $number) {
-            $result += (float) $number;
-        }
-
-        return $result;
-    }
-
-    /**
-     * Returns the sum of all the given numbers.
-     *
-     * @param array<int> $numbers
-     */
-    function sum(array $numbers): int
-    {
-        $result = 0;
-
-        foreach ($numbers as $number) {
-            $result += $number;
-        }
-
-        return $result;
-    }
+    return $result;
 }

--- a/packages/support/src/Path/functions.php
+++ b/packages/support/src/Path/functions.php
@@ -2,155 +2,155 @@
 
 declare(strict_types=1);
 
-namespace Tempest\Support\Path {
-    use Stringable;
+namespace Tempest\Support\Path;
 
-    use function Tempest\Support\Regex\matches;
-    use function Tempest\Support\Str\ends_with;
-    use function Tempest\Support\Str\starts_with;
+use Stringable;
 
-    /**
-     * Determines whether the given path is a relative path. The path is not checked against the filesystem.
-     */
-    function is_relative_path(null|Stringable|string ...$parts): bool
-    {
-        return ! namespace\is_absolute_path(...$parts);
-    }
+use function Tempest\Support\Regex\matches;
+use function Tempest\Support\Str\ends_with;
+use function Tempest\Support\Str\starts_with;
 
-    /**
-     * Converts the given absolute path to a path relative to `$from`.
-     * If the given path is not an absolute path, it is assumed to already by relative to `$from` and will be returned as-is.
-     */
-    function to_relative_path(null|Stringable|string $from, Stringable|string ...$parts): string
-    {
-        $path = namespace\normalize(...$parts);
-        $from = $from === null ? '' : (string) $from;
+/**
+ * Determines whether the given path is a relative path. The path is not checked against the filesystem.
+ */
+function is_relative_path(null|Stringable|string ...$parts): bool
+{
+    return ! namespace\is_absolute_path(...$parts);
+}
 
-        if (is_relative_path($path)) {
-            return $path;
-        }
+/**
+ * Converts the given absolute path to a path relative to `$from`.
+ * If the given path is not an absolute path, it is assumed to already by relative to `$from` and will be returned as-is.
+ */
+function to_relative_path(null|Stringable|string $from, Stringable|string ...$parts): string
+{
+    $path = namespace\normalize(...$parts);
+    $from = $from === null ? '' : (string) $from;
 
-        $from = rtrim($from, '/');
-        $path = rtrim($path, '/');
-
-        $fromParts = explode('/', $from);
-        $pathParts = explode('/', $path);
-
-        while ($fromParts !== [] && $pathParts !== [] && $fromParts[0] === $pathParts[0]) {
-            array_shift($fromParts);
-            array_shift($pathParts);
-        }
-
-        $upDirs = count($fromParts);
-        $relativePath = str_repeat('../', $upDirs) . implode('/', $pathParts);
-
-        return $relativePath === '' ? '.' : $relativePath;
-    }
-
-    /**
-     * Determines whether the given path is an absolute path. The path is not checked against the filesystem.
-     */
-    function is_absolute_path(null|Stringable|string ...$parts): bool
-    {
-        $path = namespace\normalize(...$parts);
-
-        if (strlen($path) === 0 || '.' === $path[0]) {
-            return false;
-        }
-
-        if (preg_match('#^[a-zA-Z]:/#', $path)) {
-            return true;
-        }
-
-        return '/' === $path[0];
-    }
-
-    /**
-     * Converts the given path to an absolute path.
-     */
-    function to_absolute_path(Stringable|string $cwd, null|Stringable|string ...$parts): string
-    {
-        $cwd = namespace\normalize($cwd);
-        $path = namespace\normalize(...$parts);
-
-        if (starts_with($path, $cwd) && namespace\is_absolute_path($path)) {
-            return $path;
-        }
-
-        $segments = explode('/', namespace\normalize($cwd, $path));
-        $resolved = [];
-
-        foreach ($segments as $part) {
-            if ($part === '') {
-                continue;
-            }
-
-            if ($part === '.') {
-                continue;
-            }
-
-            if ($part === '..') {
-                if ($resolved !== []) {
-                    array_pop($resolved);
-                }
-            } else {
-                $resolved[] = $part;
-            }
-        }
-
-        $absolutePath = namespace\normalize(...$resolved);
-
-        if (matches($cwd, '#^[a-zA-Z]:/#')) {
-            return $absolutePath;
-        }
-
-        return '/' . $absolutePath;
-    }
-
-    /**
-     * Normalizes the given path to use forward-slashes.
-     */
-    function normalize(null|Stringable|string ...$paths): string
-    {
-        if ($paths === []) {
-            return '';
-        }
-
-        $paths = array_map(
-            fn (null|Stringable|string $path) => $path === null ? '' : (string) $path,
-            $paths,
-        );
-
-        // Split paths items on forward and backward slashes
-        $parts = array_reduce($paths, fn (array $carry, string $part) => [...$carry, ...explode('/', $part)], []);
-        $parts = array_reduce($parts, fn (array $carry, string $part) => [...$carry, ...explode('\\', $part)], []);
-
-        // Trim forward and backward slashes
-        $parts = array_map(fn (string $part) => trim($part, '/\\'), $parts);
-        $parts = array_filter($parts, fn (string $part) => $part !== '');
-
-        // Glue parts together
-        $path = implode('/', $parts);
-
-        // Add / if first entry starts with forward- or backward slash
-        $firstEntry = $paths[0];
-
-        if (starts_with($firstEntry, ['/', '\\'])) {
-            $path = '/' . $path;
-        }
-
-        // Add / if last entry ends with forward- or backward slash
-        $lastEntry = $paths[count($paths) - 1];
-
-        if ((count($paths) > 1 || strlen($lastEntry) > 1) && ends_with($lastEntry, ['/', '\\'])) {
-            $path .= '/';
-        }
-
-        // Restore virtual phar prefix
-        if (str_starts_with($path, 'phar:')) {
-            $path = str_replace('phar:', 'phar://', $path);
-        }
-
+    if (is_relative_path($path)) {
         return $path;
     }
+
+    $from = rtrim($from, '/');
+    $path = rtrim($path, '/');
+
+    $fromParts = explode('/', $from);
+    $pathParts = explode('/', $path);
+
+    while ($fromParts !== [] && $pathParts !== [] && $fromParts[0] === $pathParts[0]) {
+        array_shift($fromParts);
+        array_shift($pathParts);
+    }
+
+    $upDirs = count($fromParts);
+    $relativePath = str_repeat('../', $upDirs) . implode('/', $pathParts);
+
+    return $relativePath === '' ? '.' : $relativePath;
+}
+
+/**
+ * Determines whether the given path is an absolute path. The path is not checked against the filesystem.
+ */
+function is_absolute_path(null|Stringable|string ...$parts): bool
+{
+    $path = namespace\normalize(...$parts);
+
+    if (strlen($path) === 0 || '.' === $path[0]) {
+        return false;
+    }
+
+    if (preg_match('#^[a-zA-Z]:/#', $path)) {
+        return true;
+    }
+
+    return '/' === $path[0];
+}
+
+/**
+ * Converts the given path to an absolute path.
+ */
+function to_absolute_path(Stringable|string $cwd, null|Stringable|string ...$parts): string
+{
+    $cwd = namespace\normalize($cwd);
+    $path = namespace\normalize(...$parts);
+
+    if (starts_with($path, $cwd) && namespace\is_absolute_path($path)) {
+        return $path;
+    }
+
+    $segments = explode('/', namespace\normalize($cwd, $path));
+    $resolved = [];
+
+    foreach ($segments as $part) {
+        if ($part === '') {
+            continue;
+        }
+
+        if ($part === '.') {
+            continue;
+        }
+
+        if ($part === '..') {
+            if ($resolved !== []) {
+                array_pop($resolved);
+            }
+        } else {
+            $resolved[] = $part;
+        }
+    }
+
+    $absolutePath = namespace\normalize(...$resolved);
+
+    if (matches($cwd, '#^[a-zA-Z]:/#')) {
+        return $absolutePath;
+    }
+
+    return '/' . $absolutePath;
+}
+
+/**
+ * Normalizes the given path to use forward-slashes.
+ */
+function normalize(null|Stringable|string ...$paths): string
+{
+    if ($paths === []) {
+        return '';
+    }
+
+    $paths = array_map(
+        fn (null|Stringable|string $path) => $path === null ? '' : (string) $path,
+        $paths,
+    );
+
+    // Split paths items on forward and backward slashes
+    $parts = array_reduce($paths, fn (array $carry, string $part) => [...$carry, ...explode('/', $part)], []);
+    $parts = array_reduce($parts, fn (array $carry, string $part) => [...$carry, ...explode('\\', $part)], []);
+
+    // Trim forward and backward slashes
+    $parts = array_map(fn (string $part) => trim($part, '/\\'), $parts);
+    $parts = array_filter($parts, fn (string $part) => $part !== '');
+
+    // Glue parts together
+    $path = implode('/', $parts);
+
+    // Add / if first entry starts with forward- or backward slash
+    $firstEntry = $paths[0];
+
+    if (starts_with($firstEntry, ['/', '\\'])) {
+        $path = '/' . $path;
+    }
+
+    // Add / if last entry ends with forward- or backward slash
+    $lastEntry = $paths[count($paths) - 1];
+
+    if ((count($paths) > 1 || strlen($lastEntry) > 1) && ends_with($lastEntry, ['/', '\\'])) {
+        $path .= '/';
+    }
+
+    // Restore virtual phar prefix
+    if (str_starts_with($path, 'phar:')) {
+        $path = str_replace('phar:', 'phar://', $path);
+    }
+
+    return $path;
 }

--- a/packages/support/src/Regex/functions.php
+++ b/packages/support/src/Regex/functions.php
@@ -2,136 +2,129 @@
 
 declare(strict_types=1);
 
-namespace Tempest\Support\Regex {
-    use Closure;
-    use RuntimeException;
-    use Stringable;
+namespace Tempest\Support\Regex;
 
-    use function Tempest\Support\arr;
-    use function Tempest\Support\Arr\filter;
-    use function Tempest\Support\Arr\first;
-    use function Tempest\Support\Arr\get_by_key;
-    use function Tempest\Support\Arr\wrap;
-    use function Tempest\Support\Str\starts_with;
-    use function Tempest\Support\Str\strip_end;
-    use function Tempest\Support\Str\strip_start;
+use Closure;
+use RuntimeException;
+use Stringable;
 
-    /**
-     * Returns portions of the `$subject` that match the given `$pattern`. If `$global` is set to `true`, returns all matches. Otherwise, only returns the first one.
-     *
-     * @param non-empty-string $pattern The pattern to match against.
-     * @param 0|2|256|512|768 $flags
-     */
-    function get_matches(Stringable|string $subject, Stringable|string $pattern, bool $global = false, int $flags = 0, int $offset = 0): array
-    {
-        if (str_ends_with($pattern, 'g')) {
-            $global = true;
-            $pattern = strip_end($pattern, 'g');
-        }
+use function Tempest\Support\arr;
+use function Tempest\Support\Arr\filter;
+use function Tempest\Support\Arr\first;
+use function Tempest\Support\Arr\get_by_key;
+use function Tempest\Support\Arr\wrap;
+use function Tempest\Support\Str\starts_with;
+use function Tempest\Support\Str\strip_end;
+use function Tempest\Support\Str\strip_start;
 
-        return call_preg($global ? 'preg_match_all' : 'preg_match', static function () use ($subject, $pattern, $global, $flags, $offset): array {
-            $matches = [];
-            $result = match ($global) {
-                true => preg_match_all(
-                    (string) $pattern,
-                    (string) $subject,
-                    $matches,
-                    $flags,
-                    $offset,
-                ),
-                false => preg_match(
-                    (string) $pattern,
-                    (string) $subject,
-                    $matches,
-                    $flags,
-                    $offset,
-                ),
-            };
-
-            if ($result === false || $result === 0) {
-                return [];
-            }
-
-            return $matches;
-        });
+/**
+ * Returns portions of the `$subject` that match the given `$pattern`. If `$global` is set to `true`, returns all matches. Otherwise, only returns the first one.
+ *
+ * @param non-empty-string $pattern The pattern to match against.
+ * @param 0|2|256|512|768 $flags
+ */
+function get_matches(Stringable|string $subject, Stringable|string $pattern, bool $global = false, int $flags = 0, int $offset = 0): array
+{
+    if (str_ends_with($pattern, 'g')) {
+        $global = true;
+        $pattern = strip_end($pattern, 'g');
     }
 
-    /**
-     * Returns the specified matches of `$pattern` in `$subject`.
-     *
-     * @param non-empty-string $pattern The pattern to match against.
-     */
-    function get_all_matches(
-        Stringable|string $subject,
-        Stringable|string $pattern,
-        Stringable|string|int|array $matches = 0,
-        int $offset = 0,
-    ): array {
-        $result = get_matches($subject, $pattern, true, PREG_SET_ORDER, $offset);
+    return call_preg($global ? 'preg_match_all' : 'preg_match', static function () use ($subject, $pattern, $global, $flags, $offset): array {
+        $matches = [];
+        $result = match ($global) {
+            true => preg_match_all(
+                (string) $pattern,
+                (string) $subject,
+                $matches,
+                $flags,
+                $offset,
+            ),
+            false => preg_match(
+                (string) $pattern,
+                (string) $subject,
+                $matches,
+                $flags,
+                $offset,
+            ),
+        };
 
+        if ($result === false || $result === 0) {
+            return [];
+        }
+
+        return $matches;
+    });
+}
+
+/**
+ * Returns the specified matches of `$pattern` in `$subject`.
+ *
+ * @param non-empty-string $pattern The pattern to match against.
+ */
+function get_all_matches(
+    Stringable|string $subject,
+    Stringable|string $pattern,
+    Stringable|string|int|array $matches = 0,
+    int $offset = 0,
+): array {
+    $result = get_matches($subject, $pattern, true, PREG_SET_ORDER, $offset);
+
+    return arr($result)
+        ->map(fn (array $result) => filter($result, fn ($_, string|int $key) => in_array($key, wrap($matches), strict: false)))
+        ->toArray();
+}
+
+/**
+ * Returns the specified match of `$pattern` in `$subject`. If no match is specified, returns the whole matching array.
+ *
+ * @param non-empty-string $pattern The pattern to match against.
+ * @param 0|256|512|768 $flags
+ */
+function get_match(
+    Stringable|string $subject,
+    Stringable|string $pattern,
+    null|array|Stringable|int|string $match = null,
+    mixed $default = null,
+    int $flags = 0,
+    int $offset = 0,
+): null|int|string|array {
+    $result = get_matches($subject, $pattern, false, $flags, $offset);
+
+    if ($match === null) {
+        return $result;
+    }
+
+    if (is_array($match)) {
         return arr($result)
-            ->map(fn (array $result) => filter($result, fn ($_, string|int $key) => in_array($key, wrap($matches), strict: false)))
+            ->filter(fn ($_, string|int $key) => in_array($key, $match, strict: false))
+            ->mapWithKeys(fn (array $matches, string|int $key) => yield $key => first($matches))
             ->toArray();
     }
 
-    /**
-     * Returns the specified match of `$pattern` in `$subject`. If no match is specified, returns the whole matching array.
-     *
-     * @param non-empty-string $pattern The pattern to match against.
-     * @param 0|256|512|768 $flags
-     */
-    function get_match(
-        Stringable|string $subject,
-        Stringable|string $pattern,
-        null|array|Stringable|int|string $match = null,
-        mixed $default = null,
-        int $flags = 0,
-        int $offset = 0,
-    ): null|int|string|array {
-        $result = get_matches($subject, $pattern, false, $flags, $offset);
+    return get_by_key($result, $match, $default);
+}
 
-        if ($match === null) {
-            return $result;
-        }
+/**
+ * Determines if $subject matches the given $pattern.
+ *
+ * @param non-empty-string $pattern The pattern to match against.
+ */
+function matches(string $subject, string $pattern, int $offset = 0): bool
+{
+    return call_preg('preg_match', static fn (): int|false => preg_match($pattern, $subject, offset: $offset)) === 1;
+}
 
-        if (is_array($match)) {
-            return arr($result)
-                ->filter(fn ($_, string|int $key) => in_array($key, $match, strict: false))
-                ->mapWithKeys(fn (array $matches, string|int $key) => yield $key => first($matches))
-                ->toArray();
-        }
-
-        return get_by_key($result, $match, $default);
-    }
-
-    /**
-     * Determines if $subject matches the given $pattern.
-     *
-     * @param non-empty-string $pattern The pattern to match against.
-     */
-    function matches(string $subject, string $pattern, int $offset = 0): bool
-    {
-        return call_preg('preg_match', static fn (): int|false => preg_match($pattern, $subject, offset: $offset)) === 1;
-    }
-
-    /**
-     * Returns the '$haystack' string with all occurrences of `$pattern` replaced by `$replacement`.
-     *
-     * @param non-empty-string $pattern The pattern to search for.
-     * @param null|positive-int $limit The maximum possible replacements for $pattern within $haystack.
-     */
-    function replace(array|string $haystack, array|string $pattern, Closure|array|string $replacement, ?int $limit = null): string
-    {
-        if ($replacement instanceof Closure) {
-            return (string) call_preg('preg_replace_callback', static fn (): ?string => preg_replace_callback(
-                $pattern,
-                $replacement,
-                $haystack,
-                $limit ?? -1,
-            ));
-        }
-
-        return (string) call_preg('preg_replace', static fn (): ?string => preg_replace(
+/**
+ * Returns the '$haystack' string with all occurrences of `$pattern` replaced by `$replacement`.
+ *
+ * @param non-empty-string $pattern The pattern to search for.
+ * @param null|positive-int $limit The maximum possible replacements for $pattern within $haystack.
+ */
+function replace(array|string $haystack, array|string $pattern, Closure|array|string $replacement, ?int $limit = null): string
+{
+    if ($replacement instanceof Closure) {
+        return (string) call_preg('preg_replace_callback', static fn (): ?string => preg_replace_callback(
             $pattern,
             $replacement,
             $haystack,
@@ -139,76 +132,83 @@ namespace Tempest\Support\Regex {
         ));
     }
 
-    /**
-     * Returns the '$haystack' string with all occurrences of the keys of
-     * '$replacements' (patterns) replaced by the corresponding values.
-     *
-     * @param array<non-empty-string, string> $replacements An array where the keys are regular expression patterns, and the values are the replacements.
-     * @param null|positive-int $limit The maximum possible replacements for each pattern in $haystack.
-     */
-    function replace_every(string $haystack, array $replacements, ?int $limit = null): string
-    {
-        return (string) call_preg('preg_replace', static fn (): ?string => preg_replace(
-            array_keys($replacements),
-            array_values($replacements),
-            $haystack,
-            $limit ?? -1,
-        ));
+    return (string) call_preg('preg_replace', static fn (): ?string => preg_replace(
+        $pattern,
+        $replacement,
+        $haystack,
+        $limit ?? -1,
+    ));
+}
+
+/**
+ * Returns the '$haystack' string with all occurrences of the keys of
+ * '$replacements' (patterns) replaced by the corresponding values.
+ *
+ * @param array<non-empty-string, string> $replacements An array where the keys are regular expression patterns, and the values are the replacements.
+ * @param null|positive-int $limit The maximum possible replacements for each pattern in $haystack.
+ */
+function replace_every(string $haystack, array $replacements, ?int $limit = null): string
+{
+    return (string) call_preg('preg_replace', static fn (): ?string => preg_replace(
+        array_keys($replacements),
+        array_values($replacements),
+        $haystack,
+        $limit ?? -1,
+    ));
+}
+
+/**
+ * @return null|array{message: string, code: int, pattern_message: null|string}
+ * @internal
+ */
+function get_preg_error(string $function): ?array
+{
+    $code = preg_last_error();
+    if ($code === PREG_NO_ERROR) {
+        return null;
     }
 
-    /**
-     * @return null|array{message: string, code: int, pattern_message: null|string}
-     * @internal
-     */
-    function get_preg_error(string $function): ?array
-    {
-        $code = preg_last_error();
-        if ($code === PREG_NO_ERROR) {
-            return null;
-        }
+    $messages = [
+        PREG_INTERNAL_ERROR => 'Internal error',
+        PREG_BAD_UTF8_ERROR => 'Malformed UTF-8 characters, possibly incorrectly encoded',
+        PREG_BAD_UTF8_OFFSET_ERROR => 'The offset did not correspond to the beginning of a valid UTF-8 code point',
+        PREG_BACKTRACK_LIMIT_ERROR => 'Backtrack limit exhausted',
+        PREG_RECURSION_LIMIT_ERROR => 'Recursion limit exhausted',
+        PREG_JIT_STACKLIMIT_ERROR => 'JIT stack limit exhausted',
+    ];
 
-        $messages = [
-            PREG_INTERNAL_ERROR => 'Internal error',
-            PREG_BAD_UTF8_ERROR => 'Malformed UTF-8 characters, possibly incorrectly encoded',
-            PREG_BAD_UTF8_OFFSET_ERROR => 'The offset did not correspond to the beginning of a valid UTF-8 code point',
-            PREG_BACKTRACK_LIMIT_ERROR => 'Backtrack limit exhausted',
-            PREG_RECURSION_LIMIT_ERROR => 'Recursion limit exhausted',
-            PREG_JIT_STACKLIMIT_ERROR => 'JIT stack limit exhausted',
-        ];
+    $message = $messages[$code] ?? 'Unknown error';
+    $result = ['message' => $message, 'code' => $code, 'pattern_message' => null];
+    $error = error_get_last();
 
-        $message = $messages[$code] ?? 'Unknown error';
-        $result = ['message' => $message, 'code' => $code, 'pattern_message' => null];
-        $error = error_get_last();
-
-        if ($error !== null && starts_with($error['message'], $function)) {
-            $result['pattern_message'] = strip_start($error['message'], sprintf('%s(): ', $function));
-        }
-
-        return $result;
+    if ($error !== null && starts_with($error['message'], $function)) {
+        $result['pattern_message'] = strip_start($error['message'], sprintf('%s(): ', $function));
     }
 
-    /**
-     * @template T
-     *
-     * @param non-empty-string $function
-     * @param Closure(): T $closure
-     *
-     * @return T
-     * @internal
-     */
-    function call_preg(string $function, Closure $closure): mixed
-    {
-        error_clear_last();
-        $result = @$closure();
+    return $result;
+}
 
-        if ($error = get_preg_error($function)) {
-            if ($error['pattern_message'] !== null) {
-                throw new InvalidPatternException($error['pattern_message'], $error['code']);
-            }
+/**
+ * @template T
+ *
+ * @param non-empty-string $function
+ * @param Closure(): T $closure
+ *
+ * @return T
+ * @internal
+ */
+function call_preg(string $function, Closure $closure): mixed
+{
+    error_clear_last();
+    $result = @$closure();
 
-            throw new RuntimeException($error['message'], $error['code']);
+    if ($error = get_preg_error($function)) {
+        if ($error['pattern_message'] !== null) {
+            throw new InvalidPatternException($error['pattern_message'], $error['code']);
         }
 
-        return $result;
+        throw new RuntimeException($error['message'], $error['code']);
     }
+
+    return $result;
 }

--- a/packages/support/src/Str/functions.php
+++ b/packages/support/src/Str/functions.php
@@ -2,933 +2,933 @@
 
 declare(strict_types=1);
 
-namespace Tempest\Support\Str {
-    use BackedEnum;
-    use Stringable;
-    use Tempest\Support\Arr;
-    use UnitEnum;
-    use voku\helper\ASCII;
+namespace Tempest\Support\Str;
 
-    use function levenshtein as php_levenshtein;
-    use function metaphone as php_metaphone;
-    use function strip_tags as php_strip_tags;
-    use function Tempest\Support\arr;
+use BackedEnum;
+use Stringable;
+use Tempest\Support\Arr;
+use UnitEnum;
+use voku\helper\ASCII;
 
-    /**
-     * Converts the given string to title case.
-     */
-    function to_title_case(Stringable|string $string): string
-    {
-        return mb_convert_case((string) $string, mode: MB_CASE_TITLE, encoding: 'UTF-8');
-    }
+use function levenshtein as php_levenshtein;
+use function metaphone as php_metaphone;
+use function strip_tags as php_strip_tags;
+use function Tempest\Support\arr;
 
-    /**
-     * Converts the given string to a naive sentence case. This doesn't detect proper nouns and proper adjectives that should stay capitalized.
-     */
-    function to_sentence_case(Stringable|string $string): string
-    {
-        $words = array_map(
-            callback: fn (string $string) => to_lower_case($string),
-            array: to_words($string),
-        );
+/**
+ * Converts the given string to title case.
+ */
+function to_title_case(Stringable|string $string): string
+{
+    return mb_convert_case((string) $string, mode: MB_CASE_TITLE, encoding: 'UTF-8');
+}
 
-        return upper_first(implode(' ', $words));
-    }
+/**
+ * Converts the given string to a naive sentence case. This doesn't detect proper nouns and proper adjectives that should stay capitalized.
+ */
+function to_sentence_case(Stringable|string $string): string
+{
+    $words = array_map(
+        callback: fn (string $string) => to_lower_case($string),
+        array: to_words($string),
+    );
 
-    /**
-     * Converts the given string to lower case.
-     */
-    function to_lower_case(Stringable|string $string): string
-    {
-        return mb_strtolower((string) $string, encoding: 'UTF-8');
-    }
+    return upper_first(implode(' ', $words));
+}
 
-    /**
-     * Converts the given string to upper case.
-     */
-    function to_upper_case(Stringable|string $string): string
-    {
-        return mb_strtoupper((string) $string, encoding: 'UTF-8');
-    }
+/**
+ * Converts the given string to lower case.
+ */
+function to_lower_case(Stringable|string $string): string
+{
+    return mb_strtolower((string) $string, encoding: 'UTF-8');
+}
 
-    /**
-     * Converts the given string to snake case.
-     *
-     * @mago-expect lint:require-preg-quote-delimiter
-     */
-    function to_snake_case(Stringable|string $string, Stringable|string $delimiter = '_'): string
-    {
-        $string = (string) $string;
-        $delimiter = (string) $delimiter;
+/**
+ * Converts the given string to upper case.
+ */
+function to_upper_case(Stringable|string $string): string
+{
+    return mb_strtoupper((string) $string, encoding: 'UTF-8');
+}
 
-        if (ctype_lower($string)) {
-            return $string;
-        }
+/**
+ * Converts the given string to snake case.
+ *
+ * @mago-expect lint:require-preg-quote-delimiter
+ */
+function to_snake_case(Stringable|string $string, Stringable|string $delimiter = '_'): string
+{
+    $string = (string) $string;
+    $delimiter = (string) $delimiter;
 
-        $string = preg_replace('/(?<=\p{Ll}|\p{N})(\p{Lu})/u', $delimiter . '$1', $string);
-        $string = preg_replace('/(?<=\p{Lu})(\p{Lu}\p{Ll})/u', $delimiter . '$1', $string);
-        $string = preg_replace('![^' . preg_quote($delimiter) . '\pL\pN\s]+!u', $delimiter, mb_strtolower($string, 'UTF-8'));
-        $string = preg_replace('/\s+/u', $delimiter, $string);
-        $string = trim($string, $delimiter);
-
-        return namespace\deduplicate($string, $delimiter);
-    }
-
-    /**
-     * Returns an array of words from the specified string.
-     * This is more accurate than {@see str_word_count()}.
-     */
-    function to_words(Stringable|string $string): array
-    {
-        // Remove 'words' that don't consist of alphanumerical characters or punctuation
-        $words = trim(preg_replace("#[^(\w|\d|\'|\"|\.|\!|\?|;|,|\\|\/|\-|:|\&|@)]+#", ' ', (string) $string));
-        // Remove one-letter 'words' that consist only of punctuation
-        $words = trim(preg_replace("#\s*[(\'|\"|\.|\!|\?|;|,|\\|\/|\-|:|\&|@)]\s*#", ' ', $words));
-
-        return array_values(array_filter(explode(' ', namespace\deduplicate($words))));
-    }
-
-    /**
-     * Counts the number of words in the given string.
-     */
-    function word_count(Stringable|string $string): int
-    {
-        return count(to_words($string));
-    }
-
-    /**
-     * Converts the given string to kebab case.
-     */
-    function to_kebab_case(Stringable|string $string): string
-    {
-        return to_snake_case((string) $string, delimiter: '-');
-    }
-
-    /**
-     * Converts the given string to pascal case.
-     */
-    function to_pascal_case(Stringable|string $string): string
-    {
-        $string = (string) $string;
-        $words = explode(' ', str_replace(['-', '_'], ' ', $string));
-        $studlyWords = array_map(mb_ucfirst(...), $words);
-
-        return implode('', $studlyWords);
-    }
-
-    /**
-     * Converts the given string to camel case.
-     */
-    function to_camel_case(Stringable|string $string): string
-    {
-        return lcfirst(to_pascal_case((string) $string));
-    }
-
-    /**
-     * Converts the given string to an URL-safe slug.
-     *
-     * @param bool $replaceSymbols Adds some more replacements e.g. "£" with "pound".
-     */
-    function to_slug(Stringable|string $string, Stringable|string $separator = '-', array $replacements = [], bool $replaceSymbols = true): string
-    {
-        return ASCII::to_slugify((string) $string, (string) $separator, replacements: $replacements, replace_extra_symbols: $replaceSymbols);
-    }
-
-    /**
-     * Transliterates the given string to ASCII.
-     *
-     * @param string $language Language of the source string. Defaults to english.
-     */
-    function to_ascii(Stringable|string $string, Stringable|string $language = 'en'): string
-    {
-        return ASCII::to_ascii((string) $string, (string) $language, replace_single_chars_only: false);
-    }
-
-    /**
-     * Checks whether the given string is valid ASCII.
-     */
-    function is_ascii(Stringable|string $string): bool
-    {
-        return ASCII::is_ascii((string) $string);
-    }
-
-    /**
-     * Changes the case of the first letter to uppercase.
-     */
-    function upper_first(Stringable|string $string): string
-    {
-        return mb_ucfirst((string) $string);
-    }
-
-    /**
-     * Changes the case of the first letter to lowercase.
-     */
-    function lower_first(Stringable|string $string): string
-    {
-        return mb_lcfirst((string) $string);
-    }
-
-    /**
-     * Replaces consecutive instances of a given character with a single character.
-     */
-    function deduplicate(Stringable|string $string, Stringable|string|iterable $characters = ' '): string
-    {
-        $string = (string) $string;
-
-        foreach (Arr\wrap($characters) as $character) {
-            $string = preg_replace('/' . preg_quote($character, '/') . '+/u', $character, $string);
-        }
-
+    if (ctype_lower($string)) {
         return $string;
     }
 
-    /**
-     * Ensures the given string starts with the specified `$prefix`.
-     */
-    function ensure_starts_with(Stringable|string $string, Stringable|string $prefix): string
-    {
-        return $prefix . preg_replace('/^(?:' . preg_quote($prefix, '/') . ')+/u', replacement: '', subject: (string) $string);
+    $string = preg_replace('/(?<=\p{Ll}|\p{N})(\p{Lu})/u', $delimiter . '$1', $string);
+    $string = preg_replace('/(?<=\p{Lu})(\p{Lu}\p{Ll})/u', $delimiter . '$1', $string);
+    $string = preg_replace('![^' . preg_quote($delimiter) . '\pL\pN\s]+!u', $delimiter, mb_strtolower($string, 'UTF-8'));
+    $string = preg_replace('/\s+/u', $delimiter, $string);
+    $string = trim($string, $delimiter);
+
+    return namespace\deduplicate($string, $delimiter);
+}
+
+/**
+ * Returns an array of words from the specified string.
+ * This is more accurate than {@see str_word_count()}.
+ */
+function to_words(Stringable|string $string): array
+{
+    // Remove 'words' that don't consist of alphanumerical characters or punctuation
+    $words = trim(preg_replace("#[^(\w|\d|\'|\"|\.|\!|\?|;|,|\\|\/|\-|:|\&|@)]+#", ' ', (string) $string));
+    // Remove one-letter 'words' that consist only of punctuation
+    $words = trim(preg_replace("#\s*[(\'|\"|\.|\!|\?|;|,|\\|\/|\-|:|\&|@)]\s*#", ' ', $words));
+
+    return array_values(array_filter(explode(' ', namespace\deduplicate($words))));
+}
+
+/**
+ * Counts the number of words in the given string.
+ */
+function word_count(Stringable|string $string): int
+{
+    return count(to_words($string));
+}
+
+/**
+ * Converts the given string to kebab case.
+ */
+function to_kebab_case(Stringable|string $string): string
+{
+    return to_snake_case((string) $string, delimiter: '-');
+}
+
+/**
+ * Converts the given string to pascal case.
+ */
+function to_pascal_case(Stringable|string $string): string
+{
+    $string = (string) $string;
+    $words = explode(' ', str_replace(['-', '_'], ' ', $string));
+    $studlyWords = array_map(mb_ucfirst(...), $words);
+
+    return implode('', $studlyWords);
+}
+
+/**
+ * Converts the given string to camel case.
+ */
+function to_camel_case(Stringable|string $string): string
+{
+    return lcfirst(to_pascal_case((string) $string));
+}
+
+/**
+ * Converts the given string to an URL-safe slug.
+ *
+ * @param bool $replaceSymbols Adds some more replacements e.g. "£" with "pound".
+ */
+function to_slug(Stringable|string $string, Stringable|string $separator = '-', array $replacements = [], bool $replaceSymbols = true): string
+{
+    return ASCII::to_slugify((string) $string, (string) $separator, replacements: $replacements, replace_extra_symbols: $replaceSymbols);
+}
+
+/**
+ * Transliterates the given string to ASCII.
+ *
+ * @param string $language Language of the source string. Defaults to english.
+ */
+function to_ascii(Stringable|string $string, Stringable|string $language = 'en'): string
+{
+    return ASCII::to_ascii((string) $string, (string) $language, replace_single_chars_only: false);
+}
+
+/**
+ * Checks whether the given string is valid ASCII.
+ */
+function is_ascii(Stringable|string $string): bool
+{
+    return ASCII::is_ascii((string) $string);
+}
+
+/**
+ * Changes the case of the first letter to uppercase.
+ */
+function upper_first(Stringable|string $string): string
+{
+    return mb_ucfirst((string) $string);
+}
+
+/**
+ * Changes the case of the first letter to lowercase.
+ */
+function lower_first(Stringable|string $string): string
+{
+    return mb_lcfirst((string) $string);
+}
+
+/**
+ * Replaces consecutive instances of a given character with a single character.
+ */
+function deduplicate(Stringable|string $string, Stringable|string|iterable $characters = ' '): string
+{
+    $string = (string) $string;
+
+    foreach (Arr\wrap($characters) as $character) {
+        $string = preg_replace('/' . preg_quote($character, '/') . '+/u', $character, $string);
     }
 
-    /**
-     * Ensures the given string ends with the specified `$cap`.
-     */
-    function ensure_ends_with(Stringable|string $string, Stringable|string $cap): string
-    {
-        return preg_replace('/(?:' . preg_quote((string) $cap, '/') . ')+$/u', replacement: '', subject: (string) $string) . $cap;
-    }
+    return $string;
+}
 
-    /**
-     * Returns the remainder of the string after the first occurrence of the given value.
-     */
-    function after_first(Stringable|string $string, Stringable|string|array $search): string
-    {
-        $string = (string) $string;
-        $search = normalize_string($search);
+/**
+ * Ensures the given string starts with the specified `$prefix`.
+ */
+function ensure_starts_with(Stringable|string $string, Stringable|string $prefix): string
+{
+    return $prefix . preg_replace('/^(?:' . preg_quote($prefix, '/') . ')+/u', replacement: '', subject: (string) $string);
+}
 
-        if ($search === '' || $search === []) {
-            return $string;
-        }
+/**
+ * Ensures the given string ends with the specified `$cap`.
+ */
+function ensure_ends_with(Stringable|string $string, Stringable|string $cap): string
+{
+    return preg_replace('/(?:' . preg_quote((string) $cap, '/') . ')+$/u', replacement: '', subject: (string) $string) . $cap;
+}
 
-        $nearestPosition = mb_strlen($string); // Initialize with a large value
-        $foundSearch = '';
+/**
+ * Returns the remainder of the string after the first occurrence of the given value.
+ */
+function after_first(Stringable|string $string, Stringable|string|array $search): string
+{
+    $string = (string) $string;
+    $search = normalize_string($search);
 
-        foreach (Arr\wrap($search) as $term) {
-            $position = mb_strpos($string, $term);
-
-            if ($position !== false && $position < $nearestPosition) {
-                $nearestPosition = $position;
-                $foundSearch = $term;
-            }
-        }
-
-        if ($nearestPosition === mb_strlen($string)) {
-            return $string;
-        }
-
-        return mb_substr($string, $nearestPosition + mb_strlen($foundSearch));
-    }
-
-    /**
-     * Returns the remainder of the string after the last occurrence of the given value.
-     */
-    function after_last(Stringable|string $string, Stringable|string|array $search): string
-    {
-        $string = (string) $string;
-        $search = normalize_string($search);
-
-        if ($search === '' || $search === []) {
-            return $string;
-        }
-
-        $farthestPosition = -1;
-        $foundSearch = null;
-
-        foreach (Arr\wrap($search) as $term) {
-            $position = mb_strrpos($string, $term);
-
-            if ($position !== false && $position > $farthestPosition) {
-                $farthestPosition = $position;
-                $foundSearch = $term;
-            }
-        }
-
-        if ($farthestPosition === -1 || $foundSearch === null) {
-            return $string;
-        }
-
-        return mb_substr($string, $farthestPosition + mb_strlen($foundSearch));
-    }
-
-    /**
-     * Returns the portion of the string before the first occurrence of the given value.
-     */
-    function before_first(Stringable|string $string, Stringable|string|array $search): string
-    {
-        $string = (string) $string;
-        $search = normalize_string($search);
-
-        if ($search === '' || $search === []) {
-            return $string;
-        }
-
-        $nearestPosition = mb_strlen($string);
-
-        foreach (Arr\wrap($search) as $char) {
-            $position = mb_strpos($string, $char);
-
-            if ($position !== false && $position < $nearestPosition) {
-                $nearestPosition = $position;
-            }
-        }
-
-        if ($nearestPosition === mb_strlen($string)) {
-            return $string;
-        }
-
-        return mb_substr($string, start: 0, length: $nearestPosition);
-    }
-
-    /**
-     * Returns the portion of the string before the last occurrence of the given value.
-     */
-    function before_last(Stringable|string $string, Stringable|string|array $search): string
-    {
-        $string = (string) $string;
-        $search = normalize_string($search);
-
-        if ($search === '' || $search === []) {
-            return $string;
-        }
-
-        $farthestPosition = -1;
-
-        foreach (Arr\wrap($search) as $char) {
-            $position = mb_strrpos($string, $char);
-
-            if ($position !== false && $position > $farthestPosition) {
-                $farthestPosition = $position;
-            }
-        }
-
-        if ($farthestPosition === -1) {
-            return $string;
-        }
-
-        return mb_substr($string, start: 0, length: $farthestPosition);
-    }
-
-    /**
-     * Returns the multi-bytes length of the string.
-     */
-    function length(Stringable|string $string): int
-    {
-        return mb_strlen((string) $string);
-    }
-
-    /**
-     * Returns the base name of the string, assuming the string is a class name.
-     */
-    function class_basename(Stringable|string $string): string
-    {
-        return basename(str_replace('\\', '/', (string) $string));
-    }
-
-    /**
-     * Asserts whether the string starts with one of the given needles.
-     */
-    function starts_with(Stringable|string $string, Stringable|string|array $needles): bool
-    {
-        $string = (string) $string;
-
-        if (! is_array($needles)) {
-            $needles = [$needles];
-        }
-
-        return array_any($needles, fn ($needle) => str_starts_with($string, (string) $needle));
-    }
-
-    /**
-     * Asserts whether the string ends with one of the given `$needles`.
-     */
-    function ends_with(Stringable|string $string, Stringable|string|array $needles): bool
-    {
-        $string = (string) $string;
-
-        if (! is_array($needles)) {
-            $needles = [$needles];
-        }
-
-        return array_any($needles, static fn ($needle) => str_ends_with($string, (string) $needle));
-    }
-
-    /**
-     * Replaces the first occurrence of `$search` with `$replace`.
-     */
-    function replace_first(Stringable|string $string, array|Stringable|string $search, Stringable|string $replace): string
-    {
-        $string = (string) $string;
-        $search = normalize_string($search);
-
-        foreach (Arr\wrap($search) as $item) {
-            if ($item === '') {
-                continue;
-            }
-
-            $position = strpos($string, (string) $item);
-
-            if ($position === false) {
-                continue;
-            }
-
-            return substr_replace($string, $replace, $position, strlen($item));
-        }
-
+    if ($search === '' || $search === []) {
         return $string;
     }
 
-    /**
-     * Replaces the last occurrence of `$search` with `$replace`.
-     */
-    function replace_last(Stringable|string $string, array|Stringable|string $search, Stringable|string $replace): string
-    {
-        $string = (string) $string;
-        $search = normalize_string($search);
+    $nearestPosition = mb_strlen($string); // Initialize with a large value
+    $foundSearch = '';
 
-        foreach (Arr\wrap($search) as $item) {
-            if ($item === '') {
-                continue;
-            }
+    foreach (Arr\wrap($search) as $term) {
+        $position = mb_strpos($string, $term);
 
-            $position = strrpos($string, (string) $item);
-
-            if ($position === false) {
-                continue;
-            }
-
-            return substr_replace($string, $replace, $position, strlen($item));
+        if ($position !== false && $position < $nearestPosition) {
+            $nearestPosition = $position;
+            $foundSearch = $term;
         }
+    }
 
+    if ($nearestPosition === mb_strlen($string)) {
         return $string;
     }
 
-    /**
-     * Replaces `$search` with `$replace` if `$search` is at the end of the string.
-     */
-    function replace_end(Stringable|string $string, array|Stringable|string $search, Stringable|string $replace): string
-    {
-        $string = (string) $string;
-        $search = normalize_string($search);
+    return mb_substr($string, $nearestPosition + mb_strlen($foundSearch));
+}
 
-        foreach (Arr\wrap($search) as $item) {
-            if ($item === '') {
-                continue;
-            }
+/**
+ * Returns the remainder of the string after the last occurrence of the given value.
+ */
+function after_last(Stringable|string $string, Stringable|string|array $search): string
+{
+    $string = (string) $string;
+    $search = normalize_string($search);
 
-            if (! ends_with($string, $item)) {
-                continue;
-            }
-
-            return replace_last($string, $item, $replace);
-        }
-
+    if ($search === '' || $search === []) {
         return $string;
     }
 
-    /**
-     * Replaces `$search` with `$replace` if `$search` is at the start of the string.
-     */
-    function replace_start(Stringable|string $string, array|Stringable|string $search, Stringable|string $replace): string
-    {
-        $string = (string) $string;
+    $farthestPosition = -1;
+    $foundSearch = null;
 
-        foreach (Arr\wrap($search) as $item) {
-            if ($item === '') {
-                continue;
-            }
+    foreach (Arr\wrap($search) as $term) {
+        $position = mb_strrpos($string, $term);
 
-            if (! starts_with($string, $item)) {
-                continue;
-            }
-
-            return replace_first($string, $item, $replace);
+        if ($position !== false && $position > $farthestPosition) {
+            $farthestPosition = $position;
+            $foundSearch = $term;
         }
+    }
 
+    if ($farthestPosition === -1 || $foundSearch === null) {
         return $string;
     }
 
-    /**
-     * Strips the specified `$prefix` from the start of the string.
-     */
-    function strip_start(Stringable|string $string, array|Stringable|string $prefix): string
-    {
-        return replace_start($string, $prefix, '');
-    }
+    return mb_substr($string, $farthestPosition + mb_strlen($foundSearch));
+}
 
-    /**
-     * Strips the specified `$suffix` from the end of the string.
-     */
-    function strip_end(Stringable|string $string, array|Stringable|string $suffix): string
-    {
-        return replace_end($string, $suffix, '');
-    }
+/**
+ * Returns the portion of the string before the first occurrence of the given value.
+ */
+function before_first(Stringable|string $string, Stringable|string|array $search): string
+{
+    $string = (string) $string;
+    $search = normalize_string($search);
 
-    /**
-     * Replaces the portion of the specified `$length` at the specified `$position` with the specified `$replace`.
-     */
-    function replace_at(Stringable|string $string, int $position, int $length, Stringable|string $replace): string
-    {
-        $string = (string) $string;
-
-        if ($length < 0) {
-            $position += $length;
-            $length = abs($length);
-        }
-
-        return substr_replace($string, (string) $replace, $position, $length);
-    }
-
-    /**
-     * Returns the '$haystack' string with all occurrences of the keys of `$replacements` replaced by the corresponding values.
-     *
-     * @param array<string, string> $replacements
-     */
-    function replace_every(Stringable|string $haystack, array $replacements): string
-    {
-        $string = (string) $haystack;
-
-        foreach ($replacements as $needle => $replacement) {
-            $string = namespace\replace($string, $needle, (string) $replacement);
-        }
-
+    if ($search === '' || $search === []) {
         return $string;
     }
 
-    /**
-     * Appends the given strings to the string.
-     */
-    function append(Stringable|string $string, string|Stringable ...$append): string
-    {
-        return $string . implode('', $append);
+    $nearestPosition = mb_strlen($string);
+
+    foreach (Arr\wrap($search) as $char) {
+        $position = mb_strpos($string, $char);
+
+        if ($position !== false && $position < $nearestPosition) {
+            $nearestPosition = $position;
+        }
     }
 
-    /**
-     * Prepends the given strings to the string.
-     */
-    function prepend(Stringable|string $string, string|Stringable ...$prepend): string
-    {
-        return implode('', $prepend) . $string;
-    }
-
-    /**
-     * Returns the portion of the string between the widest possible instances of the given strings.
-     */
-    function between(Stringable|string $string, string|Stringable $from, string|Stringable $to): string
-    {
-        $string = (string) $string;
-        $from = normalize_string($from);
-        $to = normalize_string($to);
-
-        if ($from === '' || $to === '') {
-            return $string;
-        }
-
-        return before_last(after_first($string, $from), $to);
-    }
-
-    /**
-     * Wraps the string with the given string. If `$after` is specified, it will be appended instead of `$before`.
-     */
-    function wrap(Stringable|string $string, string|Stringable $before, string|Stringable|null $after = null): string
-    {
-        return $before . $string . ($after ??= $before);
-    }
-
-    /**
-     * Removes the specified `$before` and `$after` from the beginning and the end of the string.
-     */
-    function unwrap(Stringable|string $string, string|Stringable $before, string|Stringable|null $after = null, bool $strict = true): string
-    {
-        $string = (string) $string;
-
-        if ($string === '') {
-            return $string;
-        }
-
-        if ($after === null) {
-            $after = $before;
-        }
-
-        if (! $strict) {
-            return before_last(after_first($string, $before), $after);
-        }
-
-        if (starts_with($string, $before) && ends_with($string, $after)) {
-            return before_last(after_first($string, $before), $after);
-        }
-
+    if ($nearestPosition === mb_strlen($string)) {
         return $string;
     }
 
-    /**
-     * Replaces all occurrences of the given `$search` with `$replace`.
-     */
-    function replace(Stringable|string $string, Stringable|string|array $search, Stringable|string|array $replace): string
-    {
-        $string = (string) $string;
-        $search = normalize_string($search);
-        $replace = normalize_string($replace);
+    return mb_substr($string, start: 0, length: $nearestPosition);
+}
 
-        return str_replace($search, $replace, $string);
+/**
+ * Returns the portion of the string before the last occurrence of the given value.
+ */
+function before_last(Stringable|string $string, Stringable|string|array $search): string
+{
+    $string = (string) $string;
+    $search = normalize_string($search);
+
+    if ($search === '' || $search === []) {
+        return $string;
     }
 
-    /**
-     * Extracts an excerpt from the string.
-     */
-    function excerpt(Stringable|string $string, int $from, int $to, bool $asArray = false): string|array
-    {
-        $string = (string) $string;
-        $lines = explode(PHP_EOL, $string);
+    $farthestPosition = -1;
 
-        $from = max(0, $from - 1);
-        $to = min($to - 1, count($lines));
-        $lines = array_slice($lines, offset: $from, length: $to - $from + 1, preserve_keys: true);
+    foreach (Arr\wrap($search) as $char) {
+        $position = mb_strrpos($string, $char);
 
-        if ($asArray) {
-            return arr($lines)
-                ->mapWithKeys(fn (string $line, int $number) => yield $number + 1 => $line)
-                ->toArray();
+        if ($position !== false && $position > $farthestPosition) {
+            $farthestPosition = $position;
         }
-
-        return implode(PHP_EOL, $lines);
     }
 
-    /**
-     * Truncates the string to the specified amount of characters.
-     */
-    function truncate_end(Stringable|string $string, int $characters, Stringable|string $end = ''): string
-    {
-        $string = (string) $string;
-        $end = (string) $end;
-
-        if (mb_strwidth($string, 'UTF-8') <= $characters) {
-            return $string;
-        }
-
-        if ($characters < 0) {
-            $characters = mb_strlen($string) + $characters;
-        }
-
-        return rtrim(mb_strimwidth($string, 0, $characters, encoding: 'UTF-8')) . $end;
+    if ($farthestPosition === -1) {
+        return $string;
     }
 
-    /**
-     * Truncates the string to the specified amount of characters from the start.
-     */
-    function truncate_start(Stringable|string $string, int $characters, Stringable|string $start = ''): string
-    {
-        return reverse(truncate_end(reverse((string) $string), $characters, (string) $start));
+    return mb_substr($string, start: 0, length: $farthestPosition);
+}
+
+/**
+ * Returns the multi-bytes length of the string.
+ */
+function length(Stringable|string $string): int
+{
+    return mb_strlen((string) $string);
+}
+
+/**
+ * Returns the base name of the string, assuming the string is a class name.
+ */
+function class_basename(Stringable|string $string): string
+{
+    return basename(str_replace('\\', '/', (string) $string));
+}
+
+/**
+ * Asserts whether the string starts with one of the given needles.
+ */
+function starts_with(Stringable|string $string, Stringable|string|array $needles): bool
+{
+    $string = (string) $string;
+
+    if (! is_array($needles)) {
+        $needles = [$needles];
     }
 
-    /**
-     * Reverses the string.
-     */
-    function reverse(Stringable|string $string): string
-    {
-        return implode('', array_reverse(mb_str_split((string) $string, length: 1)));
+    return array_any($needles, fn ($needle) => str_starts_with($string, (string) $needle));
+}
+
+/**
+ * Asserts whether the string ends with one of the given `$needles`.
+ */
+function ends_with(Stringable|string $string, Stringable|string|array $needles): bool
+{
+    $string = (string) $string;
+
+    if (! is_array($needles)) {
+        $needles = [$needles];
     }
 
-    /**
-     * Gets parts of the string.
-     */
-    function slice(Stringable|string $string, int $start, ?int $length = null): string
-    {
-        $stringLength = namespace\length($string);
+    return array_any($needles, static fn ($needle) => str_ends_with($string, (string) $needle));
+}
 
-        if (0 === $start && (null === $length || $stringLength <= $length)) {
-            return $string;
+/**
+ * Replaces the first occurrence of `$search` with `$replace`.
+ */
+function replace_first(Stringable|string $string, array|Stringable|string $search, Stringable|string $replace): string
+{
+    $string = (string) $string;
+    $search = normalize_string($search);
+
+    foreach (Arr\wrap($search) as $item) {
+        if ($item === '') {
+            continue;
         }
 
-        return mb_substr((string) $string, $start, $length);
+        $position = strpos($string, (string) $item);
+
+        if ($position === false) {
+            continue;
+        }
+
+        return substr_replace($string, $replace, $position, strlen($item));
     }
 
-    /**
-     * Checks whether the given string contains the specified `$needle`.
-     */
-    function contains(Stringable|string $string, Stringable|string|array $needle): bool
-    {
-        foreach (Arr\wrap($needle) as $item) {
-            if (str_contains((string) $string, (string) $item)) {
-                return true;
-            }
+    return $string;
+}
+
+/**
+ * Replaces the last occurrence of `$search` with `$replace`.
+ */
+function replace_last(Stringable|string $string, array|Stringable|string $search, Stringable|string $replace): string
+{
+    $string = (string) $string;
+    $search = normalize_string($search);
+
+    foreach (Arr\wrap($search) as $item) {
+        if ($item === '') {
+            continue;
         }
 
-        return false;
+        $position = strrpos($string, (string) $item);
+
+        if ($position === false) {
+            continue;
+        }
+
+        return substr_replace($string, $replace, $position, strlen($item));
     }
 
-    /**
-     * Takes the specified amount of characters. If `$length` is negative, starts from the end.
-     */
-    function take(Stringable|string $string, int $length): string
-    {
-        $string = (string) $string;
+    return $string;
+}
 
-        if ($length < 0) {
-            return slice($string, $length);
+/**
+ * Replaces `$search` with `$replace` if `$search` is at the end of the string.
+ */
+function replace_end(Stringable|string $string, array|Stringable|string $search, Stringable|string $replace): string
+{
+    $string = (string) $string;
+    $search = normalize_string($search);
+
+    foreach (Arr\wrap($search) as $item) {
+        if ($item === '') {
+            continue;
         }
 
-        return slice($string, 0, $length);
+        if (! ends_with($string, $item)) {
+            continue;
+        }
+
+        return replace_last($string, $item, $replace);
     }
 
-    /**
-     * Chunks the string into parts of the specified `$length`.
-     */
-    function chunk(Stringable|string $string, int $length): array
-    {
-        $string = (string) $string;
+    return $string;
+}
 
-        if ($length <= 0) {
-            return [];
+/**
+ * Replaces `$search` with `$replace` if `$search` is at the start of the string.
+ */
+function replace_start(Stringable|string $string, array|Stringable|string $search, Stringable|string $replace): string
+{
+    $string = (string) $string;
+
+    foreach (Arr\wrap($search) as $item) {
+        if ($item === '') {
+            continue;
         }
 
-        if ($string === '') {
-            return [''];
+        if (! starts_with($string, $item)) {
+            continue;
         }
 
-        $chunks = [];
-
-        foreach (str_split($string, $length) as $chunk) {
-            $chunks[] = $chunk;
-        }
-
-        return $chunks;
+        return replace_first($string, $item, $replace);
     }
 
-    /**
-     * Strips HTML and PHP tags from the string.
-     */
-    function strip_tags(Stringable|string $string, null|string|array $allowed = null): string
-    {
-        $string = (string) $string;
+    return $string;
+}
 
-        $allowed = arr($allowed)
-            ->map(fn (string $tag) => wrap($tag, '<', '>'))
+/**
+ * Strips the specified `$prefix` from the start of the string.
+ */
+function strip_start(Stringable|string $string, array|Stringable|string $prefix): string
+{
+    return replace_start($string, $prefix, '');
+}
+
+/**
+ * Strips the specified `$suffix` from the end of the string.
+ */
+function strip_end(Stringable|string $string, array|Stringable|string $suffix): string
+{
+    return replace_end($string, $suffix, '');
+}
+
+/**
+ * Replaces the portion of the specified `$length` at the specified `$position` with the specified `$replace`.
+ */
+function replace_at(Stringable|string $string, int $position, int $length, Stringable|string $replace): string
+{
+    $string = (string) $string;
+
+    if ($length < 0) {
+        $position += $length;
+        $length = abs($length);
+    }
+
+    return substr_replace($string, (string) $replace, $position, $length);
+}
+
+/**
+ * Returns the '$haystack' string with all occurrences of the keys of `$replacements` replaced by the corresponding values.
+ *
+ * @param array<string, string> $replacements
+ */
+function replace_every(Stringable|string $haystack, array $replacements): string
+{
+    $string = (string) $haystack;
+
+    foreach ($replacements as $needle => $replacement) {
+        $string = namespace\replace($string, $needle, (string) $replacement);
+    }
+
+    return $string;
+}
+
+/**
+ * Appends the given strings to the string.
+ */
+function append(Stringable|string $string, string|Stringable ...$append): string
+{
+    return $string . implode('', $append);
+}
+
+/**
+ * Prepends the given strings to the string.
+ */
+function prepend(Stringable|string $string, string|Stringable ...$prepend): string
+{
+    return implode('', $prepend) . $string;
+}
+
+/**
+ * Returns the portion of the string between the widest possible instances of the given strings.
+ */
+function between(Stringable|string $string, string|Stringable $from, string|Stringable $to): string
+{
+    $string = (string) $string;
+    $from = normalize_string($from);
+    $to = normalize_string($to);
+
+    if ($from === '' || $to === '') {
+        return $string;
+    }
+
+    return before_last(after_first($string, $from), $to);
+}
+
+/**
+ * Wraps the string with the given string. If `$after` is specified, it will be appended instead of `$before`.
+ */
+function wrap(Stringable|string $string, string|Stringable $before, string|Stringable|null $after = null): string
+{
+    return $before . $string . ($after ??= $before);
+}
+
+/**
+ * Removes the specified `$before` and `$after` from the beginning and the end of the string.
+ */
+function unwrap(Stringable|string $string, string|Stringable $before, string|Stringable|null $after = null, bool $strict = true): string
+{
+    $string = (string) $string;
+
+    if ($string === '') {
+        return $string;
+    }
+
+    if ($after === null) {
+        $after = $before;
+    }
+
+    if (! $strict) {
+        return before_last(after_first($string, $before), $after);
+    }
+
+    if (starts_with($string, $before) && ends_with($string, $after)) {
+        return before_last(after_first($string, $before), $after);
+    }
+
+    return $string;
+}
+
+/**
+ * Replaces all occurrences of the given `$search` with `$replace`.
+ */
+function replace(Stringable|string $string, Stringable|string|array $search, Stringable|string|array $replace): string
+{
+    $string = (string) $string;
+    $search = normalize_string($search);
+    $replace = normalize_string($replace);
+
+    return str_replace($search, $replace, $string);
+}
+
+/**
+ * Extracts an excerpt from the string.
+ */
+function excerpt(Stringable|string $string, int $from, int $to, bool $asArray = false): string|array
+{
+    $string = (string) $string;
+    $lines = explode(PHP_EOL, $string);
+
+    $from = max(0, $from - 1);
+    $to = min($to - 1, count($lines));
+    $lines = array_slice($lines, offset: $from, length: $to - $from + 1, preserve_keys: true);
+
+    if ($asArray) {
+        return arr($lines)
+            ->mapWithKeys(fn (string $line, int $number) => yield $number + 1 => $line)
             ->toArray();
-
-        return php_strip_tags($string, $allowed);
     }
 
-    /**
-     * Pads the string to the given `$width` and centers the text in it.
-     */
-    function align_center(Stringable|string $string, ?int $width, int $padding = 0): string
-    {
-        $text = trim((string) $string);
-        $textLength = length($text);
-        $actualWidth = max($width ?? 0, $textLength + (2 * $padding));
-        $leftPadding = (int) floor(($actualWidth - $textLength) / 2);
-        $rightPadding = $actualWidth - $leftPadding - $textLength;
+    return implode(PHP_EOL, $lines);
+}
 
-        return str_repeat(' ', $leftPadding) . $text . str_repeat(' ', $rightPadding);
+/**
+ * Truncates the string to the specified amount of characters.
+ */
+function truncate_end(Stringable|string $string, int $characters, Stringable|string $end = ''): string
+{
+    $string = (string) $string;
+    $end = (string) $end;
+
+    if (mb_strwidth($string, 'UTF-8') <= $characters) {
+        return $string;
     }
 
-    /**
-     * Pads the string to the given `$width` and aligns the text to the right.
-     */
-    function align_right(Stringable|string $string, ?int $width, int $padding = 0): string
-    {
-        $text = trim((string) $string);
-        $textLength = length($text);
-        $actualWidth = max($width ?? 0, $textLength + (2 * $padding));
-        $leftPadding = $actualWidth - $textLength - $padding;
-
-        return str_repeat(' ', $leftPadding) . $text . str_repeat(' ', $padding);
+    if ($characters < 0) {
+        $characters = mb_strlen($string) + $characters;
     }
 
-    /**
-     * Pads the string to the given `$width` and aligns the text to the left.
-     */
-    function align_left(Stringable|string $string, ?int $width, int $padding = 0): string
-    {
-        $text = trim((string) $string);
-        $textLength = length($text);
-        $actualWidth = max($width ?? 0, $textLength + (2 * $padding));
-        $rightPadding = $actualWidth - $textLength - $padding;
+    return rtrim(mb_strimwidth($string, 0, $characters, encoding: 'UTF-8')) . $end;
+}
 
-        return str_repeat(' ', $padding) . $text . str_repeat(' ', $rightPadding);
+/**
+ * Truncates the string to the specified amount of characters from the start.
+ */
+function truncate_start(Stringable|string $string, int $characters, Stringable|string $start = ''): string
+{
+    return reverse(truncate_end(reverse((string) $string), $characters, (string) $start));
+}
+
+/**
+ * Reverses the string.
+ */
+function reverse(Stringable|string $string): string
+{
+    return implode('', array_reverse(mb_str_split((string) $string, length: 1)));
+}
+
+/**
+ * Gets parts of the string.
+ */
+function slice(Stringable|string $string, int $start, ?int $length = null): string
+{
+    $stringLength = namespace\length($string);
+
+    if (0 === $start && (null === $length || $stringLength <= $length)) {
+        return $string;
     }
 
-    /**
-     * Returns the string padded to the total length by appending the `$pad_string` to the left.
-     *
-     * If the length of the input string plus the pad string exceeds the total
-     * length, the pad string will be truncated. If the total length is less than or
-     * equal to the length of the input string, no padding will occur.
-     *
-     * Example:
-     *      pad_left('Ay', 4)
-     *      => '  Ay'
-     *
-     *      pad_left('ay', 3, 'A')
-     *      => 'Aay'
-     *
-     *      pad_left('eet', 4, 'Yeeeee')
-     *      => 'Yeet'
-     *
-     *      pad_left('مرحبا', 8, 'م')
-     *      => 'ممممرحبا'
-     *
-     * @param non-empty-string $padString
-     * @param int<0, max> $totalLength
-     */
-    function pad_left(string $string, int $totalLength, string $padString = ' '): string
-    {
-        do {
-            $length = namespace\length($string);
+    return mb_substr((string) $string, $start, $length);
+}
 
-            if ($length >= $totalLength) {
-                return $string;
-            }
-
-            /** @var int<0, max> $remaining */
-            $remaining = $totalLength - $length;
-
-            if ($remaining <= namespace\length($padString)) {
-                $padString = namespace\slice($padString, 0, $remaining);
-            }
-
-            $string = $padString . $string;
-        } while (true);
+/**
+ * Checks whether the given string contains the specified `$needle`.
+ */
+function contains(Stringable|string $string, Stringable|string|array $needle): bool
+{
+    foreach (Arr\wrap($needle) as $item) {
+        if (str_contains((string) $string, (string) $item)) {
+            return true;
+        }
     }
 
-    /**
-     * Returns the string padded to the total length by appending the `$pad_string` to the right.
-     *
-     * If the length of the input string plus the pad string exceeds the total
-     * length, the pad string will be truncated. If the total length is less than or
-     * equal to the length of the input string, no padding will occur.
-     *
-     * Example:
-     *      pad_right('Ay', 4)
-     *      => 'Ay  '
-     *
-     *      pad_right('Ay', 5, 'y')
-     *      => 'Ayyyy'
-     *
-     *      pad_right('Yee', 4, 't')
-     *      => 'Yeet'
-     *
-     *      pad_right('مرحبا', 8, 'ا')
-     *      => 'مرحباااا'
-     *
-     * @param non-empty-string $padString
-     * @param int<0, max> $totalLength
-     */
-    function pad_right(string $string, int $totalLength, string $padString = ' '): string
-    {
-        do {
-            $length = namespace\length($string);
+    return false;
+}
 
-            if ($length >= $totalLength) {
-                return $string;
-            }
+/**
+ * Takes the specified amount of characters. If `$length` is negative, starts from the end.
+ */
+function take(Stringable|string $string, int $length): string
+{
+    $string = (string) $string;
 
-            /** @var int<0, max> $remaining */
-            $remaining = $totalLength - $length;
-
-            if ($remaining <= namespace\length($padString)) {
-                $padString = namespace\slice($padString, 0, $remaining);
-            }
-
-            $string .= $padString;
-        } while (true);
+    if ($length < 0) {
+        return slice($string, $length);
     }
 
-    /**
-     * Inserts the specified `$insertion` at the specified `$position`.
-     */
-    function insert_at(Stringable|string $string, int $position, string $insertion): string
-    {
-        $string = (string) $string;
+    return slice($string, 0, $length);
+}
 
-        return mb_substr($string, 0, $position) . $insertion . mb_substr($string, $position);
+/**
+ * Chunks the string into parts of the specified `$length`.
+ */
+function chunk(Stringable|string $string, int $length): array
+{
+    $string = (string) $string;
+
+    if ($length <= 0) {
+        return [];
     }
 
-    /**
-     * Calculates the levenshtein difference between two strings.
-     */
-    function levenshtein(Stringable|string $string, string|Stringable $other): int
-    {
-        return php_levenshtein((string) $string, (string) $other);
+    if ($string === '') {
+        return [''];
     }
 
-    /**
-     * Calculate the metaphone key of a string.
-     */
-    function metaphone(Stringable|string $string, int $phonemes = 0): string
-    {
-        return php_metaphone((string) $string, $phonemes);
+    $chunks = [];
+
+    foreach (str_split($string, $length) as $chunk) {
+        $chunks[] = $chunk;
     }
 
-    /**
-     * Checks whether a string is empty
-     */
-    function is_empty(Stringable|string $string): bool
-    {
-        return (string) $string === '';
-    }
+    return $chunks;
+}
 
-    /**
-     * Asserts whether the string is equal to the given string.
-     */
-    function equals(Stringable|string $string, string|Stringable $other): bool
-    {
-        return (string) $string === (string) $other;
-    }
+/**
+ * Strips HTML and PHP tags from the string.
+ */
+function strip_tags(Stringable|string $string, null|string|array $allowed = null): string
+{
+    $string = (string) $string;
 
-    /**
-     * Parses the given value to a string, returning the default value if it is not a string or `Stringable`.
-     */
-    function parse(mixed $string, ?string $default = ''): ?string
-    {
-        if (is_string($string)) {
+    $allowed = arr($allowed)
+        ->map(fn (string $tag) => wrap($tag, '<', '>'))
+        ->toArray();
+
+    return php_strip_tags($string, $allowed);
+}
+
+/**
+ * Pads the string to the given `$width` and centers the text in it.
+ */
+function align_center(Stringable|string $string, ?int $width, int $padding = 0): string
+{
+    $text = trim((string) $string);
+    $textLength = length($text);
+    $actualWidth = max($width ?? 0, $textLength + (2 * $padding));
+    $leftPadding = (int) floor(($actualWidth - $textLength) / 2);
+    $rightPadding = $actualWidth - $leftPadding - $textLength;
+
+    return str_repeat(' ', $leftPadding) . $text . str_repeat(' ', $rightPadding);
+}
+
+/**
+ * Pads the string to the given `$width` and aligns the text to the right.
+ */
+function align_right(Stringable|string $string, ?int $width, int $padding = 0): string
+{
+    $text = trim((string) $string);
+    $textLength = length($text);
+    $actualWidth = max($width ?? 0, $textLength + (2 * $padding));
+    $leftPadding = $actualWidth - $textLength - $padding;
+
+    return str_repeat(' ', $leftPadding) . $text . str_repeat(' ', $padding);
+}
+
+/**
+ * Pads the string to the given `$width` and aligns the text to the left.
+ */
+function align_left(Stringable|string $string, ?int $width, int $padding = 0): string
+{
+    $text = trim((string) $string);
+    $textLength = length($text);
+    $actualWidth = max($width ?? 0, $textLength + (2 * $padding));
+    $rightPadding = $actualWidth - $textLength - $padding;
+
+    return str_repeat(' ', $padding) . $text . str_repeat(' ', $rightPadding);
+}
+
+/**
+ * Returns the string padded to the total length by appending the `$pad_string` to the left.
+ *
+ * If the length of the input string plus the pad string exceeds the total
+ * length, the pad string will be truncated. If the total length is less than or
+ * equal to the length of the input string, no padding will occur.
+ *
+ * Example:
+ *      pad_left('Ay', 4)
+ *      => '  Ay'
+ *
+ *      pad_left('ay', 3, 'A')
+ *      => 'Aay'
+ *
+ *      pad_left('eet', 4, 'Yeeeee')
+ *      => 'Yeet'
+ *
+ *      pad_left('مرحبا', 8, 'م')
+ *      => 'ممممرحبا'
+ *
+ * @param non-empty-string $padString
+ * @param int<0, max> $totalLength
+ */
+function pad_left(string $string, int $totalLength, string $padString = ' '): string
+{
+    do {
+        $length = namespace\length($string);
+
+        if ($length >= $totalLength) {
             return $string;
         }
 
-        if (is_int($string) || is_float($string)) {
-            return (string) $string;
+        /** @var int<0, max> $remaining */
+        $remaining = $totalLength - $length;
+
+        if ($remaining <= namespace\length($padString)) {
+            $padString = namespace\slice($padString, 0, $remaining);
         }
 
-        if ($string instanceof Stringable) {
-            return (string) $string;
+        $string = $padString . $string;
+    } while (true);
+}
+
+/**
+ * Returns the string padded to the total length by appending the `$pad_string` to the right.
+ *
+ * If the length of the input string plus the pad string exceeds the total
+ * length, the pad string will be truncated. If the total length is less than or
+ * equal to the length of the input string, no padding will occur.
+ *
+ * Example:
+ *      pad_right('Ay', 4)
+ *      => 'Ay  '
+ *
+ *      pad_right('Ay', 5, 'y')
+ *      => 'Ayyyy'
+ *
+ *      pad_right('Yee', 4, 't')
+ *      => 'Yeet'
+ *
+ *      pad_right('مرحبا', 8, 'ا')
+ *      => 'مرحباااا'
+ *
+ * @param non-empty-string $padString
+ * @param int<0, max> $totalLength
+ */
+function pad_right(string $string, int $totalLength, string $padString = ' '): string
+{
+    do {
+        $length = namespace\length($string);
+
+        if ($length >= $totalLength) {
+            return $string;
         }
 
-        if ($string instanceof BackedEnum) {
-            return (string) $string->value;
+        /** @var int<0, max> $remaining */
+        $remaining = $totalLength - $length;
+
+        if ($remaining <= namespace\length($padString)) {
+            $padString = namespace\slice($padString, 0, $remaining);
         }
 
-        if ($string instanceof UnitEnum) {
-            return $string->name;
-        }
+        $string .= $padString;
+    } while (true);
+}
 
-        if (is_object($string) && method_exists($string, '__toString')) {
-            return (string) $string;
-        }
+/**
+ * Inserts the specified `$insertion` at the specified `$position`.
+ */
+function insert_at(Stringable|string $string, int $position, string $insertion): string
+{
+    $string = (string) $string;
 
-        return $default;
+    return mb_substr($string, 0, $position) . $insertion . mb_substr($string, $position);
+}
+
+/**
+ * Calculates the levenshtein difference between two strings.
+ */
+function levenshtein(Stringable|string $string, string|Stringable $other): int
+{
+    return php_levenshtein((string) $string, (string) $other);
+}
+
+/**
+ * Calculate the metaphone key of a string.
+ */
+function metaphone(Stringable|string $string, int $phonemes = 0): string
+{
+    return php_metaphone((string) $string, $phonemes);
+}
+
+/**
+ * Checks whether a string is empty
+ */
+function is_empty(Stringable|string $string): bool
+{
+    return (string) $string === '';
+}
+
+/**
+ * Asserts whether the string is equal to the given string.
+ */
+function equals(Stringable|string $string, string|Stringable $other): bool
+{
+    return (string) $string === (string) $other;
+}
+
+/**
+ * Parses the given value to a string, returning the default value if it is not a string or `Stringable`.
+ */
+function parse(mixed $string, ?string $default = ''): ?string
+{
+    if (is_string($string)) {
+        return $string;
     }
 
-    /**
-     * Normalizes `Stringable` to string, while keeping other values the same.
-     *
-     * @internal
-     */
-    function normalize_string(mixed $value): mixed
-    {
-        if ($value instanceof Stringable) {
-            return (string) $value;
-        }
-
-        return $value;
+    if (is_int($string) || is_float($string)) {
+        return (string) $string;
     }
+
+    if ($string instanceof Stringable) {
+        return (string) $string;
+    }
+
+    if ($string instanceof BackedEnum) {
+        return (string) $string->value;
+    }
+
+    if ($string instanceof UnitEnum) {
+        return $string->name;
+    }
+
+    if (is_object($string) && method_exists($string, '__toString')) {
+        return (string) $string;
+    }
+
+    return $default;
+}
+
+/**
+ * Normalizes `Stringable` to string, while keeping other values the same.
+ *
+ * @internal
+ */
+function normalize_string(mixed $value): mixed
+{
+    if ($value instanceof Stringable) {
+        return (string) $value;
+    }
+
+    return $value;
 }

--- a/packages/support/src/functions.php
+++ b/packages/support/src/functions.php
@@ -2,81 +2,81 @@
 
 declare(strict_types=1);
 
-namespace Tempest\Support {
-    use Closure;
-    use Stringable;
-    use Tempest\Support\Arr\ImmutableArray;
-    use Tempest\Support\Path\Path;
-    use Tempest\Support\Str\ImmutableString;
+namespace Tempest\Support;
 
-    /**
-     * Creates an instance of {@see \Tempest\Support\Str\ImmutableString} using the given `$string`.
-     */
-    function str(Stringable|int|string|null $string = ''): ImmutableString
-    {
-        return new ImmutableString($string);
-    }
+use Closure;
+use Stringable;
+use Tempest\Support\Arr\ImmutableArray;
+use Tempest\Support\Path\Path;
+use Tempest\Support\Str\ImmutableString;
 
-    /**
-     * Creates an instance of {@see \Tempest\Support\Arr\ImmutableArray} using the given `$input`. If `$input` is not an array, it will be wrapped in one.
-     */
-    function arr(mixed $input = []): ImmutableArray
-    {
-        return new ImmutableArray($input);
-    }
+/**
+ * Creates an instance of {@see \Tempest\Support\Str\ImmutableString} using the given `$string`.
+ */
+function str(Stringable|int|string|null $string = ''): ImmutableString
+{
+    return new ImmutableString($string);
+}
 
-    /**
-     * Normalizes the given path without checking it against the filesystem.
-     */
-    function path(Stringable|string ...$parts): Path
-    {
-        return new Path(...$parts);
-    }
+/**
+ * Creates an instance of {@see \Tempest\Support\Arr\ImmutableArray} using the given `$input`. If `$input` is not an array, it will be wrapped in one.
+ */
+function arr(mixed $input = []): ImmutableArray
+{
+    return new ImmutableArray($input);
+}
 
-    /**
-     * Executes the callback with the given `$value` and returns the same `$value`.
-     *
-     * @template T
-     *
-     * @param T $value
-     * @param (callable(T): void) $callback
-     *
-     * @return T
-     */
-    function tap(mixed $value, callable $callback): mixed
-    {
-        $callback($value);
+/**
+ * Normalizes the given path without checking it against the filesystem.
+ */
+function path(Stringable|string ...$parts): Path
+{
+    return new Path(...$parts);
+}
 
-        return $value;
-    }
+/**
+ * Executes the callback with the given `$value` and returns the same `$value`.
+ *
+ * @template T
+ *
+ * @param T $value
+ * @param (callable(T): void) $callback
+ *
+ * @return T
+ */
+function tap(mixed $value, callable $callback): mixed
+{
+    $callback($value);
 
-    /**
-     * Returns a tuple containing the result of the `$callback` as the first element and the error message as the second element if there was an error.
-     *
-     * @template T
-     *
-     * @param (Closure(): T) $callback
-     *
-     * @return array{0: T, 1: ?string}
-     */
-    function box(Closure $callback): array
-    {
-        $lastMessage = null;
+    return $value;
+}
 
-        set_error_handler(static function (int $_type, string $message) use (&$lastMessage): void { // @phpstan-ignore argument.type
-            $lastMessage = $message;
-        });
+/**
+ * Returns a tuple containing the result of the `$callback` as the first element and the error message as the second element if there was an error.
+ *
+ * @template T
+ *
+ * @param (Closure(): T) $callback
+ *
+ * @return array{0: T, 1: ?string}
+ */
+function box(Closure $callback): array
+{
+    $lastMessage = null;
 
-        try {
-            $value = $callback();
+    set_error_handler(static function (int $_type, string $message) use (&$lastMessage): void { // @phpstan-ignore argument.type
+        $lastMessage = $message;
+    });
 
-            if (null !== $lastMessage && Str\contains($lastMessage, '): ')) {
-                $lastMessage = Str\after_first(Str\to_lower_case($lastMessage), '): ');
-            }
+    try {
+        $value = $callback();
 
-            return [$value, $lastMessage];
-        } finally {
-            restore_error_handler();
+        if (null !== $lastMessage && Str\contains($lastMessage, '): ')) {
+            $lastMessage = Str\after_first(Str\to_lower_case($lastMessage), '): ');
         }
+
+        return [$value, $lastMessage];
+    } finally {
+        restore_error_handler();
     }
 }

--- a/packages/upgrade/config/sets/tempest30.php
+++ b/packages/upgrade/config/sets/tempest30.php
@@ -1,6 +1,7 @@
 <?php
 
 use Rector\Config\RectorConfig;
+use Tempest\Upgrade\Tempest3\UpdateCommandFunctionImportsRector;
 use Tempest\Upgrade\Tempest3\UpdateExceptionProcessorRector;
 use Tempest\Upgrade\Tempest3\UpdateHasContextRector;
 use Tempest\Upgrade\Tempest3\UpdateMapperFunctionImportsRector;
@@ -10,6 +11,7 @@ return static function (RectorConfig $config): void {
     $config->importNames();
     $config->importShortClasses();
 
+    $config->rule(UpdateCommandFunctionImportsRector::class);
     $config->rule(UpdateMapperFunctionImportsRector::class);
     $config->rule(UpdateViewFunctionImportsRector::class);
     $config->rule(UpdateExceptionProcessorRector::class);

--- a/packages/upgrade/config/sets/tempest30.php
+++ b/packages/upgrade/config/sets/tempest30.php
@@ -6,6 +6,7 @@ use Tempest\Upgrade\Tempest3\UpdateEventFunctionImportsRector;
 use Tempest\Upgrade\Tempest3\UpdateExceptionProcessorRector;
 use Tempest\Upgrade\Tempest3\UpdateHasContextRector;
 use Tempest\Upgrade\Tempest3\UpdateMapperFunctionImportsRector;
+use Tempest\Upgrade\Tempest3\UpdateReflectionFunctionImportsRector;
 use Tempest\Upgrade\Tempest3\UpdateViewFunctionImportsRector;
 
 return static function (RectorConfig $config): void {
@@ -15,6 +16,7 @@ return static function (RectorConfig $config): void {
     $config->rule(UpdateCommandFunctionImportsRector::class);
     $config->rule(UpdateEventFunctionImportsRector::class);
     $config->rule(UpdateMapperFunctionImportsRector::class);
+    $config->rule(UpdateReflectionFunctionImportsRector::class);
     $config->rule(UpdateViewFunctionImportsRector::class);
     $config->rule(UpdateExceptionProcessorRector::class);
     $config->rule(UpdateHasContextRector::class);

--- a/packages/upgrade/config/sets/tempest30.php
+++ b/packages/upgrade/config/sets/tempest30.php
@@ -1,6 +1,8 @@
 <?php
 
 use Rector\Config\RectorConfig;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
 use Tempest\Upgrade\Tempest3\UpdateCommandFunctionImportsRector;
 use Tempest\Upgrade\Tempest3\UpdateContainerFunctionImportsRector;
 use Tempest\Upgrade\Tempest3\UpdateEventFunctionImportsRector;
@@ -11,8 +13,8 @@ use Tempest\Upgrade\Tempest3\UpdateReflectionFunctionImportsRector;
 use Tempest\Upgrade\Tempest3\UpdateViewFunctionImportsRector;
 
 return static function (RectorConfig $config): void {
-    $config->importNames();
-    $config->importShortClasses();
+    SimpleParameterProvider::setParameter(Option::AUTO_IMPORT_NAMES, value: true);
+    SimpleParameterProvider::setParameter(Option::IMPORT_SHORT_CLASSES, value: true);
 
     $config->rule(UpdateCommandFunctionImportsRector::class);
     $config->rule(UpdateContainerFunctionImportsRector::class);

--- a/packages/upgrade/config/sets/tempest30.php
+++ b/packages/upgrade/config/sets/tempest30.php
@@ -2,6 +2,7 @@
 
 use Rector\Config\RectorConfig;
 use Tempest\Upgrade\Tempest3\UpdateCommandFunctionImportsRector;
+use Tempest\Upgrade\Tempest3\UpdateEventFunctionImportsRector;
 use Tempest\Upgrade\Tempest3\UpdateExceptionProcessorRector;
 use Tempest\Upgrade\Tempest3\UpdateHasContextRector;
 use Tempest\Upgrade\Tempest3\UpdateMapperFunctionImportsRector;
@@ -12,6 +13,7 @@ return static function (RectorConfig $config): void {
     $config->importShortClasses();
 
     $config->rule(UpdateCommandFunctionImportsRector::class);
+    $config->rule(UpdateEventFunctionImportsRector::class);
     $config->rule(UpdateMapperFunctionImportsRector::class);
     $config->rule(UpdateViewFunctionImportsRector::class);
     $config->rule(UpdateExceptionProcessorRector::class);

--- a/packages/upgrade/config/sets/tempest30.php
+++ b/packages/upgrade/config/sets/tempest30.php
@@ -2,6 +2,7 @@
 
 use Rector\Config\RectorConfig;
 use Tempest\Upgrade\Tempest3\UpdateCommandFunctionImportsRector;
+use Tempest\Upgrade\Tempest3\UpdateContainerFunctionImportsRector;
 use Tempest\Upgrade\Tempest3\UpdateEventFunctionImportsRector;
 use Tempest\Upgrade\Tempest3\UpdateExceptionProcessorRector;
 use Tempest\Upgrade\Tempest3\UpdateHasContextRector;
@@ -14,6 +15,7 @@ return static function (RectorConfig $config): void {
     $config->importShortClasses();
 
     $config->rule(UpdateCommandFunctionImportsRector::class);
+    $config->rule(UpdateContainerFunctionImportsRector::class);
     $config->rule(UpdateEventFunctionImportsRector::class);
     $config->rule(UpdateMapperFunctionImportsRector::class);
     $config->rule(UpdateReflectionFunctionImportsRector::class);

--- a/packages/upgrade/src/Tempest3/UpdateCommandFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateCommandFunctionImportsRector.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tempest\Upgrade\Tempest3;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+
+final class UpdateCommandFunctionImportsRector extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\UseItem::class,
+            Node\Expr\FuncCall::class,
+        ];
+    }
+
+    public function refactor(Node $node): ?int
+    {
+        if ($node instanceof Node\UseItem) {
+            if ($node->name->toString() === 'Tempest\command') {
+                $node->name = new Node\Name('Tempest\CommandBus\command');
+            }
+
+            return null;
+        }
+
+        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
+            $functionName = $node->name->toString();
+
+            if ($functionName === 'Tempest\command') {
+                $node->name = new Node\Name\FullyQualified('Tempest\CommandBus\command');
+
+                return null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/upgrade/src/Tempest3/UpdateCommandFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateCommandFunctionImportsRector.php
@@ -21,18 +21,6 @@ final class UpdateCommandFunctionImportsRector extends AbstractRector
             if ($node->name->toString() === 'Tempest\command') {
                 $node->name = new Node\Name('Tempest\CommandBus\command');
             }
-
-            return null;
-        }
-
-        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
-            $functionName = $node->name->toString();
-
-            if ($functionName === 'Tempest\command') {
-                $node->name = new Node\Name\FullyQualified('Tempest\CommandBus\command');
-
-                return null;
-            }
         }
 
         return null;

--- a/packages/upgrade/src/Tempest3/UpdateCommandFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateCommandFunctionImportsRector.php
@@ -21,6 +21,18 @@ final class UpdateCommandFunctionImportsRector extends AbstractRector
             if ($node->name->toString() === 'Tempest\command') {
                 $node->name = new Node\Name('Tempest\CommandBus\command');
             }
+
+            return null;
+        }
+
+        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
+            $functionName = $node->name->toString();
+
+            if ($functionName === 'Tempest\command') {
+                $node->name = new Node\Name\FullyQualified('Tempest\CommandBus\command');
+
+                return null;
+            }
         }
 
         return null;

--- a/packages/upgrade/src/Tempest3/UpdateContainerFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateContainerFunctionImportsRector.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tempest\Upgrade\Tempest3;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+
+final class UpdateContainerFunctionImportsRector extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\UseItem::class,
+            Node\Expr\FuncCall::class,
+        ];
+    }
+
+    public function refactor(Node $node): ?int
+    {
+        if ($node instanceof Node\UseItem) {
+            if ($node->name->toString() === 'Tempest\get') {
+                $node->name = new Node\Name('Tempest\Container\get');
+            }
+
+            if ($node->name->toString() === 'Tempest\invoke') {
+                $node->name = new Node\Name('Tempest\Container\invoke');
+            }
+
+            return null;
+        }
+
+        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
+            $functionName = $node->name->toString();
+
+            if ($functionName === 'Tempest\get') {
+                $node->name = new Node\Name\FullyQualified('Tempest\Container\get');
+
+                return null;
+            }
+
+            if ($functionName === 'Tempest\invoke') {
+                $node->name = new Node\Name\FullyQualified('Tempest\Container\invoke');
+
+                return null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/upgrade/src/Tempest3/UpdateContainerFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateContainerFunctionImportsRector.php
@@ -25,24 +25,6 @@ final class UpdateContainerFunctionImportsRector extends AbstractRector
             if ($node->name->toString() === 'Tempest\invoke') {
                 $node->name = new Node\Name('Tempest\Container\invoke');
             }
-
-            return null;
-        }
-
-        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
-            $functionName = $node->name->toString();
-
-            if ($functionName === 'Tempest\get') {
-                $node->name = new Node\Name\FullyQualified('Tempest\Container\get');
-
-                return null;
-            }
-
-            if ($functionName === 'Tempest\invoke') {
-                $node->name = new Node\Name\FullyQualified('Tempest\Container\invoke');
-
-                return null;
-            }
         }
 
         return null;

--- a/packages/upgrade/src/Tempest3/UpdateContainerFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateContainerFunctionImportsRector.php
@@ -25,6 +25,24 @@ final class UpdateContainerFunctionImportsRector extends AbstractRector
             if ($node->name->toString() === 'Tempest\invoke') {
                 $node->name = new Node\Name('Tempest\Container\invoke');
             }
+
+            return null;
+        }
+
+        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
+            $functionName = $node->name->toString();
+
+            if ($functionName === 'Tempest\get') {
+                $node->name = new Node\Name\FullyQualified('Tempest\Container\get');
+
+                return null;
+            }
+
+            if ($functionName === 'Tempest\invoke') {
+                $node->name = new Node\Name\FullyQualified('Tempest\Container\invoke');
+
+                return null;
+            }
         }
 
         return null;

--- a/packages/upgrade/src/Tempest3/UpdateEventFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateEventFunctionImportsRector.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tempest\Upgrade\Tempest3;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+
+final class UpdateEventFunctionImportsRector extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\UseItem::class,
+            Node\Expr\FuncCall::class,
+        ];
+    }
+
+    public function refactor(Node $node): ?int
+    {
+        if ($node instanceof Node\UseItem) {
+            if ($node->name->toString() === 'Tempest\event') {
+                $node->name = new Node\Name('Tempest\EventBus\event');
+            }
+
+            if ($node->name->toString() === 'Tempest\listen') {
+                $node->name = new Node\Name('Tempest\EventBus\listen');
+            }
+
+            return null;
+        }
+
+        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
+            $functionName = $node->name->toString();
+
+            if ($functionName === 'Tempest\event') {
+                $node->name = new Node\Name\FullyQualified('Tempest\EventBus\event');
+
+                return null;
+            }
+
+            if ($functionName === 'Tempest\listen') {
+                $node->name = new Node\Name\FullyQualified('Tempest\EventBus\listen');
+
+                return null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/upgrade/src/Tempest3/UpdateEventFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateEventFunctionImportsRector.php
@@ -25,6 +25,24 @@ final class UpdateEventFunctionImportsRector extends AbstractRector
             if ($node->name->toString() === 'Tempest\listen') {
                 $node->name = new Node\Name('Tempest\EventBus\listen');
             }
+
+            return null;
+        }
+
+        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
+            $functionName = $node->name->toString();
+
+            if ($functionName === 'Tempest\event') {
+                $node->name = new Node\Name\FullyQualified('Tempest\EventBus\event');
+
+                return null;
+            }
+
+            if ($functionName === 'Tempest\listen') {
+                $node->name = new Node\Name\FullyQualified('Tempest\EventBus\listen');
+
+                return null;
+            }
         }
 
         return null;

--- a/packages/upgrade/src/Tempest3/UpdateEventFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateEventFunctionImportsRector.php
@@ -25,24 +25,6 @@ final class UpdateEventFunctionImportsRector extends AbstractRector
             if ($node->name->toString() === 'Tempest\listen') {
                 $node->name = new Node\Name('Tempest\EventBus\listen');
             }
-
-            return null;
-        }
-
-        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
-            $functionName = $node->name->toString();
-
-            if ($functionName === 'Tempest\event') {
-                $node->name = new Node\Name\FullyQualified('Tempest\EventBus\event');
-
-                return null;
-            }
-
-            if ($functionName === 'Tempest\listen') {
-                $node->name = new Node\Name\FullyQualified('Tempest\EventBus\listen');
-
-                return null;
-            }
         }
 
         return null;

--- a/packages/upgrade/src/Tempest3/UpdateMapperFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateMapperFunctionImportsRector.php
@@ -25,24 +25,6 @@ final class UpdateMapperFunctionImportsRector extends AbstractRector
             if ($node->name->toString() === 'Tempest\make') {
                 $node->name = new Node\Name('Tempest\Mapper\make');
             }
-
-            return null;
-        }
-
-        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
-            $functionName = $node->name->toString();
-
-            if ($functionName === 'Tempest\map') {
-                $node->name = new Node\Name\FullyQualified('Tempest\Mapper\map');
-
-                return null;
-            }
-
-            if ($functionName === 'Tempest\make') {
-                $node->name = new Node\Name\FullyQualified('Tempest\Mapper\make');
-
-                return null;
-            }
         }
 
         return null;

--- a/packages/upgrade/src/Tempest3/UpdateMapperFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateMapperFunctionImportsRector.php
@@ -25,6 +25,24 @@ final class UpdateMapperFunctionImportsRector extends AbstractRector
             if ($node->name->toString() === 'Tempest\make') {
                 $node->name = new Node\Name('Tempest\Mapper\make');
             }
+
+            return null;
+        }
+
+        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
+            $functionName = $node->name->toString();
+
+            if ($functionName === 'Tempest\map') {
+                $node->name = new Node\Name\FullyQualified('Tempest\Mapper\map');
+
+                return null;
+            }
+
+            if ($functionName === 'Tempest\make') {
+                $node->name = new Node\Name\FullyQualified('Tempest\Mapper\make');
+
+                return null;
+            }
         }
 
         return null;

--- a/packages/upgrade/src/Tempest3/UpdateReflectionFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateReflectionFunctionImportsRector.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tempest\Upgrade\Tempest3;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+
+final class UpdateReflectionFunctionImportsRector extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\UseItem::class,
+            Node\Expr\FuncCall::class,
+        ];
+    }
+
+    public function refactor(Node $node): ?int
+    {
+        if ($node instanceof Node\UseItem) {
+            if ($node->name->toString() === 'Tempest\reflect') {
+                $node->name = new Node\Name('Tempest\Reflection\reflect');
+            }
+
+            return null;
+        }
+
+        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
+            $functionName = $node->name->toString();
+
+            if ($functionName === 'Tempest\reflect') {
+                $node->name = new Node\Name\FullyQualified('Tempest\Reflection\reflect');
+
+                return null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/packages/upgrade/src/Tempest3/UpdateReflectionFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateReflectionFunctionImportsRector.php
@@ -21,6 +21,18 @@ final class UpdateReflectionFunctionImportsRector extends AbstractRector
             if ($node->name->toString() === 'Tempest\reflect') {
                 $node->name = new Node\Name('Tempest\Reflection\reflect');
             }
+
+            return null;
+        }
+
+        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
+            $functionName = $node->name->toString();
+
+            if ($functionName === 'Tempest\reflect') {
+                $node->name = new Node\Name\FullyQualified('Tempest\Reflection\reflect');
+
+                return null;
+            }
         }
 
         return null;

--- a/packages/upgrade/src/Tempest3/UpdateReflectionFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateReflectionFunctionImportsRector.php
@@ -21,18 +21,6 @@ final class UpdateReflectionFunctionImportsRector extends AbstractRector
             if ($node->name->toString() === 'Tempest\reflect') {
                 $node->name = new Node\Name('Tempest\Reflection\reflect');
             }
-
-            return null;
-        }
-
-        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
-            $functionName = $node->name->toString();
-
-            if ($functionName === 'Tempest\reflect') {
-                $node->name = new Node\Name\FullyQualified('Tempest\Reflection\reflect');
-
-                return null;
-            }
         }
 
         return null;

--- a/packages/upgrade/src/Tempest3/UpdateViewFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateViewFunctionImportsRector.php
@@ -25,16 +25,6 @@ final class UpdateViewFunctionImportsRector extends AbstractRector
             return null;
         }
 
-        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
-            $functionName = $node->name->toString();
-
-            if ($functionName === 'Tempest\view') {
-                $node->name = new Node\Name\FullyQualified('Tempest\View\view');
-
-                return null;
-            }
-        }
-
         return null;
     }
 }

--- a/packages/upgrade/src/Tempest3/UpdateViewFunctionImportsRector.php
+++ b/packages/upgrade/src/Tempest3/UpdateViewFunctionImportsRector.php
@@ -25,6 +25,16 @@ final class UpdateViewFunctionImportsRector extends AbstractRector
             return null;
         }
 
+        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
+            $functionName = $node->name->toString();
+
+            if ($functionName === 'Tempest\view') {
+                $node->name = new Node\Name\FullyQualified('Tempest\View\view');
+
+                return null;
+            }
+        }
+
         return null;
     }
 }

--- a/packages/view/src/Components/x-component.view.php
+++ b/packages/view/src/Components/x-component.view.php
@@ -7,7 +7,7 @@
 use Tempest\View\Renderers\TempestViewRenderer;
 use Tempest\View\Slot;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 use function Tempest\View\view;
 
 $attributeString = $attributes

--- a/packages/view/src/Components/x-icon.view.php
+++ b/packages/view/src/Components/x-icon.view.php
@@ -7,7 +7,7 @@
 use Tempest\Core\Environment;
 use Tempest\Icon\Icon;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 use function Tempest\Support\str;
 
 $class ??= null;

--- a/packages/view/src/Components/x-input.view.php
+++ b/packages/view/src/Components/x-input.view.php
@@ -10,7 +10,7 @@
 use Tempest\Http\Session\FormSession;
 use Tempest\Validation\Validator;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 use function Tempest\Support\str;
 
 /** @var FormSession $formSession */

--- a/packages/view/src/Components/x-markdown.view.php
+++ b/packages/view/src/Components/x-markdown.view.php
@@ -7,7 +7,7 @@
 use League\CommonMark\MarkdownConverter;
 use Tempest\View\Slot;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 $content ??= $slots[Slot::DEFAULT]->content ?? '';
 $markdown = get(MarkdownConverter::class);

--- a/packages/vite/src/functions.php
+++ b/packages/vite/src/functions.php
@@ -6,7 +6,7 @@ namespace Tempest\Vite;
 
 use Tempest\Vite\Vite;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 /**
  * Gets tags for the specified or configured `$entrypoints`.

--- a/packages/vite/src/functions.php
+++ b/packages/vite/src/functions.php
@@ -2,17 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Tempest {
-    use Tempest\Support\Html\HtmlString;
-    use Tempest\Vite\Vite;
+namespace Tempest\Vite;
 
-    /**
-     * Inject tags for the specified or configured `$entrypoints`.
-     */
-    function vite_tags(null|string|array $entrypoints = null): HtmlString
-    {
-        return new HtmlString(
-            string: implode('', get(Vite::class)->getTags(is_array($entrypoints) ? $entrypoints : [$entrypoints])),
-        );
-    }
+use Tempest\Vite\Vite;
+
+use function Tempest\get;
+
+/**
+ * Gets tags for the specified or configured `$entrypoints`.
+ */
+function get_tags(null|string|array $entrypoints = null): array
+{
+    return get(Vite::class)->getTags(is_array($entrypoints) ? $entrypoints : [$entrypoints]);
 }

--- a/packages/vite/src/x-vite-tags.view.php
+++ b/packages/vite/src/x-vite-tags.view.php
@@ -4,14 +4,15 @@
  * @var string|null $entrypoint
  */
 
+use Tempest\Support\Html\HtmlString;
+use Tempest\Vite;
 use Tempest\Vite\ViteConfig;
 
 use function Tempest\get;
-use function Tempest\vite_tags;
 
 $viteConfig = get(ViteConfig::class);
-
-$html = vite_tags($entrypoints ?? $entrypoint ?? $viteConfig->entrypoints);
+$tags = Vite\get_tags($entrypoints ?? $entrypoint ?? $viteConfig->entrypoints);
+$html = new HtmlString(implode('', $tags));
 ?>
 
 {!! $html !!}

--- a/packages/vite/src/x-vite-tags.view.php
+++ b/packages/vite/src/x-vite-tags.view.php
@@ -8,7 +8,7 @@ use Tempest\Support\Html\HtmlString;
 use Tempest\Vite;
 use Tempest\Vite\ViteConfig;
 
-use function Tempest\get;
+use function Tempest\Container\get;
 
 $viteConfig = get(ViteConfig::class);
 $tags = Vite\get_tags($entrypoints ?? $entrypoint ?? $viteConfig->entrypoints);

--- a/tests/Fixtures/Console/DispatchAsyncCommand.php
+++ b/tests/Fixtures/Console/DispatchAsyncCommand.php
@@ -9,7 +9,7 @@ use Tempest\Console\HasConsole;
 use Tests\Tempest\Integration\CommandBus\Fixtures\MyAsyncCommand;
 use Tests\Tempest\Integration\CommandBus\Fixtures\MyFailingAsyncCommand;
 
-use function Tempest\command;
+use function Tempest\CommandBus\command;
 
 final readonly class DispatchAsyncCommand
 {

--- a/tests/Integration/CommandBus/AsyncCommandTest.php
+++ b/tests/Integration/CommandBus/AsyncCommandTest.php
@@ -12,7 +12,7 @@ use Tests\Tempest\Fixtures\Handlers\MyAsyncCommandHandler;
 use Tests\Tempest\Integration\CommandBus\Fixtures\MyAsyncCommand;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-use function Tempest\command;
+use function Tempest\CommandBus\command;
 use function Tempest\Support\arr;
 
 /**

--- a/tests/Integration/CommandBus/CommandBusTest.php
+++ b/tests/Integration/CommandBus/CommandBusTest.php
@@ -12,7 +12,7 @@ use Tests\Tempest\Fixtures\Commands\MyCommand;
 use Tests\Tempest\Fixtures\Commands\MyCommandBusMiddleware;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-use function Tempest\command;
+use function Tempest\CommandBus\command;
 
 /**
  * @internal

--- a/tests/Integration/Core/DiscoveryCacheTest.php
+++ b/tests/Integration/Core/DiscoveryCacheTest.php
@@ -11,7 +11,7 @@ use Tempest\Discovery\DiscoveryLocation;
 use Tests\Tempest\Integration\Core\Fixtures\TestDiscovery;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-use function Tempest\reflect;
+use function Tempest\Reflection\reflect;
 
 final class DiscoveryCacheTest extends FrameworkIntegrationTestCase
 {

--- a/tests/Integration/EventBus/EventBusTest.php
+++ b/tests/Integration/EventBus/EventBusTest.php
@@ -16,7 +16,7 @@ use Tests\Tempest\Fixtures\Events\TestEventHandler;
 use Tests\Tempest\Fixtures\Handlers\EventInterfaceHandler;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-use function Tempest\event;
+use function Tempest\EventBus\event;
 
 /**
  * @internal

--- a/tests/Integration/EventBus/EventIntegrationTestCase.php
+++ b/tests/Integration/EventBus/EventIntegrationTestCase.php
@@ -8,7 +8,7 @@ use Tempest\EventBus\Tests\Fixtures\MyEventHandler;
 use Tests\Tempest\Fixtures\Events\ItHappened;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-use function Tempest\event;
+use function Tempest\EventBus\event;
 
 /**
  * @internal

--- a/tests/Integration/Mapper/CasterFactoryTest.php
+++ b/tests/Integration/Mapper/CasterFactoryTest.php
@@ -12,7 +12,7 @@ use Tempest\Mapper\Casters\NativeDateTimeCaster;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithSerializerProperties;
 
-use function Tempest\reflect;
+use function Tempest\Reflection\reflect;
 
 final class CasterFactoryTest extends FrameworkIntegrationTestCase
 {

--- a/tests/Integration/Mapper/SerializerFactoryTest.php
+++ b/tests/Integration/Mapper/SerializerFactoryTest.php
@@ -21,7 +21,7 @@ use Tests\Tempest\Integration\Mapper\Fixtures\NestedObjectB;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithSerializerProperties;
 use Tests\Tempest\Integration\Mapper\Fixtures\SerializableObject;
 
-use function Tempest\reflect;
+use function Tempest\Reflection\reflect;
 
 final class SerializerFactoryTest extends FrameworkIntegrationTestCase
 {

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -884,7 +884,7 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         $this->registerViewComponent('x-a', '<a><x-slot /></a>');
         $this->registerViewComponent('x-b', <<<'HTML'
         <?php 
-        use function \Tempest\get;
+        use function \Tempest\Container\get;
         use \Tempest\Core\Environment;
         ?>
         {{ get(Environment::class)->value }}

--- a/tests/Integration/Vite/FunctionsTest.php
+++ b/tests/Integration/Vite/FunctionsTest.php
@@ -4,38 +4,35 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Vite;
 
+use PHPUnit\Framework\Attributes\PreCondition;
+use PHPUnit\Framework\Attributes\Test;
 use Tempest\Support\Html\HtmlString;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
-use function Tempest\vite_tags;
+use function Tempest\Vite\get_tags;
 
 /**
  * @internal
  */
 final class FunctionsTest extends FrameworkIntegrationTestCase
 {
-    protected function setUp(): void
+    #[PreCondition]
+    protected function configure(): void
     {
-        parent::setUp();
-
         $this->vite->setRootDirectory(__DIR__ . '/Fixtures/tmp');
     }
 
-    public function test_vite_tags(): void
+    #[Test]
+    public function vite_tags(): void
     {
         $this->vite->call(
-            callback: function (): void {
-                $tags = vite_tags('src/main.ts');
-
-                $this->assertInstanceOf(HtmlString::class, $tags);
-                $this->assertSame(
-                    expected: implode('', [
-                        '<script type="module" src="http://localhost:5173/@vite/client"></script>',
-                        '<script type="module" src="http://localhost:5173/src/main.ts"></script>',
-                    ]),
-                    actual: (string) vite_tags('src/main.ts'),
-                );
-            },
+            callback: fn () => $this->assertSame(
+                expected: [
+                    '<script type="module" src="http://localhost:5173/@vite/client"></script>',
+                    '<script type="module" src="http://localhost:5173/src/main.ts"></script>',
+                ],
+                actual: get_tags('src/main.ts'),
+            ),
             files: [
                 'public/vite-tempest' => ['url' => 'http://localhost:5173'],
                 'src/main.ts' => '',

--- a/tests/Integration/Vite/FunctionsTest.php
+++ b/tests/Integration/Vite/FunctionsTest.php
@@ -6,7 +6,6 @@ namespace Tests\Tempest\Integration\Vite;
 
 use PHPUnit\Framework\Attributes\PreCondition;
 use PHPUnit\Framework\Attributes\Test;
-use Tempest\Support\Html\HtmlString;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 use function Tempest\Vite\get_tags;


### PR DESCRIPTION
This pull request:
- Removes the nesting in `functions.php` files
- Updates the namespace of some functions from `Tempest` to `Tempest\<Package>`
- Adds Rectors to upgrade these namespaces in userland