### PR TITLE
perf(discovery): support caching discovery in one build pass

### DIFF
--- a/packages/discovery/src/BootDiscovery.php
+++ b/packages/discovery/src/BootDiscovery.php
@@ -28,16 +28,18 @@ final class BootDiscovery
     /**
      * @param class-string<Discovery>[]|null $discoveryClasses
      * @param DiscoveryLocation[]|null $discoveryLocations
+     *
+     * @return Discovery[]
      */
-    public function __invoke(
-        ?array $discoveryClasses = null,
-        ?array $discoveryLocations = null,
-    ): void {
+    public function __invoke(?array $discoveryClasses = null, ?array $discoveryLocations = null): array
+    {
         $discoveries = $this->build($discoveryClasses, $discoveryLocations);
 
         foreach ($discoveries as $discovery) {
             $this->applyDiscovery($discovery);
         }
+
+        return $discoveries;
     }
 
     /**
@@ -45,10 +47,8 @@ final class BootDiscovery
      * @param DiscoveryLocation[]|null $discoveryLocations
      * @return Discovery[]
      */
-    public function build(
-        ?array $discoveryClasses = null,
-        ?array $discoveryLocations = null,
-    ): array {
+    public function build(?array $discoveryClasses = null, ?array $discoveryLocations = null): array
+    {
         $discoveryLocations ??= $this->config->locations;
 
         if ($discoveryClasses === null) {

--- a/packages/discovery/src/GenerateDiscoveryCache.php
+++ b/packages/discovery/src/GenerateDiscoveryCache.php
@@ -9,6 +9,7 @@ final class GenerateDiscoveryCache
     /**
      * @param class-string<Discovery>[]|null $discoveryClasses
      * @param DiscoveryLocation[]|null $discoveryLocations
+     * @param Discovery[]|null $discoveries
      */
     public function __invoke(
         ContainerInterface $container,
@@ -16,17 +17,16 @@ final class GenerateDiscoveryCache
         DiscoveryCache $cache,
         ?array $discoveryClasses = null,
         ?array $discoveryLocations = null,
+        ?array $discoveries = null,
     ): void {
         $originalStrategy = $cache->strategy;
         $cache = $cache->withStrategy(DiscoveryCacheStrategy::NONE);
 
-        $bootDiscovery = new BootDiscovery(
+        $discoveries ??= new BootDiscovery(
             container: $container,
             config: $config,
             cache: $cache,
-        );
-
-        $discoveries = $bootDiscovery->build($discoveryClasses, $discoveryLocations);
+        )->build($discoveryClasses, $discoveryLocations);
 
         foreach ($config->locations as $location) {
             $cache->store($location, $discoveries);


### PR DESCRIPTION
This pull request adds support for caching Discovery with only one `build` pass.

It's not a big deal that this is not the case, because we don't care about `discovery:generate` performance, however since it does load the files it go through, some files can be loaded twice during the lifespan of the application, and that may cause issues (such as with files declaring functions without verifying if they exist before).

So this work by allowing `(new BootDiscovery)()` to return the list of discoveries, and allowing `(new GenerateDiscoveryCache)()` to receive a list of discoveries, in which case it skips building it again.