### PR TITLE
feat(testing): add `assertJsonSubset` to test response helper

### DIFF
--- a/src/Tempest/Framework/Testing/Http/TestResponseHelper.php
+++ b/src/Tempest/Framework/Testing/Http/TestResponseHelper.php
@@ -555,6 +555,54 @@ final class TestResponseHelper
     }
 
     /**
+     * Assert that the JSON response contains the given subset.
+     *
+     * The keys can also be specified using dot notation.
+     *
+     * ### Example
+     * ```
+     * // using dot notation
+     * $this->http->get(uri([BookController::class, 'index']))
+     *     ->assertJsonSubset([
+     *         'id' => 1,
+     *         'title' => 'Timeline Taxi',
+     *         'author.name' => 'Brent',
+     *     ]);
+     *
+     * // using nested arrays
+     * $this->http->get(uri([BookController::class, 'index']))
+     *     ->assertJsonSubset([
+     *         'id' => 1,
+     *         'title' => 'Timeline Taxi',
+     *         'author' => [
+     *             'name' => 'Brent',
+     *         ],
+     *     ]);
+     * ```
+     *
+     * @param array<string, mixed> $expected
+     */
+    public function assertJsonSubset(array $expected): self
+    {
+        $expected = arr($expected)->undot()->dot()->toArray();
+        $actual = arr($this->response->body)->dot()->toArray();
+
+        foreach ($expected as $key => $value) {
+            Assert::assertArrayHasKey(
+                key: $key,
+                array: $actual,
+            );
+
+            Assert::assertEquals(
+                expected: $value,
+                actual: $actual[$key],
+            );
+        }
+
+        return $this;
+    }
+
+    /**
      * Asserts the response contains the given keys.
      *
      * The keys can also be specified using dot notation.

--- a/tests/Integration/Testing/Http/TestResponseHelperTest.php
+++ b/tests/Integration/Testing/Http/TestResponseHelperTest.php
@@ -226,6 +226,17 @@ final class TestResponseHelperTest extends TestCase
         $helper->assertJson(['title' => 'Timeline Taxi', 'author.name' => 'John']);
     }
 
+    public function test_assert_json_subset(): void
+    {
+        $helper = new TestResponseHelper(
+            new GenericResponse(status: Status::OK, body: ['title' => 'Timeline Taxi', 'author' => ['name' => 'John', 'country' => 'NL']]),
+            new GenericRequest(Method::GET, '/'),
+        );
+
+        $helper->assertJsonSubset(['title' => 'Timeline Taxi', 'author' => ['country' => 'NL']]);
+        $helper->assertJsonSubset(['title' => 'Timeline Taxi', 'author.country' => 'NL']);
+    }
+
     public static function provide_assert_status_cases(): iterable
     {
         return [


### PR DESCRIPTION
This PR adds a new testing helper, `assertJsonSubset()`. It provides recursive JSON subset matching, allowing tests to assert only specific nested keys without requiring full JSON equality. This is useful when responses include additional framework‑generated data and you only want to verify the fields relevant to the test.