### PR TITLE
docs: use list instead of table

### DIFF
--- a/docs/1-essentials/04-console-commands.md
+++ b/docs/1-essentials/04-console-commands.md
@@ -278,12 +278,10 @@ After adding or removing commands, regenerate the metadata:
 
 ### Available commands
 
-| Command                | Description                                                              |
-|------------------------|--------------------------------------------------------------------------|
-| `completion:install`   | Install the completion script and generate metadata.                     |
-| `completion:generate`  | Regenerate the completion metadata JSON.                                 |
-| `completion:show`      | Output the completion script to stdout (useful for custom installation). |
-| `completion:uninstall` | Remove the installed completion script.                                  |
+- `completion:install` — Install the completion script and generate metadata.
+- `completion:generate` — Regenerate the completion metadata JSON.
+- `completion:show` — Output the completion script to stdout (useful for custom installation).
+- `completion:uninstall` — Remove the installed completion script.
 
 ## Middleware
 


### PR DESCRIPTION
Using a markdown table breaks the docs:

<img width="1984" height="568" alt="CleanShot 2026-02-20 at 04 17 30@2x" src="https://github.com/user-attachments/assets/9c1cdaaa-363d-4cc2-89e0-9df8d2eab13c" />

Adding `->addExtension(new TableExtension())` to the `MarkdownInitializer` in `tempest-docs` would fix this issue and we could keep the table.

<img width="1760" height="604" alt="CleanShot 2026-02-20 at 04 22 09@2x" src="https://github.com/user-attachments/assets/a4c6b8a0-0bcb-4ddf-b91d-57dd1225827f" />


If that's the route we want to  go with, this PR can be closed without merging.