### PR TITLE
feat(discovery): support containers with autowiring

### DIFF
--- a/packages/discovery/src/BootDiscovery.php
+++ b/packages/discovery/src/BootDiscovery.php
@@ -8,7 +8,7 @@ use AssertionError;
 use Closure;
 use Pest\Exceptions\InvalidPestCommand;
 use Psr\Container\ContainerInterface;
-use Tempest\Container\GenericContainer;
+use Psr\Container\NotFoundExceptionInterface;
 use Tempest\Reflection\ClassReflector;
 use Tempest\Support\Filesystem;
 use Throwable;
@@ -260,16 +260,17 @@ final class BootDiscovery
     /**
      * Create a discovery instance from a class name.
      * Optionally set the cached discovery items whenever caching is enabled.
+     *
      * @template T of Discovery
      * @param class-string<T> $discoveryClass
      * @return T
      */
     private function resolveDiscovery(string $discoveryClass): Discovery
     {
-        if ($this->container instanceof GenericContainer || $this->container->has($discoveryClass)) {
+        try {
             /** @var Discovery $discovery */
             $discovery = $this->container->get($discoveryClass);
-        } else {
+        } catch (NotFoundExceptionInterface) {
             /** @var Discovery $discovery */
             $discovery = new $discoveryClass();
         }

--- a/packages/discovery/src/BootDiscovery.php
+++ b/packages/discovery/src/BootDiscovery.php
@@ -269,17 +269,19 @@ final class BootDiscovery
      */
     private function resolveDiscovery(string $discoveryClass): Discovery
     {
+        $discovery = null;
+
         try {
             /** @var Discovery $discovery */
             $discovery = $this->container->get($discoveryClass);
         } catch (NotFoundExceptionInterface) {
+            // @mago-expect lint:no-empty-catch-clause
         }
 
-        if (! $discovery instanceof Discovery) {
+        if ($discovery === null) {
             try {
-                /** @var Discovery $discovery */
                 $discovery = new $discoveryClass();
-            } catch (ArgumentCountError) {
+            } catch (ArgumentCountError) { // @phpstan-ignore catch.neverThrown
                 throw DiscoveryClassCouldNotBeResolved::forDiscoveryClass($discoveryClass);
             }
         }

--- a/packages/discovery/src/BootDiscovery.php
+++ b/packages/discovery/src/BootDiscovery.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Tempest\Discovery;
 
+use ArgumentCountError;
 use AssertionError;
 use Closure;
 use Pest\Exceptions\InvalidPestCommand;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Tempest\Discovery\Exceptions\DiscoveryClassCouldNotBeResolved;
 use Tempest\Reflection\ClassReflector;
 use Tempest\Support\Filesystem;
 use Throwable;
@@ -271,8 +273,15 @@ final class BootDiscovery
             /** @var Discovery $discovery */
             $discovery = $this->container->get($discoveryClass);
         } catch (NotFoundExceptionInterface) {
-            /** @var Discovery $discovery */
-            $discovery = new $discoveryClass();
+        }
+
+        if (! $discovery instanceof Discovery) {
+            try {
+                /** @var Discovery $discovery */
+                $discovery = new $discoveryClass();
+            } catch (ArgumentCountError) {
+                throw DiscoveryClassCouldNotBeResolved::forDiscoveryClass($discoveryClass);
+            }
         }
 
         $discovery->setItems(new DiscoveryItems());

--- a/packages/discovery/src/Exceptions/DiscoveryClassCouldNotBeResolved.php
+++ b/packages/discovery/src/Exceptions/DiscoveryClassCouldNotBeResolved.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tempest\Discovery\Exceptions;
+
+use Exception;
+
+final class DiscoveryClassCouldNotBeResolved extends Exception implements DiscoveryException
+{
+    public static function forDiscoveryClass(string $discoveryClass): self
+    {
+        return new self("Failed to resolve discovery class [{$discoveryClass}]: it is not bound in the container and cannot be instantiated without constructor arguments.");
+    }
+}

--- a/packages/discovery/src/Exceptions/DiscoveryException.php
+++ b/packages/discovery/src/Exceptions/DiscoveryException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tempest\Discovery\Exceptions;
+
+interface DiscoveryException {}


### PR DESCRIPTION
This pull request updates `BootDiscovery` so it doesn't assume every container except Tempest's do not support autowiring.

The previous behavior was to check the container instance, verify if it was a Tempest container _or_ if that the container knew about the discovery class. If that was the case, it would resolve the class using the container, and otherwise it would create an instance manually.

However, other containers may support autowiring as well, so instead, I updated the behavior to first try resolving the class from the container, and if it failed with a `Psr\Container\NotFoundExceptionInterface`, only then try to create an instance manually. If the class required arguments and could not be instantiated, a nice error is thrown.