### PR TITLE
feat(http): add overridable `getBody()` hook to `IsResponse`

### DIFF
--- a/packages/http/src/IsResponse.php
+++ b/packages/http/src/IsResponse.php
@@ -19,7 +19,12 @@ trait IsResponse
 {
     private(set) Status $status = Status::OK;
 
-    private(set) View|string|array|Generator|JsonSerializable|null $body = null;
+    private View|string|array|Generator|JsonSerializable|null $bodyValue = null;
+
+    private(set) View|string|array|Generator|JsonSerializable|null $body {
+        get => $this->getBody();
+        set => $this->bodyValue = $value;
+    }
 
     /** @var \Tempest\Http\Header[] */
     private(set) array $headers = [];
@@ -121,6 +126,11 @@ trait IsResponse
         $this->status = $status;
 
         return $this;
+    }
+
+    protected function getBody(): View|string|array|Generator|JsonSerializable|null
+    {
+        return $this->bodyValue;
     }
 
     public function setBody(View|string|array|Generator|null $body): self


### PR DESCRIPTION
Adds a protected `getBody()` method to the `IsResponse` trait that can be overridden in classes that need lazy body resolution. This is useful when building response objects that support method chaining (e.g. `->with()`, `->flash()`, `->cache()`) where the body should only be resolved once all mutations have been applied, rather than eagerly in the constructor.