### PR TITLE
fix(view): improve slot rendering

### DIFF
--- a/packages/view/src/Elements/ViewComponentElement.php
+++ b/packages/view/src/Elements/ViewComponentElement.php
@@ -41,8 +41,7 @@ final class ViewComponentElement implements Element, WithToken
         private readonly ViewCache $viewCache,
         private readonly ViewComponent $viewComponent,
         array $attributes,
-    )
-    {
+    ) {
         $this->attributes = $attributes;
 
         $this->viewComponentAttributes = arr($attributes)
@@ -100,7 +99,8 @@ final class ViewComponentElement implements Element, WithToken
     {
         $slots = $this->getSlots();
 
-        $compiled = $this->compileComponent()
+        $compiled = $this
+            ->compileComponent()
             ->prepend(
                 sprintf(
                     '<?php return function ($attributes, $slots, $scopedVariables %s %s %s) { extract($scopedVariables, EXTR_SKIP); ?>',
@@ -153,9 +153,7 @@ final class ViewComponentElement implements Element, WithToken
         $buffer = '';
 
         foreach ($tokens as $i => $token) {
-            $shouldApplyFallthrough = $i === 0
-                && $token->type === TokenType::OPEN_TAG_START
-                && $token->tag !== 'x-slot';
+            $shouldApplyFallthrough = $i === 0 && $token->type === TokenType::OPEN_TAG_START && $token->tag !== 'x-slot';
 
             if ($shouldApplyFallthrough) {
                 $attributes = arr($token->htmlAttributes)
@@ -201,8 +199,7 @@ final class ViewComponentElement implements Element, WithToken
         iterable $tokens,
         ImmutableArray $slots,
         bool $parentIsComponent = false,
-    ): string
-    {
+    ): string {
         $buffer = '';
 
         foreach ($tokens as $token) {
@@ -238,9 +235,7 @@ final class ViewComponentElement implements Element, WithToken
 
     private function compileRegularOpeningTag(Token $token): string
     {
-        return $token->content
-            . $token->compileAttributes()
-            . $token->endingToken?->compile();
+        return $token->content . $token->compileAttributes() . $token->endingToken?->compile();
     }
 
     private function compileSlotToken(Token $slotToken, ImmutableArray $slots): string

--- a/packages/view/src/Elements/ViewComponentElement.php
+++ b/packages/view/src/Elements/ViewComponentElement.php
@@ -213,12 +213,12 @@ final class ViewComponentElement implements Element, WithToken
     {
         $buffer = '';
 
-        $isNestedComponentToken = $parentToken !== null && $this->isViewComponentToken($parentToken);
+        $parentIsComponent = $parentToken !== null && $this->isViewComponentToken($parentToken);
 
         foreach ($tokens as $token) {
             if ($token->tag === 'x-slot') {
-                if ($isNestedComponentToken && $token->getAttribute('name') !== null) {
-                    // Preserve named slots inside child components: they are outgoing slot-fillers for that child.
+                // Preserve named slots inside child components: they are outgoing slot-fillers for that child.
+                if ($parentIsComponent && $token->getAttribute('name') !== null) {
                     $buffer .= $this->compileRegularOpeningTag($token);
                     $buffer .= $this->compileTokens(tokens: $token->children, parentToken: $token);
                     $buffer .= $token->closingToken?->compile();

--- a/packages/view/src/Elements/ViewComponentElement.php
+++ b/packages/view/src/Elements/ViewComponentElement.php
@@ -41,7 +41,8 @@ final class ViewComponentElement implements Element, WithToken
         private readonly ViewCache $viewCache,
         private readonly ViewComponent $viewComponent,
         array $attributes,
-    ) {
+    )
+    {
         $this->attributes = $attributes;
 
         $this->viewComponentAttributes = arr($attributes)
@@ -99,11 +100,7 @@ final class ViewComponentElement implements Element, WithToken
     {
         $slots = $this->getSlots();
 
-        $compiled = str($this->viewComponent->contents);
-
-        $compiled = $this->applyFallthroughAttributes($compiled);
-
-        $compiled = $compiled
+        $compiled = $this->compileComponent()
             ->prepend(
                 sprintf(
                     '<?php return function ($attributes, $slots, $scopedVariables %s %s %s) { extract($scopedVariables, EXTR_SKIP); ?>',
@@ -113,11 +110,6 @@ final class ViewComponentElement implements Element, WithToken
                 ),
             )
             ->append('<?php };');
-
-        $compiled = str($this->compileSlotTokens(
-            tokens: TempestViewParser::ast($compiled->toString()),
-            slots: $slots,
-        ));
 
         $compiledView = $this->compiler->compileWithSourceMap(
             $compiled->toString(),
@@ -154,21 +146,70 @@ final class ViewComponentElement implements Element, WithToken
         );
     }
 
-    private function compileSlotTokens(iterable $tokens, ImmutableArray $slots, bool $parentIsComponent = false): string
+    private function compileComponent(): ImmutableString
+    {
+        $tokens = TempestViewParser::ast($this->viewComponent->contents);
+        $slots = $this->getSlots();
+        $buffer = '';
+
+        foreach ($tokens as $i => $token) {
+            $shouldApplyFallthrough = $i === 0
+                && $token->type === TokenType::OPEN_TAG_START
+                && $token->tag !== 'x-slot';
+
+            if ($shouldApplyFallthrough) {
+                $attributes = arr($token->htmlAttributes)
+                    ->map(fn (string $value) => new MutableString($value));
+
+                foreach (['class', 'style', 'id'] as $name) {
+                    $attributes = $this->applyFallthroughAttribute($attributes, $name);
+                }
+
+                $attributeString = $attributes
+                    ->map(fn (MutableString $value, string $key) => sprintf('%s="%s"', $key, $value->trim()))
+                    ->implode(' ')
+                    ->when(
+                        fn (ImmutableString $s) => $s->isNotEmpty(),
+                        fn (ImmutableString $s) => $s->prepend(' '),
+                    );
+
+                $tag = str($token->content)->afterFirst('<')->trim()->toString();
+
+                $buffer .= sprintf('<%s%s>', $tag, $attributeString);
+
+                $buffer .= $this->compileSlotTokens(
+                    tokens: $token->children,
+                    slots: $slots,
+                    parentIsComponent: $this->isNestedComponentToken($token),
+                );
+
+                if ($token->closingToken?->type !== TokenType::SELF_CLOSING_TAG_END) {
+                    $buffer .= $token->closingToken?->compile();
+                }
+            } else {
+                $buffer .= $this->compileSlotTokens(
+                    tokens: [$token],
+                    slots: $slots,
+                );
+            }
+        }
+
+        return str($buffer);
+    }
+
+    private function compileSlotTokens(
+        iterable $tokens,
+        ImmutableArray $slots,
+        bool $parentIsComponent = false,
+    ): string
     {
         $buffer = '';
 
         foreach ($tokens as $token) {
-            if (! $token instanceof Token) {
-                continue;
-            }
-
             if ($token->tag === 'x-slot') {
                 if ($parentIsComponent && $token->getAttribute('name') !== null) {
                     // Preserve named slots inside child components: they are outgoing slot-fillers for that child.
-                    $buffer .= $token->content;
-                    $buffer .= $token->compileAttributes();
-                    $buffer .= $token->endingToken?->compile();
+                    $buffer .= $this->compileRegularOpeningTag($token);
                     $buffer .= $this->compileSlotTokens($token->children, $slots);
                     $buffer .= $token->closingToken?->compile();
                 } else {
@@ -183,9 +224,7 @@ final class ViewComponentElement implements Element, WithToken
                 continue;
             }
 
-            $buffer .= $token->content;
-            $buffer .= $token->compileAttributes();
-            $buffer .= $token->endingToken?->compile();
+            $buffer .= $this->compileRegularOpeningTag($token);
             $buffer .= $this->compileSlotTokens(
                 tokens: $token->children,
                 slots: $slots,
@@ -197,9 +236,16 @@ final class ViewComponentElement implements Element, WithToken
         return $buffer;
     }
 
+    private function compileRegularOpeningTag(Token $token): string
+    {
+        return $token->content
+            . $token->compileAttributes()
+            . $token->endingToken?->compile();
+    }
+
     private function compileSlotToken(Token $slotToken, ImmutableArray $slots): string
     {
-        $name = $slotToken->getAttribute('name') ?: Slot::DEFAULT;
+        $name = $this->resolveSlotName($slotToken);
         $slot = $slots[$name] ?? null;
         $default = $slotToken->compileChildren();
 
@@ -228,6 +274,25 @@ final class ViewComponentElement implements Element, WithToken
         }
 
         return $compiled;
+    }
+
+    private function resolveSlotName(Token $slotToken): string
+    {
+        $name = $slotToken->getAttribute('name');
+
+        if ($name !== null && $name !== '') {
+            return $name;
+        }
+
+        if (preg_match('/\sname\s*=\s*"(?<name>[\w-]+)"/', $slotToken->content, $matches) === 1) {
+            return $matches['name'];
+        }
+
+        if (preg_match("/\sname\s*=\s*'(?<name>[\\w-]+)'/", $slotToken->content, $matches) === 1) {
+            return $matches['name'];
+        }
+
+        return Slot::DEFAULT;
     }
 
     private function isNestedComponentToken(Token $token): bool
@@ -262,34 +327,6 @@ final class ViewComponentElement implements Element, WithToken
         }
 
         return null;
-    }
-
-    private function applyFallthroughAttributes(ImmutableString $compiled): ImmutableString
-    {
-        return $compiled->replaceRegex(
-            regex: '/^<(?<tag>[\w-]+)(.*?["\s])?>/',
-            replace: function (array $matches): string {
-                /** @var Token $token */
-                $token = TempestViewParser::ast($matches[0])[0];
-
-                $attributes = arr($token->htmlAttributes)
-                    ->map(fn (string $value) => new MutableString($value));
-
-                foreach (['class', 'style', 'id'] as $name) {
-                    $attributes = $this->applyFallthroughAttribute($attributes, $name);
-                }
-
-                $attributeString = $attributes
-                    ->map(fn (MutableString $value, string $key) => sprintf('%s="%s"', $key, $value->trim()))
-                    ->implode(' ')
-                    ->when(
-                        fn (ImmutableString $s) => $s->isNotEmpty(),
-                        fn (ImmutableString $s) => $s->prepend(' '),
-                    );
-
-                return sprintf('<%s%s>', $matches['tag'], $attributeString);
-            },
-        );
     }
 
     private function applyFallthroughAttribute(ImmutableArray $attributes, string $name): ImmutableArray

--- a/packages/view/src/Elements/ViewComponentElement.php
+++ b/packages/view/src/Elements/ViewComponentElement.php
@@ -43,7 +43,8 @@ final class ViewComponentElement implements Element, WithToken
         private readonly ViewCache $viewCache,
         private readonly ViewComponent $viewComponent,
         array $attributes,
-    ) {
+    )
+    {
         $this->attributes = $attributes;
 
         $this->viewComponentAttributes = arr($attributes)
@@ -157,50 +158,58 @@ final class ViewComponentElement implements Element, WithToken
     private function compileComponent(): ImmutableString
     {
         $tokens = TempestViewParser::ast($this->viewComponent->contents);
+
         $buffer = '';
 
+        /**
+         * @var int $i
+         * @var Token $token
+         */
         foreach ($tokens as $i => $token) {
+            // Fallthrough attributes will be applied to the first element in the component.
             $shouldApplyFallthrough = $i === 0 && $token->type === TokenType::OPEN_TAG_START && $token->tag !== 'x-slot';
 
-            if ($shouldApplyFallthrough) {
-                $attributes = arr($token->htmlAttributes)
-                    ->map(fn (string $value) => new MutableString($value));
-
-                foreach (['class', 'style', 'id'] as $name) {
-                    $attributes = $this->applyFallthroughAttribute($attributes, $name);
-                }
-
-                $attributeString = $attributes
-                    ->map(fn (MutableString $value, string $key) => sprintf('%s="%s"', $key, $value->trim()))
-                    ->implode(' ')
-                    ->when(
-                        fn (ImmutableString $s) => $s->isNotEmpty(),
-                        fn (ImmutableString $s) => $s->prepend(' '),
-                    );
-
-                $tag = str($token->content)->afterFirst('<')->trim()->toString();
-
-                $buffer .= sprintf('<%s%s>', $tag, $attributeString);
-
-                $buffer .= $this->compileSlotTokens(
-                    tokens: $token->children,
-                    parentToken: $token,
-                );
-
-                if ($token->closingToken?->type !== TokenType::SELF_CLOSING_TAG_END) {
-                    $buffer .= $token->closingToken?->compile();
-                }
-            } else {
-                $buffer .= $this->compileSlotTokens(
+            if (! $shouldApplyFallthrough) {
+                // Anything else is is compiled like normal
+                $buffer .= $this->compileTokens(
                     tokens: [$token],
                 );
+
+                continue;
+            }
+
+            $attributes = arr($token->htmlAttributes)
+                ->map(fn (string $value) => new MutableString($value));
+
+            // class, style, and id are fallthrough attributes
+            $attributes = $this->applyFallthroughAttribute($attributes, 'class');
+            $attributes = $this->applyFallthroughAttribute($attributes, 'style');
+            $attributes = $this->applyFallthroughAttribute($attributes, 'id');
+
+            $attributeString = $attributes
+                ->map(fn (MutableString $value, string $key) => sprintf('%s="%s"', $key, $value->trim()))
+                ->implode(' ')
+                ->when(
+                    fn (ImmutableString $s) => $s->isNotEmpty(),
+                    fn (ImmutableString $s) => $s->prepend(' '),
+                );
+
+            $buffer .= sprintf('<%s%s>', $token->tag, $attributeString);
+
+            $buffer .= $this->compileTokens(
+                tokens: $token->children,
+                parentToken: $token,
+            );
+
+            if ($token->closingToken?->type !== TokenType::SELF_CLOSING_TAG_END) {
+                $buffer .= $token->closingToken?->compile();
             }
         }
 
         return str($buffer);
     }
 
-    private function compileSlotTokens(iterable $tokens, ?Token $parentToken = null): string
+    private function compileTokens(iterable $tokens, ?Token $parentToken = null): string
     {
         $buffer = '';
 
@@ -211,7 +220,7 @@ final class ViewComponentElement implements Element, WithToken
                 if ($isNestedComponentToken && $token->getAttribute('name') !== null) {
                     // Preserve named slots inside child components: they are outgoing slot-fillers for that child.
                     $buffer .= $this->compileRegularOpeningTag($token);
-                    $buffer .= $this->compileSlotTokens(tokens: $token->children, parentToken: $token);
+                    $buffer .= $this->compileTokens(tokens: $token->children, parentToken: $token);
                     $buffer .= $token->closingToken?->compile();
                 } else {
                     $buffer .= $this->compileSlotToken($token);
@@ -226,7 +235,7 @@ final class ViewComponentElement implements Element, WithToken
             }
 
             $buffer .= $this->compileRegularOpeningTag($token);
-            $buffer .= $this->compileSlotTokens(tokens: $token->children, parentToken: $token);
+            $buffer .= $this->compileTokens(tokens: $token->children, parentToken: $token);
             $buffer .= $token->closingToken?->compile();
         }
 

--- a/packages/view/src/Elements/ViewComponentElement.php
+++ b/packages/view/src/Elements/ViewComponentElement.php
@@ -165,6 +165,7 @@ final class ViewComponentElement implements Element, WithToken
 
             if ($token->tag === 'x-slot') {
                 if ($parentIsComponent && $token->getAttribute('name') !== null) {
+                    // Preserve named slots inside child components: they are outgoing slot-fillers for that child.
                     $buffer .= $token->content;
                     $buffer .= $token->compileAttributes();
                     $buffer .= $token->endingToken?->compile();

--- a/packages/view/src/Elements/ViewComponentElement.php
+++ b/packages/view/src/Elements/ViewComponentElement.php
@@ -200,12 +200,11 @@ final class ViewComponentElement implements Element, WithToken
         return str($buffer);
     }
 
-    private function compileSlotTokens(
-        iterable $tokens,
-        ?Token $parentToken = null,
-    ): string {
+    private function compileSlotTokens(iterable $tokens, ?Token $parentToken = null): string
+    {
         $buffer = '';
-        $isNestedComponentToken = $parentToken !== null && $this->isNestedComponentToken($parentToken);
+
+        $isNestedComponentToken = $parentToken !== null && $this->isViewComponentToken($parentToken);
 
         foreach ($tokens as $token) {
             if ($token->tag === 'x-slot') {
@@ -292,7 +291,7 @@ final class ViewComponentElement implements Element, WithToken
         return Slot::DEFAULT;
     }
 
-    private function isNestedComponentToken(Token $token): bool
+    private function isViewComponentToken(Token $token): bool
     {
         if ($token->tag === null) {
             return false;

--- a/packages/view/src/Elements/ViewComponentElement.php
+++ b/packages/view/src/Elements/ViewComponentElement.php
@@ -43,8 +43,7 @@ final class ViewComponentElement implements Element, WithToken
         private readonly ViewCache $viewCache,
         private readonly ViewComponent $viewComponent,
         array $attributes,
-    )
-    {
+    ) {
         $this->attributes = $attributes;
 
         $this->viewComponentAttributes = arr($attributes)

--- a/packages/view/src/Elements/ViewComponentElement.php
+++ b/packages/view/src/Elements/ViewComponentElement.php
@@ -13,6 +13,7 @@ use Tempest\View\Export\ViewObjectExporter;
 use Tempest\View\Parser\TempestViewCompiler;
 use Tempest\View\Parser\TempestViewParser;
 use Tempest\View\Parser\Token;
+use Tempest\View\Parser\TokenType;
 use Tempest\View\Slot;
 use Tempest\View\ViewCache;
 use Tempest\View\ViewComponent;
@@ -113,42 +114,10 @@ final class ViewComponentElement implements Element, WithToken
             )
             ->append('<?php };');
 
-        $compiled = $compiled->replaceRegex(
-            regex: '/<x-slot\s*(name="(?<name>[\w-]+)")?((\s*\/>)|>(?<default>(.|\n)*?)<\/x-slot>)/',
-            replace: function ($matches) use ($slots) {
-                $name = $matches['name'] ?: Slot::DEFAULT;
-
-                $slot = $slots[$name] ?? null;
-
-                $default = $matches['default'] ?? null;
-
-                if ($slot === null) {
-                    if ($default) {
-                        // There's no slot, but there's a default value in the view component
-                        return $default;
-                    }
-
-                    // A slot doesn't have any content, so we'll comment it out.
-                    // This is to prevent DOM parsing errors (slots in <head> tags is one example, see #937)
-                    return $this->environment->isLocal() ? '<!--' . $matches[0] . '-->' : '';
-                }
-
-                $slotElement = $this->getSlotElement($slot->name);
-
-                if ($slotElement === null) {
-                    return $default;
-                }
-
-                $compiled = $this->compiler->compileElement($slotElement);
-
-                // There's no default slot content, but there's a default value in the view component
-                if (trim($compiled) === '') {
-                    return $default;
-                }
-
-                return $compiled;
-            },
-        );
+        $compiled = str($this->compileSlotTokens(
+            tokens: TempestViewParser::ast($compiled->toString()),
+            slots: $slots,
+        ));
 
         $compiledView = $this->compiler->compileWithSourceMap(
             $compiled->toString(),
@@ -183,6 +152,94 @@ final class ViewComponentElement implements Element, WithToken
                 ? ', ' . $this->scopedVariables->map(fn (string $name) => "{$name}: \${$name}")->implode(', ')
                 : '',
         );
+    }
+
+    private function compileSlotTokens(iterable $tokens, ImmutableArray $slots, bool $parentIsComponent = false): string
+    {
+        $buffer = '';
+
+        foreach ($tokens as $token) {
+            if (! $token instanceof Token) {
+                continue;
+            }
+
+            if ($token->tag === 'x-slot') {
+                if ($parentIsComponent && $token->getAttribute('name') !== null) {
+                    $buffer .= $token->content;
+                    $buffer .= $token->compileAttributes();
+                    $buffer .= $token->endingToken?->compile();
+                    $buffer .= $this->compileSlotTokens($token->children, $slots);
+                    $buffer .= $token->closingToken?->compile();
+                } else {
+                    $buffer .= $this->compileSlotToken($token, $slots);
+                }
+
+                continue;
+            }
+
+            if ($token->type !== TokenType::OPEN_TAG_START) {
+                $buffer .= $token->compile();
+                continue;
+            }
+
+            $buffer .= $token->content;
+            $buffer .= $token->compileAttributes();
+            $buffer .= $token->endingToken?->compile();
+            $buffer .= $this->compileSlotTokens(
+                tokens: $token->children,
+                slots: $slots,
+                parentIsComponent: $this->isNestedComponentToken($token),
+            );
+            $buffer .= $token->closingToken?->compile();
+        }
+
+        return $buffer;
+    }
+
+    private function compileSlotToken(Token $slotToken, ImmutableArray $slots): string
+    {
+        $name = $slotToken->getAttribute('name') ?: Slot::DEFAULT;
+        $slot = $slots[$name] ?? null;
+        $default = $slotToken->compileChildren();
+
+        if ($slot === null) {
+            if ($default !== '') {
+                // There's no slot, but there's a default value in the view component
+                return $default;
+            }
+
+            // A slot doesn't have any content, so we'll comment it out.
+            // This is to prevent DOM parsing errors (slots in <head> tags is one example, see #937)
+            return $this->environment->isLocal() ? '<!--' . $slotToken->compile() . '-->' : '';
+        }
+
+        $slotElement = $this->getSlotElement($slot->name);
+
+        if ($slotElement === null) {
+            return $default;
+        }
+
+        $compiled = $this->compiler->compileElement($slotElement);
+
+        // There's no default slot content, but there's a default value in the view component
+        if (trim($compiled) === '') {
+            return $default;
+        }
+
+        return $compiled;
+    }
+
+    private function isNestedComponentToken(Token $token): bool
+    {
+        if ($token->tag === null) {
+            return false;
+        }
+
+        if (! str_starts_with($token->tag, 'x-')) {
+            return false;
+        }
+
+        return $token->tag !== 'x-slot';
     }
 
     private function getSlotElement(string $name): SlotElement|CollectionElement|null

--- a/packages/view/src/Elements/ViewComponentElement.php
+++ b/packages/view/src/Elements/ViewComponentElement.php
@@ -34,6 +34,8 @@ final class ViewComponentElement implements Element, WithToken
 
     private ImmutableArray $viewComponentAttributes;
 
+    private ?ImmutableArray $slots = null;
+
     public function __construct(
         public readonly Token $token,
         private readonly Environment $environment,
@@ -76,6 +78,10 @@ final class ViewComponentElement implements Element, WithToken
     /** @return ImmutableArray<array-key, Slot> */
     public function getSlots(): ImmutableArray
     {
+        if ($this->slots !== null) {
+            return $this->slots;
+        }
+
         $slots = arr();
 
         $defaultTokens = [];
@@ -92,7 +98,9 @@ final class ViewComponentElement implements Element, WithToken
 
         $slots[Slot::DEFAULT] = Slot::default(...$defaultTokens);
 
-        return $slots;
+        $this->slots = $slots;
+
+        return $this->slots;
     }
 
     public function compile(): string
@@ -149,7 +157,6 @@ final class ViewComponentElement implements Element, WithToken
     private function compileComponent(): ImmutableString
     {
         $tokens = TempestViewParser::ast($this->viewComponent->contents);
-        $slots = $this->getSlots();
         $buffer = '';
 
         foreach ($tokens as $i => $token) {
@@ -177,8 +184,7 @@ final class ViewComponentElement implements Element, WithToken
 
                 $buffer .= $this->compileSlotTokens(
                     tokens: $token->children,
-                    slots: $slots,
-                    parentIsComponent: $this->isNestedComponentToken($token),
+                    parentToken: $token,
                 );
 
                 if ($token->closingToken?->type !== TokenType::SELF_CLOSING_TAG_END) {
@@ -187,7 +193,6 @@ final class ViewComponentElement implements Element, WithToken
             } else {
                 $buffer .= $this->compileSlotTokens(
                     tokens: [$token],
-                    slots: $slots,
                 );
             }
         }
@@ -197,20 +202,20 @@ final class ViewComponentElement implements Element, WithToken
 
     private function compileSlotTokens(
         iterable $tokens,
-        ImmutableArray $slots,
-        bool $parentIsComponent = false,
+        ?Token $parentToken = null,
     ): string {
         $buffer = '';
+        $isNestedComponentToken = $parentToken !== null && $this->isNestedComponentToken($parentToken);
 
         foreach ($tokens as $token) {
             if ($token->tag === 'x-slot') {
-                if ($parentIsComponent && $token->getAttribute('name') !== null) {
+                if ($isNestedComponentToken && $token->getAttribute('name') !== null) {
                     // Preserve named slots inside child components: they are outgoing slot-fillers for that child.
                     $buffer .= $this->compileRegularOpeningTag($token);
-                    $buffer .= $this->compileSlotTokens($token->children, $slots);
+                    $buffer .= $this->compileSlotTokens(tokens: $token->children, parentToken: $token);
                     $buffer .= $token->closingToken?->compile();
                 } else {
-                    $buffer .= $this->compileSlotToken($token, $slots);
+                    $buffer .= $this->compileSlotToken($token);
                 }
 
                 continue;
@@ -222,11 +227,7 @@ final class ViewComponentElement implements Element, WithToken
             }
 
             $buffer .= $this->compileRegularOpeningTag($token);
-            $buffer .= $this->compileSlotTokens(
-                tokens: $token->children,
-                slots: $slots,
-                parentIsComponent: $this->isNestedComponentToken($token),
-            );
+            $buffer .= $this->compileSlotTokens(tokens: $token->children, parentToken: $token);
             $buffer .= $token->closingToken?->compile();
         }
 
@@ -238,8 +239,9 @@ final class ViewComponentElement implements Element, WithToken
         return $token->content . $token->compileAttributes() . $token->endingToken?->compile();
     }
 
-    private function compileSlotToken(Token $slotToken, ImmutableArray $slots): string
+    private function compileSlotToken(Token $slotToken): string
     {
+        $slots = $this->getSlots();
         $name = $this->resolveSlotName($slotToken);
         $slot = $slots[$name] ?? null;
         $default = $slotToken->compileChildren();

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -911,6 +911,23 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         $this->assertSnippetsMatch('<a><b>hi</b></a>', $html);
     }
 
+    public function test_nested_component_slot_forwarding(): void
+    {
+        $this->view->registerViewComponent('x-a', '<aside><x-slot name="left" /></aside><main><x-slot /></main>');
+        $this->view->registerViewComponent('x-b', <<<'HTML'
+        <x-a>
+            <x-slot name="left">left</x-slot>
+            <x-slot/>
+        </x-a>
+        HTML);
+
+        $html = $this->view->render(<<<'HTML'
+        <x-b>main</x-b>
+        HTML);
+
+        $this->assertSnippetsMatch('<aside>left</aside><main>main</main>', $html);
+    }
+
     public function test_nested_slots_with_escaping(): void
     {
         $this->view->registerViewComponent('x-a', '<a><x-slot /></a>');
@@ -1213,5 +1230,45 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         HTML);
 
         $this->assertSnippetsMatch('<div class="a"><div><div class="b">/</div>"></div></div>">', $html);
+    }
+
+    public function test_nested_slot_rendering()
+    {
+        $this->view->registerViewComponent('x-a', <<<'HTML'
+        <div>
+            <div class="left">
+                <x-slot name="left"/>
+            </div>
+        
+            <div class="main">
+                <x-slot/>
+            </div>
+        </div>
+        HTML);
+
+        $this->view->registerViewComponent('x-b', <<<'HTML'
+        <x-a>
+            <x-slot name="left">
+                left
+            </x-slot>
+            
+            <x-slot/>
+        </x-a>
+        HTML);
+
+        $html = $this->view->render(<<<'HTML'
+        <x-b>
+            main
+        </x-b>
+        HTML);
+
+        $expected = <<<'HTML'
+        <div>
+            <div class="left">left</div>
+            <div class="main">main</div>
+        </div>
+        HTML;
+
+        $this->assertSnippetsMatch($expected, $html);
     }
 }

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -1239,7 +1239,7 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
             <div class="left">
                 <x-slot name="left"/>
             </div>
-        
+
             <div class="main">
                 <x-slot/>
             </div>

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -1232,7 +1232,7 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         $this->assertSnippetsMatch('<div class="a"><div><div class="b">/</div>"></div></div>">', $html);
     }
 
-    public function test_nested_slot_rendering()
+    public function test_nested_slot_rendering(): void
     {
         $this->view->registerViewComponent('x-a', <<<'HTML'
         <div>


### PR DESCRIPTION
This PR moves from regex based slot rendering to to AST, and then does some cleanup so that we can combine two AST-parse steps into one.

Because of AST-based slot rendering, we can now detect wether a named slot lives inside a component, thus meaning it's a named slot for that component and should be compiled differently. This closes #2071