### PR TITLE
fix(discovery): discover packages using `tempest/discovery`

### DIFF
--- a/packages/discovery/src/AutoloadDiscoveryLocations.php
+++ b/packages/discovery/src/AutoloadDiscoveryLocations.php
@@ -101,7 +101,7 @@ final readonly class AutoloadDiscoveryLocations
             }
 
             $packagePath = normalize($composerPath, $package['install-path'] ?? '');
-            $requiresTempest = isset($package['require']['tempest/framework']) || isset($package['require']['tempest/core']);
+            $requiresTempest = isset($package['require']['tempest/discovery']) || isset($package['require']['tempest/framework']) || isset($package['require']['tempest/core']);
             $hasPsr4Namespaces = isset($package['autoload']['psr-4']);
 
             if (! ($requiresTempest && $hasPsr4Namespaces)) {


### PR DESCRIPTION
I believe detecting `tempest/discovery` is needed to detect all packages relying on Discovery outside of the Tempest ecosystem