### PR TITLE
fix(discovery): allow specifying discovery classes and locations during cache generation

### DIFF
--- a/packages/discovery/src/GenerateDiscoveryCache.php
+++ b/packages/discovery/src/GenerateDiscoveryCache.php
@@ -6,10 +6,16 @@ use Psr\Container\ContainerInterface;
 
 final class GenerateDiscoveryCache
 {
+    /**
+     * @param class-string<Discovery>[]|null $discoveryClasses
+     * @param DiscoveryLocation[]|null $discoveryLocations
+     */
     public function __invoke(
         ContainerInterface $container,
         DiscoveryConfig $config,
         DiscoveryCache $cache,
+        ?array $discoveryClasses = null,
+        ?array $discoveryLocations = null,
     ): void {
         $originalStrategy = $cache->strategy;
         $cache = $cache->withStrategy(DiscoveryCacheStrategy::NONE);
@@ -20,7 +26,7 @@ final class GenerateDiscoveryCache
             cache: $cache,
         );
 
-        $discoveries = $bootDiscovery->build();
+        $discoveries = $bootDiscovery->build($discoveryClasses, $discoveryLocations);
 
         foreach ($config->locations as $location) {
             $cache->store($location, $discoveries);


### PR DESCRIPTION
Since we have the ability to specify the discovery classes instead of using `autoload`, we also need to be able to pass them to `GenerateDiscoveryCache` to generate a proper cache