### PR TITLE
fix: import predefined constants using use const

### DIFF
--- a/packages/cryptography/src/Password/HashingAlgorithm.php
+++ b/packages/cryptography/src/Password/HashingAlgorithm.php
@@ -2,6 +2,9 @@
 
 namespace Tempest\Cryptography\Password;
 
+use const PASSWORD_ARGON2ID;
+use const PASSWORD_BCRYPT;
+
 enum HashingAlgorithm: string
 {
     /**


### PR DESCRIPTION
When I ran `create-project`, an error occurred during `discovery:generate`.

```
> @php ./vendor/bin/tempest discovery:generate --no-interaction

Fatal error: Uncaught Error: Undefined constant "Tempest\Cryptography\Password\PASSWORD_ARGON2ID" in /mnt/c/Users/username/works/tempest-sample/vendor/tempest/framework/packages/cryptography/src/Password/HashingAlgorithm.php:10
```

This was caused by directly calling PHP constants within a namespace, so I used `use const` to load global constants.

```
$ php -v
PHP 8.5.4 (cli) (built: Mar 22 2026 00:50:35) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.5.4, Copyright (c) Zend Technologies
    with Zend OPcache v8.5.4, Copyright (c), by Zend Technologies
```

Composer version 2.9.5 2026-01-29 11:40:53