### PR TITLE
feat(discovery): add support for dynamic path exlusion

### DIFF
--- a/packages/discovery/src/BootDiscovery.php
+++ b/packages/discovery/src/BootDiscovery.php
@@ -197,7 +197,7 @@ final class BootDiscovery
                 } elseif (class_exists($className)) {
                     $input = new ClassReflector($className);
                 }
-            } catch (AssertionError|\Pest\Exceptions\InvalidPestCommand) {
+            } catch (AssertionError|\Pest\Exceptions\InvalidPestCommand) { // @phpstan-ignore class.notFound
                 // Workaround for Pest test files autoloading.
                 // @mago-expect lint:no-empty-catch-clause
             }

--- a/packages/discovery/src/BootDiscovery.php
+++ b/packages/discovery/src/BootDiscovery.php
@@ -197,7 +197,7 @@ final class BootDiscovery
                 } elseif (class_exists($className)) {
                     $input = new ClassReflector($className);
                 }
-            } catch (AssertionError) {
+            } catch (AssertionError|\Pest\Exceptions\InvalidPestCommand) {
                 // Workaround for Pest test files autoloading.
                 // @mago-expect lint:no-empty-catch-clause
             }

--- a/packages/discovery/src/DiscoveryConfig.php
+++ b/packages/discovery/src/DiscoveryConfig.php
@@ -2,11 +2,15 @@
 
 namespace Tempest\Discovery;
 
+use Closure;
 use Tempest\Support\Filesystem;
 
 final class DiscoveryConfig
 {
     private array $skipDiscovery = [];
+
+    /** @var array<Closure(string): bool> */
+    private array $skipUsing = [];
 
     /** @var array<array-key, class-string<\Tempest\Discovery\Discovery>> The loaded discovery classes that will be used during discovery */
     public array $classes = [];
@@ -25,7 +29,24 @@ final class DiscoveryConfig
 
     public function shouldSkip(string $input): bool
     {
-        return $this->skipDiscovery[$input] ?? false;
+        if (array_key_exists($input, $this->skipDiscovery)) {
+            return true;
+        }
+
+        foreach ($this->skipUsing as $closure) {
+            if ($closure($input) === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function skipUsing(Closure $closure): self
+    {
+        $this->skipUsing[] = $closure;
+
+        return $this;
     }
 
     public function skipClasses(string ...$classNames): self

--- a/packages/discovery/src/DiscoveryConfig.php
+++ b/packages/discovery/src/DiscoveryConfig.php
@@ -42,6 +42,7 @@ final class DiscoveryConfig
         return false;
     }
 
+    /** @param (Closure(string): bool) $closure */
     public function skipUsing(Closure $closure): self
     {
         $this->skipUsing[] = $closure;


### PR DESCRIPTION
This pull request adds support for dynamically excluding paths from being discovered:

```php
new DiscoveryConfig(
    locations: [
        new DiscoveryLocation('Module\\', base_path('src/Modules')),
        new DiscoveryLocation('Infrastructure\\', base_path('src/Infrastructure')),
        new DiscoveryLocation('Integrations\\', base_path('src/Integrations')),
    ],
)->skipUsing(static function (string $input) {
    if (str_ends_with($input, needle: 'Test.php')) {
        return true;
    }

    if (str_ends_with($input, needle: 'Pest.php')) {
        return true;
    }

    return false;
});
```

It also includes another fix for when Tempest scans a Pest test file:

<img width="567" height="138" alt="CleanShot 2026-03-13 at 16 19 47" src="https://github.com/user-attachments/assets/b71af1ad-1a5b-42b8-a808-26f2ebe69fd9" />

When encountering a test or `Pest.php` file, `class_exists` or `new ClassReflector` throws because it autoloads the file.