### PR TITLE
fix(mapper): setting virtual properties

### DIFF
--- a/packages/mapper/src/Mappers/ArrayToObjectMapper.php
+++ b/packages/mapper/src/Mappers/ArrayToObjectMapper.php
@@ -150,6 +150,10 @@ final class ArrayToObjectMapper implements Mapper
     private function setChildParentRelation(object $parent, mixed $child, ClassReflector $childClass): void
     {
         foreach ($childClass->getPublicProperties() as $childProperty) {
+            if ($childProperty->isVirtual()) {
+                continue;
+            }
+
             if ($childProperty->getType()->equals($parent::class)) {
                 $valueToSet = $parent;
             } elseif ($childProperty->getIterableType()?->equals($parent::class)) {

--- a/tests/Integration/Mapper/Fixtures/ChildObjectWithGetterOnly.php
+++ b/tests/Integration/Mapper/Fixtures/ChildObjectWithGetterOnly.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+final class ChildObjectWithGetterOnly
+{
+    public string $name;
+
+    public ParentObjectWithGetterChild $parent;
+
+    /** @var \Tests\Tempest\Integration\Mapper\Fixtures\ParentObjectWithGetterChild[] */
+    public array $parentCollection;
+
+    public string $upperName {
+        get => strtoupper($this->name);
+    }
+}

--- a/tests/Integration/Mapper/Fixtures/ChildObjectWithVirtualProperty.php
+++ b/tests/Integration/Mapper/Fixtures/ChildObjectWithVirtualProperty.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+final class ChildObjectWithVirtualProperty
+{
+    public string $name;
+
+    public ParentObjectWithVirtualChild $parent;
+
+    /** @var \Tests\Tempest\Integration\Mapper\Fixtures\ParentObjectWithVirtualChild[] */
+    public array $parentCollection;
+
+    /** @var \Tests\Tempest\Integration\Mapper\Fixtures\ParentObjectWithVirtualChild */
+    public ParentObjectWithVirtualChild $virtualParent {
+        get => $this->parent;
+    }
+}

--- a/tests/Integration/Mapper/Fixtures/ParentObjectWithGetterChild.php
+++ b/tests/Integration/Mapper/Fixtures/ParentObjectWithGetterChild.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+final class ParentObjectWithGetterChild
+{
+    public string $name;
+
+    public ?ChildObjectWithGetterOnly $child = null;
+
+    /** @var \Tests\Tempest\Integration\Mapper\Fixtures\ChildObjectWithGetterOnly[] */
+    public array $children = [];
+}

--- a/tests/Integration/Mapper/Fixtures/ParentObjectWithVirtualChild.php
+++ b/tests/Integration/Mapper/Fixtures/ParentObjectWithVirtualChild.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+final class ParentObjectWithVirtualChild
+{
+    public string $name;
+
+    public ?ChildObjectWithVirtualProperty $child = null;
+
+    /** @var \Tests\Tempest\Integration\Mapper\Fixtures\ChildObjectWithVirtualProperty[] */
+    public array $children = [];
+}

--- a/tests/Integration/Mapper/Mappers/ArrayToObjectMapperTest.php
+++ b/tests/Integration/Mapper/Mappers/ArrayToObjectMapperTest.php
@@ -18,6 +18,8 @@ use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMagicGetter;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMyObject;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithPrimitiveArrayProperties;
 use Tests\Tempest\Integration\Mapper\Fixtures\ParentObject;
+use Tests\Tempest\Integration\Mapper\Fixtures\ParentObjectWithGetterChild;
+use Tests\Tempest\Integration\Mapper\Fixtures\ParentObjectWithVirtualChild;
 use Tests\Tempest\Integration\Mapper\Fixtures\ParentWithChildrenObject;
 
 use function Tempest\Mapper\map;
@@ -165,6 +167,84 @@ final class ArrayToObjectMapperTest extends FrameworkIntegrationTestCase
 
         $this->assertCount(1, $object->roles);
         $this->assertSame(EnumToBeMappedToArray::ADMIN, $object->roles[0]);
+    }
+
+    public function test_parent_child_with_virtual_property(): void
+    {
+        $parent = map(
+            [
+                'name' => 'a',
+                'child' => ['name' => 'b'],
+            ],
+        )
+            ->to(ParentObjectWithVirtualChild::class);
+
+        $this->assertSame('a', $parent->name);
+        $this->assertSame('b', $parent->child->name);
+        $this->assertSame('a', $parent->child->parent->name);
+        $this->assertSame('a', $parent->child->parentCollection[0]->name);
+        $this->assertSame('a', $parent->child->virtualParent->name);
+    }
+
+    public function test_parent_children_with_virtual_property(): void
+    {
+        $parent = map(
+            [
+                'name' => 'a',
+                'children' => [['name' => 'b'], ['name' => 'c']],
+            ],
+        )
+            ->to(ParentObjectWithVirtualChild::class);
+
+        $this->assertSame('a', $parent->name);
+
+        $this->assertSame('b', $parent->children[0]->name);
+        $this->assertSame('a', $parent->children[0]->parent->name);
+        $this->assertSame('a', $parent->children[0]->parentCollection[0]->name);
+        $this->assertSame('a', $parent->children[0]->virtualParent->name);
+
+        $this->assertSame('c', $parent->children[1]->name);
+        $this->assertSame('a', $parent->children[1]->parent->name);
+        $this->assertSame('a', $parent->children[1]->parentCollection[0]->name);
+        $this->assertSame('a', $parent->children[1]->virtualParent->name);
+    }
+
+    public function test_parent_child_with_getter_only_property(): void
+    {
+        $parent = map(
+            [
+                'name' => 'a',
+                'child' => ['name' => 'hello'],
+            ],
+        )
+            ->to(ParentObjectWithGetterChild::class);
+
+        $this->assertSame('a', $parent->name);
+        $this->assertSame('hello', $parent->child->name);
+        $this->assertSame('HELLO', $parent->child->upperName);
+        $this->assertSame('a', $parent->child->parent->name);
+        $this->assertSame('a', $parent->child->parentCollection[0]->name);
+    }
+
+    public function test_parent_children_with_getter_only_property(): void
+    {
+        $parent = map(
+            [
+                'name' => 'a',
+                'children' => [['name' => 'hello'], ['name' => 'world']],
+            ],
+        )
+            ->to(ParentObjectWithGetterChild::class);
+
+        $this->assertSame('a', $parent->name);
+
+        $this->assertSame('hello', $parent->children[0]->name);
+        $this->assertSame('HELLO', $parent->children[0]->upperName);
+        $this->assertSame('a', $parent->children[0]->parent->name);
+
+        $this->assertSame('world', $parent->children[1]->name);
+        $this->assertSame('WORLD', $parent->children[1]->upperName);
+        $this->assertSame('a', $parent->children[1]->parent->name);
     }
 
     public function test_map_primitive_array_properties(): void


### PR DESCRIPTION
virtual properties with fqcn docblocks were parsed as relations, causing setValue to fail on read-only props

got today to fix my issue with csfixer to autoset fcqn in docblocks that led me to discover this issue ;)