### PR TITLE
feat(console): throw clear exception when sending unexpected input during console interactions

### DIFF
--- a/packages/console/src/Input/MemoryInputBuffer.php
+++ b/packages/console/src/Input/MemoryInputBuffer.php
@@ -6,6 +6,7 @@ namespace Tempest\Console\Input;
 
 use Exception;
 use Fiber;
+use FiberError;
 use Tempest\Console\InputBuffer;
 use Tempest\Console\Key;
 
@@ -25,7 +26,22 @@ final class MemoryInputBuffer implements InputBuffer
                 : (string) $line;
         }
 
-        $this->fiber?->resume();
+        try {
+            $this->fiber?->resume();
+        } catch (FiberError) {
+            throw new \RuntimeException(sprintf(
+                'Tried to send [%s] to the console, but no input was expected.',
+                implode(
+                    separator: ', ',
+                    array: array_map(
+                        callback: fn (int|string|Key $i) => is_string($i)
+                            ? rtrim($i)
+                            : $i->value,
+                        array: $input,
+                    ),
+                ),
+            ));
+        }
     }
 
     public function read(int $bytes): string


### PR DESCRIPTION
This PR updates the memory input buffer to provide a better exception when trying to send an input while it is not expected.

Previously, the error was "Tried to resume a Fiber that was not paused". Now, the exception clearly tells what the test is doing wrong.

See: https://github.com/tempestphp/tempest-framework/pull/1899