### PR TITLE
feat(database)!: change mysql uuid type from `varchar(36)` to `char(36)`

### DIFF
--- a/packages/database/src/QueryStatements/UuidPrimaryKeyStatement.php
+++ b/packages/database/src/QueryStatements/UuidPrimaryKeyStatement.php
@@ -16,7 +16,7 @@ final readonly class UuidPrimaryKeyStatement implements QueryStatement
     public function compile(DatabaseDialect $dialect): string
     {
         return match ($dialect) {
-            DatabaseDialect::MYSQL => sprintf('`%s` VARCHAR(36) PRIMARY KEY', $this->name),
+            DatabaseDialect::MYSQL => sprintf('`%s` CHAR(36) PRIMARY KEY', $this->name),
             DatabaseDialect::POSTGRESQL => sprintf('`%s` UUID PRIMARY KEY', $this->name),
             DatabaseDialect::SQLITE => sprintf('`%s` TEXT PRIMARY KEY', $this->name),
         };

--- a/packages/database/tests/QueryStatements/CreateTableStatementTest.php
+++ b/packages/database/tests/QueryStatements/CreateTableStatementTest.php
@@ -206,7 +206,7 @@ final class CreateTableStatementTest extends TestCase
             DatabaseDialect::MYSQL,
             <<<SQL
             CREATE TABLE `users` (
-                `uuid` VARCHAR(36) PRIMARY KEY, 
+                `uuid` CHAR(36) PRIMARY KEY, 
                 `name` TEXT NOT NULL, 
                 `email` TEXT NOT NULL
             );

--- a/packages/database/tests/QueryStatements/UuidPrimaryKeyStatementTest.php
+++ b/packages/database/tests/QueryStatements/UuidPrimaryKeyStatementTest.php
@@ -20,7 +20,7 @@ final class UuidPrimaryKeyStatementTest extends TestCase
         $statement = new UuidPrimaryKeyStatement('uuid');
         $compiled = $statement->compile(DatabaseDialect::MYSQL);
 
-        $this->assertSame('`uuid` VARCHAR(36) PRIMARY KEY', $compiled);
+        $this->assertSame('`uuid` CHAR(36) PRIMARY KEY', $compiled);
     }
 
     #[Test]
@@ -47,6 +47,6 @@ final class UuidPrimaryKeyStatementTest extends TestCase
         $statement = new UuidPrimaryKeyStatement();
         $compiled = $statement->compile(DatabaseDialect::MYSQL);
 
-        $this->assertSame('`id` VARCHAR(36) PRIMARY KEY', $compiled);
+        $this->assertSame('`id` CHAR(36) PRIMARY KEY', $compiled);
     }
 }


### PR DESCRIPTION
Fixes #1966.

I propose to open a new issue regarding the changes from `CHAR(36)` to `BINARY(16)` for UUID storage.