### PR TITLE
chore: exclude rector in mago.toml due to clash causing false positives

### DIFF
--- a/mago.toml
+++ b/mago.toml
@@ -14,6 +14,7 @@ excludes = [
 	"**/*.input.php",
 	"**/*.expected.php",
 	"**/.tempest",
+	"./vendor/rector", #see https://github.com/carthage-software/mago/issues/1237 rector clashes and throws errors in tests
 ]
 
 [formatter]


### PR DESCRIPTION
See https://github.com/carthage-software/mago/issues/1237 - rector and phpunit have some clashes and the recommended fix in mago is to exclude rector, which makes sense because rector doesn't really need to be in there due to the way it works.