### PR TITLE
feat(console): add ability to prevent built-in console commands from loading

### DIFF
--- a/packages/console/src/ConsoleApplication.php
+++ b/packages/console/src/ConsoleApplication.php
@@ -43,7 +43,7 @@ final readonly class ConsoleApplication implements Application
 
         $consoleConfig = $container->get(ConsoleConfig::class);
         $consoleConfig->name ??= $name;
-        $consoleConfig->loadBuiltInCommands ??= $loadBuiltInCommands;
+        $consoleConfig->loadBuiltInCommands = $loadBuiltInCommands ?? $consoleConfig->loadBuiltInCommands;
 
         return $container->get(ConsoleApplication::class);
     }

--- a/packages/console/src/ConsoleApplication.php
+++ b/packages/console/src/ConsoleApplication.php
@@ -22,27 +22,30 @@ final readonly class ConsoleApplication implements Application
     /**
      * Boots the console application.
      *
-     * @param string $name The name of the console application.
      * @param string|null $root The root directory of the application. By default, the current working directory.
      * @param \Tempest\Discovery\DiscoveryLocation[] $discoveryLocations The locations to use for class discovery.
      * @param string|null $internalStorage The *absolute* internal storage directory for Tempest.
+     * @param string $name The name of the console application.
+     * @param bool $loadBuiltInCommands Whether to load built-in Tempest console commands.
      */
     public static function boot(
-        string $name = 'Tempest',
         ?string $root = null,
         array $discoveryLocations = [],
         ?string $internalStorage = null,
+        ?string $name = null,
+        ?bool $loadBuiltInCommands = true,
     ): self {
-        $internalStorage ??= '.' . Str\to_kebab_case($name);
+        if (! $internalStorage && $name) {
+            $internalStorage = sprintf('.%s', Str\to_kebab_case($name));
+        }
+
         $container = Tempest::boot($root, $discoveryLocations, $internalStorage);
 
-        $application = $container->get(ConsoleApplication::class);
-
-        // Application-specific config
         $consoleConfig = $container->get(ConsoleConfig::class);
-        $consoleConfig->name = $name;
+        $consoleConfig->name ??= $name;
+        $consoleConfig->loadBuiltInCommands ??= $loadBuiltInCommands;
 
-        return $application;
+        return $container->get(ConsoleApplication::class);
     }
 
     public function run(): never

--- a/packages/console/src/ConsoleConfig.php
+++ b/packages/console/src/ConsoleConfig.php
@@ -9,15 +9,36 @@ use Tempest\Reflection\MethodReflector;
 
 final class ConsoleConfig
 {
+    /**
+     * List of registered console commands.
+     *
+     * @var ConsoleCommand[] $commands
+     */
+    public array $commands = [];
+
+    /**
+     * The path to the log file where console output will be recorded.
+     */
+    public ?string $logPath = null;
+
+    /**
+     * Middleware stack for console commands.
+     *
+     * @see https://tempestphp.com/current/essentials/console-commands#middleware
+     *
+     * @var Middleware<\Tempest\Console\ConsoleMiddleware>
+     */
+    public Middleware $middleware {
+        get => $this->middleware ??= new Middleware();
+    }
+
+    /**
+     * @param ?string $name The name of the application. Will appear in console command menus.
+     * @param bool $loadBuiltInCommands Whether to load built-in Tempest commands.
+     */
     public function __construct(
-        public string $name = 'Tempest',
-
-        /** @var ConsoleCommand[] $commands */
-        public array $commands = [],
-        public ?string $logPath = null,
-
-        /** @var Middleware<\Tempest\Console\ConsoleMiddleware> */
-        public Middleware $middleware = new Middleware(),
+        public ?string $name = null,
+        public bool $loadBuiltInCommands = true,
     ) {}
 
     public function addCommand(MethodReflector $handler, ConsoleCommand $consoleCommand): self

--- a/packages/console/src/Discovery/ConsoleCommandDiscovery.php
+++ b/packages/console/src/Discovery/ConsoleCommandDiscovery.php
@@ -28,6 +28,10 @@ final class ConsoleCommandDiscovery implements Discovery
                 continue;
             }
 
+            if (! $this->consoleConfig->loadBuiltInCommands && $location->isTempest()) {
+                continue;
+            }
+
             $this->discoveryItems->add($location, [$method, $consoleCommand]);
         }
     }

--- a/packages/console/src/Initializers/LogOutputBufferInitializer.php
+++ b/packages/console/src/Initializers/LogOutputBufferInitializer.php
@@ -10,8 +10,7 @@ use Tempest\Container\Container;
 use Tempest\Container\Initializer;
 use Tempest\Container\Singleton;
 use Tempest\Core\Kernel;
-
-use function Tempest\Support\path;
+use Tempest\Support\Path;
 
 final readonly class LogOutputBufferInitializer implements Initializer
 {
@@ -21,7 +20,7 @@ final readonly class LogOutputBufferInitializer implements Initializer
         $consoleConfig = $container->get(ConsoleConfig::class);
         $kernel = $container->get(Kernel::class);
 
-        $path = $consoleConfig->logPath ?? path($kernel->root, 'console.log')->toString();
+        $path = $consoleConfig->logPath ?? Path\normalize($kernel->root, 'console.log');
 
         return new LogOutputBuffer($path);
     }

--- a/packages/console/src/Middleware/OverviewMiddleware.php
+++ b/packages/console/src/Middleware/OverviewMiddleware.php
@@ -12,6 +12,7 @@ use Tempest\Console\ConsoleMiddleware;
 use Tempest\Console\ConsoleMiddlewareCallable;
 use Tempest\Console\ExitCode;
 use Tempest\Console\Initializers\Invocation;
+use Tempest\Core\AppConfig;
 use Tempest\Core\DiscoveryCache;
 use Tempest\Core\Priority;
 
@@ -23,6 +24,7 @@ final readonly class OverviewMiddleware implements ConsoleMiddleware
 {
     public function __construct(
         private Console $console,
+        private AppConfig $appConfig,
         private ConsoleConfig $consoleConfig,
         private DiscoveryCache $discoveryCache,
     ) {}
@@ -41,7 +43,7 @@ final readonly class OverviewMiddleware implements ConsoleMiddleware
     private function renderOverview(bool $showHidden = false): void
     {
         $this->console->header(
-            header: $this->consoleConfig->name,
+            header: $this->consoleConfig->name ?? $this->appConfig->name ?? 'Tempest',
             subheader: 'This is an overview of available commands.' . PHP_EOL . 'Type <em><command> --help</em> to get more help about a specific command.',
         );
 

--- a/packages/console/src/Testing/ConsoleTester.php
+++ b/packages/console/src/Testing/ConsoleTester.php
@@ -20,6 +20,7 @@ use Tempest\Console\Output\MemoryOutputBuffer;
 use Tempest\Console\OutputBuffer;
 use Tempest\Container\Container;
 use Tempest\Highlight\Highlighter;
+use Tempest\Validation\Validator;
 
 final class ConsoleTester
 {
@@ -174,7 +175,7 @@ final class ConsoleTester
 
     public function useInteractiveTerminal(): self
     {
-        $this->componentRenderer = new InteractiveComponentRenderer();
+        $this->componentRenderer = new InteractiveComponentRenderer($this->container->get(Validator::class));
 
         return $this;
     }

--- a/packages/core/src/Tempest.php
+++ b/packages/core/src/Tempest.php
@@ -8,19 +8,15 @@ use Tempest\Container\Container;
 
 final readonly class Tempest
 {
-    public static function boot(
-        ?string $root = null,
-        /** @var \Tempest\Discovery\DiscoveryLocation[] $discoveryLocations */
-        array $discoveryLocations = [],
-        ?string $internalStorage = null,
-    ): Container {
-        $root ??= getcwd();
-
-        // Kernel
-        return FrameworkKernel::boot(
-            root: $root,
+    /** @param \Tempest\Discovery\DiscoveryLocation[] $discoveryLocations */
+    public static function boot(?string $root = null, array $discoveryLocations = [], ?string $internalStorage = null): Container
+    {
+        $kernel = FrameworkKernel::boot(
+            root: $root ?? getcwd(),
             discoveryLocations: $discoveryLocations,
             internalStorage: $internalStorage,
-        )->container;
+        );
+
+        return $kernel->container;
     }
 }

--- a/packages/discovery/src/DiscoveryLocation.php
+++ b/packages/discovery/src/DiscoveryLocation.php
@@ -29,9 +29,14 @@ final class DiscoveryLocation
         return new self($namespace->namespace, $namespace->path);
     }
 
+    public function isTempest(): bool
+    {
+        return str_starts_with($this->namespace, 'Tempest');
+    }
+
     public function isVendor(): bool
     {
-        return str_contains($this->path, '/vendor/') || str_contains($this->path, '\\vendor\\') || str_starts_with($this->namespace, 'Tempest');
+        return str_contains($this->path, '/vendor/') || str_contains($this->path, '\\vendor\\') || $this->isTempest();
     }
 
     public function toClassName(string $path): string


### PR DESCRIPTION
This PR updates `ConsoleApplication::boot` and `ConsoleConfig` to add options to prevent the built-in console commands from being loaded, which is useful in a context where we are building an external CLI application on top of `temnpest/console`.

The loading prevention is done through `DiscoveryLocation`, which already had support for detecting if the class came from Tempest directly (by checking the namespace).

The console command discovery uses the new option in `ConsoleConfig` and this heuristic to determine whether to load a specific command.

This _may_ cause issues if we ever build an external but first-party console application which namespace starts with `Tempest`, so we might need to update how this work later. However, for now I think it is good enough.