### PR TITLE
feat(database): autodetect char size by default value

### DIFF
--- a/packages/database/src/QueryStatements/CharStatement.php
+++ b/packages/database/src/QueryStatements/CharStatement.php
@@ -19,11 +19,11 @@ final readonly class CharStatement implements QueryStatement
     public function compile(DatabaseDialect $dialect): string
     {
         return sprintf(
-            '%s CHAR(%s) %s %s',
+            '%s CHAR(%s)%s%s',
             $dialect->quoteIdentifier($this->name),
-            $this->size,
-            $this->default !== null ? "DEFAULT '{$this->default}'" : '',
-            $this->nullable ? '' : 'NOT NULL',
+            $this->size === 1 && $this->default !== null ? mb_strlen($this->default) : $this->size,
+            $this->default !== null ? " DEFAULT '{$this->default}'" : '',
+            $this->nullable ? '' : ' NOT NULL',
         );
     }
 }

--- a/packages/database/src/QueryStatements/CharStatement.php
+++ b/packages/database/src/QueryStatements/CharStatement.php
@@ -19,7 +19,7 @@ final readonly class CharStatement implements QueryStatement
 
     public function compile(DatabaseDialect $dialect): string
     {
-        if ($this->size !== null && $this->default !== null && $this->size !== mb_strlen($this->default)) {
+        if ($this->size !== null && $this->default !== null && $this->size < mb_strlen($this->default)) {
             throw new DefaultValueWasInvalid($this->name, $this->default);
         }
 

--- a/packages/database/src/QueryStatements/CharStatement.php
+++ b/packages/database/src/QueryStatements/CharStatement.php
@@ -5,25 +5,43 @@ declare(strict_types=1);
 namespace Tempest\Database\QueryStatements;
 
 use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\Exceptions\DefaultValueWasInvalid;
 use Tempest\Database\QueryStatement;
 
 final readonly class CharStatement implements QueryStatement
 {
     public function __construct(
         private string $name,
-        private int $size,
+        private ?int $size = null,
         private bool $nullable = false,
         private ?string $default = null,
     ) {}
 
     public function compile(DatabaseDialect $dialect): string
     {
+        if ($this->size !== null && $this->default !== null && $this->size !== mb_strlen($this->default)) {
+            throw new DefaultValueWasInvalid($this->name, $this->default);
+        }
+
         return sprintf(
             '%s CHAR(%s)%s%s',
             $dialect->quoteIdentifier($this->name),
-            $this->size === 1 && $this->default !== null ? mb_strlen($this->default) : $this->size,
+            $this->determineSize(),
             $this->default !== null ? " DEFAULT '{$this->default}'" : '',
             $this->nullable ? '' : ' NOT NULL',
         );
+    }
+
+    public function determineSize(): int
+    {
+        if ($this->size !== null) {
+            return $this->size;
+        }
+
+        if ($this->default !== null) {
+            return mb_strlen($this->default);
+        }
+
+        return 1;
     }
 }

--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -186,7 +186,7 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
     /**
      * Adds a `CHAR` column to the table.
      */
-    public function char(string $name, bool $nullable = false, ?string $default = null, int $size = 1): self
+    public function char(string $name, bool $nullable = false, ?string $default = null, ?int $size = null): self
     {
         $this->statements[] = new CharStatement(
             name: $name,

--- a/packages/database/tests/QueryStatements/CharStatementTest.php
+++ b/packages/database/tests/QueryStatements/CharStatementTest.php
@@ -25,4 +25,31 @@ final class CharStatementTest extends TestCase
         $this->assertSame($expectedMysql, $statement->compile(DatabaseDialect::MYSQL));
         $this->assertSame($expectedPgsql, $statement->compile(DatabaseDialect::POSTGRESQL));
     }
+
+    #[Test]
+    public function test_determine_char_size(): void
+    {
+        $fixedSizeStatement = new CharStatement(
+            name: 'foo',
+            size: 10,
+        );
+        $expectedMysql = '`foo` CHAR(10) NOT NULL';
+        $this->assertSame($expectedMysql, $fixedSizeStatement->compile(DatabaseDialect::MYSQL));
+
+        $defaultSizeStatement = new CharStatement(
+            name: 'foo',
+            size: 1,
+            default: 'foo_bar',
+        );
+        $expectedMysql = '`foo` CHAR(7) DEFAULT \'foo_bar\' NOT NULL';
+        $this->assertSame($expectedMysql, $defaultSizeStatement->compile(DatabaseDialect::MYSQL));
+
+        $fixedAndDefaultSizeStatement = new CharStatement(
+            name: 'foo',
+            size: 10,
+            default: 'foo_bar',
+        );
+        $expectedMysql = '`foo` CHAR(10) DEFAULT \'foo_bar\' NOT NULL';
+        $this->assertSame($expectedMysql, $fixedAndDefaultSizeStatement->compile(DatabaseDialect::MYSQL));
+    }
 }

--- a/packages/database/tests/QueryStatements/CharStatementTest.php
+++ b/packages/database/tests/QueryStatements/CharStatementTest.php
@@ -54,7 +54,7 @@ final class CharStatementTest extends TestCase
     }
 
     #[Test]
-    public function test_mismatch_char_size_and_default_value_length(): void
+    public function test_char_size_less_than_default_value_length(): void
     {
         $this->expectException(DefaultValueWasInvalid::class);
 
@@ -64,5 +64,16 @@ final class CharStatementTest extends TestCase
             default: 'foo_bar',
         );
         $statement->compile(DatabaseDialect::MYSQL);
+    }
+
+    public function test_char_size_greater_than_default_value_length(): void
+    {
+        $statement = new CharStatement(
+            name: 'foo',
+            size: 10,
+            default: 'foo_bar',
+        );
+        $expectedMysql = '`foo` CHAR(10) DEFAULT \'foo_bar\' NOT NULL';
+        $this->assertSame($expectedMysql, $statement->compile(DatabaseDialect::MYSQL));
     }
 }

--- a/packages/database/tests/QueryStatements/CharStatementTest.php
+++ b/packages/database/tests/QueryStatements/CharStatementTest.php
@@ -5,6 +5,7 @@ namespace Tempest\Database\Tests\QueryStatements;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\Exceptions\DefaultValueWasInvalid;
 use Tempest\Database\QueryStatements\CharStatement;
 
 final class CharStatementTest extends TestCase
@@ -38,7 +39,6 @@ final class CharStatementTest extends TestCase
 
         $defaultSizeStatement = new CharStatement(
             name: 'foo',
-            size: 1,
             default: 'foo_bar',
         );
         $expectedMysql = '`foo` CHAR(7) DEFAULT \'foo_bar\' NOT NULL';
@@ -46,10 +46,23 @@ final class CharStatementTest extends TestCase
 
         $fixedAndDefaultSizeStatement = new CharStatement(
             name: 'foo',
-            size: 10,
+            size: 7,
             default: 'foo_bar',
         );
-        $expectedMysql = '`foo` CHAR(10) DEFAULT \'foo_bar\' NOT NULL';
+        $expectedMysql = '`foo` CHAR(7) DEFAULT \'foo_bar\' NOT NULL';
         $this->assertSame($expectedMysql, $fixedAndDefaultSizeStatement->compile(DatabaseDialect::MYSQL));
+    }
+
+    #[Test]
+    public function test_mismatch_char_size_and_default_value_length(): void
+    {
+        $this->expectException(DefaultValueWasInvalid::class);
+
+        $statement = new CharStatement(
+            name: 'foo',
+            size: 1,
+            default: 'foo_bar',
+        );
+        $statement->compile(DatabaseDialect::MYSQL);
     }
 }


### PR DESCRIPTION
The default value will now be considered as char size if no char size ist specified.