### PR TITLE
feat(console): allow overriding internal storage in `boot`

### DIFF
--- a/packages/console/src/ConsoleApplication.php
+++ b/packages/console/src/ConsoleApplication.php
@@ -10,6 +10,7 @@ use Tempest\Container\Container;
 use Tempest\Core\Application;
 use Tempest\Core\Kernel;
 use Tempest\Core\Tempest;
+use Tempest\Support\Str;
 
 final readonly class ConsoleApplication implements Application
 {
@@ -18,13 +19,22 @@ final readonly class ConsoleApplication implements Application
         private ConsoleArgumentBag $argumentBag,
     ) {}
 
-    /** @param \Tempest\Discovery\DiscoveryLocation[] $discoveryLocations */
+    /**
+     * Boots the console application.
+     *
+     * @param string $name The name of the console application.
+     * @param string|null $root The root directory of the application. By default, the current working directory.
+     * @param \Tempest\Discovery\DiscoveryLocation[] $discoveryLocations The locations to use for class discovery.
+     * @param string|null $internalStorage The *absolute* internal storage directory for Tempest.
+     */
     public static function boot(
         string $name = 'Tempest',
         ?string $root = null,
         array $discoveryLocations = [],
+        ?string $internalStorage = null,
     ): self {
-        $container = Tempest::boot($root, $discoveryLocations);
+        $internalStorage ??= '.' . Str\to_kebab_case($name);
+        $container = Tempest::boot($root, $discoveryLocations, $internalStorage);
 
         $application = $container->get(ConsoleApplication::class);
 


### PR DESCRIPTION
This pull request adds the ability for external console applications using Tempest to override the internal storage directory, to avoid conflicts when being used alongside another Tempest application.

Additionally, I made it so that the internal storage directory is based on the console application's name. For Tempest, the name is `Tempest`, so the directory is `.tempest` (as before).

If the application name was `MyApp`, it would be a kebab-cased version of it, `.my-app`.