### PR TITLE
fix(database): relations joins overshadowing if property name conflict in chain

### DIFF
--- a/packages/database/src/BelongsTo.php
+++ b/packages/database/src/BelongsTo.php
@@ -17,6 +17,8 @@ use function Tempest\Support\str;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class BelongsTo implements Relation
 {
+    use HasTableAlias;
+
     public PropertyReflector $property;
 
     public string $name {
@@ -62,7 +64,7 @@ final class BelongsTo implements Relation
         $relationModel = inspect($this->property->getType()->asClass());
         $tableReference = $this->isSelfReferencing()
             ? $this->property->getName()
-            : $relationModel->getTableName();
+            : $this->getTableAlias($relationModel->getTableName());
 
         return $relationModel
             ->getSelectFields()
@@ -79,8 +81,12 @@ final class BelongsTo implements Relation
     {
         $relationModel = inspect($this->property->getType()->asClass());
         $ownerModel = inspect($this->property->getClass());
+        $tableAlias = $this->getTableAlias($relationModel->getTableName());
 
-        $relationJoin = $this->getRelationJoin($relationModel);
+        $relationJoin = $this->getRelationJoin(
+            relationModel: $relationModel,
+            tableAlias: $tableAlias,
+        );
         $ownerJoin = $this->getOwnerJoin($ownerModel);
 
         if ($this->isSelfReferencing()) {
@@ -93,21 +99,26 @@ final class BelongsTo implements Relation
             ));
         }
 
+        $tableName = $relationModel->getTableName();
+        $tableRef = $tableAlias !== $tableName
+            ? sprintf('%s AS %s', $tableName, $tableAlias)
+            : $tableName;
+
         // LEFT JOIN authors ON authors.id = books.author_id
         return new JoinStatement(sprintf(
             'LEFT JOIN %s ON %s = %s',
-            $relationModel->getTableName(),
+            $tableRef,
             $relationJoin,
             $ownerJoin,
         ));
     }
 
-    private function getRelationJoin(ModelInspector $relationModel): string
+    private function getRelationJoin(ModelInspector $relationModel, string $tableAlias): string
     {
         $relationJoin = $this->relationJoin;
         $tableReference = $this->isSelfReferencing()
             ? $this->property->getName()
-            : $relationModel->getTableName();
+            : $tableAlias;
 
         if ($relationJoin && ! strpos($relationJoin, '.')) {
             $relationJoin = sprintf('%s.%s', $tableReference, $relationJoin);

--- a/packages/database/src/BelongsToMany.php
+++ b/packages/database/src/BelongsToMany.php
@@ -18,6 +18,8 @@ use function Tempest\Support\str;
 #[Attribute(flags: Attribute::TARGET_PROPERTY)]
 final class BelongsToMany implements Relation
 {
+    use HasTableAlias;
+
     public PropertyReflector $property;
 
     public string $name {
@@ -361,14 +363,5 @@ final class BelongsToMany implements Relation
             $tableAlias,
             $primaryKey,
         );
-    }
-
-    private function getTableAlias(string $tableName): string
-    {
-        if ($this->parent === null || $this->parent === '') {
-            return $tableName;
-        }
-
-        return str(string: $this->parent)->replace('.', '_')->append('_', $this->property->getName())->toString();
     }
 }

--- a/packages/database/src/BelongsToMany.php
+++ b/packages/database/src/BelongsToMany.php
@@ -54,7 +54,7 @@ final class BelongsToMany implements Relation
             ->map(map: fn (
                 $field,
             ) => new FieldStatement(
-                field: $this->getTableAlias(tableName: $targetModel->getTableName()) . '.' . $field,
+                field: "{$this->getTableAlias(tableName: $targetModel->getTableName())}.{$field}",
             )
                 ->withAlias(
                     alias: sprintf(

--- a/packages/database/src/BelongsToMany.php
+++ b/packages/database/src/BelongsToMany.php
@@ -54,7 +54,7 @@ final class BelongsToMany implements Relation
             ->map(map: fn (
                 $field,
             ) => new FieldStatement(
-                field: $targetModel->getTableName() . '.' . $field,
+                field: $this->getTableAlias(tableName: $targetModel->getTableName()) . '.' . $field,
             )
                 ->withAlias(
                     alias: sprintf(
@@ -120,7 +120,6 @@ final class BelongsToMany implements Relation
             ownerModel: $ownerModel,
             targetModel: $targetModel,
         );
-
         return new JoinStatement(
             statement: sprintf(
                 '%s %s',
@@ -131,6 +130,7 @@ final class BelongsToMany implements Relation
                 $this->buildSecondJoin(
                     targetModel: $targetModel,
                     pivotTable: $pivotTable,
+                    tableAlias: $this->getTableAlias(tableName: $targetModel->getTableName()),
                 ),
             ),
         );
@@ -174,11 +174,20 @@ final class BelongsToMany implements Relation
     private function buildSecondJoin(
         ModelInspector $targetModel,
         string $pivotTable,
+        string $tableAlias,
     ): string {
+        $tableName = $targetModel->getTableName();
+        $tableRef = $tableAlias !== $tableName
+            ? sprintf('%s AS %s', $tableName, $tableAlias)
+            : $tableName;
+
         return sprintf(
             'LEFT JOIN %s ON %s = %s',
-            $targetModel->getTableName(),
-            $this->resolveRelatedRelationJoin(targetModel: $targetModel),
+            $tableRef,
+            $this->resolveRelatedRelationJoin(
+                targetModel: $targetModel,
+                tableAlias: $tableAlias,
+            ),
             $this->resolveRelatedOwnerJoin(
                 targetModel: $targetModel,
                 pivotTable: $pivotTable,
@@ -316,7 +325,7 @@ final class BelongsToMany implements Relation
     /**
      * PK on target: target.id
      */
-    private function resolveRelatedRelationJoin(ModelInspector $targetModel): string
+    private function resolveRelatedRelationJoin(ModelInspector $targetModel, string $tableAlias): string
     {
         $relatedRelationJoin = $this->relatedRelationJoin;
 
@@ -329,7 +338,7 @@ final class BelongsToMany implements Relation
         ) {
             return sprintf(
                 '%s.%s',
-                $targetModel->getTableName(),
+                $tableAlias,
                 $relatedRelationJoin,
             );
         }
@@ -349,8 +358,17 @@ final class BelongsToMany implements Relation
 
         return sprintf(
             '%s.%s',
-            $targetModel->getTableName(),
+            $tableAlias,
             $primaryKey,
         );
+    }
+
+    private function getTableAlias(string $tableName): string
+    {
+        if ($this->parent === null || $this->parent === '') {
+            return $tableName;
+        }
+
+        return str(string: $this->parent)->replace('.', '_')->append('_', $this->property->getName())->toString();
     }
 }

--- a/packages/database/src/Builder/ModelInspector.php
+++ b/packages/database/src/Builder/ModelInspector.php
@@ -606,8 +606,12 @@ final class ModelInspector
         $relationModel = inspect($currentRelation);
         $modelType = $relationModel->getName();
 
+        $fullPath = $parent !== ''
+            ? "{$parent}.{$currentRelationName}"
+            : $currentRelationName;
+
         if (in_array($modelType, $visitedPaths, true)) {
-            return [$currentRelationName => $currentRelation->setParent($parent)];
+            return [$fullPath => $currentRelation->setParent($parent)];
         }
 
         $newRelationString = implode('.', $relationNames);
@@ -618,7 +622,7 @@ final class ModelInspector
             $currentRelationName,
         ), '.');
 
-        $relations = [$currentRelationName => $currentRelation];
+        $relations = [$fullPath => $currentRelation];
 
         return [
             ...$relations,
@@ -659,7 +663,10 @@ final class ModelInspector
                 continue;
             }
 
-            $relations[$property->getName()] = $currentRelation->setParent($parent);
+            $fullPath = $parent !== ''
+                ? "{$parent}.{$currentRelationName}"
+                : $currentRelationName;
+            $relations[$fullPath] = $currentRelation->setParent($parent);
             $newVisitedPaths = [...$visitedPaths, $this->getName()];
 
             foreach ($relationModel->resolveEagerRelations($newParent, $newVisitedPaths) as $name => $nestedEagerRelation) {

--- a/packages/database/src/HasMany.php
+++ b/packages/database/src/HasMany.php
@@ -17,6 +17,8 @@ use function Tempest\Support\str;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class HasMany implements Relation
 {
+    use HasTableAlias;
+
     public PropertyReflector $property;
 
     public string $name {
@@ -42,7 +44,7 @@ final class HasMany implements Relation
         $relationModel = inspect($this->property->getIterableType()->asClass());
         $tableReference = $this->isSelfReferencing()
             ? $this->property->getName()
-            : $relationModel->getTableName();
+            : $this->getTableAlias($relationModel->getTableName());
 
         return $relationModel
             ->getSelectFields()
@@ -87,8 +89,13 @@ final class HasMany implements Relation
     {
         $ownerModel = inspect($this->property->getIterableType()->asClass());
         $relationModel = inspect($this->property->getClass());
+        $tableAlias = $this->getTableAlias($ownerModel->getTableName());
 
-        $ownerJoin = $this->getOwnerJoin($ownerModel, $relationModel);
+        $ownerJoin = $this->getOwnerJoin(
+            ownerModel: $ownerModel,
+            relationModel: $relationModel,
+            tableAlias: $tableAlias,
+        );
         $relationJoin = $this->getRelationJoin($relationModel);
 
         if ($this->isSelfReferencing()) {
@@ -101,20 +108,25 @@ final class HasMany implements Relation
             ));
         }
 
+        $tableName = $ownerModel->getTableName();
+        $tableRef = $tableAlias !== $tableName
+            ? sprintf('%s AS %s', $tableName, $tableAlias)
+            : $tableName;
+
         return new JoinStatement(sprintf(
             'LEFT JOIN %s ON %s = %s',
-            $ownerModel->getTableName(),
+            $tableRef,
             $ownerJoin,
             $relationJoin,
         ));
     }
 
-    private function getOwnerJoin(ModelInspector $ownerModel, ModelInspector $relationModel): string
+    private function getOwnerJoin(ModelInspector $ownerModel, ModelInspector $relationModel, string $tableAlias): string
     {
         $ownerJoin = $this->ownerJoin;
         $tableReference = $this->isSelfReferencing()
             ? $this->property->getName()
-            : $ownerModel->getTableName();
+            : $tableAlias;
 
         if ($ownerJoin && ! strpos($ownerJoin, '.')) {
             $ownerJoin = sprintf(

--- a/packages/database/src/HasManyThrough.php
+++ b/packages/database/src/HasManyThrough.php
@@ -17,6 +17,8 @@ use function Tempest\Support\str;
 #[Attribute(flags: Attribute::TARGET_PROPERTY)]
 final class HasManyThrough implements Relation
 {
+    use HasTableAlias;
+
     public PropertyReflector $property;
 
     public string $name {
@@ -56,7 +58,7 @@ final class HasManyThrough implements Relation
             ->map(map: fn (
                 $field,
             ) => new FieldStatement(
-                field: $targetModel->getTableName() . '.' . $field,
+                field: "{$this->getTableAlias(tableName: $targetModel->getTableName())}.{$field}",
             )
                 ->withAlias(
                     alias: sprintf(
@@ -152,12 +154,19 @@ final class HasManyThrough implements Relation
         ModelInspector $intermediateModel,
         ModelInspector $targetModel,
     ): string {
+        $tableAlias = $this->getTableAlias(tableName: $targetModel->getTableName());
+        $tableName = $targetModel->getTableName();
+        $tableRef = $tableAlias !== $tableName
+            ? sprintf('%s AS %s', $tableName, $tableAlias)
+            : $tableName;
+
         return sprintf(
             'LEFT JOIN %s ON %s = %s',
-            $targetModel->getTableName(),
+            $tableRef,
             $this->resolveThroughOwnerJoin(
                 targetModel: $targetModel,
                 intermediateModel: $intermediateModel,
+                tableAlias: $tableAlias,
             ),
             $this->resolveThroughRelationJoin(intermediateModel: $intermediateModel),
         );
@@ -244,6 +253,7 @@ final class HasManyThrough implements Relation
     private function resolveThroughOwnerJoin(
         ModelInspector $targetModel,
         ModelInspector $intermediateModel,
+        string $tableAlias,
     ): string {
         $throughOwnerJoin = $this->throughOwnerJoin;
 
@@ -256,7 +266,7 @@ final class HasManyThrough implements Relation
         ) {
             return sprintf(
                 '%s.%s',
-                $targetModel->getTableName(),
+                $tableAlias,
                 $throughOwnerJoin,
             );
         }
@@ -276,7 +286,7 @@ final class HasManyThrough implements Relation
 
         return sprintf(
             '%s.%s',
-            $targetModel->getTableName(),
+            $tableAlias,
             str(string: $intermediateModel->getTableName())->singularizeLastWord() . '_' . $primaryKey,
         );
     }

--- a/packages/database/src/HasOne.php
+++ b/packages/database/src/HasOne.php
@@ -17,6 +17,8 @@ use function Tempest\Support\str;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class HasOne implements Relation
 {
+    use HasTableAlias;
+
     public PropertyReflector $property;
 
     public string $name {
@@ -42,7 +44,7 @@ final class HasOne implements Relation
         $relationModel = inspect($this->property->getType()->asClass());
         $tableReference = $this->isSelfReferencing()
             ? $this->property->getName()
-            : $relationModel->getTableName();
+            : $this->getTableAlias($relationModel->getTableName());
 
         return $relationModel
             ->getSelectFields()
@@ -59,8 +61,13 @@ final class HasOne implements Relation
     {
         $ownerModel = inspect($this->property->getType()->asClass());
         $relationModel = inspect($this->property->getClass());
+        $tableAlias = $this->getTableAlias($ownerModel->getTableName());
 
-        $ownerJoin = $this->getOwnerJoin($ownerModel, $relationModel);
+        $ownerJoin = $this->getOwnerJoin(
+            ownerModel: $ownerModel,
+            relationModel: $relationModel,
+            tableAlias: $tableAlias,
+        );
         $relationJoin = $this->getRelationJoin($relationModel);
 
         if ($this->isSelfReferencing()) {
@@ -73,20 +80,25 @@ final class HasOne implements Relation
             ));
         }
 
+        $tableName = $ownerModel->getTableName();
+        $tableRef = $tableAlias !== $tableName
+            ? sprintf('%s AS %s', $tableName, $tableAlias)
+            : $tableName;
+
         return new JoinStatement(sprintf(
             'LEFT JOIN %s ON %s = %s',
-            $ownerModel->getTableName(),
+            $tableRef,
             $ownerJoin,
             $relationJoin,
         ));
     }
 
-    private function getOwnerJoin(ModelInspector $ownerModel, ModelInspector $relationModel): string
+    private function getOwnerJoin(ModelInspector $ownerModel, ModelInspector $relationModel, string $tableAlias): string
     {
         $ownerJoin = $this->ownerJoin;
         $tableReference = $this->isSelfReferencing()
             ? $this->property->getName()
-            : $ownerModel->getTableName();
+            : $tableAlias;
 
         if ($ownerJoin && ! strpos($ownerJoin, '.')) {
             $ownerJoin = sprintf(

--- a/packages/database/src/HasOneThrough.php
+++ b/packages/database/src/HasOneThrough.php
@@ -17,6 +17,8 @@ use function Tempest\Support\str;
 #[Attribute(flags: Attribute::TARGET_PROPERTY)]
 final class HasOneThrough implements Relation
 {
+    use HasTableAlias;
+
     public PropertyReflector $property;
 
     public string $name {
@@ -57,7 +59,7 @@ final class HasOneThrough implements Relation
                 map: fn (
                     $field,
                 ) => new FieldStatement(
-                    field: $targetModel->getTableName() . '.' . $field,
+                    field: "{$this->getTableAlias(tableName: $targetModel->getTableName())}.{$field}",
                 )
                     ->withAlias(
                         alias: sprintf(
@@ -109,12 +111,19 @@ final class HasOneThrough implements Relation
         ModelInspector $intermediateModel,
         ModelInspector $targetModel,
     ): string {
+        $tableAlias = $this->getTableAlias(tableName: $targetModel->getTableName());
+        $tableName = $targetModel->getTableName();
+        $tableRef = $tableAlias !== $tableName
+            ? sprintf('%s AS %s', $tableName, $tableAlias)
+            : $tableName;
+
         return sprintf(
             'LEFT JOIN %s ON %s = %s',
-            $targetModel->getTableName(),
+            $tableRef,
             $this->resolveThroughOwnerJoin(
                 targetModel: $targetModel,
                 intermediateModel: $intermediateModel,
+                tableAlias: $tableAlias,
             ),
             $this->resolveThroughRelationJoin(intermediateModel: $intermediateModel),
         );
@@ -201,6 +210,7 @@ final class HasOneThrough implements Relation
     private function resolveThroughOwnerJoin(
         ModelInspector $targetModel,
         ModelInspector $intermediateModel,
+        string $tableAlias,
     ): string {
         $throughOwnerJoin = $this->throughOwnerJoin;
 
@@ -213,7 +223,7 @@ final class HasOneThrough implements Relation
         ) {
             return sprintf(
                 '%s.%s',
-                $targetModel->getTableName(),
+                $tableAlias,
                 $throughOwnerJoin,
             );
         }
@@ -233,7 +243,7 @@ final class HasOneThrough implements Relation
 
         return sprintf(
             '%s.%s',
-            $targetModel->getTableName(),
+            $tableAlias,
             str(string: $intermediateModel->getTableName())->singularizeLastWord() . '_' . $primaryKey,
         );
     }

--- a/packages/database/src/HasTableAlias.php
+++ b/packages/database/src/HasTableAlias.php
@@ -14,6 +14,15 @@ trait HasTableAlias
             return $tableName;
         }
 
-        return str(string: $this->parent)->replace('.', '_')->append('_', $this->property->getName())->toString();
+        return str(string: $this->parent)
+            ->replace(
+                search: '.',
+                replace: '_',
+            )
+            ->append(
+                '_',
+                $this->property->getName(),
+            )
+            ->toString();
     }
 }

--- a/packages/database/src/HasTableAlias.php
+++ b/packages/database/src/HasTableAlias.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database;
+
+use function Tempest\Support\str;
+
+trait HasTableAlias
+{
+    private function getTableAlias(string $tableName): string
+    {
+        if ($this->parent === null || $this->parent === '') {
+            return $tableName;
+        }
+
+        return str(string: $this->parent)->replace('.', '_')->append('_', $this->property->getName())->toString();
+    }
+}

--- a/tests/Integration/Database/Builder/SelectQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/SelectQueryBuilderTest.php
@@ -12,6 +12,9 @@ use Tests\Tempest\Fixtures\Migrations\CreateBookTable;
 use Tests\Tempest\Fixtures\Migrations\CreateChapterTable;
 use Tests\Tempest\Fixtures\Migrations\CreateIsbnTable;
 use Tests\Tempest\Fixtures\Migrations\CreatePublishersTable;
+use Tempest\Database\BelongsToMany;
+use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\Table;
 use Tests\Tempest\Fixtures\Models\AWithEager;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Fixtures\Modules\Books\Models\AuthorType;
@@ -735,4 +738,51 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
             $query->compile(),
         );
     }
+
+    public function test_select_with_duplicate_belongs_to_many_target_table(): void
+    {
+        $query = query(model: UserWithRoleAndDirectPermissions::class)
+            ->select()
+            ->with('role', 'role.permissions', 'permissions')
+            ->build();
+
+        $this->assertSameWithoutBackticks(
+            'SELECT users.id AS `users.id`, users.name AS `users.name`, users.role_id AS `users.role_id`, roles.id AS `role.id`, roles.name AS `role.name`, role_permissions.id AS `role.permissions.id`, role_permissions.label AS `role.permissions.label`, permissions.id AS `permissions.id`, permissions.label AS `permissions.label` FROM `users` LEFT JOIN roles ON roles.id = users.role_id LEFT JOIN permissions_roles ON permissions_roles.role_id = roles.id LEFT JOIN permissions AS role_permissions ON role_permissions.id = permissions_roles.permission_id LEFT JOIN permissions_users ON permissions_users.user_id = users.id LEFT JOIN permissions ON permissions.id = permissions_users.permission_id',
+            $query->compile(),
+        );
+    }
+}
+
+#[Table(name: 'users')]
+final class UserWithRoleAndDirectPermissions
+{
+    use IsDatabaseModel;
+
+    public string $name;
+
+    public ?RoleWithPermissions $role = null;
+
+    /** @var \Tests\Tempest\Integration\Database\Builder\Permission[] */
+    #[BelongsToMany(pivot: 'permissions_users')]
+    public array $permissions = [];
+}
+
+#[Table(name: 'roles')]
+final class RoleWithPermissions
+{
+    use IsDatabaseModel;
+
+    public string $name;
+
+    /** @var \Tests\Tempest\Integration\Database\Builder\Permission[] */
+    #[BelongsToMany(pivot: 'permissions_roles')]
+    public array $permissions = [];
+}
+
+#[Table(name: 'permissions')]
+final class Permission
+{
+    use IsDatabaseModel;
+
+    public string $label;
 }

--- a/tests/Integration/Database/Builder/SelectQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/SelectQueryBuilderTest.php
@@ -494,7 +494,7 @@ final class SelectQueryBuilderTest extends FrameworkIntegrationTestCase
         $query = AWithEager::select()->with('b.c')->compile();
 
         $this->assertSameWithoutBackticks(
-            'SELECT a.id AS `a.id`, a.b_id AS `a.b_id`, b.id AS `b.id`, b.c_id AS `b.c_id`, c.id AS `b.c.id`, c.name AS `b.c.name` FROM `a` LEFT JOIN b ON b.id = a.b_id LEFT JOIN c ON c.id = b.c_id',
+            'SELECT a.id AS `a.id`, a.b_id AS `a.b_id`, b.id AS `b.id`, b.c_id AS `b.c_id`, b_c.id AS `b.c.id`, b_c.name AS `b.c.name` FROM `a` LEFT JOIN b ON b.id = a.b_id LEFT JOIN c AS b_c ON b_c.id = b.c_id',
             $query,
         );
     }

--- a/tests/Integration/Database/Builder/SelectQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/SelectQueryBuilderTest.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Database\Builder;
 
+use Tempest\Database\BelongsToMany;
 use Tempest\Database\Builder\QueryBuilders\SelectQueryBuilder;
 use Tempest\Database\Direction;
+use Tempest\Database\IsDatabaseModel;
 use Tempest\Database\Migrations\CreateMigrationsTable;
+use Tempest\Database\Table;
 use Tests\Tempest\Fixtures\Migrations\CreateAuthorTable;
 use Tests\Tempest\Fixtures\Migrations\CreateBookTable;
 use Tests\Tempest\Fixtures\Migrations\CreateChapterTable;
 use Tests\Tempest\Fixtures\Migrations\CreateIsbnTable;
 use Tests\Tempest\Fixtures\Migrations\CreatePublishersTable;
-use Tempest\Database\BelongsToMany;
-use Tempest\Database\IsDatabaseModel;
-use Tempest\Database\Table;
 use Tests\Tempest\Fixtures\Models\AWithEager;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Fixtures\Modules\Books\Models\AuthorType;

--- a/tests/Integration/Database/CircularEagerLoadingTest.php
+++ b/tests/Integration/Database/CircularEagerLoadingTest.php
@@ -35,7 +35,7 @@ final class CircularEagerLoadingTest extends FrameworkIntegrationTestCase
         $relations = $userInspector->resolveRelations('profile.user.profile');
 
         $this->assertArrayHasKey('profile', $relations);
-        $this->assertArrayHasKey('user', $relations);
+        $this->assertArrayHasKey('profile.user', $relations);
         $this->assertCount(2, $relations);
     }
 

--- a/tests/Integration/Database/ModelInspector/BelongsToManyTest.php
+++ b/tests/Integration/Database/ModelInspector/BelongsToManyTest.php
@@ -54,8 +54,23 @@ final class BelongsToManyTest extends FrameworkIntegrationTestCase
             ->setParent(name: 'parent');
 
         $this->assertSame(
-            expected: 'target.data AS `parent.targets.data`',
+            expected: 'parent_targets.data AS `parent.targets.data`',
             actual: $relation->getSelectFields()[1]->compile(DatabaseDialect::SQLITE),
+        );
+    }
+
+    public function test_belongs_to_many_with_parent_join_uses_alias(): void
+    {
+        $model = inspect(model: BelongsToManyOwnerModel::class);
+        $relation = $model
+            ->getRelation(name: 'targets')
+            ->setParent(name: 'parent');
+
+        $this->assertSame(
+            expected: 'LEFT JOIN owner_target ON owner_target.owner_id = owner.id LEFT JOIN target AS parent_targets ON parent_targets.id = owner_target.target_id',
+            actual: $relation
+                ->getJoinStatement()
+                ->compile(dialect: DatabaseDialect::SQLITE),
         );
     }
 

--- a/tests/Integration/Database/ModelInspector/BelongsToTest.php
+++ b/tests/Integration/Database/ModelInspector/BelongsToTest.php
@@ -85,7 +85,7 @@ final class BelongsToTest extends FrameworkIntegrationTestCase
         $relation = $model->getRelation('relation')->setParent('parent');
 
         $this->assertSame(
-            'relation.name AS `parent.relation.name`',
+            'parent_relation.name AS `parent.relation.name`',
             $relation->getSelectFields()[1]->compile(DatabaseDialect::SQLITE),
         );
     }

--- a/tests/Integration/Database/ModelInspector/HasManyTest.php
+++ b/tests/Integration/Database/ModelInspector/HasManyTest.php
@@ -80,7 +80,7 @@ final class HasManyTest extends FrameworkIntegrationTestCase
         $relation = $model->getRelation('owners')->setParent('parent');
 
         $this->assertSame(
-            'owner.relation_id AS `parent.owners.relation_id`',
+            'parent_owners.relation_id AS `parent.owners.relation_id`',
             $relation->getSelectFields()[1]->compile(DatabaseDialect::SQLITE),
         );
     }

--- a/tests/Integration/Database/ModelInspector/HasManyThroughTest.php
+++ b/tests/Integration/Database/ModelInspector/HasManyThroughTest.php
@@ -59,7 +59,7 @@ final class HasManyThroughTest extends FrameworkIntegrationTestCase
             ->setParent(name: 'parent');
 
         $this->assertSame(
-            expected: 'target.data AS `parent.targets.data`',
+            expected: 'parent_targets.data AS `parent.targets.data`',
             actual: $relation->getSelectFields()[2]->compile(DatabaseDialect::SQLITE),
         );
     }

--- a/tests/Integration/Database/ModelInspector/HasOneTest.php
+++ b/tests/Integration/Database/ModelInspector/HasOneTest.php
@@ -80,7 +80,7 @@ final class HasOneTest extends FrameworkIntegrationTestCase
         $relation = $model->getRelation('owner')->setParent('parent');
 
         $this->assertSame(
-            'owner.relation_id AS `parent.owner.relation_id`',
+            'parent_owner.relation_id AS `parent.owner.relation_id`',
             $relation->getSelectFields()[1]->compile(DatabaseDialect::SQLITE),
         );
     }

--- a/tests/Integration/Database/ModelInspector/HasOneThroughTest.php
+++ b/tests/Integration/Database/ModelInspector/HasOneThroughTest.php
@@ -55,7 +55,7 @@ final class HasOneThroughTest extends FrameworkIntegrationTestCase
             ->setParent(name: 'parent');
 
         $this->assertSame(
-            expected: 'target.data AS `parent.target.data`',
+            expected: 'parent_target.data AS `parent.target.data`',
             actual: $relation->getSelectFields()[2]->compile(DatabaseDialect::SQLITE),
         );
     }


### PR DESCRIPTION
in a case the parent model has the same property name as child model one is overshadowed leading to invalid query

Given models like this:

```php
final class User
{
    public Role $role;

    #[BelongsToMany]
    public array $permissions;
}

final class Role
{
    #[BelongsToMany]
    public array $permissions;
}

final class Permission
{
    public string $label;
}
```

User::select()->with('role', 'role.permissions', 'permissions')->all();

would lead to user.role.permissions being overshadowed by user.permissions and dropped