### PR TITLE
chore: add .tempest to mago excludes

### DIFF
--- a/mago.toml
+++ b/mago.toml
@@ -13,6 +13,7 @@ excludes = [
 	"**/*.stub.php",
 	"**/*.input.php",
 	"**/*.expected.php",
+	"**/.tempest",
 ]
 
 [formatter]


### PR DESCRIPTION
I've noted that when running phpunit tests, some packages create a .tempest folder. It's already .gitignore'd so also adding it to mago excludes.

Tested locally.