### PR TITLE
feat(database): add current to date

### DIFF
--- a/packages/database/src/Config/DatabaseDialect.php
+++ b/packages/database/src/Config/DatabaseDialect.php
@@ -29,6 +29,14 @@ enum DatabaseDialect: string
         };
     }
 
+    public function encloseExpressionDefault(string $expression): string
+    {
+        return match ($this) {
+            self::MYSQL => sprintf('(%s)', $expression),
+            default => sprintf('%s', $expression),
+        };
+    }
+
     public function isTableNotFoundError(QueryWasInvalid $queryWasInvalid): bool
     {
         $pdoException = $queryWasInvalid->pdoException;

--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -249,12 +249,13 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
     /**
      * Adds a `DATE` column to the table.
      */
-    public function date(string $name, bool $nullable = false, ?string $default = null): self
+    public function date(string $name, bool $nullable = false, ?string $default = null, bool $current = false): self
     {
         $this->statements[] = new DateStatement(
             name: $name,
             nullable: $nullable,
             default: $default,
+            current: $current,
         );
 
         return $this;

--- a/packages/database/src/QueryStatements/DateStatement.php
+++ b/packages/database/src/QueryStatements/DateStatement.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Database\QueryStatements;
 
+use InvalidArgumentException;
 use Tempest\Database\Config\DatabaseDialect;
 use Tempest\Database\QueryStatement;
 
@@ -13,15 +14,28 @@ final readonly class DateStatement implements QueryStatement
         private string $name,
         private bool $nullable = false,
         private ?string $default = null,
+        private bool $current = false,
     ) {}
 
     public function compile(DatabaseDialect $dialect): string
     {
+        if ($this->default !== null && $this->current) {
+            throw new InvalidArgumentException("Cannot set both `default` and `current` for date column `{$this->name}`.");
+        }
+
+        $default = match (true) {
+            $this->current => $dialect->encloseExpressionDefault('CURRENT_DATE'),
+            $this->default !== null => "'{$this->default}'",
+            default => null,
+        };
+
+        $name = $dialect->quoteIdentifier($this->name);
+
         return sprintf(
-            '%s DATE %s %s',
-            $dialect->quoteIdentifier($this->name),
-            $this->default !== null ? "DEFAULT '{$this->default}'" : '',
-            $this->nullable ? '' : 'NOT NULL',
+            '%s DATE%s%s',
+            $name,
+            $default !== null ? " DEFAULT {$default}" : '',
+            $this->nullable ? '' : ' NOT NULL',
         );
     }
 }

--- a/packages/database/tests/QueryStatements/DateStatementTest.php
+++ b/packages/database/tests/QueryStatements/DateStatementTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tempest\Database\Tests\QueryStatements;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\QueryStatements\DateStatement;
+
+final class DateStatementTest extends TestCase
+{
+    #[Test]
+    public function test_date(): void
+    {
+        $statement = new DateStatement(
+            name: 'foo',
+            default: '2026-01-01',
+        );
+
+        $expectedMysql = '`foo` DATE DEFAULT \'2026-01-01\' NOT NULL';
+        $expectedPgsql = '"foo" DATE DEFAULT \'2026-01-01\' NOT NULL';
+
+        $this->assertSame($expectedMysql, $statement->compile(DatabaseDialect::MYSQL));
+        $this->assertSame($expectedPgsql, $statement->compile(DatabaseDialect::POSTGRESQL));
+    }
+
+    #[Test]
+    public function test_date_with_current(): void
+    {
+        $statement = new DateStatement(
+            name: 'foo',
+            nullable: true,
+            current: true,
+        );
+
+        $expectedMysql = '`foo` DATE DEFAULT (CURRENT_DATE)';
+        $expectedPgsql = '"foo" DATE DEFAULT CURRENT_DATE';
+
+        $this->assertSame($expectedMysql, $statement->compile(DatabaseDialect::MYSQL));
+        $this->assertSame($expectedPgsql, $statement->compile(DatabaseDialect::POSTGRESQL));
+    }
+
+    #[Test]
+    public function test_date_with_default_and_current(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $statement = new DateStatement(
+            name: 'foo',
+            nullable: true,
+            default: '2026-01-01',
+            current: true,
+        );
+        $statement->compile(DatabaseDialect::MYSQL);
+    }
+}


### PR DESCRIPTION
Adds `current` to the `date` function. Extends #2016 

Will only work with MySQL >= 8.0.13 as default expressions for e.g. CURRENT_DATE were added then.