### PR TITLE
feat(database): support datetime columns with `CURRENT_TIMESTAMP` as the default value

### DIFF
--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -227,13 +227,17 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
 
     /**
      * Adds a datetime column to the table. Uses `DATETIME` for MySQL/SQLite and `TIMESTAMP` for PostgreSQL.
+     *
+     * @param string|null $default The default value for the column. Cannot be set if `current` is `true`.
+     * @param bool $current Whether to use `CURRENT_TIMESTAMP` as the default value. Cannot be set if `default` is not `null`.
      */
-    public function datetime(string $name, bool $nullable = false, ?string $default = null): self
+    public function datetime(string $name, bool $nullable = false, ?string $default = null, bool $current = false): self
     {
         $this->statements[] = new DatetimeStatement(
             name: $name,
             nullable: $nullable,
             default: $default,
+            current: $current,
         );
 
         return $this;

--- a/packages/database/src/QueryStatements/DatetimeStatement.php
+++ b/packages/database/src/QueryStatements/DatetimeStatement.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Database\QueryStatements;
 
+use InvalidArgumentException;
 use Tempest\Database\Config\DatabaseDialect;
 use Tempest\Database\QueryStatement;
 
@@ -13,21 +14,32 @@ final readonly class DatetimeStatement implements QueryStatement
         private string $name,
         private bool $nullable = false,
         private ?string $default = null,
+        private bool $current = false,
     ) {}
 
     public function compile(DatabaseDialect $dialect): string
     {
+        if ($this->default !== null && $this->current === true) {
+            throw new InvalidArgumentException("Cannot set both `default` and `current` for datetime column `{$this->name}`.");
+        }
+
+        $default = match (true) {
+            $this->current => 'CURRENT_TIMESTAMP',
+            $this->default !== null => "'{$this->default}'",
+            default => null,
+        };
+
         return match ($dialect) {
             DatabaseDialect::POSTGRESQL => sprintf(
                 '`%s` TIMESTAMP %s %s',
                 $this->name,
-                $this->default !== null ? "DEFAULT '{$this->default}'" : '',
+                $default !== null ? "DEFAULT {$default}" : '',
                 $this->nullable ? '' : 'NOT NULL',
             ),
             default => sprintf(
                 '`%s` DATETIME %s %s',
                 $this->name,
-                $this->default !== null ? "DEFAULT '{$this->default}'" : '',
+                $default !== null ? "DEFAULT {$default}" : '',
                 $this->nullable ? '' : 'NOT NULL',
             ),
         };

--- a/packages/database/tests/QueryStatements/CreateTableStatementTest.php
+++ b/packages/database/tests/QueryStatements/CreateTableStatementTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Tempest\Database\Tests\QueryStatements;
 
 use Generator;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Tempest\Database\Config\DatabaseDialect;
 use Tempest\Database\QueryStatements\CreateTableStatement;
@@ -229,6 +231,57 @@ final class CreateTableStatementTest extends TestCase
                 `uuid` TEXT PRIMARY KEY, 
                 `name` TEXT NOT NULL, 
                 `email` TEXT NOT NULL
+            );
+            SQL,
+        ];
+    }
+
+    #[DataProvider('provide_datetime_current_database_dialects')]
+    #[Test]
+    public function datetime_current_default(DatabaseDialect $dialect, string $validSql): void
+    {
+        $statement = new CreateTableStatement('users')
+            ->datetime('created_at', current: true)
+            ->compile($dialect);
+
+        $this->assertSame($validSql, $statement);
+    }
+
+    #[Test]
+    public function datetime_current_conflicts_with_default(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new CreateTableStatement('users')
+            ->datetime('created_at', default: '2000-01-01 00:00:00', current: true)
+            ->compile(DatabaseDialect::MYSQL);
+    }
+
+    public static function provide_datetime_current_database_dialects(): iterable
+    {
+        yield 'mysql' => [
+            DatabaseDialect::MYSQL,
+            <<<SQL
+            CREATE TABLE `users` (
+                `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL
+            );
+            SQL,
+        ];
+
+        yield 'postgresql' => [
+            DatabaseDialect::POSTGRESQL,
+            <<<SQL
+            CREATE TABLE `users` (
+                `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+            );
+            SQL,
+        ];
+
+        yield 'sqlite' => [
+            DatabaseDialect::SQLITE,
+            <<<SQL
+            CREATE TABLE `users` (
+                `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL
             );
             SQL,
         ];


### PR DESCRIPTION
This PR adds support for creating a datetime column with its default value set to the current timestamp.

```php
new CreateTableStatement('users')
    ->datetime('created_at', current: true);
```

Related to #2016