### PR TITLE
chore: phpunit/phpunit CVE-2026-24765

### DIFF
--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -66,7 +66,7 @@ jobs:
         uses: supercharge/redis-github-action@1.7.0
 
       - name: Install PHPUnit
-        run: composer global require phpunit/phpunit:12.4.0
+        run: composer global require phpunit/phpunit:12.5.8
 
       - name: Setup problem matchers
         run: |

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "phpat/phpat": "^0.11.0",
         "phpbench/phpbench": "84.x-dev",
         "phpstan/phpstan": "^2.0",
-        "phpunit/phpunit": "^12.2.3",
+        "phpunit/phpunit": "^12.5.8",
         "predis/predis": "^3.0.0",
         "riskio/oauth2-auth0": "^2.4",
         "smolblog/oauth2-twitter": "^1.0",

--- a/packages/generation/composer.json
+++ b/packages/generation/composer.json
@@ -21,6 +21,6 @@
     },
     "require-dev": {
         "spatie/phpunit-snapshot-assertions": "^5.1.8",
-        "phpunit/phpunit": "^12.2.3"
+        "phpunit/phpunit": "^12.5.8"
     }
 }

--- a/packages/http-client/composer.json
+++ b/packages/http-client/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "guzzlehttp/psr7": "^2.6.1",
-        "phpunit/phpunit": "^12.2.3"
+        "phpunit/phpunit": "^12.5.8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Backport of #1932 to 2.x branch.

Updates PHPUnit constraint to address CVE-2026-24765.