### PR TITLE
fix(router): render all development exceptions with Tempest's view renderer

### DIFF
--- a/packages/router/src/GenericResponseSender.php
+++ b/packages/router/src/GenericResponseSender.php
@@ -19,8 +19,10 @@ use Tempest\Http\Responses\EventStream;
 use Tempest\Http\Responses\File;
 use Tempest\Http\ServerSentEvent;
 use Tempest\Http\ServerSentMessage;
+use Tempest\Router\Exceptions\DevelopmentException;
 use Tempest\Support\Arr;
 use Tempest\Support\Json;
+use Tempest\View\Renderers\TempestViewRenderer;
 use Tempest\View\View;
 use Tempest\View\ViewRenderer;
 
@@ -104,12 +106,21 @@ final readonly class GenericResponseSender implements ResponseSender
         } elseif (is_array($body) || $body instanceof JsonSerializable) {
             echo json_encode($body);
         } elseif ($body instanceof View) {
-            echo $this->viewRenderer->render($body);
+            $this->renderView($response);
         } else {
             echo $body;
         }
 
         ob_flush();
+    }
+
+    private function renderView(Response $response): void
+    {
+        if ($response instanceof DevelopmentException) {
+            echo $this->container->get(TempestViewRenderer::class)->render($response->body);
+        } else {
+            echo $this->viewRenderer->render($response->body);
+        }
     }
 
     private function sendEventStream(EventStream $response): void


### PR DESCRIPTION
Closes #1963

`DevelopmentException`'s view returns a Tempest view, which is not compatible with Twig/Blade/whatever. This PR specifically looks for that response to use the Tempest view renderer to handle it.