### PR TITLE
fix(auth): handle OIDC provider identifier keys

### DIFF
--- a/packages/auth/src/OAuth/OAuthUser.php
+++ b/packages/auth/src/OAuth/OAuthUser.php
@@ -12,7 +12,7 @@ final readonly class OAuthUser
         /**
          * The unique identifier for the user from the OAuth provider.
          */
-        #[MapFrom('id', 'Id', 'uid', 'uuid')]
+        #[MapFrom('id', 'Id', 'uid', 'uuid', 'sub')]
         public string $id,
 
         /**

--- a/packages/mapper/src/Mappers/ArrayToObjectMapper.php
+++ b/packages/mapper/src/Mappers/ArrayToObjectMapper.php
@@ -85,7 +85,7 @@ final class ArrayToObjectMapper implements Mapper
             if ($property->isVirtual()) {
                 continue;
             }
-            
+
             if ($property->isReadonly()) {
                 continue;
             }

--- a/packages/mapper/src/Mappers/ArrayToObjectMapper.php
+++ b/packages/mapper/src/Mappers/ArrayToObjectMapper.php
@@ -85,6 +85,9 @@ final class ArrayToObjectMapper implements Mapper
             if ($property->isVirtual()) {
                 continue;
             }
+            if ($property->isReadonly()) {
+                continue;
+            }
 
             $property->unset($targetObject);
         }
@@ -198,11 +201,6 @@ final class ArrayToObjectMapper implements Mapper
         array &$unsetProperties,
     ): void {
         if ($property->hasDefaultValue()) {
-            return;
-        }
-
-        if ($property->isReadonly()) {
-            $missingValues[] = $propertyName;
             return;
         }
 

--- a/packages/mapper/src/Mappers/ArrayToObjectMapper.php
+++ b/packages/mapper/src/Mappers/ArrayToObjectMapper.php
@@ -201,6 +201,11 @@ final class ArrayToObjectMapper implements Mapper
             return;
         }
 
+        if ($property->isReadonly()) {
+            $missingValues[] = $propertyName;
+            return;
+        }
+
         $isStrictProperty = $isStrictClass || $property->hasAttribute(Strict::class);
 
         if ($isStrictProperty) {

--- a/packages/mapper/src/Mappers/ArrayToObjectMapper.php
+++ b/packages/mapper/src/Mappers/ArrayToObjectMapper.php
@@ -85,6 +85,7 @@ final class ArrayToObjectMapper implements Mapper
             if ($property->isVirtual()) {
                 continue;
             }
+            
             if ($property->isReadonly()) {
                 continue;
             }


### PR DESCRIPTION
Hello,

after talking on the Discord we figured, that Keycloak (and supposedly other Providers) pass "sub" instead of "id, uuid..." as identificator. Thus adding to the mapping with this PR.

Also: If a property is readonly, we should not try to unset it.

Credits go to @xHeaven 