### PR TITLE
fix(view): do not cache views in local environments by default

### DIFF
--- a/packages/view/src/Initializers/ViewCacheInitializer.php
+++ b/packages/view/src/Initializers/ViewCacheInitializer.php
@@ -28,6 +28,6 @@ final class ViewCacheInitializer implements Initializer
             return false;
         }
 
-        return (bool) env('VIEW_CACHE', default: Environment::guessFromEnvironment());
+        return (bool) env('VIEW_CACHE', default: Environment::guessFromEnvironment()->requiresCaution());
     }
 }

--- a/tests/Integration/View/ViewCacheTest.php
+++ b/tests/Integration/View/ViewCacheTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Tempest\Integration\View;
 
 use PHPUnit\Framework\Attributes\Test;
-use Tempest\Core\Environment;
 use Tempest\View\ViewCache;
 use Tempest\View\ViewCachePool;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;

--- a/tests/Integration/View/ViewCacheTest.php
+++ b/tests/Integration/View/ViewCacheTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\View;
 
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Core\Environment;
 use Tempest\View\ViewCache;
 use Tempest\View\ViewCachePool;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -42,7 +44,63 @@ final class ViewCacheTest extends FrameworkIntegrationTestCase
             rmdir(self::DIRECTORY);
         }
 
+        putenv('ENVIRONMENT=testing');
+        putenv('VIEW_CACHE=');
+        putenv('INTERNAL_CACHES=');
+
         parent::tearDown();
+    }
+
+    #[Test]
+    public function enabled_by_default_in_production(): void
+    {
+        putenv('ENVIRONMENT=production');
+
+        $this->container->unregister(ViewCache::class);
+
+        $this->assertTrue($this->container->get(ViewCache::class)->enabled);
+    }
+
+    #[Test]
+    public function enabled_by_default_in_staging(): void
+    {
+        putenv('ENVIRONMENT=staging');
+
+        $this->container->unregister(ViewCache::class);
+
+        $this->assertTrue($this->container->get(ViewCache::class)->enabled);
+    }
+
+    #[Test]
+    public function disabled_by_default_locally(): void
+    {
+        putenv('ENVIRONMENT=local');
+
+        $this->container->unregister(ViewCache::class);
+
+        $this->assertFalse($this->container->get(ViewCache::class)->enabled);
+    }
+
+    #[Test]
+    public function overriden_by_internal_caches_in_production(): void
+    {
+        putenv('ENVIRONMENT=production');
+        putenv('INTERNAL_CACHES=false');
+
+        $this->container->unregister(ViewCache::class);
+
+        $this->assertFalse($this->container->get(ViewCache::class)->enabled);
+    }
+
+    #[Test]
+    public function overriden_by_view_cache_locally(): void
+    {
+        putenv('ENVIRONMENT=local');
+        putenv('VIEW_CACHE=true');
+
+        $this->container->unregister(ViewCache::class);
+
+        $this->assertTrue($this->container->get(ViewCache::class)->enabled);
     }
 
     public function test_view_cache(): void


### PR DESCRIPTION
There was an oversight in https://github.com/tempestphp/tempest-framework/pull/1838, fixed and properly tested in this PR.