### PR TITLE
fix(cryptography): add `key:generate` hint to invalid key exceptions

### DIFF
--- a/packages/cryptography/src/Encryption/EncryptionKey.php
+++ b/packages/cryptography/src/Encryption/EncryptionKey.php
@@ -16,7 +16,7 @@ final readonly class EncryptionKey implements Stringable
         }
 
         if (strlen($value) !== $algorithm->getKeyLength()) {
-            throw EncryptionKeyWasInvalid::becauseLengthMismatched($algorithm);
+            throw EncryptionKeyWasInvalid::becauseLengthMismatched($algorithm, strlen($value));
         }
     }
 

--- a/packages/cryptography/src/Encryption/Exceptions/EncryptionKeyWasInvalid.php
+++ b/packages/cryptography/src/Encryption/Exceptions/EncryptionKeyWasInvalid.php
@@ -16,13 +16,16 @@ final class EncryptionKeyWasInvalid extends Exception implements EncryptionExcep
 
     public static function becauseItIsMissing(EncryptionAlgorithm $algorithm): self
     {
-        return new self('The encryption key is missing or empty. Ensure you have a `SIGNING_KEY` environment variable.', $algorithm);
+        return new self(
+            'The encryption key is missing or empty. Ensure you have a `SIGNING_KEY` environment variable, or generate one with `php tempest key:generate`.',
+            $algorithm,
+        );
     }
 
-    public static function becauseLengthMismatched(EncryptionAlgorithm $algorithm): self
+    public static function becauseLengthMismatched(EncryptionAlgorithm $algorithm, int $actualLength): self
     {
         return new self(
-            "The encryption key length does not match the expected length ({$algorithm->getKeyLength()}).",
+            "The encryption key length ({$actualLength}) does not match the expected length ({$algorithm->getKeyLength()}). Generate a valid key with `php tempest key:generate`.",
             $algorithm,
         );
     }

--- a/packages/cryptography/src/Encryption/Exceptions/EncryptionKeyWasInvalid.php
+++ b/packages/cryptography/src/Encryption/Exceptions/EncryptionKeyWasInvalid.php
@@ -17,16 +17,16 @@ final class EncryptionKeyWasInvalid extends Exception implements EncryptionExcep
     public static function becauseItIsMissing(EncryptionAlgorithm $algorithm): self
     {
         return new self(
-            'The encryption key is missing or empty. Ensure you have a `SIGNING_KEY` environment variable, or generate one with `php tempest key:generate`.',
-            $algorithm,
+            message: 'The encryption key is missing or empty. Generate a valid `SIGNING_KEY` with `php tempest key:generate`.',
+            algorithm: $algorithm,
         );
     }
 
     public static function becauseLengthMismatched(EncryptionAlgorithm $algorithm, int $actualLength): self
     {
         return new self(
-            "The encryption key length ({$actualLength}) does not match the expected length ({$algorithm->getKeyLength()}). Generate a valid key with `php tempest key:generate`.",
-            $algorithm,
+            message: "The encryption key length ({$actualLength}) does not match the expected length ({$algorithm->getKeyLength()}). Generate a valid `SIGNING_KEY` with `php tempest key:generate`.",
+            algorithm: $algorithm,
         );
     }
 }

--- a/packages/cryptography/src/GenerateSigningKeyCommand.php
+++ b/packages/cryptography/src/GenerateSigningKeyCommand.php
@@ -21,7 +21,11 @@ if (class_exists(\Tempest\Console\ConsoleCommand::class)) {
             private Console $console,
         ) {}
 
-        #[ConsoleCommand('key:generate', description: 'Generates the signing key required to sign and verify data.')]
+        #[ConsoleCommand(
+            name: 'key:generate',
+            description: 'Generates the signing key required to sign and verify data.',
+            aliases: ['generate:key'],
+        )]
         public function __invoke(bool $override = true): ExitCode
         {
             $key = EncryptionKey::generate($this->encryptionConfig->algorithm);

--- a/packages/cryptography/src/Signing/Exceptions/SigningKeyWasInvalid.php
+++ b/packages/cryptography/src/Signing/Exceptions/SigningKeyWasInvalid.php
@@ -8,6 +8,6 @@ final class SigningKeyWasInvalid extends Exception implements SigningException
 {
     public static function becauseItIsMissing(): self
     {
-        return new self('The signing key is missing or empty. Ensure you have a `SIGNING_KEY` environment variable, or generate one with `php tempest key:generate`.');
+        return new self('The signing key is missing or empty. Generate a valid `SIGNING_KEY` with `php tempest key:generate`.');
     }
 }

--- a/packages/cryptography/src/Signing/Exceptions/SigningKeyWasInvalid.php
+++ b/packages/cryptography/src/Signing/Exceptions/SigningKeyWasInvalid.php
@@ -8,6 +8,6 @@ final class SigningKeyWasInvalid extends Exception implements SigningException
 {
     public static function becauseItIsMissing(): self
     {
-        return new self('The signing key is missing or empty. Ensure you have a `SIGNING_KEY` environment variable.');
+        return new self('The signing key is missing or empty. Ensure you have a `SIGNING_KEY` environment variable, or generate one with `php tempest key:generate`.');
     }
 }


### PR DESCRIPTION
Fixes https://github.com/tempestphp/tempest-framework/issues/1918.