### PR TITLE
fix(command-bus): prevent crash when accessing deleted pending commands

### DIFF
--- a/packages/command-bus/src/AsyncCommandRepositories/FileCommandRepository.php
+++ b/packages/command-bus/src/AsyncCommandRepositories/FileCommandRepository.php
@@ -53,6 +53,10 @@ final readonly class FileCommandRepository implements CommandRepository
     {
         return arr(glob(__DIR__ . '/../stored-commands/*.pending.txt'))
             ->mapWithKeys(function (string $path) {
+                if (! Filesystem\is_file($path)) {
+                    return;
+                }
+
                 $uuid = str_replace('.pending.txt', '', pathinfo($path, PATHINFO_BASENAME));
                 $payload = Filesystem\read_file($path);
 


### PR DESCRIPTION
Fixes https://github.com/tempestphp/tempest-framework/issues/1651.