### PR TITLE
fix(database): target `whereHas` callback to the target table instead of the pivot table

### DIFF
--- a/packages/database/src/BelongsToMany.php
+++ b/packages/database/src/BelongsToMany.php
@@ -376,10 +376,17 @@ final class BelongsToMany implements Relation
         $ownerTable = $ownerModel->getTableName();
         $fk = $this->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord()->append(suffix: "_{$ownerPK}");
 
+        $targetTable = $targetModel->getTableName();
+        $targetPK = $targetModel->getPrimaryKey();
+        $targetFK = $this->relatedOwnerJoin ?? str(string: $targetTable)->singularizeLastWord()->append(suffix: "_{$targetPK}");
+
         return new WhereExistsStatement(
             relatedTable: $pivotTable,
             relatedModelName: $targetModel->getName(),
             condition: "{$pivotTable}.{$fk} = {$ownerTable}.{$ownerPK}",
+            joinStatement: new JoinStatement(
+                statement: "INNER JOIN {$targetTable} ON {$targetTable}.{$targetPK} = {$pivotTable}.{$targetFK}",
+            ),
         );
     }
 }

--- a/packages/database/src/Builder/QueryBuilders/HasWhereRelationMethods.php
+++ b/packages/database/src/Builder/QueryBuilders/HasWhereRelationMethods.php
@@ -154,6 +154,7 @@ trait HasWhereRelationMethods
             relatedTable: $existsStatement->relatedTable,
             relatedModelName: $existsStatement->relatedModelName,
             condition: $existsStatement->condition,
+            joinStatement: $existsStatement->joinStatement,
             innerWheres: $innerWheres,
             negate: $negate,
             useCount: $useCount,

--- a/packages/database/src/HasManyThrough.php
+++ b/packages/database/src/HasManyThrough.php
@@ -334,6 +334,7 @@ final class HasManyThrough implements Relation
     {
         $ownerModel = inspect(model: $this->property->getClass());
         $intermediateModel = inspect(model: $this->through);
+        $targetModel = inspect(model: $this->property->getIterableType()->asClass());
 
         $intermediateTable = $intermediateModel->getTableName();
         $ownerTable = $ownerModel->getTableName();
@@ -341,10 +342,17 @@ final class HasManyThrough implements Relation
 
         $fk = $this->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord()->append(suffix: "_{$ownerPK}");
 
+        $targetTable = $targetModel->getTableName();
+        $intermediatePK = $intermediateModel->getPrimaryKey();
+        $targetFK = $this->throughOwnerJoin ?? str(string: $intermediateTable)->singularizeLastWord()->append(suffix: "_{$intermediatePK}");
+
         return new WhereExistsStatement(
             relatedTable: $intermediateTable,
-            relatedModelName: inspect(model: $this->property->getIterableType()->asClass())->getName(),
+            relatedModelName: $targetModel->getName(),
             condition: "{$intermediateTable}.{$fk} = {$ownerTable}.{$ownerPK}",
+            joinStatement: new JoinStatement(
+                statement: "INNER JOIN {$targetTable} ON {$targetTable}.{$targetFK} = {$intermediateTable}.{$intermediatePK}",
+            ),
         );
     }
 }

--- a/packages/database/src/HasOneThrough.php
+++ b/packages/database/src/HasOneThrough.php
@@ -291,6 +291,7 @@ final class HasOneThrough implements Relation
     {
         $ownerModel = inspect(model: $this->property->getClass());
         $intermediateModel = inspect(model: $this->through);
+        $targetModel = inspect(model: $this->property->getType()->asClass());
 
         $intermediateTable = $intermediateModel->getTableName();
         $ownerTable = $ownerModel->getTableName();
@@ -298,10 +299,17 @@ final class HasOneThrough implements Relation
 
         $fk = $this->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord()->append(suffix: "_{$ownerPK}");
 
+        $targetTable = $targetModel->getTableName();
+        $intermediatePK = $intermediateModel->getPrimaryKey();
+        $targetFK = $this->throughOwnerJoin ?? str(string: $intermediateTable)->singularizeLastWord()->append(suffix: "_{$intermediatePK}");
+
         return new WhereExistsStatement(
             relatedTable: $intermediateTable,
-            relatedModelName: inspect(model: $this->property->getType()->asClass())->getName(),
+            relatedModelName: $targetModel->getName(),
             condition: "{$intermediateTable}.{$fk} = {$ownerTable}.{$ownerPK}",
+            joinStatement: new JoinStatement(
+                statement: "INNER JOIN {$targetTable} ON {$targetTable}.{$targetFK} = {$intermediateTable}.{$intermediatePK}",
+            ),
         );
     }
 }

--- a/packages/database/src/QueryStatements/WhereExistsStatement.php
+++ b/packages/database/src/QueryStatements/WhereExistsStatement.php
@@ -15,6 +15,7 @@ final readonly class WhereExistsStatement implements QueryStatement
         public string $relatedTable,
         public string $relatedModelName,
         public string $condition,
+        public ?JoinStatement $joinStatement = null,
         private ImmutableArray $innerWheres = new ImmutableArray(),
         private bool $negate = false,
         private bool $useCount = false,
@@ -44,14 +45,20 @@ final readonly class WhereExistsStatement implements QueryStatement
             }
         }
 
+        $fromClause = $this->relatedTable;
+
+        if ($this->joinStatement instanceof JoinStatement && $this->innerWheres->isNotEmpty()) {
+            $fromClause .= ' ' . $this->joinStatement->compile(dialect: $dialect);
+        }
+
         if ($this->useCount) {
-            return "(SELECT COUNT(*) FROM {$this->relatedTable} WHERE {$whereClause}) {$this->operator->value} {$this->count}";
+            return "(SELECT COUNT(*) FROM {$fromClause} WHERE {$whereClause}) {$this->operator->value} {$this->count}";
         }
 
         $keyword = $this->negate
             ? 'NOT EXISTS'
             : 'EXISTS';
 
-        return "{$keyword} (SELECT 1 FROM {$this->relatedTable} WHERE {$whereClause})";
+        return "{$keyword} (SELECT 1 FROM {$fromClause} WHERE {$whereClause})";
     }
 }

--- a/tests/Integration/Database/Builder/WhereHasTest.php
+++ b/tests/Integration/Database/Builder/WhereHasTest.php
@@ -257,6 +257,69 @@ final class WhereHasTest extends FrameworkIntegrationTestCase
     }
 
     #[Test]
+    public function where_has_on_belongs_to_many_with_callback(): void
+    {
+        $sql = Tag::select()
+            ->whereHas(
+                relation: 'books',
+                callback: function (SelectQueryBuilder $query): void {
+                    $query->whereField(
+                        field: 'title',
+                        value: 'LOTR 1',
+                    );
+                },
+            )
+            ->compile();
+
+        $this->assertSameWithoutBackticks(
+            'SELECT tags.id AS tags.id, tags.label AS tags.label FROM tags WHERE EXISTS (SELECT 1 FROM books_tags INNER JOIN books ON books.id = books_tags.book_id WHERE books_tags.tag_id = tags.id AND books.title = ?)',
+            $sql,
+        );
+    }
+
+    #[Test]
+    public function where_has_on_belongs_to_many_with_callback_filters_correctly(): void
+    {
+        $this->seed();
+
+        $tags = Tag::select()
+            ->whereHas(
+                relation: 'books',
+                callback: function (SelectQueryBuilder $query): void {
+                    $query->whereField(
+                        field: 'title',
+                        value: 'LOTR 1',
+                    );
+                },
+            )
+            ->all();
+
+        $this->assertCount(1, $tags);
+        $this->assertSame('fantasy', $tags[0]->label);
+    }
+
+    #[Test]
+    public function where_doesnt_have_on_belongs_to_many_with_callback(): void
+    {
+        $this->seed();
+
+        $tags = Tag::select()
+            ->whereDoesntHave(
+                relation: 'books',
+                callback: function (SelectQueryBuilder $query): void {
+                    $query->whereField(
+                        field: 'title',
+                        value: 'LOTR 1',
+                    );
+                },
+            )
+            ->all();
+
+        $this->assertCount(1, $tags);
+        $this->assertSame('orphan', $tags[0]->label);
+    }
+
+    #[Test]
     public function where_has_on_has_many_through_relation(): void
     {
         $sql = Tag::select()

--- a/tests/Integration/Database/Builder/WhereHasTest.php
+++ b/tests/Integration/Database/Builder/WhereHasTest.php
@@ -346,6 +346,69 @@ final class WhereHasTest extends FrameworkIntegrationTestCase
     }
 
     #[Test]
+    public function where_has_on_has_many_through_with_callback(): void
+    {
+        $sql = Tag::select()
+            ->whereHas(
+                relation: 'reviewers',
+                callback: function (SelectQueryBuilder $query): void {
+                    $query->whereField(
+                        field: 'name',
+                        value: 'Alice',
+                    );
+                },
+            )
+            ->compile();
+
+        $this->assertSameWithoutBackticks(
+            'SELECT tags.id AS tags.id, tags.label AS tags.label FROM tags WHERE EXISTS (SELECT 1 FROM book_reviews INNER JOIN reviewers ON reviewers.book_review_id = book_reviews.id WHERE book_reviews.tag_id = tags.id AND reviewers.name = ?)',
+            $sql,
+        );
+    }
+
+    #[Test]
+    public function where_has_on_has_many_through_with_callback_filters_correctly(): void
+    {
+        $this->seed();
+
+        $tags = Tag::select()
+            ->whereHas(
+                relation: 'reviewers',
+                callback: function (SelectQueryBuilder $query): void {
+                    $query->whereField(
+                        field: 'name',
+                        value: 'Alice',
+                    );
+                },
+            )
+            ->all();
+
+        $this->assertCount(1, $tags);
+        $this->assertSame('fantasy', $tags[0]->label);
+    }
+
+    #[Test]
+    public function where_has_on_has_one_through_with_callback(): void
+    {
+        $sql = Tag::select()
+            ->whereHas(
+                relation: 'topReviewer',
+                callback: function (SelectQueryBuilder $query): void {
+                    $query->whereField(
+                        field: 'name',
+                        value: 'Alice',
+                    );
+                },
+            )
+            ->compile();
+
+        $this->assertSameWithoutBackticks(
+            'SELECT tags.id AS tags.id, tags.label AS tags.label FROM tags WHERE EXISTS (SELECT 1 FROM book_reviews INNER JOIN reviewers ON reviewers.book_review_id = book_reviews.id WHERE book_reviews.tag_id = tags.id AND reviewers.name = ?)',
+            $sql,
+        );
+    }
+
+    #[Test]
     public function where_has_with_count_compiles_count_subquery(): void
     {
         $sql = Author::select()


### PR DESCRIPTION
needed to add missing join for belongs to many, has one through and has many through because callback from where has helpers was targeting pivot table instead of target table