### PR TITLE
refactor(support): remove `withoutKeys` and rename `withKeys` to `removeKeysExcept`

### DIFF
--- a/packages/support/src/Arr/ManipulatesArray.php
+++ b/packages/support/src/Arr/ManipulatesArray.php
@@ -129,7 +129,19 @@ trait ManipulatesArray
      */
     public function removeKeys(string|int|array $keys): self
     {
-        return $this->createOrModify(remove_keys($this->value, $keys));
+        return $this->createOrModify(namespace\remove_keys($this->value, $keys));
+    }
+
+    /**
+     * Removes all keys and their values from the array, except the ones provided by `$keys`.
+     *
+     * @param array-key|array<array-key> $keys The keys of the items to preserve.
+     *
+     * @return static<TKey, TValue>
+     */
+    public function removeKeysExcept(string|int|array $keys): self
+    {
+        return $this->createOrModify(namespace\remove_keys_except($this->value, $keys));
     }
 
     /**
@@ -322,32 +334,6 @@ trait ManipulatesArray
     public function intersectKeys(array|self ...$arrays): self
     {
         return $this->createOrModify(namespace\intersect_keys($this->value, ...$arrays));
-    }
-
-    /**
-     * Returns a new instance of the array, with only key=>value pairs from the first array where the key matches the values
-     * from the second array; a wrapper around intersectKeys with an array_flip for convenience.
-     *
-     * @param array<TKey, TValue>|static<TKey, TValue> ...$arrays
-     *
-     * @return static<TKey, TValue>
-     */
-    public function withKeys(array|self ...$arrays): self
-    {
-        return $this->createOrModify(namespace\intersect_keys($this->value, array_flip(...$arrays)));
-    }
-
-    /**
-     * Returns a new instance of the array, without the key=>value pairs from the first array where the key matches the values
-     * from the second array; a wrapper around diffKeys with an array_flip for convenience.
-     *
-     * @param array<TKey, TValue>|static<TKey, TValue> ...$arrays
-     *
-     * @return static<TKey, TValue>
-     */
-    public function withoutKeys(array|self ...$arrays): self
-    {
-        return $this->createOrModify(namespace\diff_keys($this->value, array_flip(...$arrays)));
     }
 
     /**

--- a/packages/support/src/Arr/functions.php
+++ b/packages/support/src/Arr/functions.php
@@ -139,11 +139,29 @@ function shuffle(iterable $array): array
  * @param array-key|array<array-key> $keys The keys of the items to remove.
  * @return array<TKey,TValue>
  */
-function remove_keys(iterable $array, string|int|array $keys): array
+function remove_keys(iterable $array, string|int|iterable $keys): array
 {
     $array = to_array($array);
 
     return namespace\forget_keys($array, $keys);
+}
+
+/**
+ * Removes all key/value pairs that don't match the provided ones. The array is not mutated.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @param array<TKey,TValue> $array
+ * @param array-key|array<array-key> $keys The keys of the items to preserve.
+ * @return array<TKey,TValue>
+ */
+function remove_keys_except(iterable $array, string|int|iterable $keys): array
+{
+    $array = to_array($array);
+    $keys = to_array($keys);
+
+    return namespace\forget_keys($array, array_diff(array_keys($array), $keys));
 }
 
 /**

--- a/packages/support/tests/Arr/ManipulatesArrayTest.php
+++ b/packages/support/tests/Arr/ManipulatesArrayTest.php
@@ -574,40 +574,22 @@ final class ManipulatesArrayTest extends TestCase
         $this->assertSame($expected, $current);
     }
 
-    public function test_with_keys(): void
+    public function test_remove_keys_except(): void
     {
         $collection = arr([
             'first_name' => 'John',
             'last_name' => 'Doe',
             'age' => 42,
         ]);
+
         $current = $collection
-            ->withKeys(['first_name', 'last_name'])
+            ->removeKeysExcept(['age'])
             ->toArray();
-        $expected = [
-            'first_name' => 'John',
-            'last_name' => 'Doe',
-        ];
 
-        $this->assertSame($expected, $current);
-    }
-
-    public function test_without_keys(): void
-    {
-        $collection = arr([
-            'first_name' => 'John',
-            'last_name' => 'Doe',
-            'age' => 42,
-        ]);
-        $current = $collection
-            ->withoutKeys(['age'])
-            ->toArray();
-        $expected = [
-            'first_name' => 'John',
-            'last_name' => 'Doe',
-        ];
-
-        $this->assertSame($expected, $current);
+        $this->assertSame(
+            ['age' => 42],
+            $current,
+        );
     }
 
     public function test_unique_with_basic_item(): void


### PR DESCRIPTION
Follow-up of https://github.com/tempestphp/tempest-framework/pull/2094:

- `withKeys` implied to me that we're adding keys to the array, which was not the case
- `withoutKeys` is almost the same as `removeKeys`

I initially thought it would be better to have different names based on the mutability of the array, but I realized we already had this issue with `removeKeys` for instance, and other existing methods as well. So that will be for another time.

Instead, I made these changes:
- Removed `withoutKeys`, which had almost the same functionality as `removeKeys`
- Removed `withKeys` in favor of `removeKeysExcept`, which has almost the same functionality as `withKeys` except it has the same API as `removeKeys`.