### PR TITLE
fix(database): convert backtick identifiers to double quotes for postgres

### DIFF
--- a/packages/database/src/Config/DatabaseDialect.php
+++ b/packages/database/src/Config/DatabaseDialect.php
@@ -21,6 +21,14 @@ enum DatabaseDialect: string
         };
     }
 
+    public function quoteIdentifier(string $identifier): string
+    {
+        return match ($this) {
+            self::MYSQL, self::SQLITE => sprintf('`%s`', $identifier),
+            self::POSTGRESQL => sprintf('"%s"', $identifier),
+        };
+    }
+
     public function isTableNotFoundError(QueryWasInvalid $queryWasInvalid): bool
     {
         $pdoException = $queryWasInvalid->pdoException;

--- a/packages/database/src/Query.php
+++ b/packages/database/src/Query.php
@@ -76,7 +76,7 @@ final class Query
         }
 
         if ($dialect === DatabaseDialect::POSTGRESQL) {
-            $sql = str_replace('`', '', $sql);
+            $sql = str_replace('`', '"', $sql);
         }
 
         return new ImmutableString($sql);

--- a/packages/database/src/QueryStatements/AlterTableStatement.php
+++ b/packages/database/src/QueryStatements/AlterTableStatement.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tempest\Database\QueryStatements;
 
-use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\Config\DatabaseDialect;
 use Tempest\Database\HasTrailingStatements;
 use Tempest\Database\QueryStatement;
@@ -92,7 +91,7 @@ final class AlterTableStatement implements QueryStatement, HasTrailingStatements
         if ($this->statements !== []) {
             return sprintf(
                 'ALTER TABLE %s %s;',
-                new TableDefinition($this->tableName),
+                $dialect->quoteIdentifier($this->tableName),
                 arr($this->statements)
                     ->map(fn (QueryStatement $queryStatement) => str($queryStatement->compile($dialect))->trim()->replace('  ', ' '))
                     ->filter(fn (ImmutableString $line) => $line->isNotEmpty())

--- a/packages/database/src/QueryStatements/BooleanStatement.php
+++ b/packages/database/src/QueryStatements/BooleanStatement.php
@@ -27,8 +27,8 @@ final readonly class BooleanStatement implements QueryStatement
         }
 
         return sprintf(
-            '`%s` BOOLEAN %s %s',
-            $this->name,
+            '%s BOOLEAN %s %s',
+            $dialect->quoteIdentifier($this->name),
             $default !== null ? "DEFAULT {$default}" : '',
             $this->nullable ? '' : 'NOT NULL',
         );

--- a/packages/database/src/QueryStatements/CharStatement.php
+++ b/packages/database/src/QueryStatements/CharStatement.php
@@ -18,8 +18,8 @@ final readonly class CharStatement implements QueryStatement
     public function compile(DatabaseDialect $dialect): string
     {
         return sprintf(
-            '`%s` CHAR %s %s',
-            $this->name,
+            '%s CHAR %s %s',
+            $dialect->quoteIdentifier($this->name),
             $this->default !== null ? "DEFAULT '{$this->default}'" : '',
             $this->nullable ? '' : 'NOT NULL',
         );

--- a/packages/database/src/QueryStatements/CountStatement.php
+++ b/packages/database/src/QueryStatements/CountStatement.php
@@ -33,7 +33,7 @@ final class CountStatement implements QueryStatement, HasWhereStatements
 
         $query = arr([
             sprintf('SELECT %s', $countField->compile($dialect)),
-            sprintf('FROM `%s`', $this->table->name),
+            sprintf('FROM %s', $dialect->quoteIdentifier($this->table->name)),
         ]);
 
         if ($this->joins->isNotEmpty()) {

--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tempest\Database\QueryStatements;
 
 use BackedEnum;
-use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\Config\DatabaseDialect;
 use Tempest\Database\Enums\DatabaseTextLength;
 use Tempest\Database\HasTrailingStatements;
@@ -400,7 +399,7 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
     {
         return sprintf(
             'CREATE TABLE %s (%s);',
-            new TableDefinition($this->tableName),
+            $dialect->quoteIdentifier($this->tableName),
             arr($this->statements)
                 // Remove BelongsTo for sqlLite as it does not support those queries
                 ->filter(fn (QueryStatement $queryStatement) => ! ($dialect === DatabaseDialect::SQLITE && $queryStatement instanceof BelongsToStatement))

--- a/packages/database/src/QueryStatements/DateStatement.php
+++ b/packages/database/src/QueryStatements/DateStatement.php
@@ -18,8 +18,8 @@ final readonly class DateStatement implements QueryStatement
     public function compile(DatabaseDialect $dialect): string
     {
         return sprintf(
-            '`%s` DATE %s %s',
-            $this->name,
+            '%s DATE %s %s',
+            $dialect->quoteIdentifier($this->name),
             $this->default !== null ? "DEFAULT '{$this->default}'" : '',
             $this->nullable ? '' : 'NOT NULL',
         );

--- a/packages/database/src/QueryStatements/DatetimeStatement.php
+++ b/packages/database/src/QueryStatements/DatetimeStatement.php
@@ -29,16 +29,18 @@ final readonly class DatetimeStatement implements QueryStatement
             default => null,
         };
 
+        $name = $dialect->quoteIdentifier($this->name);
+
         return match ($dialect) {
             DatabaseDialect::POSTGRESQL => sprintf(
-                '`%s` TIMESTAMP %s %s',
-                $this->name,
+                '%s TIMESTAMP %s %s',
+                $name,
                 $default !== null ? "DEFAULT {$default}" : '',
                 $this->nullable ? '' : 'NOT NULL',
             ),
             default => sprintf(
-                '`%s` DATETIME %s %s',
-                $this->name,
+                '%s DATETIME %s %s',
+                $name,
                 $default !== null ? "DEFAULT {$default}" : '',
                 $this->nullable ? '' : 'NOT NULL',
             ),

--- a/packages/database/src/QueryStatements/DeleteStatement.php
+++ b/packages/database/src/QueryStatements/DeleteStatement.php
@@ -25,7 +25,7 @@ final class DeleteStatement implements QueryStatement, HasWhereStatements
         }
 
         $query = arr([
-            sprintf('DELETE FROM `%s`', $this->table->name),
+            sprintf('DELETE FROM %s', $dialect->quoteIdentifier($this->table->name)),
         ]);
 
         if ($this->where->isNotEmpty()) {

--- a/packages/database/src/QueryStatements/DropConstraintStatement.php
+++ b/packages/database/src/QueryStatements/DropConstraintStatement.php
@@ -26,8 +26,8 @@ final readonly class DropConstraintStatement implements QueryStatement
 
         return match ($dialect) {
             DatabaseDialect::MYSQL => sprintf(
-                'ALTER TABLE `%s` DROP CONSTRAINT %s',
-                $foreignTable,
+                'ALTER TABLE %s DROP CONSTRAINT %s',
+                $dialect->quoteIdentifier($foreignTable),
                 $constraintName,
             ),
             default => '',

--- a/packages/database/src/QueryStatements/DropTableStatement.php
+++ b/packages/database/src/QueryStatements/DropTableStatement.php
@@ -36,8 +36,8 @@ final class DropTableStatement implements QueryStatement, HasLeadingStatements
     public function compile(DatabaseDialect $dialect): string
     {
         return match ($dialect) {
-            DatabaseDialect::POSTGRESQL => sprintf('DROP TABLE IF EXISTS `%s` CASCADE', $this->tableName),
-            default => sprintf('DROP TABLE IF EXISTS `%s`', $this->tableName),
+            DatabaseDialect::POSTGRESQL => sprintf('DROP TABLE IF EXISTS %s CASCADE', $dialect->quoteIdentifier($this->tableName)),
+            default => sprintf('DROP TABLE IF EXISTS %s', $dialect->quoteIdentifier($this->tableName)),
         };
     }
 }

--- a/packages/database/src/QueryStatements/EnumStatement.php
+++ b/packages/database/src/QueryStatements/EnumStatement.php
@@ -35,23 +35,25 @@ final readonly class EnumStatement implements QueryStatement
             $defaultValue = null;
         }
 
+        $name = $dialect->quoteIdentifier($this->name);
+
         return match ($dialect) {
             DatabaseDialect::MYSQL => sprintf(
-                '`%s` ENUM(%s) %s %s',
-                $this->name,
+                '%s ENUM(%s) %s %s',
+                $name,
                 $cases->implode(', '),
                 $defaultValue !== null ? "DEFAULT '{$defaultValue}'" : '',
                 $this->nullable ? '' : 'NOT NULL',
             ),
             DatabaseDialect::SQLITE => sprintf(
-                '`%s` TEXT %s %s',
-                $this->name,
+                '%s TEXT %s %s',
+                $name,
                 $defaultValue !== null ? "DEFAULT '{$defaultValue}'" : '',
                 $this->nullable ? '' : 'NOT NULL',
             ),
             DatabaseDialect::POSTGRESQL => sprintf(
-                '"%s" "%s" %s %s',
-                $this->name,
+                '%s "%s" %s %s',
+                $name,
                 str($this->enumClass)->replace('\\\\', '_'),
                 $defaultValue !== null ? "DEFAULT ('{$defaultValue}')" : '',
                 $this->nullable ? '' : 'NOT NULL',

--- a/packages/database/src/QueryStatements/FieldStatement.php
+++ b/packages/database/src/QueryStatements/FieldStatement.php
@@ -29,27 +29,18 @@ final class FieldStatement implements QueryStatement
             $aliasPrefix = $this->aliasPrefix ? "{$this->aliasPrefix}." : '';
 
             if ($this->alias === true) {
-                $alias = sprintf(
-                    '`%s%s`',
-                    $aliasPrefix,
-                    str_replace('`', '', $field),
-                );
+                $alias = $aliasPrefix . str_replace('`', '', $field);
             } elseif ($this->alias) {
-                $alias = sprintf(
-                    '`%s%s`',
-                    $aliasPrefix,
-                    $this->alias,
-                );
+                $alias = $aliasPrefix . $this->alias;
             }
         } else {
-            $alias = $parts[1];
+            $alias = trim($parts[1], '`" ');
         }
 
         $field = arr(explode('.', $field))
-            ->map(fn (string $part) => trim($part, '` '))
+            ->map(fn (string $part) => trim($part, '`" '))
             ->map(
                 function (string $part) use ($dialect) {
-                    // Function calls are never wrapped in backticks.
                     if (str_contains($part, '(')) {
                         return $part;
                     }
@@ -58,7 +49,7 @@ final class FieldStatement implements QueryStatement
                         return $part;
                     }
 
-                    return sprintf('`%s`', $part);
+                    return $dialect->quoteIdentifier($part);
                 },
             )
             ->implode('.');
@@ -67,10 +58,7 @@ final class FieldStatement implements QueryStatement
             return $field;
         }
 
-        return match ($dialect) {
-            DatabaseDialect::POSTGRESQL => sprintf('%s AS "%s"', $field, trim($alias, '`')),
-            default => sprintf('%s AS `%s`', $field, trim($alias, '`')),
-        };
+        return sprintf('%s AS %s', $field, $dialect->quoteIdentifier($alias));
     }
 
     public function withAliasPrefix(?string $prefix = null): self

--- a/packages/database/src/QueryStatements/FloatStatement.php
+++ b/packages/database/src/QueryStatements/FloatStatement.php
@@ -18,8 +18,8 @@ final readonly class FloatStatement implements QueryStatement
     public function compile(DatabaseDialect $dialect): string
     {
         return sprintf(
-            '`%s` FLOAT %s %s',
-            $this->name,
+            '%s FLOAT %s %s',
+            $dialect->quoteIdentifier($this->name),
             $this->default !== null ? "DEFAULT {$this->default}" : '',
             $this->nullable ? '' : 'NOT NULL',
         );

--- a/packages/database/src/QueryStatements/IdentityStatement.php
+++ b/packages/database/src/QueryStatements/IdentityStatement.php
@@ -15,6 +15,6 @@ final readonly class IdentityStatement implements QueryStatement
 
     public function compile(DatabaseDialect $dialect): string
     {
-        return sprintf('`%s`', $this->name);
+        return $dialect->quoteIdentifier($this->name);
     }
 }

--- a/packages/database/src/QueryStatements/IndexStatement.php
+++ b/packages/database/src/QueryStatements/IndexStatement.php
@@ -19,12 +19,15 @@ final readonly class IndexStatement implements QueryStatement
 
     public function compile(DatabaseDialect $dialect): string
     {
-        $columns = arr($this->columns)->implode('`, `')->wrap('`', '`');
+        $columns = arr($this->columns)
+            ->map($dialect->quoteIdentifier(...))
+            ->implode(', ');
 
-        $indexName = str($this->tableName . ' ' . $columns->replace(',', '')->snake())->snake()->toString();
+        $rawColumns = arr($this->columns)->implode('_');
+        $indexName = str($this->tableName . '_' . $rawColumns)->snake()->toString();
 
-        $on = sprintf('`%s` (%s)', $this->tableName, $columns);
+        $on = sprintf('%s (%s)', $dialect->quoteIdentifier($this->tableName), $columns);
 
-        return sprintf('CREATE INDEX `%s` ON %s', $indexName, $on);
+        return sprintf('CREATE INDEX %s ON %s', $dialect->quoteIdentifier($indexName), $on);
     }
 }

--- a/packages/database/src/QueryStatements/InsertStatement.php
+++ b/packages/database/src/QueryStatements/InsertStatement.php
@@ -55,7 +55,7 @@ final class InsertStatement implements QueryStatement
             $sql = sprintf(
                 'INSERT INTO %s (%s) VALUES %s',
                 $this->table,
-                $columns->map(fn (string $column) => "`{$column}`")->implode(', '),
+                $columns->map($dialect->quoteIdentifier(...))->implode(', '),
                 $entryPlaceholders,
             );
         }

--- a/packages/database/src/QueryStatements/IntegerStatement.php
+++ b/packages/database/src/QueryStatements/IntegerStatement.php
@@ -19,17 +19,19 @@ final readonly class IntegerStatement implements QueryStatement
 
     public function compile(DatabaseDialect $dialect): string
     {
+        $name = $dialect->quoteIdentifier($this->name);
+
         return match ($dialect) {
             DatabaseDialect::SQLITE => sprintf(
-                '`%s` INTEGER %s %s %s',
-                $this->name,
+                '%s INTEGER %s %s %s',
+                $name,
                 $this->unsigned ? 'UNSIGNED' : '',
                 $this->default !== null ? "DEFAULT {$this->default}" : '',
                 $this->nullable ? '' : 'NOT NULL',
             ),
             default => sprintf(
-                '`%s` %s %s %s %s',
-                $this->name,
+                '%s %s %s %s %s',
+                $name,
                 is_int($this->size) ? DatabaseIntegerSize::fromBytes($this->size)->toString() : $this->size->toString(),
                 $this->unsigned ? 'UNSIGNED' : '',
                 $this->default !== null ? "DEFAULT {$this->default}" : '',

--- a/packages/database/src/QueryStatements/JsonStatement.php
+++ b/packages/database/src/QueryStatements/JsonStatement.php
@@ -22,21 +22,23 @@ final readonly class JsonStatement implements QueryStatement
             throw new DefaultValueWasInvalid($this->name, $this->default);
         }
 
+        $name = $dialect->quoteIdentifier($this->name);
+
         return match ($dialect) {
             DatabaseDialect::MYSQL => sprintf(
-                '`%s` JSON %s',
-                $this->name,
+                '%s JSON %s',
+                $name,
                 $this->nullable ? '' : 'NOT NULL',
             ),
             DatabaseDialect::SQLITE => sprintf(
-                '`%s` TEXT %s %s',
-                $this->name,
+                '%s TEXT %s %s',
+                $name,
                 $this->default !== null ? "DEFAULT '{$this->default}'" : '',
                 $this->nullable ? '' : 'NOT NULL',
             ),
             DatabaseDialect::POSTGRESQL => sprintf(
-                '`%s` JSONB %s %s',
-                $this->name,
+                '%s JSONB %s %s',
+                $name,
                 $this->default !== null ? "DEFAULT ('{$this->default}')" : '',
                 $this->nullable ? '' : 'NOT NULL',
             ),

--- a/packages/database/src/QueryStatements/PrimaryKeyStatement.php
+++ b/packages/database/src/QueryStatements/PrimaryKeyStatement.php
@@ -15,10 +15,12 @@ final readonly class PrimaryKeyStatement implements QueryStatement
 
     public function compile(DatabaseDialect $dialect): string
     {
+        $name = $dialect->quoteIdentifier($this->name);
+
         return match ($dialect) {
-            DatabaseDialect::MYSQL => sprintf('`%s` INTEGER PRIMARY KEY AUTO_INCREMENT', $this->name),
-            DatabaseDialect::POSTGRESQL => sprintf('`%s` SERIAL PRIMARY KEY', $this->name),
-            DatabaseDialect::SQLITE => sprintf('`%s` INTEGER PRIMARY KEY AUTOINCREMENT', $this->name),
+            DatabaseDialect::MYSQL => "{$name} INTEGER PRIMARY KEY AUTO_INCREMENT",
+            DatabaseDialect::POSTGRESQL => "{$name} SERIAL PRIMARY KEY",
+            DatabaseDialect::SQLITE => "{$name} INTEGER PRIMARY KEY AUTOINCREMENT",
         };
     }
 }

--- a/packages/database/src/QueryStatements/SetStatement.php
+++ b/packages/database/src/QueryStatements/SetStatement.php
@@ -27,8 +27,8 @@ final readonly class SetStatement implements QueryStatement
 
         return match ($dialect) {
             DatabaseDialect::MYSQL => sprintf(
-                '`%s` SET (%s) %s %s',
-                $this->name,
+                '%s SET (%s) %s %s',
+                $dialect->quoteIdentifier($this->name),
                 "'" . implode("', '", $this->values) . "'",
                 $this->default ? "DEFAULT '{$this->default}'" : '',
                 $this->nullable ? '' : 'NOT NULL',

--- a/packages/database/src/QueryStatements/TextStatement.php
+++ b/packages/database/src/QueryStatements/TextStatement.php
@@ -19,16 +19,18 @@ final readonly class TextStatement implements QueryStatement
 
     public function compile(DatabaseDialect $dialect): string
     {
+        $name = $dialect->quoteIdentifier($this->name);
+
         return match ($dialect) {
             DatabaseDialect::MYSQL => sprintf(
-                '`%s` %s %s',
-                $this->name,
+                '%s %s %s',
+                $name,
                 $this->getSQLTypeDeclaration($this->length),
                 $this->nullable ? '' : 'NOT NULL',
             ),
             default => sprintf(
-                '`%s` TEXT %s %s',
-                $this->name,
+                '%s TEXT %s %s',
+                $name,
                 $this->default !== null ? "DEFAULT '{$this->default}'" : '',
                 $this->nullable ? '' : 'NOT NULL',
             ),

--- a/packages/database/src/QueryStatements/UniqueStatement.php
+++ b/packages/database/src/QueryStatements/UniqueStatement.php
@@ -19,12 +19,15 @@ final readonly class UniqueStatement implements QueryStatement
 
     public function compile(DatabaseDialect $dialect): string
     {
-        $columns = arr($this->columns)->implode('`, `')->wrap('`', '`');
+        $columns = arr($this->columns)
+            ->map($dialect->quoteIdentifier(...))
+            ->implode(', ');
 
-        $indexName = str($this->tableName . ' ' . $columns->replace(',', '')->snake())->snake()->toString();
+        $rawColumns = arr($this->columns)->implode('_');
+        $indexName = str($this->tableName . '_' . $rawColumns)->snake()->toString();
 
-        $on = sprintf('`%s` (%s)', $this->tableName, $columns);
+        $on = sprintf('%s (%s)', $dialect->quoteIdentifier($this->tableName), $columns);
 
-        return sprintf('CREATE UNIQUE INDEX `%s` ON %s', $indexName, $on);
+        return sprintf('CREATE UNIQUE INDEX %s ON %s', $dialect->quoteIdentifier($indexName), $on);
     }
 }

--- a/packages/database/src/QueryStatements/UpdateStatement.php
+++ b/packages/database/src/QueryStatements/UpdateStatement.php
@@ -27,7 +27,7 @@ final class UpdateStatement implements QueryStatement, HasWhereStatements
         }
 
         $query = arr([
-            sprintf('UPDATE `%s`', $this->table->name),
+            sprintf('UPDATE %s', $dialect->quoteIdentifier($this->table->name)),
         ]);
 
         if ($this->values->isEmpty()) {
@@ -35,7 +35,7 @@ final class UpdateStatement implements QueryStatement, HasWhereStatements
         }
 
         $query[] = 'SET ' . $this->values
-            ->map(fn (mixed $_, mixed $key) => "`{$key}` = ?")
+            ->map(fn (mixed $_, mixed $key) => $dialect->quoteIdentifier($key) . ' = ?')
             ->implode(', ');
 
         if ($this->where->isNotEmpty()) {

--- a/packages/database/src/QueryStatements/UuidPrimaryKeyStatement.php
+++ b/packages/database/src/QueryStatements/UuidPrimaryKeyStatement.php
@@ -15,10 +15,12 @@ final readonly class UuidPrimaryKeyStatement implements QueryStatement
 
     public function compile(DatabaseDialect $dialect): string
     {
+        $name = $dialect->quoteIdentifier($this->name);
+
         return match ($dialect) {
-            DatabaseDialect::MYSQL => sprintf('`%s` CHAR(36) PRIMARY KEY', $this->name),
-            DatabaseDialect::POSTGRESQL => sprintf('`%s` UUID PRIMARY KEY', $this->name),
-            DatabaseDialect::SQLITE => sprintf('`%s` TEXT PRIMARY KEY', $this->name),
+            DatabaseDialect::MYSQL => "{$name} CHAR(36) PRIMARY KEY",
+            DatabaseDialect::POSTGRESQL => "{$name} UUID PRIMARY KEY",
+            DatabaseDialect::SQLITE => "{$name} TEXT PRIMARY KEY",
         };
     }
 }

--- a/packages/database/src/QueryStatements/VarcharStatement.php
+++ b/packages/database/src/QueryStatements/VarcharStatement.php
@@ -19,8 +19,8 @@ final readonly class VarcharStatement implements QueryStatement
     public function compile(DatabaseDialect $dialect): string
     {
         return sprintf(
-            '`%s` VARCHAR(%s) %s %s',
-            $this->name,
+            '%s VARCHAR(%s) %s %s',
+            $dialect->quoteIdentifier($this->name),
             $this->size,
             $this->default !== null ? "DEFAULT '{$this->default}'" : '',
             $this->nullable ? '' : 'NOT NULL',

--- a/packages/database/tests/QueryCompileTest.php
+++ b/packages/database/tests/QueryCompileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Tempest\Database\Tests;
 
@@ -46,7 +46,7 @@ final class QueryCompileTest extends TestCase
         $container = new GenericContainer();
         $container->singleton(
             className: Database::class,
-            definition: $database
+            definition: $database,
         );
         GenericContainer::setInstance(instance: $container);
     }
@@ -69,7 +69,7 @@ final class QueryCompileTest extends TestCase
         $container = new GenericContainer();
         $container->singleton(
             className: Database::class,
-            definition: $database
+            definition: $database,
         );
         GenericContainer::setInstance(instance: $container);
     }
@@ -92,7 +92,7 @@ final class QueryCompileTest extends TestCase
         $container = new GenericContainer();
         $container->singleton(
             className: Database::class,
-            definition: $database
+            definition: $database,
         );
         GenericContainer::setInstance(instance: $container);
     }
@@ -145,7 +145,7 @@ final class QueryCompileTest extends TestCase
 
         $this->assertSame(
             'SELECT 1',
-            $query->compile()->toString()
+            $query->compile()->toString(),
         );
     }
 

--- a/packages/database/tests/QueryCompileTest.php
+++ b/packages/database/tests/QueryCompileTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tempest\Database\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Container\GenericContainer;
+use Tempest\Database\Config\MysqlConfig;
+use Tempest\Database\Config\PostgresConfig;
+use Tempest\Database\Config\SQLiteConfig;
+use Tempest\Database\Connection\PDOConnection;
+use Tempest\Database\Database;
+use Tempest\Database\GenericDatabase;
+use Tempest\Database\Query;
+use Tempest\Database\Transactions\GenericTransactionManager;
+use Tempest\EventBus\EventBusConfig;
+use Tempest\EventBus\GenericEventBus;
+use Tempest\Mapper\SerializerFactory;
+
+final class QueryCompileTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        GenericContainer::setInstance(instance: null);
+
+        parent::tearDown();
+    }
+
+    private function createDatabaseWithMysqlDialect(): void
+    {
+        $config = new MysqlConfig();
+        $connection = new PDOConnection(config: $config);
+
+        $database = new GenericDatabase(
+            connection: $connection,
+            transactionManager: new GenericTransactionManager(connection: $connection),
+            serializerFactory: new SerializerFactory(container: new GenericContainer()),
+            eventBus: new GenericEventBus(
+                container: new GenericContainer(),
+                eventBusConfig: new EventBusConfig(),
+            ),
+        );
+
+        $container = new GenericContainer();
+        $container->singleton(
+            className: Database::class,
+            definition: $database
+        );
+        GenericContainer::setInstance(instance: $container);
+    }
+
+    private function createDatabaseWithPostgresDialect(): void
+    {
+        $config = new PostgresConfig();
+        $connection = new PDOConnection(config: $config);
+
+        $database = new GenericDatabase(
+            connection: $connection,
+            transactionManager: new GenericTransactionManager(connection: $connection),
+            serializerFactory: new SerializerFactory(container: new GenericContainer()),
+            eventBus: new GenericEventBus(
+                container: new GenericContainer(),
+                eventBusConfig: new EventBusConfig(),
+            ),
+        );
+
+        $container = new GenericContainer();
+        $container->singleton(
+            className: Database::class,
+            definition: $database
+        );
+        GenericContainer::setInstance(instance: $container);
+    }
+
+    private function createDatabaseWithSqliteDialect(): void
+    {
+        $config = new SQLiteConfig(path: ':memory:');
+        $connection = new PDOConnection(config: $config);
+
+        $database = new GenericDatabase(
+            connection: $connection,
+            transactionManager: new GenericTransactionManager(connection: $connection),
+            serializerFactory: new SerializerFactory(container: new GenericContainer()),
+            eventBus: new GenericEventBus(
+                container: new GenericContainer(),
+                eventBusConfig: new EventBusConfig(),
+            ),
+        );
+
+        $container = new GenericContainer();
+        $container->singleton(
+            className: Database::class,
+            definition: $database
+        );
+        GenericContainer::setInstance(instance: $container);
+    }
+
+    #[Test]
+    public function postgresql_converts_backticks_to_double_quotes(): void
+    {
+        $this->createDatabaseWithPostgresDialect();
+
+        $query = new Query(sql: 'SELECT `name`, `email` FROM `users` WHERE `id` = ?');
+
+        $this->assertSame(
+            'SELECT "name", "email" FROM "users" WHERE "id" = ?',
+            $query->compile()->toString(),
+        );
+    }
+
+    #[Test]
+    public function postgresql_handles_qualified_identifiers(): void
+    {
+        $this->createDatabaseWithPostgresDialect();
+
+        $query = new Query(sql: 'SELECT `users`.`name` FROM `users`');
+
+        $this->assertSame(
+            'SELECT "users"."name" FROM "users"',
+            $query->compile()->toString(),
+        );
+    }
+
+    #[Test]
+    public function postgresql_handles_reserved_words(): void
+    {
+        $this->createDatabaseWithPostgresDialect();
+
+        $query = new Query(sql: 'SELECT `order`, `user`, `type` FROM `group`');
+
+        $this->assertSame(
+            'SELECT "order", "user", "type" FROM "group"',
+            $query->compile()->toString(),
+        );
+    }
+
+    #[Test]
+    public function postgresql_passes_through_sql_without_backticks(): void
+    {
+        $this->createDatabaseWithPostgresDialect();
+
+        $query = new Query(sql: 'SELECT 1');
+
+        $this->assertSame(
+            'SELECT 1',
+            $query->compile()->toString()
+        );
+    }
+
+    #[Test]
+    public function mysql_retains_backticks(): void
+    {
+        $this->createDatabaseWithMysqlDialect();
+
+        $query = new Query(sql: 'SELECT `name` FROM `users` WHERE `id` = ?');
+
+        $this->assertSame(
+            'SELECT `name` FROM `users` WHERE `id` = ?',
+            $query->compile()->toString(),
+        );
+    }
+
+    #[Test]
+    public function sqlite_retains_backticks(): void
+    {
+        $this->createDatabaseWithSqliteDialect();
+
+        $query = new Query(sql: 'SELECT `name` FROM `users` WHERE `id` = ?');
+
+        $this->assertSame(
+            'SELECT `name` FROM `users` WHERE `id` = ?',
+            $query->compile()->toString(),
+        );
+    }
+}

--- a/packages/database/tests/QueryStatements/AlterTableStatementTest.php
+++ b/packages/database/tests/QueryStatements/AlterTableStatementTest.php
@@ -26,8 +26,16 @@ final class AlterTableStatementTest extends TestCase
             ->index('foo')
             ->unique('bar');
 
-        $this->assertEqualsIgnoringCase('CREATE INDEX `table_foo` ON `table` (`foo`)', $alterStatement->trailingStatements[0]->compile($dialect));
-        $this->assertEqualsIgnoringCase('CREATE UNIQUE INDEX `table_bar` ON `table` (`bar`)', $alterStatement->trailingStatements[1]->compile($dialect));
+        $q = $dialect->quoteIdentifier(...);
+
+        $this->assertEqualsIgnoringCase(
+            'CREATE INDEX ' . $q('table_foo') . ' ON ' . $q('table') . ' (' . $q('foo') . ')',
+            $alterStatement->trailingStatements[0]->compile($dialect),
+        );
+        $this->assertEqualsIgnoringCase(
+            'CREATE UNIQUE INDEX ' . $q('table_bar') . ' ON ' . $q('table') . ' (' . $q('bar') . ')',
+            $alterStatement->trailingStatements[1]->compile($dialect),
+        );
     }
 
     #[TestWith([DatabaseDialect::MYSQL])]
@@ -35,7 +43,8 @@ final class AlterTableStatementTest extends TestCase
     #[TestWith([DatabaseDialect::SQLITE])]
     public function test_alter_add_column(DatabaseDialect $dialect): void
     {
-        $expected = "ALTER TABLE `table` ADD `bar` VARCHAR(42) DEFAULT 'xx' ;";
+        $q = $dialect->quoteIdentifier(...);
+        $expected = 'ALTER TABLE ' . $q('table') . ' ADD ' . $q('bar') . " VARCHAR(42) DEFAULT 'xx' ;";
         $statement = new AlterTableStatement('table')
             ->add(new VarcharStatement('bar', 42, true, 'xx'))
             ->compile($dialect);
@@ -61,7 +70,7 @@ final class AlterTableStatementTest extends TestCase
     #[TestWith([DatabaseDialect::POSTGRESQL])]
     public function test_alter_add_belongs_to_postgresql(DatabaseDialect $dialect): void
     {
-        $expected = 'ALTER TABLE `table` ADD CONSTRAINT `fk_parent_table_foo` FOREIGN KEY(foo) REFERENCES parent(bar) ON DELETE RESTRICT ON UPDATE NO ACTION ;';
+        $expected = 'ALTER TABLE "table" ADD CONSTRAINT "fk_parent_table_foo" FOREIGN KEY(foo) REFERENCES parent(bar) ON DELETE RESTRICT ON UPDATE NO ACTION ;';
         $statement = new AlterTableStatement('table')
             ->add(new BelongsToStatement('table.foo', 'parent.bar'))
             ->compile($dialect);
@@ -86,7 +95,8 @@ final class AlterTableStatementTest extends TestCase
     #[TestWith([DatabaseDialect::SQLITE])]
     public function test_alter_table_drop_column(DatabaseDialect $dialect): void
     {
-        $expected = 'ALTER TABLE `table` DROP COLUMN `foo` ;';
+        $q = $dialect->quoteIdentifier(...);
+        $expected = 'ALTER TABLE ' . $q('table') . ' DROP COLUMN ' . $q('foo') . ' ;';
         $statement = new AlterTableStatement('table')
             ->dropColumn('foo')
             ->compile($dialect);
@@ -97,7 +107,7 @@ final class AlterTableStatementTest extends TestCase
     }
 
     #[TestWith([DatabaseDialect::MYSQL, 'ALTER TABLE `table` DROP CONSTRAINT `foo` ;'])]
-    #[TestWith([DatabaseDialect::POSTGRESQL, 'ALTER TABLE `table` DROP CONSTRAINT `foo` ;'])]
+    #[TestWith([DatabaseDialect::POSTGRESQL, 'ALTER TABLE "table" DROP CONSTRAINT "foo" ;'])]
     public function test_alter_table_drop_constraint(DatabaseDialect $dialect, string $expected): void
     {
         $statement = new AlterTableStatement('table')
@@ -121,7 +131,7 @@ final class AlterTableStatementTest extends TestCase
     #[TestWith([DatabaseDialect::MYSQL, "ALTER TABLE `table` ADD `foo` VARCHAR(42) DEFAULT 'bar' NOT NULL ;"])]
     #[TestWith([
         DatabaseDialect::POSTGRESQL,
-        "ALTER TABLE `table` ADD `foo` VARCHAR(42) DEFAULT 'bar' NOT NULL ;",
+        "ALTER TABLE \"table\" ADD \"foo\" VARCHAR(42) DEFAULT 'bar' NOT NULL ;",
     ])]
     #[TestWith([DatabaseDialect::SQLITE, "ALTER TABLE `table` ADD `foo` VARCHAR(42) DEFAULT 'bar' NOT NULL ;"])]
     public function test_alter_table_add_column(DatabaseDialect $dialect, string $expected): void
@@ -140,7 +150,8 @@ final class AlterTableStatementTest extends TestCase
     #[TestWith([DatabaseDialect::SQLITE])]
     public function test_alter_table_rename_column(DatabaseDialect $dialect): void
     {
-        $expected = 'ALTER TABLE `table` RENAME COLUMN `foo` TO `bar` ;';
+        $q = $dialect->quoteIdentifier(...);
+        $expected = 'ALTER TABLE ' . $q('table') . ' RENAME COLUMN ' . $q('foo') . ' TO ' . $q('bar') . ' ;';
         $statement = new AlterTableStatement('table')
             ->rename('foo', 'bar')
             ->compile($dialect);
@@ -151,7 +162,7 @@ final class AlterTableStatementTest extends TestCase
     }
 
     #[TestWith([DatabaseDialect::MYSQL, "ALTER TABLE `table` MODIFY COLUMN `foo` VARCHAR(42) DEFAULT 'bar' NOT NULL ;"])]
-    #[TestWith([DatabaseDialect::POSTGRESQL, "ALTER TABLE `table` ALTER COLUMN `foo` VARCHAR(42) DEFAULT 'bar' NOT NULL ;"])]
+    #[TestWith([DatabaseDialect::POSTGRESQL, "ALTER TABLE \"table\" ALTER COLUMN \"foo\" VARCHAR(42) DEFAULT 'bar' NOT NULL ;"])]
     public function test_alter_table_modify_column(DatabaseDialect $dialect, string $expected): void
     {
         $statement = new AlterTableStatement('table')

--- a/packages/database/tests/QueryStatements/CreateTableStatementTest.php
+++ b/packages/database/tests/QueryStatements/CreateTableStatementTest.php
@@ -46,8 +46,8 @@ final class CreateTableStatementTest extends TestCase
         yield 'postgresql' => [
             DatabaseDialect::POSTGRESQL,
             <<<SQL
-            CREATE TABLE `migrations` (
-                `id` SERIAL PRIMARY KEY, 
+            CREATE TABLE "migrations" (
+                "id" SERIAL PRIMARY KEY, 
                 `name` VARCHAR(255) NOT NULL
             );
             SQL,
@@ -109,11 +109,11 @@ final class CreateTableStatementTest extends TestCase
         yield 'postgresql' => [
             DatabaseDialect::POSTGRESQL,
             <<<SQL
-            CREATE TABLE `books` (
-                `id` SERIAL PRIMARY KEY, 
-                `author_id` INTEGER  NOT NULL, 
-                CONSTRAINT `fk_authors_books_author_id` FOREIGN KEY(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION, 
-                `name` VARCHAR(255) NOT NULL
+            CREATE TABLE "books" (
+                "id" SERIAL PRIMARY KEY, 
+                "author_id" INTEGER  NOT NULL, 
+                CONSTRAINT "fk_authors_books_author_id" FOREIGN KEY(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION, 
+                "name" VARCHAR(255) NOT NULL
             );
             SQL,
         ];
@@ -160,11 +160,11 @@ final class CreateTableStatementTest extends TestCase
         yield 'postgresql' => [
             DatabaseDialect::POSTGRESQL,
             <<<SQL
-            CREATE TABLE `books` (
-                `id` SERIAL PRIMARY KEY, 
-                `author_id` INTEGER  NOT NULL, 
-                CONSTRAINT `fk_authors_books_author_id` FOREIGN KEY(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION, 
-                `name` VARCHAR(255) NOT NULL
+            CREATE TABLE "books" (
+                "id" SERIAL PRIMARY KEY, 
+                "author_id" INTEGER  NOT NULL, 
+                CONSTRAINT "fk_authors_books_author_id" FOREIGN KEY(author_id) REFERENCES authors(id) ON DELETE CASCADE ON UPDATE NO ACTION, 
+                "name" VARCHAR(255) NOT NULL
             );
             SQL,
         ];
@@ -216,10 +216,10 @@ final class CreateTableStatementTest extends TestCase
         yield 'postgresql' => [
             DatabaseDialect::POSTGRESQL,
             <<<SQL
-            CREATE TABLE `users` (
-                `uuid` UUID PRIMARY KEY, 
-                `name` TEXT NOT NULL, 
-                `email` TEXT NOT NULL
+            CREATE TABLE "users" (
+                "uuid" UUID PRIMARY KEY, 
+                "name" TEXT NOT NULL, 
+                "email" TEXT NOT NULL
             );
             SQL,
         ];
@@ -271,8 +271,8 @@ final class CreateTableStatementTest extends TestCase
         yield 'postgresql' => [
             DatabaseDialect::POSTGRESQL,
             <<<SQL
-            CREATE TABLE `users` (
-                `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+            CREATE TABLE "users" (
+                "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
             );
             SQL,
         ];

--- a/packages/database/tests/QueryStatements/DeleteStatementTest.php
+++ b/packages/database/tests/QueryStatements/DeleteStatementTest.php
@@ -26,7 +26,9 @@ final class DeleteStatementTest extends TestCase
 
         $this->assertSame($expected, $statement->compile(DatabaseDialect::MYSQL));
         $this->assertSame($expected, $statement->compile(DatabaseDialect::SQLITE));
-        $this->assertSame($expected, $statement->compile(DatabaseDialect::POSTGRESQL));
+        $expectedPostgres = 'DELETE FROM "foo" WHERE `bar` = "1"';
+
+        $this->assertSame($expectedPostgres, $statement->compile(DatabaseDialect::POSTGRESQL));
     }
 
     public function test_exception_when_no_condition_is_set(): void

--- a/packages/database/tests/QueryStatements/FieldStatementTest.php
+++ b/packages/database/tests/QueryStatements/FieldStatementTest.php
@@ -47,12 +47,12 @@ final class FieldStatementTest extends TestCase
     public function test_postgres(): void
     {
         $this->assertSame(
-            '`table`.`field`',
+            '"table"."field"',
             new FieldStatement('`table`.`field`')->compile(DatabaseDialect::POSTGRESQL),
         );
 
         $this->assertSame(
-            '`table`.`field`',
+            '"table"."field"',
             new FieldStatement('table.field')->compile(DatabaseDialect::POSTGRESQL),
         );
     }

--- a/packages/database/tests/QueryStatements/InsertStatementTest.php
+++ b/packages/database/tests/QueryStatements/InsertStatementTest.php
@@ -26,7 +26,7 @@ final class InsertStatementTest extends TestCase
         $this->assertSame($expected, $statement->compile(DatabaseDialect::MYSQL));
         $this->assertSame($expected, $statement->compile(DatabaseDialect::SQLITE));
 
-        $expectedPostgres = 'INSERT INTO `foo` AS `bar` (`foo`, `bar`) VALUES (?, ?), (?, ?) RETURNING *';
+        $expectedPostgres = 'INSERT INTO `foo` AS `bar` ("foo", "bar") VALUES (?, ?), (?, ?) RETURNING *';
 
         $this->assertSame($expectedPostgres, $statement->compile(DatabaseDialect::POSTGRESQL));
     }

--- a/packages/database/tests/QueryStatements/UpdateStatementTest.php
+++ b/packages/database/tests/QueryStatements/UpdateStatementTest.php
@@ -28,7 +28,9 @@ final class UpdateStatementTest extends TestCase
 
         $this->assertSame($expected, $statement->compile(DatabaseDialect::MYSQL));
         $this->assertSame($expected, $statement->compile(DatabaseDialect::SQLITE));
-        $this->assertSame($expected, $statement->compile(DatabaseDialect::POSTGRESQL));
+        $expectedPostgres = 'UPDATE "foo" SET "bar" = ?, "baz" = ? WHERE `bar` = ?';
+
+        $this->assertSame($expectedPostgres, $statement->compile(DatabaseDialect::POSTGRESQL));
     }
 
     public function test_exception_when_no_values(): void

--- a/packages/database/tests/QueryStatements/UuidPrimaryKeyStatementTest.php
+++ b/packages/database/tests/QueryStatements/UuidPrimaryKeyStatementTest.php
@@ -29,7 +29,7 @@ final class UuidPrimaryKeyStatementTest extends TestCase
         $statement = new UuidPrimaryKeyStatement('uuid');
         $compiled = $statement->compile(DatabaseDialect::POSTGRESQL);
 
-        $this->assertSame('`uuid` UUID PRIMARY KEY', $compiled);
+        $this->assertSame('"uuid" UUID PRIMARY KEY', $compiled);
     }
 
     #[Test]

--- a/tests/Integration/Database/Builder/InsertQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/InsertQueryBuilderTest.php
@@ -192,7 +192,7 @@ final class InsertQueryBuilderTest extends FrameworkIntegrationTestCase
 
         $expected = match ($dialect) {
             DatabaseDialect::POSTGRESQL => <<<'SQL'
-            INSERT INTO authors (name) VALUES (?) RETURNING *
+            INSERT INTO "authors" ("name") VALUES (?) RETURNING *
             SQL,
             default => <<<'SQL'
             INSERT INTO `authors` (`name`) VALUES (?)

--- a/tests/Integration/Database/Builder/UpdateQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/UpdateQueryBuilderTest.php
@@ -314,7 +314,7 @@ final class UpdateQueryBuilderTest extends FrameworkIntegrationTestCase
 
         $expected = match ($dialect) {
             DatabaseDialect::POSTGRESQL => <<<'SQL'
-            UPDATE authors SET name = ? WHERE authors.id = ?
+            UPDATE "authors" SET "name" = ? WHERE "authors"."id" = ?
             SQL,
             default => <<<'SQL'
             UPDATE `authors` SET `name` = ? WHERE `authors`.`id` = ?

--- a/tests/Integration/FrameworkIntegrationTestCase.php
+++ b/tests/Integration/FrameworkIntegrationTestCase.php
@@ -62,7 +62,7 @@ abstract class FrameworkIntegrationTestCase extends IntegrationTest
     {
         $clean = fn (string $string): string => str($string)
             ->replace('`', '')
-            ->replaceRegex('/AS \"(?<alias>.*?)\"/', fn (array $matches) => "AS {$matches['alias']}")
+            ->replace('"', '')
             ->toString();
 
         $this->assertSame(


### PR DESCRIPTION
fix for #2088 