### PR TITLE
fix(upgrade): update rector version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0|^2.0",
         "psr/log": "^3.0.0",
-        "rector/rector": "^2.2.5",
+        "rector/rector": "^2.3.2",
         "symfony/cache": "^7.3",
         "symfony/mailer": "^7.2.6",
         "symfony/process": "^7.3",

--- a/packages/upgrade/composer.json
+++ b/packages/upgrade/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^8.5",
-        "rector/rector": "^2.2.5"
+        "rector/rector": "^2.3.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
To fix the "Service name must be a non-empty string" error. See: https://github.com/rectorphp/rector/issues/9605