### PR TITLE
feat(auth): various improvements to auth/oauth installers

### DIFF
--- a/packages/auth/src/Installer/AuthenticationInstaller.php
+++ b/packages/auth/src/Installer/AuthenticationInstaller.php
@@ -20,6 +20,8 @@ if (class_exists(\Tempest\Console\ConsoleCommand::class)) {
     {
         use PublishesFiles;
 
+        public bool $installOAuth = false;
+
         private(set) string $name = 'auth';
 
         public function __construct(
@@ -31,17 +33,28 @@ if (class_exists(\Tempest\Console\ConsoleCommand::class)) {
 
         public function install(): void
         {
-            $migration = $this->publish(__DIR__ . '/basic-user/CreateUsersTableMigration.stub.php', src_path('Authentication/CreateUsersTable.php'));
-            $this->publish(__DIR__ . '/basic-user/UserModel.stub.php', src_path('Authentication/User.php'));
+            // First question, ask whether to also install OAuth, as it changes the stubs to publish
+            $this->installOAuth = $this->shouldInstallOAuth();
+
+            // Get the appropriate stubs
+            $stubPath = $this->installOAuth ? 'oauth' : 'basic-user';
+
+            // Publish the stubs
+            $migration = $this->publish(__DIR__ . "/{$stubPath}/CreateUsersTableMigration.stub.php", src_path('Authentication/CreateUsersTable.php'));
+            $this->publish(__DIR__ . "/{$stubPath}/UserModel.stub.php", src_path('Authentication/User.php'));
+            $this->publish(__DIR__ . '/basic-user/MustBeAuthenticated.stub.php', src_path('Authentication/MustBeAuthenticated.php'));
+            $this->publish(__DIR__ . '/basic-user/LoginController.stub.php', src_path('Authentication/LoginController.php'));
             $this->publishImports();
 
+            // Offer to migrate
             if ($migration && $this->shouldMigrate()) {
                 $this->migrationManager->executeUp(
                     migration: $this->container->get(to_fqcn($migration, root: root_path())),
                 );
             }
 
-            if ($this->shouldInstallOAuth()) {
+            // Run the OAuth installer now
+            if ($this->installOAuth) {
                 $this->container->get(OAuthInstaller::class)->install();
             }
         }

--- a/packages/auth/src/Installer/OAuthInstaller.php
+++ b/packages/auth/src/Installer/OAuthInstaller.php
@@ -115,14 +115,12 @@ final class OAuthInstaller
                             'redirect-route',
                             'callback-route',
                             "'user-model-fqcn'",
-                            'provider_db_column',
                         ],
                         replace: [
                             "\\{$providerFqcn}::{$provider->name}",
                             "/auth/{$name}",
                             "/auth/{$name}/callback",
                             "\\{$userModelFqcn}::class",
-                            "{$name}_id",
                         ],
                     ),
                 );

--- a/packages/auth/src/Installer/basic-user/LoginController.stub.php
+++ b/packages/auth/src/Installer/basic-user/LoginController.stub.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tempest\Auth\Installer;
+
+use App\Authentication\User;
+use Tempest\Auth\Authentication\Authenticator;
+use Tempest\Cryptography\Password\PasswordHasher;
+use Tempest\Http\Responses\Redirect;
+use Tempest\Http\Session\PreviousUrl;
+use Tempest\Router\Get;
+use Tempest\Router\Post;
+use Tempest\View\View;
+
+use function Tempest\Database\query;
+use function Tempest\View\view;
+
+final readonly class LoginController
+{
+    public function __construct(
+        private Authenticator $authenticator,
+        private PasswordHasher $passwordHasher,
+        private PreviousUrl $previousUrl,
+    ) {}
+
+    #[Get('/auth/login')]
+    public function showLoginForm(): View
+    {
+        // TODO: implement, the code below is an example, and does not include a login form, customise to suit your application
+
+        return view('./your.login.view.php');
+    }
+
+    // This method is not required if you are implementing an OAuth-only approach
+    #[Post('/auth/login')]
+    public function login(LoginRequest $request): Redirect
+    {
+        // TODO: implement, the code below is an example, customise to suit your application
+    
+        // Database query here to check for your user //
+
+        $this->authenticator->authenticate($user);
+
+        // Get the intended URL and redirect there, or default to home
+        // getIntended() automatically consumes/removes the stored URL
+        $intendedUrl = $this->previousUrl->getIntended('/dashboard');
+
+        return new Redirect($intendedUrl)
+            ->flash('success', 'Logged in successfully');
+    }
+
+    #[Post('/auth/logout')]
+    public function logout(): Redirect
+    {
+        $this->authenticator->deauthenticate();
+
+        return new Redirect('/')
+            ->flash('success', 'You have been logged out');
+    }
+}

--- a/packages/auth/src/Installer/basic-user/LoginController.stub.php
+++ b/packages/auth/src/Installer/basic-user/LoginController.stub.php
@@ -35,8 +35,15 @@ final readonly class LoginController
     public function login(LoginRequest $request): Redirect
     {
         // TODO: implement, the code below is an example, customise to suit your application
-    
-        // Database query here to check for your user //
+
+        $user = query(User::class)
+            ->select()
+            ->where('email', $request->email)
+            ->first();
+
+        if (! $user || ! $this->passwordHasher->verify($request->password, $user->password)) {
+            return new Redirect('/login')->flash('error', 'Invalid credentials');
+        }
 
         $this->authenticator->authenticate($user);
 

--- a/packages/auth/src/Installer/basic-user/MustBeAuthenticated.stub.php
+++ b/packages/auth/src/Installer/basic-user/MustBeAuthenticated.stub.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tempest\Auth\Installer;
+
+use Tempest\Auth\Authentication\Authenticator;
+use Tempest\Core\Priority;
+use Tempest\Discovery\SkipDiscovery;
+use Tempest\Http\Request;
+use Tempest\Http\Response;
+use Tempest\Http\Responses\Redirect;
+use Tempest\Http\Session\PreviousUrl;
+use Tempest\Router\HttpMiddleware;
+use Tempest\Router\HttpMiddlewareCallable;
+
+#[SkipDiscovery]
+#[Priority(Priority::HIGHEST)]
+final readonly class MustBeAuthenticated implements HttpMiddleware
+{
+    public function __construct(
+        private Authenticator $authenticator,
+        private PreviousUrl $previousUrl,
+    ) {}
+
+    // TODO: implement, the code below is an example, customise to suit your application
+
+    public function __invoke(Request $request, HttpMiddlewareCallable $next): Response
+    {
+        // Check if user is authenticated
+        $user = $this->authenticator->current();
+
+        if ($user === null) {
+            // Store the intended URL
+            $this->previousUrl->setIntended($request->path);
+
+            // Redirect to login if not authenticated
+            return new Redirect('/auth/login')
+                ->flash('error', 'You must be logged in to access this page');
+        }
+
+        // User is authenticated, continue with request
+        return $next($request);
+    }
+}

--- a/packages/auth/src/Installer/oauth/CreateUsersTableMigration.stub.php
+++ b/packages/auth/src/Installer/oauth/CreateUsersTableMigration.stub.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tempest\Auth\Installer;
+
+use Tempest\Database\MigratesUp;
+use Tempest\Database\QueryStatement;
+use Tempest\Database\QueryStatements\CreateTableStatement;
+use Tempest\Discovery\SkipDiscovery;
+
+#[SkipDiscovery]
+final class CreateUsersTableMigration implements MigratesUp
+{
+    public string $name = '0000-00-00_create_users_table';
+
+    public function up(): QueryStatement
+    {
+        return new CreateTableStatement('users')
+            ->primary()
+            ->string('email')
+            ->string('password', nullable: true)
+            ->string('name', nullable: true)
+            ->string('nickname', nullable: true)
+            ->string('avatar', nullable: true)
+            ->string('oauth_id', nullable: true)
+            ->string('oauth_raw', nullable: true)
+            ->string('oauth_provider', nullable: true);
+    }
+}

--- a/packages/auth/src/Installer/oauth/OAuthControllerStub.php
+++ b/packages/auth/src/Installer/oauth/OAuthControllerStub.php
@@ -11,6 +11,7 @@ use Tempest\Container\Tag;
 use Tempest\Discovery\SkipDiscovery;
 use Tempest\Http\Request;
 use Tempest\Http\Responses\Redirect;
+use Tempest\Http\Session\PreviousUrl;
 use Tempest\Router\Get;
 
 use function Tempest\Database\query;
@@ -21,6 +22,7 @@ final readonly class OAuthControllerStub
     public function __construct(
         #[Tag('tag_name')]
         private OAuthClient $oauth,
+        private PreviousUrl $previousUrl,
     ) {}
 
     #[Get('redirect-route')]
@@ -32,19 +34,27 @@ final readonly class OAuthControllerStub
     #[Get('callback-route')]
     public function callback(Request $request): Redirect
     {
-        // TODO: implement, the code below is an example
+        // TODO: implement, the code below is an example, customise to suit your application
 
         $this->oauth->authenticate(
             request: $request,
             map: fn (OAuthUser $user): Authenticatable => query('user-model-fqcn')->updateOrCreate([
-                'provider_db_column' => $user->id,
+                'oauth_id' => $user->id,
             ], [
-                'provider_db_column' => $user->id,
+                'oauth_id' => $user->id,
                 'username' => $user->nickname,
                 'email' => $user->email,
+                'name' => $user->name,
+                'nickname' => $user->nickname,
+                'avatar' => $user->avatar,
+                'oauth_raw' => $user->raw,
+                'oauth_provider' => 'tag_name',
             ]),
         );
 
-        return new Redirect('/');
+        $intendedUrl = $this->previousUrl->getIntended('/dashboard');
+
+        return new Redirect($intendedUrl)
+            ->flash('success', 'Logged in successfully');
     }
 }

--- a/packages/auth/src/Installer/oauth/UserModel.stub.php
+++ b/packages/auth/src/Installer/oauth/UserModel.stub.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tempest\Auth\Installer;
+
+use Tempest\Auth\Authentication\Authenticatable;
+use Tempest\Database\Hashed;
+use Tempest\Database\PrimaryKey;
+use Tempest\Discovery\SkipDiscovery;
+
+#[SkipDiscovery]
+final class UserModel implements Authenticatable
+{
+    public PrimaryKey $id;
+
+    public function __construct(
+        public string $email,
+        #[Hashed]
+        #[\SensitiveParameter]
+        public ?string $password,
+        public ?string $name,
+        public ?string $nickname,
+        public ?string $avatar,
+        public ?string $oauth_id,
+        public ?array $oauth_raw,
+        public ?string $oauth_provider,
+    ) {}
+}

--- a/src/Tempest/Framework/Authentication/CreateUsersTable.php
+++ b/src/Tempest/Framework/Authentication/CreateUsersTable.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tempest\Framework\Authentication;
+
+use Tempest\Database\MigratesUp;
+use Tempest\Database\QueryStatement;
+use Tempest\Database\QueryStatements\CreateTableStatement;
+
+final class CreateUsersTable implements MigratesUp
+{
+    public string $name = '0000-00-00_create_users_table';
+
+    public function up(): QueryStatement
+    {
+        return new CreateTableStatement('users')
+            ->primary()
+            ->string('email')
+            ->string('password', nullable: true)
+            ->string('name', nullable: true)
+            ->string('nickname', nullable: true)
+            ->string('avatar', nullable: true)
+            ->string('oauth_id', nullable: true)
+            ->string('oauth_raw', nullable: true)
+            ->string('oauth_provider', nullable: true);
+    }
+}

--- a/tests/Integration/Auth/Installer/OAuthInstallerTest.php
+++ b/tests/Integration/Auth/Installer/OAuthInstallerTest.php
@@ -48,6 +48,7 @@ final class OAuthInstallerTest extends FrameworkIntegrationTestCase
             ->deny() // Publish MustBeAuthenticated?
             ->deny() // Publish LoginController?
             ->input($provider->value) // Pick provider
+            ->confirm() // Confirm provider
             ->confirm() // Publish $ProviderController
             ->confirm() // Publish $provider.config.php
             ->confirm() // Add to .env

--- a/tests/Integration/Auth/Installer/OAuthInstallerTest.php
+++ b/tests/Integration/Auth/Installer/OAuthInstallerTest.php
@@ -42,15 +42,16 @@ final class OAuthInstallerTest extends FrameworkIntegrationTestCase
     ): void {
         $this->console
             ->call('install auth --oauth')
-            ->confirm()
-            ->deny()
-            ->deny()
-            ->input($provider->value)
-            ->confirm()
-            ->confirm()
-            ->confirm()
-            ->confirm()
-            ->confirm()
+            ->confirm() // Running the installer, continue?
+            ->deny() // Publish CreateUsersTable?
+            ->deny() // Publish User?
+            ->deny() // Publish MustBeAuthenticated?
+            ->deny() // Publish LoginController?
+            ->input($provider->value) // Pick provider
+            ->confirm() // Publish $ProviderController
+            ->confirm() // Publish $provider.config.php
+            ->confirm() // Add to .env
+            ->confirm() // Install dependencies
             ->assertSee('The selected OAuth provider is installed in your project')
             ->assertSuccess();
 


### PR DESCRIPTION
Closes #1888 various improvements to auth/oauth installers, as follows

- (Installer) Asks whether to install OAuth first and provides different UserModel and Migration stubs with pre-populated fields matching the OAuthController
- Adds a very basic MustBeAuthenticated middleware stub, I've tested it in my own app, it's something that can be built upon but should give a working system
- Adds a very basic LoginController stub to show the login view (view NOT PROVIDED, comment explains this), post login (database query NOT PROVIDED, comment explains this), handle logout
- Implements Tempest\Http\Session\PreviousUrl to set/get the intended URL and redirect there after auth

Creating as a draft so I can add some docs to this as well.