### PR TITLE
feat(database): add support for hasmanythrough relation

### DIFF
--- a/docs/1-essentials/03-database.md
+++ b/docs/1-essentials/03-database.md
@@ -293,6 +293,30 @@ public ?Address $address = null;
 - `throughOwnerJoin`: FK on the target table pointing to the intermediate
 - `throughRelationJoin`: PK on the intermediate table
 
+### Has many through
+
+The {b`#[Tempest\Database\HasManyThrough]`} attribute defines a one-to-many relationship that traverses an intermediate model. This lets you access a collection of distant relations directly, resolved in a single SQL query with two JOINs.
+
+```php
+use Tempest\Database\HasManyThrough;
+
+final class Author
+{
+    /** @var \App\Payment\Payment[] */
+    #[HasManyThrough(Contract::class)]
+    public array $payments = [];
+}
+```
+
+The `through` parameter specifies the intermediate model class. The target model is inferred from the docblock's array type. This generates SQL like:
+
+```sql
+LEFT JOIN contracts ON contracts.author_id = authors.id
+LEFT JOIN payments ON payments.contract_id = contracts.id
+```
+
+The same optional parameters as `HasOneThrough` are available for custom join fields: `ownerJoin`, `relationJoin`, `throughOwnerJoin`, and `throughRelationJoin`.
+
 ### Using UUIDs as primary keys
 
 By default, Tempest uses auto-incrementing integers as primary keys. UUIDs can be used as primary keys instead by annotating the {b`Tempest\Database\PrimaryKey`} property with the {b`#[Tempest\Database\Uuid]`} attribute. Tempest automatically generates a UUID v7 when a new model is created:

--- a/packages/database/src/Builder/ModelInspector.php
+++ b/packages/database/src/Builder/ModelInspector.php
@@ -7,6 +7,7 @@ use Tempest\Database\BelongsTo;
 use Tempest\Database\Config\DatabaseConfig;
 use Tempest\Database\Eager;
 use Tempest\Database\HasMany;
+use Tempest\Database\HasManyThrough;
 use Tempest\Database\HasOne;
 use Tempest\Database\HasOneThrough;
 use Tempest\Database\PrimaryKey;
@@ -54,6 +55,7 @@ final class ModelInspector
         $key = match (true) {
             is_string($model) => $model,
             $model instanceof HasMany => $model->property->getIterableType()->getName(),
+            $model instanceof HasManyThrough => $model->property->getIterableType()->getName(),
             $model instanceof BelongsTo => $model->property->getType()->getName(),
             $model instanceof HasOne => $model->property->getType()->getName(),
             $model instanceof HasOneThrough => $model->property->getType()->getName(),
@@ -71,7 +73,7 @@ final class ModelInspector
     public function __construct(
         private(set) object|string $model,
     ) {
-        if ($model instanceof HasMany) {
+        if ($model instanceof HasMany || $model instanceof HasManyThrough) {
             $model = $model->property->getIterableType()->asClass();
             $this->reflector = $model;
         } elseif ($model instanceof BelongsTo || $model instanceof HasOne || $model instanceof HasOneThrough) {
@@ -164,6 +166,10 @@ final class ModelInspector
                     continue;
                 }
 
+                if ($this->getHasManyThrough($property->getName()) instanceof HasManyThrough) {
+                    continue;
+                }
+
                 $name = $property->getName();
 
                 $values[$name] = $property->getValue($this->instance);
@@ -222,6 +228,10 @@ final class ModelInspector
                 return null;
             }
 
+            if ($property->hasAttribute(HasManyThrough::class)) {
+                return null;
+            }
+
             $belongsTo = new BelongsTo();
             $belongsTo->property = $property;
 
@@ -277,6 +287,10 @@ final class ModelInspector
                 return $hasMany;
             }
 
+            if ($property->hasAttribute(HasManyThrough::class)) {
+                return null;
+            }
+
             if ($property->hasAttribute(Virtual::class)) {
                 return null;
             }
@@ -321,6 +335,29 @@ final class ModelInspector
         });
     }
 
+    public function getHasManyThrough(string $name): ?HasManyThrough
+    {
+        return $this->memoize('getHasManyThrough' . $name, function () use ($name) {
+            if (! $this->isObjectModel()) {
+                return null;
+            }
+
+            $name = str($name)->camel();
+
+            if (! $this->reflector->hasProperty($name)) {
+                return null;
+            }
+
+            $property = $this->reflector->getProperty($name);
+
+            if (($hasManyThrough = $property->getAttribute(HasManyThrough::class)) instanceof HasManyThrough) {
+                return $hasManyThrough;
+            }
+
+            return null;
+        });
+    }
+
     public function isRelation(string|PropertyReflector $name): bool
     {
         $name = $name instanceof PropertyReflector ? $name->getName() : $name;
@@ -332,6 +369,7 @@ final class ModelInspector
                 || $this->getHasOne($name) instanceof HasOne
                 || $this->getHasMany($name) instanceof HasMany
                 || $this->getHasOneThrough($name) instanceof HasOneThrough
+                || $this->getHasManyThrough($name) instanceof HasManyThrough
             ),
         );
     }
@@ -340,7 +378,10 @@ final class ModelInspector
     {
         $name = $name instanceof PropertyReflector ? $name->getName() : $name;
 
-        return $this->memoize('getRelation' . $name, fn () => $this->getBelongsTo($name) ?? $this->getHasOne($name) ?? $this->getHasMany($name) ?? $this->getHasOneThrough($name));
+        return $this->memoize(
+            'getRelation' . $name,
+            fn () => $this->getBelongsTo($name) ?? $this->getHasOne($name) ?? $this->getHasMany($name) ?? $this->getHasOneThrough($name) ?? $this->getHasManyThrough($name),
+        );
     }
 
     /**
@@ -441,6 +482,10 @@ final class ModelInspector
             }
 
             if ($relation instanceof HasOneThrough) {
+                continue;
+            }
+
+            if ($relation instanceof HasManyThrough) {
                 continue;
             }
 

--- a/packages/database/src/HasManyThrough.php
+++ b/packages/database/src/HasManyThrough.php
@@ -1,0 +1,321 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database;
+
+use Attribute;
+use Tempest\Database\Builder\ModelInspector;
+use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
+use Tempest\Database\QueryStatements\FieldStatement;
+use Tempest\Database\QueryStatements\JoinStatement;
+use Tempest\Reflection\PropertyReflector;
+use Tempest\Support\Arr\ImmutableArray;
+
+use function Tempest\Support\str;
+
+#[Attribute(flags: Attribute::TARGET_PROPERTY)]
+final class HasManyThrough implements Relation
+{
+    public PropertyReflector $property;
+
+    public string $name {
+        get => $this->property->getName();
+    }
+
+    private ?string $parent = null;
+
+    /**
+     * @param class-string $through
+     */
+    public function __construct(
+        public string $through,
+        public ?string $ownerJoin = null,
+        public ?string $relationJoin = null,
+        public ?string $throughOwnerJoin = null,
+        public ?string $throughRelationJoin = null,
+    ) {}
+
+    public function setParent(string $name): self
+    {
+        $this->parent = $name;
+
+        return $this;
+    }
+
+    public function getSelectFields(): ImmutableArray
+    {
+        $targetModel = inspect(
+            model: $this->property
+                ->getIterableType()
+                ->asClass(),
+        );
+
+        return $targetModel
+            ->getSelectFields()
+            ->map(map: fn (
+                $field,
+            ) => new FieldStatement(
+                field: $targetModel->getTableName() . '.' . $field,
+            )
+                ->withAlias(
+                    alias: sprintf(
+                        '%s.%s',
+                        $this->property->getName(),
+                        $field,
+                    ),
+                )
+                ->withAliasPrefix(prefix: $this->parent));
+    }
+
+    public function primaryKey(): string
+    {
+        $relationModel = inspect(
+            model: $this->property
+                ->getIterableType()
+                ->asClass(),
+        );
+        $primaryKey = $relationModel->getPrimaryKey();
+
+        if ($primaryKey === null) {
+            throw ModelDidNotHavePrimaryColumn::neededForRelation(
+                model: $relationModel->getName(),
+                relationType: 'HasManyThrough',
+            );
+        }
+
+        return $primaryKey;
+    }
+
+    public function idField(): string
+    {
+        $relationModel = inspect(
+            model: $this->property
+                ->getIterableType()
+                ->asClass(),
+        );
+        $primaryKey = $relationModel->getPrimaryKey();
+
+        if ($primaryKey === null) {
+            throw ModelDidNotHavePrimaryColumn::neededForRelation(
+                model: $relationModel->getName(),
+                relationType: 'HasManyThrough',
+            );
+        }
+
+        return sprintf(
+            '%s.%s',
+            $this->property->getName(),
+            $primaryKey,
+        );
+    }
+
+    public function getJoinStatement(): JoinStatement
+    {
+        $intermediateModel = inspect(model: $this->through);
+
+        return new JoinStatement(
+            statement: sprintf(
+                '%s %s',
+                $this->buildFirstJoin(
+                    ownerModel: inspect(model: $this->property->getClass()),
+                    intermediateModel: $intermediateModel,
+                ),
+                $this->buildSecondJoin(
+                    intermediateModel: $intermediateModel,
+                    targetModel: inspect(
+                        model: $this->property
+                            ->getIterableType()
+                            ->asClass(),
+                    ),
+                ),
+            ),
+        );
+    }
+
+    private function buildFirstJoin(
+        ModelInspector $ownerModel,
+        ModelInspector $intermediateModel,
+    ): string {
+        return sprintf(
+            'LEFT JOIN %s ON %s = %s',
+            $intermediateModel->getTableName(),
+            $this->resolveOwnerJoin(
+                intermediateModel: $intermediateModel,
+                ownerModel: $ownerModel,
+            ),
+            $this->resolveRelationJoin(ownerModel: $ownerModel),
+        );
+    }
+
+    private function buildSecondJoin(
+        ModelInspector $intermediateModel,
+        ModelInspector $targetModel,
+    ): string {
+        return sprintf(
+            'LEFT JOIN %s ON %s = %s',
+            $targetModel->getTableName(),
+            $this->resolveThroughOwnerJoin(
+                targetModel: $targetModel,
+                intermediateModel: $intermediateModel,
+            ),
+            $this->resolveThroughRelationJoin(intermediateModel: $intermediateModel),
+        );
+    }
+
+    private function resolveOwnerJoin(
+        ModelInspector $intermediateModel,
+        ModelInspector $ownerModel,
+    ): string {
+        $ownerJoin = $this->ownerJoin;
+
+        if (
+            $ownerJoin
+            && ! strpos(
+                haystack: $ownerJoin,
+                needle: '.',
+            )
+        ) {
+            return sprintf(
+                '%s.%s',
+                $intermediateModel->getTableName(),
+                $ownerJoin,
+            );
+        }
+
+        if ($ownerJoin) {
+            return $ownerJoin;
+        }
+
+        $primaryKey = $ownerModel->getPrimaryKey();
+
+        if ($primaryKey === null) {
+            throw ModelDidNotHavePrimaryColumn::neededForRelation(
+                model: $ownerModel->getName(),
+                relationType: 'HasManyThrough',
+            );
+        }
+
+        return sprintf(
+            '%s.%s',
+            $intermediateModel->getTableName(),
+            str(string: $ownerModel->getTableName())->singularizeLastWord() . '_' . $primaryKey,
+        );
+    }
+
+    private function resolveRelationJoin(ModelInspector $ownerModel): string
+    {
+        $relationJoin = $this->relationJoin;
+
+        if (
+            $relationJoin
+            && ! strpos(
+                haystack: $relationJoin,
+                needle: '.',
+            )
+        ) {
+            return sprintf(
+                '%s.%s',
+                $ownerModel->getTableName(),
+                $relationJoin,
+            );
+        }
+
+        if ($relationJoin) {
+            return $relationJoin;
+        }
+
+        $primaryKey = $ownerModel->getPrimaryKey();
+
+        if ($primaryKey === null) {
+            throw ModelDidNotHavePrimaryColumn::neededForRelation(
+                model: $ownerModel->getName(),
+                relationType: 'HasManyThrough',
+            );
+        }
+
+        return sprintf(
+            '%s.%s',
+            $ownerModel->getTableName(),
+            $primaryKey,
+        );
+    }
+
+    private function resolveThroughOwnerJoin(
+        ModelInspector $targetModel,
+        ModelInspector $intermediateModel,
+    ): string {
+        $throughOwnerJoin = $this->throughOwnerJoin;
+
+        if (
+            $throughOwnerJoin
+            && ! strpos(
+                haystack: $throughOwnerJoin,
+                needle: '.',
+            )
+        ) {
+            return sprintf(
+                '%s.%s',
+                $targetModel->getTableName(),
+                $throughOwnerJoin,
+            );
+        }
+
+        if ($throughOwnerJoin) {
+            return $throughOwnerJoin;
+        }
+
+        $primaryKey = $intermediateModel->getPrimaryKey();
+
+        if ($primaryKey === null) {
+            throw ModelDidNotHavePrimaryColumn::neededForRelation(
+                model: $intermediateModel->getName(),
+                relationType: 'HasManyThrough',
+            );
+        }
+
+        return sprintf(
+            '%s.%s',
+            $targetModel->getTableName(),
+            str(string: $intermediateModel->getTableName())->singularizeLastWord() . '_' . $primaryKey,
+        );
+    }
+
+    private function resolveThroughRelationJoin(ModelInspector $intermediateModel): string
+    {
+        $throughRelationJoin = $this->throughRelationJoin;
+
+        if (
+            $throughRelationJoin
+            && ! strpos(
+                haystack: $throughRelationJoin,
+                needle: '.',
+            )
+        ) {
+            return sprintf(
+                '%s.%s',
+                $intermediateModel->getTableName(),
+                $throughRelationJoin,
+            );
+        }
+
+        if ($throughRelationJoin) {
+            return $throughRelationJoin;
+        }
+
+        $primaryKey = $intermediateModel->getPrimaryKey();
+
+        if ($primaryKey === null) {
+            throw ModelDidNotHavePrimaryColumn::neededForRelation(
+                model: $intermediateModel->getName(),
+                relationType: 'HasManyThrough',
+            );
+        }
+
+        return sprintf(
+            '%s.%s',
+            $intermediateModel->getTableName(),
+            $primaryKey,
+        );
+    }
+}

--- a/packages/database/src/Mappers/SelectModelMapper.php
+++ b/packages/database/src/Mappers/SelectModelMapper.php
@@ -5,6 +5,7 @@ namespace Tempest\Database\Mappers;
 use Tempest\Database\BelongsTo;
 use Tempest\Database\Builder\ModelInspector;
 use Tempest\Database\HasMany;
+use Tempest\Database\HasManyThrough;
 use Tempest\Database\HasOne;
 use Tempest\Database\HasOneThrough;
 use Tempest\Discovery\SkipDiscovery;
@@ -93,7 +94,7 @@ final class SelectModelMapper implements Mapper
                 continue;
             }
 
-            if ($relation instanceof HasMany) {
+            if ($relation instanceof HasMany || $relation instanceof HasManyThrough) {
                 $mapped = [];
                 $relationModel = inspect($relation);
 
@@ -134,7 +135,7 @@ final class SelectModelMapper implements Mapper
                 if ($relation instanceof BelongsTo || $relation instanceof HasOne || $relation instanceof HasOneThrough) {
                     $key .= $relation->name . '.';
                     $originalKey .= $relation->name . '.';
-                } elseif ($relation instanceof HasMany) {
+                } elseif ($relation instanceof HasMany || $relation instanceof HasManyThrough) {
                     $hasManyId = $data->get($key . $relation->idField()) ?? $row[$originalKey . $relation->idField()] ?? null;
 
                     $originalKey .= $relation->name . '.';

--- a/tests/Integration/Database/ModelInspector/HasManyThroughTest.php
+++ b/tests/Integration/Database/ModelInspector/HasManyThroughTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tests\Tempest\Integration\Database\ModelInspector;
+
+use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\HasManyThrough;
+use Tempest\Database\PrimaryKey;
+use Tempest\Database\Table;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\Database\inspect;
+
+final class HasManyThroughTest extends FrameworkIntegrationTestCase
+{
+    public function test_has_many_through(): void
+    {
+        $model = inspect(model: HasManyThroughOwnerModel::class);
+        $relation = $model->getRelation(name: 'targets');
+
+        $this->assertInstanceOf(
+            expected: HasManyThrough::class,
+            actual: $relation,
+        );
+
+        $this->assertSame(
+            expected: 'LEFT JOIN intermediate ON intermediate.owner_id = owner.id LEFT JOIN target ON target.intermediate_id = intermediate.id',
+            actual: $relation
+                ->getJoinStatement()
+                ->compile(dialect: DatabaseDialect::SQLITE),
+        );
+    }
+
+    public function test_has_many_through_select_fields(): void
+    {
+        $model = inspect(model: HasManyThroughOwnerModel::class);
+        $relation = $model->getRelation(name: 'targets');
+
+        $fields = $relation->getSelectFields();
+
+        $this->assertSame(
+            expected: 'target.id AS `targets.id`',
+            actual: $fields[0]->compile(DatabaseDialect::SQLITE),
+        );
+        $this->assertSame(
+            expected: 'target.intermediate_id AS `targets.intermediate_id`',
+            actual: $fields[1]->compile(DatabaseDialect::SQLITE),
+        );
+        $this->assertSame(
+            expected: 'target.data AS `targets.data`',
+            actual: $fields[2]->compile(DatabaseDialect::SQLITE),
+        );
+    }
+
+    public function test_has_many_through_with_parent(): void
+    {
+        $model = inspect(model: HasManyThroughOwnerModel::class);
+        $relation = $model
+            ->getRelation(name: 'targets')
+            ->setParent(name: 'parent');
+
+        $this->assertSame(
+            expected: 'target.data AS `parent.targets.data`',
+            actual: $relation->getSelectFields()[2]->compile(DatabaseDialect::SQLITE),
+        );
+    }
+
+    public function test_has_many_through_with_custom_joins(): void
+    {
+        $model = inspect(model: HasManyThroughCustomOwnerModel::class);
+        $relation = $model->getRelation(name: 'targets');
+
+        $this->assertInstanceOf(
+            expected: HasManyThrough::class,
+            actual: $relation,
+        );
+
+        $this->assertSame(
+            expected: 'LEFT JOIN custom_intermediate ON custom_intermediate.custom_owner_fk = custom_owner.custom_pk LEFT JOIN target ON target.custom_intermediate_fk = custom_intermediate.custom_intermediate_pk',
+            actual: $relation
+                ->getJoinStatement()
+                ->compile(dialect: DatabaseDialect::SQLITE),
+        );
+    }
+}
+
+#[Table(name: 'owner')]
+final class HasManyThroughOwnerModel
+{
+    public PrimaryKey $id;
+
+    /** @var \Tests\Tempest\Integration\Database\ModelInspector\HasManyThroughTargetModel[] */
+    #[HasManyThrough(through: HasManyThroughIntermediateModel::class)]
+    public array $targets = [];
+
+    public string $name;
+}
+
+#[Table(name: 'intermediate')]
+final class HasManyThroughIntermediateModel
+{
+    public PrimaryKey $id;
+
+    public HasManyThroughOwnerModel $owner;
+
+    public string $value;
+}
+
+#[Table(name: 'target')]
+final class HasManyThroughTargetModel
+{
+    public PrimaryKey $id;
+
+    public HasManyThroughIntermediateModel $intermediate;
+
+    public string $data;
+}
+
+#[Table(name: 'custom_owner')]
+final class HasManyThroughCustomOwnerModel
+{
+    public PrimaryKey $custom_pk;
+
+    /** @var \Tests\Tempest\Integration\Database\ModelInspector\HasManyThroughTargetModel[] */
+    #[HasManyThrough(
+        through: HasManyThroughCustomIntermediateModel::class,
+        ownerJoin: 'custom_owner_fk',
+        relationJoin: 'custom_pk',
+        throughOwnerJoin: 'custom_intermediate_fk',
+        throughRelationJoin: 'custom_intermediate_pk',
+    )]
+    public array $targets = [];
+
+    public string $name;
+}
+
+#[Table(name: 'custom_intermediate')]
+final class HasManyThroughCustomIntermediateModel
+{
+    public PrimaryKey $custom_intermediate_pk;
+
+    public string $value;
+}


### PR DESCRIPTION
Add suport for HasManyThrough  to allow avoiding fetching model in the middle


```php
/** @var \Playground\Payment\Payment[] */
#[HasManyThrough(Contract::class)]
public array $payments = [];
```