### PR TITLE
perf(database): only use serializer factory when needed

### DIFF
--- a/packages/database/src/GenericDatabase.php
+++ b/packages/database/src/GenericDatabase.php
@@ -147,7 +147,9 @@ final class GenericDatabase implements Database
         foreach ($query->bindings as $key => $value) {
             if ($value instanceof Query) {
                 $value = $value->execute();
-            } elseif (! is_scalar($value) && ($serializer = $serializerFactory->forValue($value))) {
+            } elseif (is_string($value) || is_numeric($value)) {
+                // Keep value as is
+            } elseif ($serializer = $serializerFactory->forValue($value)) {
                 $value = $serializer->serialize($value);
             }
 

--- a/packages/database/src/GenericDatabase.php
+++ b/packages/database/src/GenericDatabase.php
@@ -147,7 +147,7 @@ final class GenericDatabase implements Database
         foreach ($query->bindings as $key => $value) {
             if ($value instanceof Query) {
                 $value = $value->execute();
-            } elseif ($serializer = $serializerFactory->forValue($value)) {
+            } elseif (! is_scalar($value) && ($serializer = $serializerFactory->forValue($value))) {
                 $value = $serializer->serialize($value);
             }
 


### PR DESCRIPTION
Scalar values won't need database serialization. The upside of this improvement is that for large amounts of raw queries, we don't need to do any type reflection, speeding up performance significantly. 