### PR TITLE
fix(intl): handle snake case when singularizing/pluralizing last words

### DIFF
--- a/packages/intl/src/Pluralizer/InflectorPluralizer.php
+++ b/packages/intl/src/Pluralizer/InflectorPluralizer.php
@@ -9,6 +9,8 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Stringable;
 
+use function Tempest\Support\str;
+
 final class InflectorPluralizer implements Pluralizer
 {
     private Inflector $inflector;
@@ -39,20 +41,66 @@ final class InflectorPluralizer implements Pluralizer
 
     public function singularizeLastWord(Stringable|string $value): string
     {
-        $string = (string) $value;
-        $parts = preg_split('/(.)(?=[A-Z])/u', $string, flags: PREG_SPLIT_DELIM_CAPTURE);
-        $lastWord = array_pop($parts);
+        $lastWord = $this->extractLastWord(value: (string) $value, prefix: $prefix, suffix: $suffix);
 
-        return implode('', $parts) . $this->singularize($lastWord);
+        if ($lastWord === null) {
+            return $suffix;
+        }
+
+        return $prefix . $this->singularize(value: $lastWord) . $suffix;
     }
 
     public function pluralizeLastWord(Stringable|string $value, int|array|Countable $count = 2): string
     {
-        $string = (string) $value;
-        $parts = preg_split('/(.)(?=[A-Z])/u', $string, flags: PREG_SPLIT_DELIM_CAPTURE);
-        $lastWord = array_pop($parts);
+        $lastWord = $this->extractLastWord(value: (string) $value, prefix: $prefix, suffix: $suffix);
 
-        return implode('', $parts) . $this->pluralize($lastWord, $count);
+        if ($lastWord === null) {
+            return $suffix;
+        }
+
+        return $prefix . $this->pluralize(value: $lastWord, count: $count) . $suffix;
+    }
+
+    private function extractLastWord(string $value, ?string &$prefix = null, ?string &$suffix = null): ?string
+    {
+        $parts = $this->splitWords(value: $value);
+
+        $last = end(array: $parts);
+        $suffix = $last !== false && str(string: $last)->trim(characters: '_')->isEmpty()
+            ? array_pop(array: $parts)
+            : '';
+
+        if (count(value: $parts) === 0) {
+            return null;
+        }
+
+        $lastWord = array_pop(array: $parts);
+        $prefix = implode(separator: '', array: $parts);
+
+        return $lastWord;
+    }
+
+    /**
+     * Splits a string into word segments and underscore delimiters.
+     *
+     * The regex splits on five boundary types:
+     *  - (_+)(?=[a-zA-Z0-9])       — underscore separators followed by a word character (snake_case, SCREAMING_SNAKE)
+     *  - (_+)$                     — trailing underscores at end of string
+     *  - (?<=[a-z0-9])(?=[A-Z])    — lowercase/digit to uppercase transition (camelCase, PascalCase)
+     *  - (?<=[A-Z])(?=[A-Z][a-z])  — end of uppercase run before a new word (HTMLElements → HTML + Elements)
+     *  - (?<=\s)(?=\S)             — whitespace to non-whitespace transition (Multiple Aircraft, small dogs)
+     *
+     * @return list<string>
+     */
+    private function splitWords(string $value): array
+    {
+        return (
+            preg_split(
+                pattern: '/(_+)(?=[a-zA-Z0-9])|(_+)$|(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|(?<=\s)(?=\S)/u',
+                subject: $value,
+                flags: PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY,
+            ) ?: []
+        );
     }
 
     private function matchCase(Stringable|string $value, Stringable|string $comparison): string

--- a/packages/intl/tests/InflectorPluralizerTest.php
+++ b/packages/intl/tests/InflectorPluralizerTest.php
@@ -19,6 +19,9 @@ final class InflectorPluralizerTest extends TestCase
     #[TestWith(['Migration', 'Migrations', 2])]
     #[TestWith(['migration', 'migrations', 2])]
     #[TestWith(['migration', 'migrations', [1, 2]])]
+    #[TestWith(['category', 'categories', 2])]
+    #[TestWith(['status', 'statuses', 2])]
+    #[TestWith(['child', 'children', 2])]
     public function test_that_pluralizer_pluralizes(string $value, string $expected, int|array|Countable $count): void
     {
         $pluralizer = new InflectorPluralizer();
@@ -28,10 +31,71 @@ final class InflectorPluralizerTest extends TestCase
 
     #[TestWith(['Migrations', 'Migration'])]
     #[TestWith(['migrations', 'migration'])]
+    #[TestWith(['categories', 'category'])]
+    #[TestWith(['statuses', 'status'])]
+    #[TestWith(['children', 'child'])]
     public function test_that_pluralizer_singularizes(string $value, string $expected): void
     {
         $pluralizer = new InflectorPluralizer();
 
         $this->assertEquals($expected, $pluralizer->singularize($value));
+    }
+
+    #[TestWith(['bookAuthors', 'bookAuthor'])]
+    #[TestWith(['BookAuthors', 'BookAuthor'])]
+    #[TestWith(['book_authors', 'book_author'])]
+    #[TestWith(['product_metadata', 'product_metadata'])]
+    #[TestWith(['user_book_categories', 'user_book_category'])]
+    #[TestWith(['authors', 'author'])]
+    #[TestWith(['', ''])]
+    #[TestWith(['BOOK_AUTHORS', 'BOOK_AUTHOR'])]
+    #[TestWith(['USER_STATUSES', 'USER_STATUS'])]
+    #[TestWith(['BOOK_CATEGORIES', 'BOOK_CATEGORY'])]
+    #[TestWith(['parseHTMLElements', 'parseHTMLElement'])]
+    #[TestWith(['HTMLElements', 'HTMLElement'])]
+    #[TestWith(['getHTTPSResponses', 'getHTTPSResponse'])]
+    #[TestWith(['_authors', '_author'])]
+    #[TestWith(['authors_', 'author_'])]
+    #[TestWith(['authors__', 'author__'])]
+    #[TestWith(['book__authors', 'book__author'])]
+    #[TestWith(['_', '_'])]
+    #[TestWith(['__', '__'])]
+    #[TestWith(['Multiple Aircraft', 'Multiple Aircraft'])]
+    #[TestWith(['multiple aircraft', 'multiple aircraft'])]
+    #[TestWith(['small dogs', 'small dog'])]
+    public function test_singularize_last_word(string $value, string $expected): void
+    {
+        $pluralizer = new InflectorPluralizer();
+
+        $this->assertEquals($expected, $pluralizer->singularizeLastWord($value));
+    }
+
+    #[TestWith(['bookAuthor', 'bookAuthors'])]
+    #[TestWith(['BookAuthor', 'BookAuthors'])]
+    #[TestWith(['book_author', 'book_authors'])]
+    #[TestWith(['product_metadata', 'product_metadata'])]
+    #[TestWith(['user_book_category', 'user_book_categories'])]
+    #[TestWith(['author', 'authors'])]
+    #[TestWith(['', ''])]
+    #[TestWith(['BOOK_AUTHOR', 'BOOK_AUTHORS'])]
+    #[TestWith(['USER_STATUS', 'USER_STATUSES'])]
+    #[TestWith(['BOOK_CATEGORY', 'BOOK_CATEGORIES'])]
+    #[TestWith(['parseHTMLElement', 'parseHTMLElements'])]
+    #[TestWith(['HTMLElement', 'HTMLElements'])]
+    #[TestWith(['getHTTPSResponse', 'getHTTPSResponses'])]
+    #[TestWith(['_author', '_authors'])]
+    #[TestWith(['author_', 'authors_'])]
+    #[TestWith(['author__', 'authors__'])]
+    #[TestWith(['book__author', 'book__authors'])]
+    #[TestWith(['_', '_'])]
+    #[TestWith(['__', '__'])]
+    #[TestWith(['Multiple Aircraft', 'Multiple Aircraft'])]
+    #[TestWith(['multiple aircraft', 'multiple aircraft'])]
+    #[TestWith(['small dog', 'small dogs'])]
+    public function test_pluralize_last_word(string $value, string $expected): void
+    {
+        $pluralizer = new InflectorPluralizer();
+
+        $this->assertEquals($expected, $pluralizer->pluralizeLastWord($value));
     }
 }


### PR DESCRIPTION
first half fix for #2086 

made regex more robust to handle things like
some__sentence
someSENTENCE
someSentence__