### PR TITLE
chore(generation): lock `nette/php-generator` version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,11 @@
         "league/mime-type-detection": "^1.16",
         "league/oauth2-client": "^2.8",
         "monolog/monolog": "^3.7.0",
-        "nette/php-generator": "^4.2.1",
+        "nette/php-generator": "4.2.1",
         "nette/schema": "^1.3.4",
         "nikic/php-parser": "^5.3",
         "php": "^8.5",
+        "phpstan/phpstan": "2.1.33",
         "psr-discovery/http-client-implementations": "^1.4",
         "psr-discovery/http-factory-implementations": "^1.2",
         "psr/cache": "^3.0",
@@ -75,7 +76,6 @@
         "patrickbussmann/oauth2-apple": "^0.3",
         "phpat/phpat": "^0.11.0",
         "phpbench/phpbench": "^1.4",
-        "phpstan/phpstan": "2.1.33",
         "phpunit/phpunit": "^12.5.8",
         "predis/predis": "^3.0.0",
         "riskio/oauth2-auth0": "^2.4",
@@ -253,7 +253,10 @@
         }
     },
     "scripts": {
-        "phpunit": "@php -d memory_limit=2G vendor/bin/phpunit --display-warnings --display-skipped --display-deprecations --display-errors --display-notices",
+        "phpunit": [
+            "Composer\\Config::disableProcessTimeout",
+            "@php -d memory_limit=2G vendor/bin/phpunit --display-warnings --display-skipped --display-deprecations --display-errors --display-notices"
+        ],
         "coverage": "vendor/bin/phpunit --coverage-html build/reports/html --coverage-clover build/reports/clover.xml",
         "fmt": "vendor/bin/mago fmt",
         "lint:fix": "vendor/bin/mago lint --fix --format-after-fix",

--- a/packages/generation/composer.json
+++ b/packages/generation/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^8.5",
-        "nette/php-generator": "^4.2.1",
+        "nette/php-generator": "4.2.1",
         "nette/schema": "^1.3.4",
         "nikic/php-parser": "^5.3",
         "tempest/support": "3.x-dev"


### PR DESCRIPTION
There was a [regression](https://github.com/nette/php-generator/commit/8ed5fd87014606d63b09b02c7dffaa049cccd3fd) in the next patch version that makes `PhpFile::setComment` no longer work alongside `declare(strict_types=1)`.

This PR locks `nette/php-generator`'s version accordingly.