### PR TITLE
refactor(cache): use xxh64 instead of crc32

### DIFF
--- a/packages/discovery/src/DiscoveryLocation.php
+++ b/packages/discovery/src/DiscoveryLocation.php
@@ -13,7 +13,7 @@ final class DiscoveryLocation
     public readonly string $path;
 
     public string $key {
-        get => (string) crc32($this->path);
+        get => hash('xxh64', $this->path);
     }
 
     public function __construct(

--- a/packages/view/src/ViewCache.php
+++ b/packages/view/src/ViewCache.php
@@ -36,7 +36,7 @@ final class ViewCache
 
     public function getCachedViewPath(string $path, Closure $compiledView): string
     {
-        $cacheKey = (string) crc32($path);
+        $cacheKey = hash('xxh64', $path);
 
         $cacheItem = $this->pool->getItem($cacheKey);
 


### PR DESCRIPTION
Fixes https://github.com/tempestphp/tempest-framework/issues/1903.

Also eliminates `crc32` from Tempest entirely, it provides almost no practical advantage over `xxh64`, while having a significantly higher collision risk.

In my benchmarks with 100M iterations `xxh64` was only ~7-10% slower compared to `crc32`.