### PR TITLE
feat(database)!: allow setting char size

### DIFF
--- a/packages/database/src/QueryStatements/CharStatement.php
+++ b/packages/database/src/QueryStatements/CharStatement.php
@@ -11,6 +11,7 @@ final readonly class CharStatement implements QueryStatement
 {
     public function __construct(
         private string $name,
+        private int $size,
         private bool $nullable = false,
         private ?string $default = null,
     ) {}
@@ -18,8 +19,9 @@ final readonly class CharStatement implements QueryStatement
     public function compile(DatabaseDialect $dialect): string
     {
         return sprintf(
-            '%s CHAR %s %s',
+            '%s CHAR(%s) %s %s',
             $dialect->quoteIdentifier($this->name),
+            $this->size,
             $this->default !== null ? "DEFAULT '{$this->default}'" : '',
             $this->nullable ? '' : 'NOT NULL',
         );

--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -186,7 +186,7 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
     /**
      * Adds a `CHAR` column to the table.
      */
-    public function char(string $name, int $size, bool $nullable = false, ?string $default = null): self
+    public function char(string $name, bool $nullable = false, ?string $default = null, int $size = 1): self
     {
         $this->statements[] = new CharStatement(
             name: $name,

--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -186,10 +186,11 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
     /**
      * Adds a `CHAR` column to the table.
      */
-    public function char(string $name, bool $nullable = false, ?string $default = null): self
+    public function char(string $name, int $size, bool $nullable = false, ?string $default = null): self
     {
         $this->statements[] = new CharStatement(
             name: $name,
+            size: $size,
             nullable: $nullable,
             default: $default,
         );

--- a/packages/database/tests/QueryStatements/CharStatementTest.php
+++ b/packages/database/tests/QueryStatements/CharStatementTest.php
@@ -20,7 +20,9 @@ final class CharStatementTest extends TestCase
         );
 
         $expectedMysql = '`foo` CHAR(36) DEFAULT \'019d38a9-5504-7a16-ab9d-520bbc289ecc\' NOT NULL';
+        $expectedPgsql = '"foo" CHAR(36) DEFAULT \'019d38a9-5504-7a16-ab9d-520bbc289ecc\' NOT NULL';
 
         $this->assertSame($expectedMysql, $statement->compile(DatabaseDialect::MYSQL));
+        $this->assertSame($expectedMysql, $statement->compile(DatabaseDialect::POSTGRESQL));
     }
 }

--- a/packages/database/tests/QueryStatements/CharStatementTest.php
+++ b/packages/database/tests/QueryStatements/CharStatementTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tempest\Database\Tests\QueryStatements;
+
+use PHPUnit\Framework\TestCase;
+use Tempest\Database\Builder\FieldDefinition;
+use Tempest\Database\Builder\TableDefinition;
+use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\QueryStatements\CharStatement;
+use Tempest\Database\QueryStatements\GroupByStatement;
+use Tempest\Database\QueryStatements\HavingStatement;
+use Tempest\Database\QueryStatements\JoinStatement;
+use Tempest\Database\QueryStatements\OrderByStatement;
+use Tempest\Database\QueryStatements\SelectStatement;
+use Tempest\Database\QueryStatements\WhereStatement;
+
+use function Tempest\Support\arr;
+
+final class CharStatementTest extends TestCase
+{
+    public function test_char(): void
+    {
+        $statement = new CharStatement(
+            name: 'foo',
+            size: 36,
+            nullable: false,
+            default: '019d38a9-5504-7a16-ab9d-520bbc289ecc',
+        );
+
+        $expectedMysql = '`foo` CHAR(36) DEFAULT \'019d38a9-5504-7a16-ab9d-520bbc289ecc\' NOT NULL';
+
+        $this->assertSame($expectedMysql, $statement->compile(DatabaseDialect::MYSQL));
+    }
+}

--- a/packages/database/tests/QueryStatements/CharStatementTest.php
+++ b/packages/database/tests/QueryStatements/CharStatementTest.php
@@ -23,6 +23,6 @@ final class CharStatementTest extends TestCase
         $expectedPgsql = '"foo" CHAR(36) DEFAULT \'019d38a9-5504-7a16-ab9d-520bbc289ecc\' NOT NULL';
 
         $this->assertSame($expectedMysql, $statement->compile(DatabaseDialect::MYSQL));
-        $this->assertSame($expectedMysql, $statement->compile(DatabaseDialect::POSTGRESQL));
+        $this->assertSame($expectedPgsql, $statement->compile(DatabaseDialect::POSTGRESQL));
     }
 }

--- a/packages/database/tests/QueryStatements/CharStatementTest.php
+++ b/packages/database/tests/QueryStatements/CharStatementTest.php
@@ -2,22 +2,14 @@
 
 namespace Tempest\Database\Tests\QueryStatements;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Tempest\Database\Builder\FieldDefinition;
-use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\Config\DatabaseDialect;
 use Tempest\Database\QueryStatements\CharStatement;
-use Tempest\Database\QueryStatements\GroupByStatement;
-use Tempest\Database\QueryStatements\HavingStatement;
-use Tempest\Database\QueryStatements\JoinStatement;
-use Tempest\Database\QueryStatements\OrderByStatement;
-use Tempest\Database\QueryStatements\SelectStatement;
-use Tempest\Database\QueryStatements\WhereStatement;
-
-use function Tempest\Support\arr;
 
 final class CharStatementTest extends TestCase
 {
+    #[Test]
     public function test_char(): void
     {
         $statement = new CharStatement(

--- a/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
@@ -34,7 +34,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
             {
                 return new CreateTableStatement('test_table')
                     ->text('text', default: 'default')
-                    ->char('char', default: 'd')
+                    ->char('char', 7, default: 'default')
                     ->varchar('varchar', default: 'default')
                     ->float('float', default: 0.1)
                     ->integer('integer', default: 1)

--- a/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/CreateTableStatementTest.php
@@ -34,7 +34,7 @@ final class CreateTableStatementTest extends FrameworkIntegrationTestCase
             {
                 return new CreateTableStatement('test_table')
                     ->text('text', default: 'default')
-                    ->char('char', 7, default: 'default')
+                    ->char('char', default: 'default', size: 7)
                     ->varchar('varchar', default: 'default')
                     ->float('float', default: 0.1)
                     ->integer('integer', default: 1)


### PR DESCRIPTION
Until now it was not possible to set a specific CHAR size inside the migration: 

```php
->char('uuid')
```

With this PR, users are now forced to set a CHAR size: 

```php
->char('uuid', 36)
```

As Postgres and MySQL consider the previous `foo CHAR` as `foo CHAR(1)`, this seems to be a breaking change. So maybe changing `private int $size = 1` would be better? 

Postgres: 
> If character (or char) lacks a specifier, it is equivalent to character(1)
(https://www.postgresql.org/docs/current/datatype-character.html)

MySQL: 
> If M is omitted, the length is 1
(https://dev.mysql.com/doc/refman/8.0/en/string-type-syntax.html)

