### PR TITLE
fix(core): properly check paths during config loading on Windows

### DIFF
--- a/packages/core/src/Kernel/LoadConfig.php
+++ b/packages/core/src/Kernel/LoadConfig.php
@@ -69,7 +69,7 @@ final readonly class LoadConfig
             })
             ->sortByCallback(function (string $path1, string $path2) use ($suffixes): int {
                 $getPriority = fn (string $path): int => match (true) {
-                    Str\contains($path, DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR) => 0,
+                    Str\contains($path, '/vendor/') => 0,
                     ! Str\contains($path, root_path()) => 0,
                     Str\contains($path, $suffixes['testing']) => 6,
                     Str\contains($path, $suffixes['development']) => 5,


### PR DESCRIPTION
PR #1535 changed the vendor path check from `/vendor/` to `DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR` to fix Windows discovery.

Later, PR #1954 added `Path\normalize` to `scan()`, which converts all paths to forward slashes. This made the `DIRECTORY_SEPARATOR` check never match on Windows (it looks for `\vendor\` in forward-slash paths), so vendor configs get the same priority as user configs and overwrite them via `strcmp` ordering.

Fixes #1982.