### PR TITLE
fix(view): correctly consume CRLF whitespace in TempestViewLexer

### DIFF
--- a/packages/view/src/Parser/TempestViewLexer.php
+++ b/packages/view/src/Parser/TempestViewLexer.php
@@ -4,7 +4,7 @@ namespace Tempest\View\Parser;
 
 final class TempestViewLexer
 {
-    private const string WHITESPACE = PHP_EOL . "\n\t\f ";
+    private const string WHITESPACE = "\r\n\t\f ";
 
     private int $position = 0;
 
@@ -35,7 +35,7 @@ final class TempestViewLexer
                 $tokens = [...$tokens, ...$this->lexCharacterData()];
             } elseif ($this->comesNext('<')) {
                 $tokens = [...$tokens, ...$this->lexTag()];
-            } elseif ($this->comesNext(' ') || $this->comesNext(PHP_EOL)) {
+            } elseif ($this->isWhitespace($this->current)) {
                 $tokens[] = $this->lexWhitespace();
             } else {
                 $tokens[] = $this->lexContent();
@@ -59,6 +59,15 @@ final class TempestViewLexer
         }
 
         return $seek;
+    }
+
+    private function isWhitespace(?string $value): bool
+    {
+        if ($value === null) {
+            return false;
+        }
+
+        return str_contains(self::WHITESPACE, $value);
     }
 
     private function seekIgnoringWhitespace(int $length = 1): ?string
@@ -220,13 +229,7 @@ final class TempestViewLexer
     {
         $buffer = '';
 
-        while ($this->current !== null) {
-            $seek = $this->seek();
-
-            if ($seek !== ' ' && $seek !== PHP_EOL) {
-                break;
-            }
-
+        while ($this->isWhitespace($this->seek())) {
             $buffer .= $this->consume();
         }
 

--- a/packages/view/tests/TempestViewLexerTest.php
+++ b/packages/view/tests/TempestViewLexerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tempest\View\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Tempest\View\Parser\TempestViewLexer;
@@ -310,6 +311,22 @@ final class TempestViewLexerTest extends TestCase
                 new Token(' x-foo=', TokenType::ATTRIBUTE_NAME),
                 new Token('"bar"', TokenType::ATTRIBUTE_VALUE),
                 new Token("\n>", TokenType::OPEN_TAG_END),
+                new Token('</div>', TokenType::CLOSING_TAG),
+            ],
+            actual: $tokens,
+        );
+    }
+
+    #[Test]
+    public function lexer_handles_crlf_attribute_boundaries(): void
+    {
+        $tokens = new TempestViewLexer("<div hidden\r\n></div>")->lex();
+
+        $this->assertTokens(
+            expected: [
+                new Token('<div', TokenType::OPEN_TAG_START),
+                new Token(' hidden', TokenType::ATTRIBUTE_NAME),
+                new Token("\r\n>", TokenType::OPEN_TAG_END),
                 new Token('</div>', TokenType::CLOSING_TAG),
             ],
             actual: $tokens,


### PR DESCRIPTION
This PR fixes a Windows-only crash.

The lexer advances one character at a time, however the previous check depended on `PHP_EOL`. On Windows, `PHP_EOL` is `\r\n` (2 characters), which caused inconsistent whitespace checks at CRLF boundaries and crashed during view rendering.