### PR TITLE
feat(support): withKeys and withoutKeys methods for manipulatesarray

### DIFF
--- a/packages/support/src/Arr/ManipulatesArray.php
+++ b/packages/support/src/Arr/ManipulatesArray.php
@@ -325,6 +325,32 @@ trait ManipulatesArray
     }
 
     /**
+     * Returns a new instance of the array, with only key=>value pairs from the first array where the key matches the values
+     * from the second array; a wrapper around intersectKeys with an array_flip for convenience.
+     *
+     * @param array<TKey, TValue>|static<TKey, TValue> ...$arrays
+     *
+     * @return static<TKey, TValue>
+     */
+    public function with(array|self ...$arrays): self
+    {
+        return $this->createOrModify(namespace\intersect_keys($this->value, array_flip(...$arrays)));
+    }
+
+    /**
+     * Returns a new instance of the array, without the key=>value pairs from the first array where the key matches the values
+     * from the second array; a wrapper around diffKeys with an array_flip for convenience.
+     *
+     * @param array<TKey, TValue>|static<TKey, TValue> ...$arrays
+     *
+     * @return static<TKey, TValue>
+     */
+    public function without(array|self ...$arrays): self
+    {
+        return $this->createOrModify(namespace\diff_keys($this->value, array_flip(...$arrays)));
+    }
+
+    /**
      * Merges the array with the given arrays.
      *
      * @param array<TKey, TValue>|static<TKey, TValue> ...$arrays The arrays to merge.

--- a/packages/support/src/Arr/ManipulatesArray.php
+++ b/packages/support/src/Arr/ManipulatesArray.php
@@ -332,7 +332,7 @@ trait ManipulatesArray
      *
      * @return static<TKey, TValue>
      */
-    public function onlyKeys(array|self ...$arrays): self
+    public function withKeys(array|self ...$arrays): self
     {
         return $this->createOrModify(namespace\intersect_keys($this->value, array_flip(...$arrays)));
     }
@@ -345,7 +345,7 @@ trait ManipulatesArray
      *
      * @return static<TKey, TValue>
      */
-    public function exceptKeys(array|self ...$arrays): self
+    public function withoutKeys(array|self ...$arrays): self
     {
         return $this->createOrModify(namespace\diff_keys($this->value, array_flip(...$arrays)));
     }

--- a/packages/support/src/Arr/ManipulatesArray.php
+++ b/packages/support/src/Arr/ManipulatesArray.php
@@ -332,7 +332,7 @@ trait ManipulatesArray
      *
      * @return static<TKey, TValue>
      */
-    public function with(array|self ...$arrays): self
+    public function onlyKeys(array|self ...$arrays): self
     {
         return $this->createOrModify(namespace\intersect_keys($this->value, array_flip(...$arrays)));
     }
@@ -345,7 +345,7 @@ trait ManipulatesArray
      *
      * @return static<TKey, TValue>
      */
-    public function without(array|self ...$arrays): self
+    public function exceptKeys(array|self ...$arrays): self
     {
         return $this->createOrModify(namespace\diff_keys($this->value, array_flip(...$arrays)));
     }

--- a/packages/support/tests/Arr/ManipulatesArrayTest.php
+++ b/packages/support/tests/Arr/ManipulatesArrayTest.php
@@ -574,6 +574,42 @@ final class ManipulatesArrayTest extends TestCase
         $this->assertSame($expected, $current);
     }
 
+    public function test_with(): void
+    {
+        $collection = arr([
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'age' => 42,
+        ]);
+        $current = $collection
+            ->with(['first_name', 'last_name'])
+            ->toArray();
+        $expected = [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+        ];
+
+        $this->assertSame($expected, $current);
+    }
+
+    public function test_without(): void
+    {
+        $collection = arr([
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'age' => 42,
+        ]);
+        $current = $collection
+            ->without(['age'])
+            ->toArray();
+        $expected = [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+        ];
+
+        $this->assertSame($expected, $current);
+    }
+
     public function test_unique_with_basic_item(): void
     {
         $collection = arr([

--- a/packages/support/tests/Arr/ManipulatesArrayTest.php
+++ b/packages/support/tests/Arr/ManipulatesArrayTest.php
@@ -574,7 +574,7 @@ final class ManipulatesArrayTest extends TestCase
         $this->assertSame($expected, $current);
     }
 
-    public function test_with(): void
+    public function test_only_keys(): void
     {
         $collection = arr([
             'first_name' => 'John',
@@ -582,7 +582,7 @@ final class ManipulatesArrayTest extends TestCase
             'age' => 42,
         ]);
         $current = $collection
-            ->with(['first_name', 'last_name'])
+            ->onlyKeys(['first_name', 'last_name'])
             ->toArray();
         $expected = [
             'first_name' => 'John',
@@ -592,7 +592,7 @@ final class ManipulatesArrayTest extends TestCase
         $this->assertSame($expected, $current);
     }
 
-    public function test_without(): void
+    public function test_except_keys(): void
     {
         $collection = arr([
             'first_name' => 'John',
@@ -600,7 +600,7 @@ final class ManipulatesArrayTest extends TestCase
             'age' => 42,
         ]);
         $current = $collection
-            ->without(['age'])
+            ->exceptKeys(['age'])
             ->toArray();
         $expected = [
             'first_name' => 'John',

--- a/packages/support/tests/Arr/ManipulatesArrayTest.php
+++ b/packages/support/tests/Arr/ManipulatesArrayTest.php
@@ -574,7 +574,7 @@ final class ManipulatesArrayTest extends TestCase
         $this->assertSame($expected, $current);
     }
 
-    public function test_only_keys(): void
+    public function test_with_keys(): void
     {
         $collection = arr([
             'first_name' => 'John',
@@ -582,7 +582,7 @@ final class ManipulatesArrayTest extends TestCase
             'age' => 42,
         ]);
         $current = $collection
-            ->onlyKeys(['first_name', 'last_name'])
+            ->withKeys(['first_name', 'last_name'])
             ->toArray();
         $expected = [
             'first_name' => 'John',
@@ -592,7 +592,7 @@ final class ManipulatesArrayTest extends TestCase
         $this->assertSame($expected, $current);
     }
 
-    public function test_except_keys(): void
+    public function test_without_keys(): void
     {
         $collection = arr([
             'first_name' => 'John',
@@ -600,7 +600,7 @@ final class ManipulatesArrayTest extends TestCase
             'age' => 42,
         ]);
         $current = $collection
-            ->exceptKeys(['age'])
+            ->withoutKeys(['age'])
             ->toArray();
         $expected = [
             'first_name' => 'John',


### PR DESCRIPTION
Suggested from #2092 - introduces convenience methods `->withKeys` and `->withoutKeys` for ManipulatesArray, and tests.

Usage examples from the test:

```php
    public function test_with_keys(): void
    {
        $collection = arr([
            'first_name' => 'John',
            'last_name' => 'Doe',
            'age' => 42,
        ]);
        $current = $collection
            ->withKeys(['first_name', 'last_name'])
            ->toArray();
        $expected = [
            'first_name' => 'John',
            'last_name' => 'Doe',
        ];

        $this->assertSame($expected, $current);
    }

    public function test_without_keys(): void
    {
        $collection = arr([
            'first_name' => 'John',
            'last_name' => 'Doe',
            'age' => 42,
        ]);
        $current = $collection
            ->withoutKeys(['age'])
            ->toArray();
        $expected = [
            'first_name' => 'John',
            'last_name' => 'Doe',
        ];

        $this->assertSame($expected, $current);
    }
```