### PR TITLE
feat(database): add configurable migration naming strategy

### DIFF
--- a/packages/database/src/Commands/MakeMigrationCommand.php
+++ b/packages/database/src/Commands/MakeMigrationCommand.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use Tempest\Console\ConsoleArgument;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Core\PublishesFiles;
+use Tempest\Database\Config\DatabaseConfig;
 use Tempest\Database\Enums\MigrationType;
 use Tempest\Database\Stubs\ObjectMigrationStub;
 use Tempest\Database\Stubs\UpMigrationStub;
@@ -25,6 +26,10 @@ use function Tempest\Support\str;
 final class MakeMigrationCommand
 {
     use PublishesFiles;
+
+    public function __construct(
+        private DatabaseConfig $databaseConfig,
+    ) {}
 
     #[ConsoleCommand(
         name: 'make:migration',
@@ -73,7 +78,7 @@ final class MakeMigrationCommand
         $suggestedPath = Str\replace(
             string: $this->getSuggestedPath('Dummy'),
             search: ['Dummy', '.php'],
-            replace: [date('Y-m-d') . '_' . $filename, '.sql'],
+            replace: [$this->databaseConfig->migrationNamingStrategy->generatePrefix() . '_' . $filename, '.sql'],
         );
 
         $targetPath = $this->promptTargetPath($suggestedPath, rules: [
@@ -120,7 +125,7 @@ final class MakeMigrationCommand
             targetPath: $targetPath,
             shouldOverride: $this->askForOverride($targetPath),
             replacements: [
-                'dummy-date' => date('Y-m-d'),
+                'dummy-date' => $this->databaseConfig->migrationNamingStrategy->generatePrefix(),
                 'dummy-table-name' => $tableName,
             ],
             manipulations: [

--- a/packages/database/src/Config/DatabaseConfig.php
+++ b/packages/database/src/Config/DatabaseConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Database\Config;
 
 use Tempest\Container\HasTag;
+use Tempest\Database\Migrations\MigrationNamingStrategy;
 use Tempest\Database\Tables\NamingStrategy;
 
 interface DatabaseConfig extends HasTag
@@ -20,6 +21,13 @@ interface DatabaseConfig extends HasTag
      * The naming strategy for database tables and columns.
      */
     public NamingStrategy $namingStrategy {
+        get;
+    }
+
+    /**
+     * The naming strategy for migration file prefixes.
+     */
+    public MigrationNamingStrategy $migrationNamingStrategy {
         get;
     }
 

--- a/packages/database/src/Config/MysqlConfig.php
+++ b/packages/database/src/Config/MysqlConfig.php
@@ -7,6 +7,8 @@ namespace Tempest\Database\Config;
 use PDO;
 use Pdo\Mysql;
 use SensitiveParameter;
+use Tempest\Database\Migrations\DatePrefixStrategy;
+use Tempest\Database\Migrations\MigrationNamingStrategy;
 use Tempest\Database\Tables\NamingStrategy;
 use Tempest\Database\Tables\PluralizedSnakeCaseStrategy;
 use UnitEnum;
@@ -28,6 +30,10 @@ final class MysqlConfig implements DatabaseConfig
 
     public bool $usePersistentConnection {
         get => $this->persistent;
+    }
+
+    public MigrationNamingStrategy $migrationNamingStrategy {
+        get => $this->migrationNaming;
     }
 
     public array $options {
@@ -70,6 +76,7 @@ final class MysqlConfig implements DatabaseConfig
      * @param string|null $clientCertificate Path to the client's SSL certificate file. Used for mutual TLS authentication.
      * @param string|null $clientKey Path to the client's SSL private key file. Used for mutual TLS authentication.
      * @param NamingStrategy $namingStrategy The naming strategy for database tables and columns.
+     * @param MigrationNamingStrategy $migrationNaming The naming strategy for migration file prefixes.
      * @param string|UnitEnum|null $tag An optional tag to identify this database configuration.
      */
     public function __construct(
@@ -89,6 +96,7 @@ final class MysqlConfig implements DatabaseConfig
         public ?string $clientCertificate = null,
         public ?string $clientKey = null,
         public NamingStrategy $namingStrategy = new PluralizedSnakeCaseStrategy(),
+        public MigrationNamingStrategy $migrationNaming = new DatePrefixStrategy(),
         public null|string|UnitEnum $tag = null,
     ) {}
 }

--- a/packages/database/src/Config/PostgresConfig.php
+++ b/packages/database/src/Config/PostgresConfig.php
@@ -6,6 +6,8 @@ namespace Tempest\Database\Config;
 
 use PDO;
 use SensitiveParameter;
+use Tempest\Database\Migrations\DatePrefixStrategy;
+use Tempest\Database\Migrations\MigrationNamingStrategy;
 use Tempest\Database\Tables\NamingStrategy;
 use Tempest\Database\Tables\PluralizedSnakeCaseStrategy;
 use UnitEnum;
@@ -31,6 +33,10 @@ final class PostgresConfig implements DatabaseConfig
         get => $this->persistent;
     }
 
+    public MigrationNamingStrategy $migrationNamingStrategy {
+        get => $this->migrationNaming;
+    }
+
     public array $options {
         get {
             $options = [];
@@ -51,6 +57,7 @@ final class PostgresConfig implements DatabaseConfig
      * @param string $database The database name to connect to.
      * @param bool $persistent Whether to use persistent connections. Persistent connections are not closed at the end of the script and are cached for reuse when another script requests a connection using the same credentials.
      * @param NamingStrategy $namingStrategy The naming strategy for database tables and columns.
+     * @param MigrationNamingStrategy $migrationNaming The naming strategy for migration file prefixes.
      * @param string|UnitEnum|null $tag An optional tag to identify this database configuration.
      */
     public function __construct(
@@ -66,6 +73,7 @@ final class PostgresConfig implements DatabaseConfig
         public string $database = 'app',
         public bool $persistent = false,
         public NamingStrategy $namingStrategy = new PluralizedSnakeCaseStrategy(),
+        public MigrationNamingStrategy $migrationNaming = new DatePrefixStrategy(),
         public null|string|UnitEnum $tag = null,
     ) {}
 }

--- a/packages/database/src/Config/SQLiteConfig.php
+++ b/packages/database/src/Config/SQLiteConfig.php
@@ -6,6 +6,8 @@ namespace Tempest\Database\Config;
 
 use PDO;
 use SensitiveParameter;
+use Tempest\Database\Migrations\DatePrefixStrategy;
+use Tempest\Database\Migrations\MigrationNamingStrategy;
 use Tempest\Database\Tables\NamingStrategy;
 use Tempest\Database\Tables\PluralizedSnakeCaseStrategy;
 use UnitEnum;
@@ -35,6 +37,10 @@ final class SQLiteConfig implements DatabaseConfig
         get => $this->persistent;
     }
 
+    public MigrationNamingStrategy $migrationNamingStrategy {
+        get => $this->migrationNaming;
+    }
+
     public array $options {
         get {
             $options = [];
@@ -51,6 +57,7 @@ final class SQLiteConfig implements DatabaseConfig
      * @param string $path Path to the SQLite database file. Use ':memory:' for an in-memory database.
      * @param bool $persistent Whether to use persistent connections. Persistent connections are not closed at the end of the script and are cached for reuse when another script requests a connection using the same credentials.
      * @param NamingStrategy $namingStrategy The naming strategy for database tables and columns.
+     * @param MigrationNamingStrategy $migrationNaming The naming strategy for migration file prefixes.
      * @param string|UnitEnum|null $tag An optional tag to identify this database configuration.
      */
     public function __construct(
@@ -58,6 +65,7 @@ final class SQLiteConfig implements DatabaseConfig
         public string $path = 'localhost',
         public bool $persistent = false,
         public NamingStrategy $namingStrategy = new PluralizedSnakeCaseStrategy(),
+        public MigrationNamingStrategy $migrationNaming = new DatePrefixStrategy(),
         public null|string|UnitEnum $tag = null,
     ) {}
 }

--- a/packages/database/src/Migrations/DatePrefixStrategy.php
+++ b/packages/database/src/Migrations/DatePrefixStrategy.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tempest\Database\Migrations;
 
+/**
+ * Generates a date-based prefix for migration names.
+ */
 final class DatePrefixStrategy implements MigrationNamingStrategy
 {
     public function generatePrefix(): string

--- a/packages/database/src/Migrations/DatePrefixStrategy.php
+++ b/packages/database/src/Migrations/DatePrefixStrategy.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Migrations;
+
+final class DatePrefixStrategy implements MigrationNamingStrategy
+{
+    public function generatePrefix(): string
+    {
+        return date('Y-m-d');
+    }
+}

--- a/packages/database/src/Migrations/MigrationNamingStrategy.php
+++ b/packages/database/src/Migrations/MigrationNamingStrategy.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Tempest\Database\Migrations;
 
+/**
+ * Represents a strategy for naming database migrations. This is used to create sortable, unique migration identifiers.
+ */
 interface MigrationNamingStrategy
 {
     /**
-     * Generate the prefix for a migration name.
-     *
-     * This is used to create sortable, unique migration identifiers.
-     * For example: '2026-01-27' or '20260127143022'.
+     * Generates the prefix for a migration name.
      */
     public function generatePrefix(): string;
 }

--- a/packages/database/src/Migrations/MigrationNamingStrategy.php
+++ b/packages/database/src/Migrations/MigrationNamingStrategy.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Migrations;
+
+interface MigrationNamingStrategy
+{
+    /**
+     * Generate the prefix for a migration name.
+     *
+     * This is used to create sortable, unique migration identifiers.
+     * For example: '2026-01-27' or '20260127143022'.
+     */
+    public function generatePrefix(): string;
+}

--- a/packages/database/src/Migrations/Uuidv7PrefixStrategy.php
+++ b/packages/database/src/Migrations/Uuidv7PrefixStrategy.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Tempest\Database\Migrations;
 
-use function Tempest\Support\Random\uuid;
+use Tempest\Support\Random;
 
+/**
+ * Generates a UUIDv7 prefix for migration names.
+ */
 final class Uuidv7PrefixStrategy implements MigrationNamingStrategy
 {
     public function generatePrefix(): string
     {
-        return uuid();
+        return Random\uuid();
     }
 }

--- a/packages/database/src/Migrations/Uuidv7PrefixStrategy.php
+++ b/packages/database/src/Migrations/Uuidv7PrefixStrategy.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Migrations;
+
+use function Tempest\Support\Random\uuid;
+
+final class Uuidv7PrefixStrategy implements MigrationNamingStrategy
+{
+    public function generatePrefix(): string
+    {
+        return uuid();
+    }
+}


### PR DESCRIPTION
This PR makes the filename prefix configurable for `raw` migrations.
Keeps the original `Y-m-d` prefix and adds a new `Uuidv7` prefix. (time-sortable)
The usecase: no collision/confusion/rename need when creating multiple migrations the same day.