### PR TITLE
refactor(core)!: migrate installers from interfaces to attributes

### DIFF
--- a/packages/auth/src/Installer/AuthenticationInstaller.php
+++ b/packages/auth/src/Installer/AuthenticationInstaller.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Tempest\Auth\Installer;
 
-use Tempest\Console\ConsoleCommand;
-use Tempest\Console\Input\ConsoleArgumentBag;
-use Tempest\Console\Input\ConsoleInputArgument;
 use Tempest\Container\Container;
 use Tempest\Core\Installer;
 use Tempest\Core\PublishesFiles;
@@ -14,54 +11,46 @@ use Tempest\Database\Migrations\MigrationManager;
 
 use function Tempest\src_path;
 
-if (class_exists(ConsoleCommand::class)) {
-    final class AuthenticationInstaller implements Installer
+final class AuthenticationInstaller
+{
+    use PublishesFiles;
+
+    public function __construct(
+        private readonly MigrationManager $migrationManager,
+        private readonly Container $container,
+    ) {}
+
+    #[Installer('Authentication', alias: 'auth')]
+    public function install(?bool $migrate = null, ?bool $oauth = null): void
     {
-        use PublishesFiles;
+        $migration = $this->publish(__DIR__ . '/basic-user/CreateUsersTableMigration.stub.php', src_path('Authentication/CreateUsersTable.php'));
+        $this->publish(__DIR__ . '/basic-user/UserModel.stub.php', src_path('Authentication/User.php'));
+        $this->publishImports();
 
-        private(set) string $name = 'auth';
-
-        public function __construct(
-            private readonly MigrationManager $migrationManager,
-            private readonly Container $container,
-            private readonly ConsoleArgumentBag $consoleArgumentBag,
-        ) {}
-
-        public function install(): void
-        {
-            $migration = $this->publish(__DIR__ . '/basic-user/CreateUsersTableMigration.stub.php', src_path('Authentication/CreateUsersTable.php'));
-            $this->publish(__DIR__ . '/basic-user/UserModel.stub.php', src_path('Authentication/User.php'));
-            $this->publishImports();
-
-            if ($migration && $this->shouldMigrate()) {
-                $this->migrationManager->up();
-            }
-
-            if ($this->shouldInstallOAuth()) {
-                $this->container->get(OAuthInstaller::class)->install();
-            }
+        if ($migration && $this->shouldMigrate($migrate)) {
+            $this->migrationManager->up();
         }
 
-        private function shouldMigrate(): bool
-        {
-            $argument = $this->consoleArgumentBag->get('migrate');
+        if ($this->shouldInstallOAuth($oauth)) {
+            $this->container->get(OAuthInstaller::class)->install();
+        }
+    }
 
-            if (! $argument instanceof ConsoleInputArgument || ! is_bool($argument->value)) {
-                return $this->console->confirm('Do you want to execute migrations?', default: false);
-            }
-
-            return (bool) $argument->value;
+    private function shouldMigrate(?bool $migrate): bool
+    {
+        if (is_bool($migrate)) {
+            return $migrate;
         }
 
-        private function shouldInstallOAuth(): bool
-        {
-            $argument = $this->consoleArgumentBag->get('oauth');
+        return $this->console->confirm('Do you want to execute migrations?', default: false);
+    }
 
-            if (! $argument instanceof ConsoleInputArgument || ! is_bool($argument->value)) {
-                return $this->console->confirm('Do you want to install OAuth?', default: false);
-            }
-
-            return (bool) $argument->value;
+    private function shouldInstallOAuth(?bool $oauth): bool
+    {
+        if (is_bool($oauth)) {
+            return $oauth;
         }
+
+        return $this->console->confirm('Do you want to install OAuth?', default: false);
     }
 }

--- a/packages/console/src/Actions/PromptForConsoleInput.php
+++ b/packages/console/src/Actions/PromptForConsoleInput.php
@@ -9,7 +9,6 @@ use Tempest\Console\Console;
 use Tempest\Console\Input\ConsoleArgumentBag;
 use Tempest\Console\Input\ConsoleArgumentDefinition;
 use Tempest\Console\Input\ConsoleInputArgument;
-use Tempest\Support\Str;
 use Tempest\Validation\Rules\IsBoolean;
 use Tempest\Validation\Rules\IsEnum;
 use Tempest\Validation\Rules\IsNotEmptyString;
@@ -26,15 +25,14 @@ final readonly class PromptForConsoleInput
         ConsoleArgumentDefinition $argumentDefinition,
     ): void {
         $isEnum = is_a($argumentDefinition->type, BackedEnum::class, allow_string: true);
-        $question = Str\to_sentence_case($argumentDefinition->name);
 
         $value = match ($argumentDefinition->type) {
             'bool' => $this->console->confirm(
-                question: $question,
+                question: $argumentDefinition->prompt ?? $argumentDefinition->name,
                 default: $argumentDefinition->default ?? false,
             ),
             default => $this->console->ask(
-                question: $question,
+                question: $argumentDefinition->prompt ?? $argumentDefinition->name,
                 options: match (true) {
                     $isEnum => $argumentDefinition->type::cases(),
                     default => null,

--- a/packages/console/src/Actions/PromptForConsoleInput.php
+++ b/packages/console/src/Actions/PromptForConsoleInput.php
@@ -14,6 +14,7 @@ use Tempest\Validation\Rules\IsEnum;
 use Tempest\Validation\Rules\IsNotEmptyString;
 use Tempest\Validation\Rules\IsNumeric;
 
+/** @internal */
 final readonly class PromptForConsoleInput
 {
     public function __construct(

--- a/packages/console/src/Actions/PromptForConsoleInput.php
+++ b/packages/console/src/Actions/PromptForConsoleInput.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Actions;
+
+use BackedEnum;
+use Tempest\Console\Console;
+use Tempest\Console\Input\ConsoleArgumentBag;
+use Tempest\Console\Input\ConsoleArgumentDefinition;
+use Tempest\Console\Input\ConsoleInputArgument;
+use Tempest\Support\Str;
+use Tempest\Validation\Rules\IsBoolean;
+use Tempest\Validation\Rules\IsEnum;
+use Tempest\Validation\Rules\IsNotEmptyString;
+use Tempest\Validation\Rules\IsNumeric;
+
+final readonly class PromptForConsoleInput
+{
+    public function __construct(
+        private Console $console,
+    ) {}
+
+    public function __invoke(
+        ConsoleArgumentBag $argumentBag,
+        ConsoleArgumentDefinition $argumentDefinition,
+    ): void {
+        $isEnum = is_a($argumentDefinition->type, BackedEnum::class, allow_string: true);
+        $question = Str\to_sentence_case($argumentDefinition->name);
+
+        $value = match ($argumentDefinition->type) {
+            'bool' => $this->console->confirm(
+                question: $question,
+                default: $argumentDefinition->default ?? false,
+            ),
+            default => $this->console->ask(
+                question: $question,
+                options: match (true) {
+                    $isEnum => $argumentDefinition->type::cases(),
+                    default => null,
+                },
+                default: $argumentDefinition->default,
+                hint: $argumentDefinition->help ?: $argumentDefinition->description,
+                validation: array_filter([
+                    $isEnum
+                        ? new IsEnum($argumentDefinition->type)
+                        : new IsNotEmptyString(),
+                    match ($argumentDefinition->type) {
+                        'bool' => new IsBoolean(),
+                        'int' => new IsNumeric(),
+                        default => null,
+                    },
+                ]),
+            ),
+        };
+
+        $argumentBag->add(new ConsoleInputArgument(
+            name: $argumentDefinition->name,
+            position: $argumentDefinition->position,
+            value: $value,
+        ));
+    }
+}

--- a/packages/console/src/Actions/ResolveConsoleInput.php
+++ b/packages/console/src/Actions/ResolveConsoleInput.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Console\Actions;
+
+use Tempest\Console\Input\ConsoleArgumentBag;
+use Tempest\Console\Input\ConsoleArgumentDefinition;
+use Tempest\Console\Input\ConsoleInputArgument;
+
+final readonly class ResolveConsoleInput
+{
+    /**
+     * @param list<ConsoleArgumentDefinition> $argumentDefinitions
+     *
+     * @return array{0: list<ConsoleInputArgument>, 1: list<ConsoleArgumentDefinition>}
+     */
+    public function __invoke(ConsoleArgumentBag $argumentBag, array $argumentDefinitions): array
+    {
+        $validArguments = [];
+        $invalidArguments = [];
+
+        foreach ($argumentDefinitions as $argumentDefinition) {
+            if ($argumentDefinition->isVariadic) {
+                $arguments = $argumentBag->findForVariadicArgument($argumentDefinition);
+
+                if ($arguments === []) {
+                    $invalidArguments[] = $argumentDefinition;
+
+                    continue;
+                }
+
+                $validArguments = [...$validArguments, ...$arguments];
+
+                continue;
+            }
+
+            $argument = $argumentDefinition->type === 'array'
+                ? $argumentBag->findArrayFor($argumentDefinition)
+                : $argumentBag->findFor($argumentDefinition);
+
+            if (! $argument instanceof ConsoleInputArgument) {
+                $invalidArguments[] = $argumentDefinition;
+
+                continue;
+            }
+
+            $validArguments[] = $argument;
+        }
+
+        return [$validArguments, $invalidArguments];
+    }
+}

--- a/packages/console/src/Actions/ResolveConsoleInput.php
+++ b/packages/console/src/Actions/ResolveConsoleInput.php
@@ -8,6 +8,7 @@ use Tempest\Console\Input\ConsoleArgumentBag;
 use Tempest\Console\Input\ConsoleArgumentDefinition;
 use Tempest\Console\Input\ConsoleInputArgument;
 
+/** @internal */
 final readonly class ResolveConsoleInput
 {
     /**

--- a/packages/console/src/ConsoleArgument.php
+++ b/packages/console/src/ConsoleArgument.php
@@ -9,9 +9,17 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 final readonly class ConsoleArgument
 {
+    /**
+     * @param null|string $name The name of the argument. If not provided, the name of the associated parameter or property will be used.
+     * @param null|string $description A short description explaining what this argument does.
+     * @param null|string $help Detailed information displayed when displayed help for the associated command.
+     * @param null|string $prompt A prompt displayed when prompting a user for this argument.
+     * @param array<int, string> $aliases Alternative names for this argument.
+     */
     public function __construct(
         public ?string $name = null,
         public ?string $description = null,
+        public ?string $prompt = null,
         public string $help = '',
         public array $aliases = [],
     ) {}

--- a/packages/console/src/ConsoleArgument.php
+++ b/packages/console/src/ConsoleArgument.php
@@ -20,7 +20,7 @@ final readonly class ConsoleArgument
         public ?string $name = null,
         public ?string $description = null,
         public ?string $prompt = null,
-        public string $help = '',
+        public ?string $help = null,
         public array $aliases = [],
     ) {}
 }

--- a/packages/console/src/ConsoleInputBuilder.php
+++ b/packages/console/src/ConsoleInputBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Console;
 
+use Tempest\Console\Actions\ResolveConsoleInput;
 use Tempest\Console\Exceptions\InvalidCommandException;
 use Tempest\Console\Input\ConsoleArgumentBag;
 use Tempest\Console\Input\ConsoleInputArgument;
@@ -20,42 +21,13 @@ final readonly class ConsoleInputBuilder
      */
     public function build(): array
     {
-        $validArguments = [];
-        $invalidArguments = [];
-
-        $argumentDefinitions = $this->command->getArgumentDefinitions();
-
-        foreach ($argumentDefinitions as $argumentDefinition) {
-            if ($argumentDefinition->isVariadic) {
-                $arguments = $this->argumentBag->findForVariadicArgument($argumentDefinition);
-
-                if ($arguments === []) {
-                    $invalidArguments[] = $argumentDefinition;
-                } else {
-                    $validArguments = [...$validArguments, ...$arguments];
-                }
-
-                continue;
-            }
-
-            $argument = $argumentDefinition->type === 'array'
-                ? $this->argumentBag->findArrayFor($argumentDefinition)
-                : $this->argumentBag->findFor($argumentDefinition);
-
-            if (! $argument instanceof ConsoleInputArgument) {
-                $invalidArguments[] = $argumentDefinition;
-
-                continue;
-            }
-
-            $validArguments[] = $argument;
-        }
+        [$validArguments, $invalidArguments] = (new ResolveConsoleInput())(
+            argumentBag: $this->argumentBag,
+            argumentDefinitions: $this->command->getArgumentDefinitions(),
+        );
 
         if ($invalidArguments !== []) {
-            throw new InvalidCommandException(
-                $this->command,
-                $invalidArguments,
-            );
+            throw new InvalidCommandException($this->command, $invalidArguments);
         }
 
         return array_map(

--- a/packages/console/src/Exceptions/InvalidCommandException.php
+++ b/packages/console/src/Exceptions/InvalidCommandException.php
@@ -10,10 +10,11 @@ use Tempest\Console\Input\ConsoleArgumentDefinition;
 
 final class InvalidCommandException extends ConsoleException
 {
+    /**
+     * @param ConsoleArgumentDefinition[] $invalidArguments
+     */
     public function __construct(
         public readonly ConsoleCommand $consoleCommand,
-
-        /** @var \Tempest\Console\Input\ConsoleArgumentDefinition[] $invalidArguments */
         public readonly array $invalidArguments,
     ) {}
 

--- a/packages/console/src/GenericConsole.php
+++ b/packages/console/src/GenericConsole.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tempest\Console;
 
-use BackedEnum;
 use Closure;
 use InvalidArgumentException;
 use Stringable;
@@ -224,7 +223,7 @@ final class GenericConsole implements Console
             $options = wrap($options);
         }
 
-        if (is_string($options) && is_a($options, BackedEnum::class, allow_string: true)) {
+        if (is_string($options) && is_a($options, UnitEnum::class, allow_string: true)) {
             $options = $options::cases();
         }
 

--- a/packages/console/src/Input/ConsoleArgumentDefinition.php
+++ b/packages/console/src/Input/ConsoleArgumentDefinition.php
@@ -12,6 +12,11 @@ use function Tempest\Support\str;
 
 final readonly class ConsoleArgumentDefinition
 {
+    /**
+     * @param null|string $description A short description explaining what this argument does.
+     * @param null|string $help Detailed information displayed when displayed help for the associated command.
+     * @param null|string $prompt A prompt displayed when prompting a user for this argument.
+     */
     public function __construct(
         public string $name,
         public string $type,
@@ -22,6 +27,7 @@ final readonly class ConsoleArgumentDefinition
         public ?string $description = null,
         public array $aliases = [],
         public ?string $help = null,
+        public ?string $prompt = null,
     ) {}
 
     public static function fromParameter(ParameterReflector $parameter): ConsoleArgumentDefinition
@@ -41,6 +47,7 @@ final readonly class ConsoleArgumentDefinition
             description: $attribute?->description,
             aliases: $attribute->aliases ?? [],
             help: $attribute?->help,
+            prompt: $attribute?->prompt,
         );
     }
 

--- a/packages/console/src/Installers/ConsoleInstaller.php
+++ b/packages/console/src/Installers/ConsoleInstaller.php
@@ -9,12 +9,11 @@ use Tempest\Core\IsComponentInstaller;
 
 use function Tempest\root_path;
 
-final class ConsoleInstaller implements Installer
+final class ConsoleInstaller
 {
     use IsComponentInstaller;
 
-    private(set) string $name = 'console';
-
+    #[Installer('Console', alias: 'console')]
     public function install(): void
     {
         $this->installMainNamespace();

--- a/packages/console/src/Middleware/InvalidCommandMiddleware.php
+++ b/packages/console/src/Middleware/InvalidCommandMiddleware.php
@@ -4,22 +4,15 @@ declare(strict_types=1);
 
 namespace Tempest\Console\Middleware;
 
-use BackedEnum;
 use Tempest\Console\Actions\ExecuteConsoleCommand;
+use Tempest\Console\Actions\PromptForConsoleInput;
 use Tempest\Console\Console;
 use Tempest\Console\ConsoleMiddleware;
 use Tempest\Console\ConsoleMiddlewareCallable;
 use Tempest\Console\Exceptions\InvalidCommandException;
 use Tempest\Console\ExitCode;
 use Tempest\Console\Initializers\Invocation;
-use Tempest\Console\Input\ConsoleInputArgument;
 use Tempest\Core\Priority;
-use Tempest\Validation\Rules\IsBoolean;
-use Tempest\Validation\Rules\IsEnum;
-use Tempest\Validation\Rules\IsNotEmptyString;
-use Tempest\Validation\Rules\IsNumeric;
-
-use function Tempest\Support\str;
 
 #[Priority(Priority::FRAMEWORK - 7)]
 final readonly class InvalidCommandMiddleware implements ConsoleMiddleware
@@ -27,6 +20,7 @@ final readonly class InvalidCommandMiddleware implements ConsoleMiddleware
     public function __construct(
         private Console $console,
         private ExecuteConsoleCommand $executeConsoleCommand,
+        private PromptForConsoleInput $promptForConsoleInput,
     ) {}
 
     public function __invoke(Invocation $invocation, ConsoleMiddlewareCallable $next): ExitCode|int
@@ -50,41 +44,10 @@ final readonly class InvalidCommandMiddleware implements ConsoleMiddleware
         }
 
         foreach ($exception->invalidArguments as $argument) {
-            $isEnum = is_a($argument->type, BackedEnum::class, allow_string: true);
-            $name = str($argument->name)->snake(' ')->upperFirst()->toString();
-
-            if ($argument->type === 'bool') {
-                $value = $this->console->confirm(
-                    question: $name,
-                    default: $argument->default ?? false,
-                );
-            } else {
-                $value = $this->console->ask(
-                    question: $name,
-                    options: match (true) {
-                        $isEnum => $argument->type::cases(),
-                        default => null,
-                    },
-                    default: $argument->default,
-                    hint: $argument->help ?: $argument->description,
-                    validation: array_filter([
-                        $isEnum
-                            ? new IsEnum($argument->type)
-                            : new IsNotEmptyString(),
-                        match ($argument->type) {
-                            'bool' => new IsBoolean(),
-                            'int' => new IsNumeric(),
-                            default => null,
-                        },
-                    ]),
-                );
-            }
-
-            $invocation->argumentBag->add(new ConsoleInputArgument(
-                name: $argument->name,
-                position: $argument->position,
-                value: $value,
-            ));
+            ($this->promptForConsoleInput)(
+                argumentBag: $invocation->argumentBag,
+                argumentDefinition: $argument,
+            );
         }
 
         return ($this->executeConsoleCommand)($invocation->consoleCommand->getName());

--- a/packages/core/src/Commands/InstallCommand.php
+++ b/packages/core/src/Commands/InstallCommand.php
@@ -47,7 +47,9 @@ if (class_exists(ConsoleCommand::class)) {
             $installer = $this->resolveInstaller($installer);
 
             if (! $installer instanceof InstallerDefinition) {
-                $this->error('The provided installer was not found.');
+                $this->console->writeln();
+                $this->console->error('The provided installer was not found.');
+
                 return;
             }
 
@@ -86,7 +88,7 @@ if (class_exists(ConsoleCommand::class)) {
             $installerArgumentBag = $this->buildInstallerArgumentBag();
             $argumentDefinitions = $this->buildInstallerArgumentDefinitions($installer);
 
-            do {
+            while (true) {
                 [$validArguments, $invalidArguments] = ($this->resolveConsoleInput)(
                     argumentBag: $installerArgumentBag,
                     argumentDefinitions: $argumentDefinitions,
@@ -114,7 +116,7 @@ if (class_exists(ConsoleCommand::class)) {
                         argumentDefinition: $argumentDefinition,
                     );
                 }
-            } while ($invalidArguments !== []);
+            }
 
             return array_map(
                 callback: fn (ConsoleInputArgument $argument) => $argument->value,

--- a/packages/core/src/Commands/InstallCommand.php
+++ b/packages/core/src/Commands/InstallCommand.php
@@ -4,15 +4,22 @@ declare(strict_types=1);
 
 namespace Tempest\Core\Commands;
 
-use Tempest\Console\Console;
+use Tempest\Console\Actions\PromptForConsoleInput;
+use Tempest\Console\Actions\ResolveConsoleInput;
+use Tempest\Console\ConsoleArgument;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\HasConsole;
+use Tempest\Console\Input\ConsoleArgumentBag;
+use Tempest\Console\Input\ConsoleArgumentDefinition;
+use Tempest\Console\Input\ConsoleInputArgument;
 use Tempest\Console\Middleware\ForceMiddleware;
 use Tempest\Container\Container;
-use Tempest\Core\Installer;
+use Tempest\Core\InstallerArgument;
 use Tempest\Core\InstallerConfig;
-
-use function Tempest\Support\arr;
+use Tempest\Core\InstallerDefinition;
+use Tempest\Intl;
+use Tempest\Support\Arr;
+use Tempest\Support\Str;
 
 if (class_exists(ConsoleCommand::class)) {
     final readonly class InstallCommand
@@ -21,38 +28,145 @@ if (class_exists(ConsoleCommand::class)) {
 
         public function __construct(
             private InstallerConfig $installerConfig,
-            private Console $console,
             private Container $container,
+            private ConsoleArgumentBag $consoleArgumentBag,
+            private ResolveConsoleInput $resolveConsoleInput,
+            private PromptForConsoleInput $promptForConsoleInput,
         ) {}
 
-        #[ConsoleCommand(name: 'install', description: 'Applies the specified installer', middleware: [ForceMiddleware::class], allowDynamicArguments: true)]
-        public function __invoke(?string $installer = null): void
-        {
+        #[ConsoleCommand(
+            name: 'install',
+            description: 'Installs and configures the specified feature',
+            middleware: [ForceMiddleware::class],
+            allowDynamicArguments: true,
+        )]
+        public function __invoke(
+            #[ConsoleArgument(description: 'The installer to apply. If not provided, you will be prompted to select one.')]
+            ?string $installer = null,
+        ): void {
             $installer = $this->resolveInstaller($installer);
 
-            if (! $installer instanceof Installer) {
-                $this->error('Installer not found');
-
+            if (! $installer instanceof InstallerDefinition) {
+                $this->error('The provided installer was not found.');
                 return;
             }
 
-            $installer->install();
+            $instance = $this->container->get($installer->handler->getDeclaringClass()->getName());
+            $arguments = $this->resolveInstallerArguments($installer);
+
+            if (! is_array($arguments)) {
+                return;
+            }
+
+            $installer->handler->invokeArgs($instance, $arguments);
         }
 
-        private function resolveInstaller(?string $search): ?Installer
+        private function resolveInstaller(?string $search): ?InstallerDefinition
         {
-            /** @var Installer[]|\Tempest\Support\Arr\ImmutableArray $installers */
-            $installers = arr($this->installerConfig->installers)
-                ->map(fn (string $installerClass) => $this->container->get($installerClass));
+            $search ??= $this->ask(
+                question: 'Choose an installer',
+                options: Arr\map_with_keys(
+                    array: $this->installerConfig->installers,
+                    map: fn (InstallerDefinition $installer) => yield $installer->id => $installer->name,
+                ),
+            );
 
-            if (! $search) {
-                $search = $this->ask(
-                    question: 'Please choose an installer',
-                    options: $installers->mapWithKeys(fn (Installer $installer) => yield $installer::class => $installer->name)->toArray(),
+            if (! is_string($search)) {
+                return null;
+            }
+
+            return Arr\first(
+                array: $this->installerConfig->installers,
+                filter: fn (InstallerDefinition $installer) => in_array($search, $installer->aliases, strict: true) || $installer->id === $search,
+            );
+        }
+
+        private function resolveInstallerArguments(InstallerDefinition $installer): ?array
+        {
+            $installerArgumentBag = $this->buildInstallerArgumentBag();
+            $argumentDefinitions = $this->buildInstallerArgumentDefinitions($installer);
+
+            do {
+                [$validArguments, $invalidArguments] = ($this->resolveConsoleInput)(
+                    argumentBag: $installerArgumentBag,
+                    argumentDefinitions: $argumentDefinitions,
+                );
+
+                if ($invalidArguments === []) {
+                    break;
+                }
+
+                if (! $this->console->supportsPrompting()) {
+                    $missingArguments = implode(', ', array_map(
+                        callback: fn (ConsoleArgumentDefinition $argumentDefinition) => $argumentDefinition->name,
+                        array: $invalidArguments,
+                    ));
+
+                    $this->console->writeln();
+                    $this->console->error(sprintf("Missing %s: {$missingArguments}", Intl\pluralize('argument', $invalidArguments)));
+
+                    return null;
+                }
+
+                foreach ($invalidArguments as $argumentDefinition) {
+                    ($this->promptForConsoleInput)(
+                        argumentBag: $installerArgumentBag,
+                        argumentDefinition: $argumentDefinition,
+                    );
+                }
+            } while ($invalidArguments !== []);
+
+            return array_map(
+                callback: fn (ConsoleInputArgument $argument) => $argument->value,
+                array: $validArguments,
+            );
+        }
+
+        private function buildInstallerArgumentBag(): ConsoleArgumentBag
+        {
+            $installerArgumentBag = new ConsoleArgumentBag([
+                $this->consoleArgumentBag->getCliName(),
+                'install',
+            ]);
+
+            $position = 0;
+
+            foreach ($this->consoleArgumentBag->all() as $argument) {
+                if ($argument->isPositional && $position === 0) {
+                    continue;
+                }
+
+                $installerArgumentBag->add(new ConsoleInputArgument(
+                    name: $argument->name,
+                    position: $argument->isPositional ? $position++ : null,
+                    value: $argument->value,
+                    isPositional: $argument->isPositional,
+                ));
+            }
+
+            return $installerArgumentBag;
+        }
+
+        /** @return list<ConsoleArgumentDefinition> */
+        private function buildInstallerArgumentDefinitions(InstallerDefinition $installer): array
+        {
+            $argumentDefinitions = [];
+
+            foreach ($installer->handler->getParameters() as $parameter) {
+                $installerArgument = $parameter->getAttribute(InstallerArgument::class);
+
+                $argumentDefinitions[] = new ConsoleArgumentDefinition(
+                    name: $installerArgument->name ?? Str\to_sentence_case($parameter->getName()),
+                    type: $parameter->getType()->getName(),
+                    default: $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null,
+                    hasDefault: $parameter->isDefaultValueAvailable(),
+                    position: $parameter->getPosition(),
+                    isVariadic: $parameter->isVariadic(),
+                    help: $installerArgument?->prompt,
                 );
             }
 
-            return $installers->first(fn (Installer $installer) => $installer::class === $search || $installer->name === $search);
+            return $argumentDefinitions;
         }
     }
 }

--- a/packages/core/src/Commands/InstallCommand.php
+++ b/packages/core/src/Commands/InstallCommand.php
@@ -154,15 +154,16 @@ if (class_exists(ConsoleCommand::class)) {
 
             foreach ($installer->handler->getParameters() as $parameter) {
                 $installerArgument = $parameter->getAttribute(InstallerArgument::class);
+                $name = $installerArgument->name ?? $parameter->getName();
 
                 $argumentDefinitions[] = new ConsoleArgumentDefinition(
-                    name: $installerArgument->name ?? Str\to_sentence_case($parameter->getName()),
+                    name: $name,
                     type: $parameter->getType()->getName(),
                     default: $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null,
                     hasDefault: $parameter->isDefaultValueAvailable(),
                     position: $parameter->getPosition(),
                     isVariadic: $parameter->isVariadic(),
-                    help: $installerArgument?->prompt,
+                    prompt: $installerArgument->prompt ?? Str\to_sentence_case($name),
                 );
             }
 

--- a/packages/core/src/Installer.php
+++ b/packages/core/src/Installer.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Tempest\Core;
 
-interface Installer
-{
-    public string $name { get; }
+use Attribute;
 
-    public function install(): void;
+#[Attribute(Attribute::TARGET_METHOD)]
+final readonly class Installer
+{
+    public function __construct(
+        public string $name,
+        /** @var string|array<string> */
+        public string|array $alias = [],
+    ) {}
 }

--- a/packages/core/src/Installer.php
+++ b/packages/core/src/Installer.php
@@ -6,6 +6,9 @@ namespace Tempest\Core;
 
 use Attribute;
 
+/**
+ * Defines an installer that will be available as an option when using the `install` console command.
+ */
 #[Attribute(Attribute::TARGET_METHOD)]
 final readonly class Installer
 {

--- a/packages/core/src/InstallerArgument.php
+++ b/packages/core/src/InstallerArgument.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Core;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final readonly class InstallerArgument
+{
+    public function __construct(
+        public ?string $name = null,
+        public ?string $prompt = null,
+    ) {}
+}

--- a/packages/core/src/InstallerConfig.php
+++ b/packages/core/src/InstallerConfig.php
@@ -4,10 +4,24 @@ declare(strict_types=1);
 
 namespace Tempest\Core;
 
+use Tempest\Reflection\MethodReflector;
+
 final class InstallerConfig
 {
+    /** @param array<string,InstallerDefinition> $installers */
     public function __construct(
-        /** @var array<array-key, class-string<\Tempest\Core\Installer>> */
         public array $installers = [],
     ) {}
+
+    public function addInstaller(MethodReflector $handler, Installer $installer): self
+    {
+        $definition = new InstallerDefinition(
+            handler: $handler,
+            installer: $installer,
+        );
+
+        $this->installers[$definition->id] = $definition;
+
+        return $this;
+    }
 }

--- a/packages/core/src/InstallerDefinition.php
+++ b/packages/core/src/InstallerDefinition.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Core;
+
+use Tempest\Reflection\MethodReflector;
+
+use function Tempest\Support\arr;
+use function Tempest\Support\Str\to_kebab_case;
+
+final class InstallerDefinition
+{
+    public function __construct(
+        public MethodReflector $handler,
+        public Installer $installer,
+    ) {}
+
+    /**
+     * Unique identifier for this installer.
+     */
+    public string $id {
+        get => sprintf('%s::%s', $this->handler->getDeclaringClass()->getName(), $this->handler->getName());
+    }
+
+    /**
+     * Human-friendly installer name.
+     */
+    public string $name {
+        get => $this->installer->name;
+    }
+
+    /**
+     * Aliases that can be used to reference this installer.
+     *
+     * @var list<string>
+     */
+    public array $aliases {
+        get => $this->aliases ??= arr($this->installer->alias)
+            ->push($this->handler->getDeclaringClass()->getName())
+            ->push(to_kebab_case($this->name))
+            ->filter()
+            ->unique()
+            ->toArray();
+    }
+}

--- a/packages/core/src/InstallerDefinition.php
+++ b/packages/core/src/InstallerDefinition.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tempest\Core;
 
 use Tempest\Reflection\MethodReflector;
+use Tempest\Support\Str;
 
 use function Tempest\Support\arr;
-use function Tempest\Support\Str\to_kebab_case;
 
 final class InstallerDefinition
 {
@@ -38,7 +38,7 @@ final class InstallerDefinition
     public array $aliases {
         get => $this->aliases ??= arr($this->installer->alias)
             ->push($this->handler->getDeclaringClass()->getName())
-            ->push(to_kebab_case($this->name))
+            ->push(Str\to_kebab_case($this->name))
             ->filter()
             ->unique()
             ->toArray();

--- a/packages/core/src/InstallerDiscovery.php
+++ b/packages/core/src/InstallerDiscovery.php
@@ -8,7 +8,6 @@ use Tempest\Discovery\Discovery;
 use Tempest\Discovery\DiscoveryLocation;
 use Tempest\Discovery\IsDiscovery;
 use Tempest\Reflection\ClassReflector;
-use Tempest\Reflection\MethodReflector;
 
 final class InstallerDiscovery implements Discovery
 {

--- a/packages/core/src/InstallerDiscovery.php
+++ b/packages/core/src/InstallerDiscovery.php
@@ -8,6 +8,7 @@ use Tempest\Discovery\Discovery;
 use Tempest\Discovery\DiscoveryLocation;
 use Tempest\Discovery\IsDiscovery;
 use Tempest\Reflection\ClassReflector;
+use Tempest\Reflection\MethodReflector;
 
 final class InstallerDiscovery implements Discovery
 {
@@ -19,15 +20,21 @@ final class InstallerDiscovery implements Discovery
 
     public function discover(DiscoveryLocation $location, ClassReflector $class): void
     {
-        if ($class->implements(Installer::class)) {
-            $this->discoveryItems->add($location, $class->getName());
+        foreach ($class->getPublicMethods() as $method) {
+            $installer = $method->getAttribute(Installer::class);
+
+            if (! $installer) {
+                continue;
+            }
+
+            $this->discoveryItems->add($location, [$method, $installer]);
         }
     }
 
     public function apply(): void
     {
-        foreach ($this->discoveryItems as $className) {
-            $this->installerConfig->installers[] = $className;
+        foreach ($this->discoveryItems as [$method, $installer]) {
+            $this->installerConfig->addInstaller($method, $installer);
         }
     }
 }

--- a/packages/core/src/IsComponentInstaller.php
+++ b/packages/core/src/IsComponentInstaller.php
@@ -8,9 +8,6 @@ use function Tempest\root_path;
 use function Tempest\Support\str;
 
 if (trait_exists(PublishesFiles::class)) {
-    /**
-     * @phpstan-require-implements \Tempest\Core\Installer
-     */
     trait IsComponentInstaller
     {
         use PublishesFiles;

--- a/packages/http/src/Session/Installer/SessionInstaller.php
+++ b/packages/http/src/Session/Installer/SessionInstaller.php
@@ -27,11 +27,17 @@ final class SessionInstaller
         ?SessionStorage $storage = null,
         ?bool $migrate = null,
     ): void {
+        /** @var null|SessionStorage $storage */
         $storage ??= $this->console->ask(
             question: 'Which session storage do you want to use?',
             options: SessionStorage::class,
             default: SessionStorage::FILE,
         );
+
+        if (! $storage instanceof SessionStorage) {
+            $this->console->error('Invalid session storage selected.');
+            return;
+        }
 
         $cleanupStrategy = match ($storage) {
             SessionStorage::REDIS => null,
@@ -67,7 +73,7 @@ final class SessionInstaller
         }
     }
 
-    private function resolveCleanupStrategy(): ?CleanupStrategy
+    private function resolveCleanupStrategy(): CleanupStrategy
     {
         $strategy = [
             'Random requests' => CleanupStrategy::RANDOM_REQUESTS,
@@ -84,13 +90,13 @@ final class SessionInstaller
         return $strategy[$result];
     }
 
-    private function resolveSessionConfigStub(SessionStorage $sessionStrategy, ?CleanupStrategy $cleanupStrategy): string
+    private function resolveSessionConfigStub(SessionStorage $storage, ?CleanupStrategy $cleanupStrategy): string
     {
-        if ($sessionStrategy === SessionStorage::REDIS) {
+        if ($storage === SessionStorage::REDIS) {
             return __DIR__ . '/session.redis.config.stub.php';
         }
 
-        return match ([$sessionStrategy, $cleanupStrategy]) {
+        return match ([$storage, $cleanupStrategy]) {
             [SessionStorage::FILE, CleanupStrategy::EVERY_REQUEST] => __DIR__ . '/session.file.every-request.config.stub.php',
             [SessionStorage::FILE, CleanupStrategy::RANDOM_REQUESTS] => __DIR__ . '/session.file.random-requests.config.stub.php',
             [SessionStorage::FILE, CleanupStrategy::DISABLED] => __DIR__ . '/session.file.disabled.config.stub.php',

--- a/packages/http/src/Session/Installer/SessionInstaller.php
+++ b/packages/http/src/Session/Installer/SessionInstaller.php
@@ -4,190 +4,114 @@ declare(strict_types=1);
 
 namespace Tempest\Http\Session\Installer;
 
-use InvalidArgumentException;
 use LogicException;
 use Tempest\Console\Console;
-use Tempest\Console\Input\ConsoleArgumentBag;
-use Tempest\Console\Input\ConsoleInputArgument;
 use Tempest\Core\Installer;
 use Tempest\Core\PublishesFiles;
 use Tempest\Database\Migrations\MigrationManager;
 use Tempest\Http\Session\CleanupStrategy;
 
-use function Tempest\root_path;
 use function Tempest\src_path;
-use function Tempest\Support\Path\to_absolute_path;
 
-final class SessionInstaller implements Installer
+final class SessionInstaller
 {
     use PublishesFiles;
-
-    private const string DATABASE = 'database';
-
-    private const string FILE = 'file';
-
-    private const string REDIS = 'redis';
-
-    private(set) string $name = 'sessions';
 
     public function __construct(
         private readonly MigrationManager $migrationManager,
         private readonly Console $console,
-        private readonly ConsoleArgumentBag $consoleArgumentBag,
     ) {}
 
-    public function install(): void
-    {
-        $sessionStrategy = $this->resolveSessionDriver();
-        $cleanupStrategy = $sessionStrategy === self::REDIS
-            ? null
-            : $this->resolveCleanupStrategy();
-
-        $configPath = $this->resolveTargetPath(
-            argumentName: 'config-path',
-            defaultPath: src_path('Sessions/session.config.php'),
+    #[Installer('Sessions', alias: 'sessions')]
+    public function install(
+        ?SessionStorage $storage = null,
+        ?bool $migrate = null,
+    ): void {
+        $storage ??= $this->console->ask(
+            question: 'Which session storage do you want to use?',
+            options: SessionStorage::class,
+            default: SessionStorage::FILE,
         );
 
-        $migration = $sessionStrategy === self::DATABASE
-            ? $this->publish(
+        $cleanupStrategy = match ($storage) {
+            SessionStorage::REDIS => null,
+            default => $this->resolveCleanupStrategy(),
+        };
+
+        $migration = match ($storage) {
+            SessionStorage::DATABASE => $this->publish(
                 source: __DIR__ . '/CreateSessionsTable.php',
                 destination: src_path('Sessions/CreateSessionsTable.php'),
-            )
-            : null;
+            ),
+            default => null,
+        };
 
         $this->publish(
-            source: $this->resolveSessionConfigStub($sessionStrategy, $cleanupStrategy),
-            destination: $configPath,
+            source: $this->resolveSessionConfigStub($storage, $cleanupStrategy),
+            destination: $this->promptTargetPath(src_path('Sessions/session.config.php')),
             confirm: false,
         );
 
         if ($cleanupStrategy && $this->shouldPublishCleanupCommand($cleanupStrategy)) {
             $this->publish(
                 source: __DIR__ . '/../CleanupSessionsCommand.php',
-                destination: $this->resolveTargetPath(
-                    argumentName: 'cleanup-command-path',
-                    defaultPath: src_path('Sessions/CleanupSessionsCommand.php'),
-                ),
+                destination: $this->promptTargetPath(src_path('Sessions/CleanupSessionsCommand.php')),
                 confirm: false,
             );
         }
 
         $this->publishImports();
 
-        if ($migration && $this->shouldMigrate()) {
+        if ($migration && $this->shouldMigrate($migrate)) {
             $this->migrationManager->up();
         }
     }
 
-    private function resolveSessionDriver(): string
+    private function resolveCleanupStrategy(): ?CleanupStrategy
     {
-        $argument = $this->consoleArgumentBag->get('strategy');
+        $strategy = [
+            'Random requests' => CleanupStrategy::RANDOM_REQUESTS,
+            'Every request' => CleanupStrategy::EVERY_REQUEST,
+            'Disabled (requires manual cleanup)' => CleanupStrategy::DISABLED,
+        ];
 
-        if ($argument instanceof ConsoleInputArgument && is_string($argument->value)) {
-            return match (strtolower(trim($argument->value))) {
-                self::FILE => self::FILE,
-                self::DATABASE => self::DATABASE,
-                self::REDIS => self::REDIS,
-                default => throw new InvalidArgumentException('Invalid session storage strategy: ' . $argument->value),
-            };
-        }
-
-        return $this->ask(
-            question: 'Which session storage strategy do you want to use?',
-            options: [
-                self::FILE => 'File',
-                self::DATABASE => 'Database',
-                self::REDIS => 'Redis',
-            ],
-            default: self::FILE,
-        );
-    }
-
-    private function resolveTargetPath(string $argumentName, string $defaultPath): string
-    {
-        $argument = $this->consoleArgumentBag->get($argumentName);
-
-        if ($argument instanceof ConsoleInputArgument && is_string($argument->value)) {
-            return to_absolute_path(root_path(), $argument->value);
-        }
-
-        return $this->promptTargetPath($defaultPath);
-    }
-
-    private function resolveCleanupStrategy(): CleanupStrategy
-    {
-        $argument = $this->consoleArgumentBag->get('cleanup-strategy');
-
-        if ($argument instanceof ConsoleInputArgument && is_string($argument->value)) {
-            $strategy = $this->parseCleanupStrategy($argument->value);
-
-            if ($strategy instanceof CleanupStrategy) {
-                return $strategy;
-            }
-        }
-
-        /** @var string $selection */
-        $selection = $this->ask(
+        $result = $this->console->ask(
             question: 'Which session cleanup strategy do you want to use?',
-            options: [
-                CleanupStrategy::RANDOM_REQUESTS->name => 'Random requests',
-                CleanupStrategy::EVERY_REQUEST->name => 'Every request',
-                CleanupStrategy::DISABLED->name => 'Disabled (schedule the cleanup command)',
-            ],
-            default: CleanupStrategy::RANDOM_REQUESTS->name,
+            options: array_keys($strategy),
+            default: array_key_first($strategy),
         );
 
-        return $this->parseCleanupStrategy($selection);
+        return $strategy[$result];
     }
 
-    private function parseCleanupStrategy(string $input): ?CleanupStrategy
+    private function resolveSessionConfigStub(SessionStorage $sessionStrategy, ?CleanupStrategy $cleanupStrategy): string
     {
-        $normalized = strtoupper(str_replace(['-', ' '], '_', $input));
-
-        return match ($normalized) {
-            CleanupStrategy::EVERY_REQUEST->name => CleanupStrategy::EVERY_REQUEST,
-            CleanupStrategy::RANDOM_REQUESTS->name => CleanupStrategy::RANDOM_REQUESTS,
-            CleanupStrategy::DISABLED->name => CleanupStrategy::DISABLED,
-            default => null,
-        };
-    }
-
-    private function resolveSessionConfigStub(string $sessionStrategy, ?CleanupStrategy $cleanupStrategy): string
-    {
-        if ($sessionStrategy === self::REDIS) {
+        if ($sessionStrategy === SessionStorage::REDIS) {
             return __DIR__ . '/session.redis.config.stub.php';
         }
 
         return match ([$sessionStrategy, $cleanupStrategy]) {
-            [self::FILE, CleanupStrategy::EVERY_REQUEST] => __DIR__ . '/session.file.every-request.config.stub.php',
-            [self::FILE, CleanupStrategy::RANDOM_REQUESTS] => __DIR__ . '/session.file.random-requests.config.stub.php',
-            [self::FILE, CleanupStrategy::DISABLED] => __DIR__ . '/session.file.disabled.config.stub.php',
-            [self::DATABASE, CleanupStrategy::EVERY_REQUEST] => __DIR__ . '/session.database.every-request.config.stub.php',
-            [self::DATABASE, CleanupStrategy::RANDOM_REQUESTS] => __DIR__ . '/session.database.random-requests.config.stub.php',
-            [self::DATABASE, CleanupStrategy::DISABLED] => __DIR__ . '/session.database.disabled.config.stub.php',
+            [SessionStorage::FILE, CleanupStrategy::EVERY_REQUEST] => __DIR__ . '/session.file.every-request.config.stub.php',
+            [SessionStorage::FILE, CleanupStrategy::RANDOM_REQUESTS] => __DIR__ . '/session.file.random-requests.config.stub.php',
+            [SessionStorage::FILE, CleanupStrategy::DISABLED] => __DIR__ . '/session.file.disabled.config.stub.php',
+            [SessionStorage::DATABASE, CleanupStrategy::EVERY_REQUEST] => __DIR__ . '/session.database.every-request.config.stub.php',
+            [SessionStorage::DATABASE, CleanupStrategy::RANDOM_REQUESTS] => __DIR__ . '/session.database.random-requests.config.stub.php',
+            [SessionStorage::DATABASE, CleanupStrategy::DISABLED] => __DIR__ . '/session.database.disabled.config.stub.php',
             default => throw new LogicException('Cleanup strategy must be provided for non-Redis session drivers.'),
         };
     }
 
-    private function shouldMigrate(): bool
+    private function shouldMigrate(?bool $migrate): bool
     {
-        $argument = $this->consoleArgumentBag->get('migrate');
-
-        if (! $argument instanceof ConsoleInputArgument || ! is_bool($argument->value)) {
-            return $this->console->confirm('Do you want to execute migrations?', default: false);
+        if (is_bool($migrate)) {
+            return $migrate;
         }
 
-        return (bool) $argument->value;
+        return $this->console->confirm('Do you want to execute migrations?', default: false);
     }
 
     private function shouldPublishCleanupCommand(CleanupStrategy $cleanupStrategy): bool
     {
-        $argument = $this->consoleArgumentBag->get('cleanup-command');
-
-        if ($argument instanceof ConsoleInputArgument && is_bool($argument->value)) {
-            return (bool) $argument->value;
-        }
-
         if ($cleanupStrategy !== CleanupStrategy::DISABLED) {
             return false;
         }

--- a/packages/http/src/Session/Installer/SessionStorage.php
+++ b/packages/http/src/Session/Installer/SessionStorage.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Session\Installer;
+
+enum SessionStorage: string
+{
+    case FILE = 'file';
+    case DATABASE = 'database';
+    case REDIS = 'redis';
+}

--- a/packages/http/src/Session/Installer/SessionStorage.php
+++ b/packages/http/src/Session/Installer/SessionStorage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Http\Session\Installer;
 
+/** @internal */
 enum SessionStorage: string
 {
     case FILE = 'file';

--- a/packages/vite/src/Installer/ViteInstaller.php
+++ b/packages/vite/src/Installer/ViteInstaller.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Tempest\Vite\Installer;
 
-use Tempest\Console\Input\ConsoleArgumentBag;
-use Tempest\Console\Input\ConsoleInputArgument;
 use Tempest\Core\Installer;
+use Tempest\Core\InstallerArgument;
 use Tempest\Core\PublishesFiles;
 use Tempest\Support\JavaScript\DependencyInstaller;
 use Tempest\Support\JavaScript\PackageManager;
@@ -16,33 +15,21 @@ use Tempest\Vite\ViteConfig;
 use function Tempest\root_path;
 use function Tempest\src_path;
 
-final class ViteInstaller implements Installer
+final class ViteInstaller
 {
     use PublishesFiles;
-
-    private(set) string $name = 'vite';
 
     public function __construct(
         private readonly DependencyInstaller $javascript,
         private readonly ViteConfig $viteConfig,
-        private readonly ConsoleArgumentBag $consoleArgumentBag,
     ) {}
 
-    private function shouldInstallTailwind(): bool
-    {
-        $argument = $this->consoleArgumentBag->get('tailwindcss');
-
-        if (! $argument instanceof ConsoleInputArgument || ! is_bool($argument->value)) {
-            return $this->console->confirm('Install Tailwind CSS as well?', default: true);
-        }
-
-        return (bool) $argument->value;
-    }
-
-    public function install(): void
-    {
-        $shouldInstallTailwind = $this->shouldInstallTailwind();
-        $templateDirectory = $shouldInstallTailwind
+    #[Installer('Vite', alias: 'vite')]
+    public function install(
+        #[InstallerArgument(prompt: 'Install Tailwind CSS as well?')]
+        bool $tailwindcss,
+    ): void {
+        $templateDirectory = $tailwindcss
             ? 'tailwindcss'
             : 'vanilla';
 
@@ -52,7 +39,7 @@ final class ViteInstaller implements Installer
             dependencies: [
                 'vite',
                 'vite-plugin-tempest',
-                ...($shouldInstallTailwind ? ['tailwindcss', '@tailwindcss/vite'] : []),
+                ...($tailwindcss ? ['tailwindcss', '@tailwindcss/vite'] : []),
             ],
             dev: true,
         );
@@ -60,7 +47,7 @@ final class ViteInstaller implements Installer
         // Publishes the Vite config
         $this->publish(__DIR__ . "/{$templateDirectory}/vite.config.ts", destination: root_path('vite.config.ts'));
         $mainTs = $this->publish(__DIR__ . "/{$templateDirectory}/main.ts", destination: src_path('main.entrypoint.ts'));
-        $mainCss = $shouldInstallTailwind
+        $mainCss = $tailwindcss
             ? $this->publish(__DIR__ . "/{$templateDirectory}/main.css", destination: src_path('main.entrypoint.css'))
             : null;
 
@@ -106,7 +93,7 @@ final class ViteInstaller implements Installer
         $packageManager = PackageManager::detect(root_path()) ?? PackageManager::NPM;
 
         $this->console->instructions([
-            $shouldInstallTailwind
+            $tailwindcss
                 ? '<strong>Vite and Tailwind CSS are now installed in your project</strong>!'
                 : '<strong>Vite is now installed in your project</strong>!',
             PHP_EOL,

--- a/packages/vite/src/Installer/ViteInstaller.php
+++ b/packages/vite/src/Installer/ViteInstaller.php
@@ -27,7 +27,7 @@ final class ViteInstaller
     #[Installer('Vite', alias: 'vite')]
     public function install(
         #[InstallerArgument(prompt: 'Install Tailwind CSS as well?')]
-        bool $tailwindcss,
+        bool $tailwindcss = true,
     ): void {
         $templateDirectory = $tailwindcss
             ? 'tailwindcss'

--- a/src/Tempest/Framework/Installers/FrameworkInstaller.php
+++ b/src/Tempest/Framework/Installers/FrameworkInstaller.php
@@ -9,12 +9,11 @@ use Tempest\Core\IsComponentInstaller;
 
 use function Tempest\root_path;
 
-final class FrameworkInstaller implements Installer
+final class FrameworkInstaller
 {
     use IsComponentInstaller;
 
-    private(set) string $name = 'framework';
-
+    #[Installer('Framework', alias: 'framework')]
     public function install(): void
     {
         $this->installMainNamespace();

--- a/src/Tempest/Framework/Installers/ViewComponentsInstaller.php
+++ b/src/Tempest/Framework/Installers/ViewComponentsInstaller.php
@@ -11,10 +11,8 @@ use Tempest\View\ViewConfig;
 use function Tempest\src_path;
 use function Tempest\Support\arr;
 
-final class ViewComponentsInstaller implements Installer
+final class ViewComponentsInstaller
 {
-    private(set) string $name = 'view-components';
-
     use HasConsole;
     use IsComponentInstaller;
 
@@ -22,6 +20,7 @@ final class ViewComponentsInstaller implements Installer
         private readonly ViewConfig $viewConfig,
     ) {}
 
+    #[Installer('View components', alias: 'view-components')]
     public function install(): void
     {
         $searchOptions = arr($this->viewConfig->viewComponents)

--- a/tests/Fixtures/TestInstaller.php
+++ b/tests/Fixtures/TestInstaller.php
@@ -9,12 +9,11 @@ use Tempest\Core\PublishesFiles;
 
 use function Tempest\src_path;
 
-final class TestInstaller implements Installer
+final class TestInstaller
 {
     use PublishesFiles;
 
-    private(set) string $name = 'test';
-
+    #[Installer('Test', alias: 'test')]
     public function install(): void
     {
         $this->publish(

--- a/tests/Integration/Core/InstallCommandTest.php
+++ b/tests/Integration/Core/InstallCommandTest.php
@@ -32,7 +32,8 @@ final class InstallCommandTest extends FrameworkIntegrationTestCase
     #[Test]
     public function class_is_adjusted(): void
     {
-        $this->console->call('install test --force');
+        $this->console
+            ->call('install test --force');
 
         $this->installer
             ->assertFileExists(

--- a/tests/Integration/Http/SessionInstallerTest.php
+++ b/tests/Integration/Http/SessionInstallerTest.php
@@ -7,6 +7,7 @@ namespace Tests\Tempest\Integration\Http;
 use PHPUnit\Framework\Attributes\PostCondition;
 use PHPUnit\Framework\Attributes\PreCondition;
 use PHPUnit\Framework\Attributes\Test;
+use Tempest\Http\Session\Installer\SessionInstaller;
 use Tempest\Support\Namespace\Psr4Namespace;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
@@ -33,13 +34,12 @@ final class SessionInstallerTest extends FrameworkIntegrationTestCase
     public function installs_database_session_config_and_migration(): void
     {
         $this->console
-            ->call('install sessions')
-            ->confirm()
+            ->call(sprintf('install %s', SessionInstaller::class))
             ->input(1)
             ->input(0)
+            ->confirm()
             ->input('App/Sessions/session.config.php')
             ->confirm()
-            ->deny()
             ->assertSuccess();
 
         $this->installer
@@ -53,8 +53,7 @@ final class SessionInstallerTest extends FrameworkIntegrationTestCase
     public function installs_file_session_config(): void
     {
         $this->console
-            ->call('install sessions')
-            ->confirm()
+            ->call(sprintf('install %s', SessionInstaller::class))
             ->input(0)
             ->input(0)
             ->input('App/Sessions/session.config.php')
@@ -69,8 +68,7 @@ final class SessionInstallerTest extends FrameworkIntegrationTestCase
     public function installs_redis_session_config(): void
     {
         $this->console
-            ->call('install sessions')
-            ->confirm()
+            ->call(sprintf('install %s', SessionInstaller::class))
             ->input(2)
             ->input('App/Sessions/session.config.php')
             ->assertSuccess();
@@ -91,8 +89,7 @@ final class SessionInstallerTest extends FrameworkIntegrationTestCase
     public function publishes_cleanup_command_when_requested(): void
     {
         $this->console
-            ->call('install sessions')
-            ->confirm()
+            ->call(sprintf('install %s', SessionInstaller::class))
             ->input(0)
             ->input(2)
             ->input('App/Sessions/session.config.php')
@@ -107,8 +104,7 @@ final class SessionInstallerTest extends FrameworkIntegrationTestCase
     public function writes_selected_cleanup_strategy_to_the_config(): void
     {
         $this->console
-            ->call('install sessions')
-            ->confirm()
+            ->call(sprintf('install %s', SessionInstaller::class))
             ->input(0)
             ->input(1)
             ->input('App/Sessions/session.config.php')

--- a/tests/Integration/Vite/ViteInstallerTest.php
+++ b/tests/Integration/Vite/ViteInstallerTest.php
@@ -2,10 +2,11 @@
 
 namespace Tests\Tempest\Integration\Vite;
 
-use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\PostCondition;
 use PHPUnit\Framework\Attributes\PreCondition;
 use PHPUnit\Framework\Attributes\Test;
 use Tempest\Core\Commands\InstallCommand;
+use Tempest\Support\Filesystem;
 use Tempest\Support\Namespace\Psr4Namespace;
 use Tempest\Vite\Installer\ViteInstaller;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -20,14 +21,13 @@ final class ViteInstallerTest extends FrameworkIntegrationTestCase
             new Psr4Namespace('App\\', $this->internalStorage . '/install/app'),
         );
 
-        mkdir($this->internalStorage . '/install/node_modules');
-
         // force usage of npm because bun will mutate Tempest's root install otherwise
-        touch($this->internalStorage . '/install/package-lock.json');
+        Filesystem\create_directory($this->internalStorage . '/install/node_modules');
+        Filesystem\create_file($this->internalStorage . '/install/package-lock.json');
     }
 
-    #[After]
-    protected function after(): void
+    #[PostCondition]
+    protected function cleanup(): void
     {
         $this->installer->clean();
     }

--- a/tests/Integration/Vite/ViteInstallerTest.php
+++ b/tests/Integration/Vite/ViteInstallerTest.php
@@ -16,14 +16,14 @@ final class ViteInstallerTest extends FrameworkIntegrationTestCase
     #[PreCondition]
     protected function configure(): void
     {
-        $this->installer->configure(
-            $this->internalStorage . '/install',
-            new Psr4Namespace('App\\', $this->internalStorage . '/install/app'),
-        );
+        $this->installer
+            ->configure(__DIR__ . '/install', new Psr4Namespace('App\\', __DIR__ . '/install/app'))
+            ->setRoot(__DIR__ . '/install');
 
-        // force usage of npm because bun will mutate Tempest's root install otherwise
-        Filesystem\create_directory($this->internalStorage . '/install/node_modules');
-        Filesystem\create_file($this->internalStorage . '/install/package-lock.json');
+        // force usage of npm because bun (which will be detected by our bun.lock)
+        // will mutate Tempest's root install otherwise
+        Filesystem\create_directory(__DIR__ . '/install/node_modules');
+        Filesystem\create_file(__DIR__ . '/install/package-lock.json');
     }
 
     #[PostCondition]

--- a/tests/Integration/Vite/ViteInstallerTest.php
+++ b/tests/Integration/Vite/ViteInstallerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\PreCondition;
 use PHPUnit\Framework\Attributes\Test;
 use Tempest\Core\Commands\InstallCommand;
 use Tempest\Support\Namespace\Psr4Namespace;
+use Tempest\Vite\Installer\ViteInstaller;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 final class ViteInstallerTest extends FrameworkIntegrationTestCase
@@ -34,11 +35,10 @@ final class ViteInstallerTest extends FrameworkIntegrationTestCase
     #[Test]
     public function intalls_vite(): void
     {
-        $this->console->call(InstallCommand::class, ['vite', '--force']);
+        $this->console->call(InstallCommand::class, [ViteInstaller::class, '--force']);
 
         $this->installer->assertFileExists('vite.config.ts');
         $this->installer->assertFileExists('app/main.entrypoint.ts');
-        $this->installer->assertFileExists('app/main.entrypoint.css');
 
         $this->installer->assertFileContains('package.json', '"vite"');
         $this->installer->assertFileContains('package.json', '"vite build"');
@@ -47,7 +47,7 @@ final class ViteInstallerTest extends FrameworkIntegrationTestCase
     #[Test]
     public function intalls_tailwindcss(): void
     {
-        $this->console->call(InstallCommand::class, ['vite', 'tailwindcss', '--force']);
+        $this->console->call(InstallCommand::class, [ViteInstaller::class, '--tailwindcss', '--force']);
 
         $this->installer->assertFileExists('app/main.entrypoint.ts');
 


### PR DESCRIPTION
This pull request changes the API for installers from an interface to an attribute.

This makes it easier to provide metadata (such as a friendly name) and makes them more flexible as well, as we can now have multiple installers in the same class.

I also made it so arguments can be typed in the signature, just like console commands, instead of being dynamic:

```php
#[Installer('Vite', alias: 'vite')]
public function install(
    #[InstallerArgument(prompt: 'Install Tailwind CSS as well?')]
    bool $tailwindcss,
): void {}
```

When an argument is mandatory, it will be prompted by the `install` command, and the prompt can be configured.

BREAKING CHANGE: `Installer` is no longer an interface but an attribute, any custom installer will need to be adapted.