### PR TITLE
fix(database): fix inserting multiple properties pointing to the same table

### DIFF
--- a/packages/database/src/BelongsTo.php
+++ b/packages/database/src/BelongsTo.php
@@ -57,7 +57,7 @@ final class BelongsTo implements Relation
             throw ModelDidNotHavePrimaryColumn::neededForRelation($relationModel->getName(), 'BelongsTo');
         }
 
-        return str($relationModel->getTableName())->singularizeLastWord() . '_' . $primaryKey;
+        return str($this->property->getName())->snake() . '_' . $primaryKey;
     }
 
     public function getSelectFields(): ImmutableArray

--- a/tests/Fixtures/Modules/Books/Models/BookTransfer.php
+++ b/tests/Fixtures/Modules/Books/Models/BookTransfer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Modules\Books\Models;
+
+use Tempest\Database\IsDatabaseModel;
+
+final class BookTransfer
+{
+    use IsDatabaseModel;
+
+    public ?Author $sender = null;
+
+    public ?Author $recipient = null;
+
+    public string $reason;
+}

--- a/tests/Integration/Database/Builder/InsertQueryBuilderTest.php
+++ b/tests/Integration/Database/Builder/InsertQueryBuilderTest.php
@@ -16,6 +16,7 @@ use Tests\Tempest\Fixtures\Migrations\CreateTagTable;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Fixtures\Modules\Books\Models\AuthorType;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
+use Tests\Tempest\Fixtures\Modules\Books\Models\BookTransfer;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Chapter;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Tag;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -247,6 +248,45 @@ final class InsertQueryBuilderTest extends FrameworkIntegrationTestCase
 
         $this->assertSameWithoutBackticks($expected, $query->compile());
         $this->assertSame(['php'], $query->bindings);
+    }
+
+    public function test_insert_with_two_relations_to_same_model(): void
+    {
+        $transfer = BookTransfer::new(
+            sender: Author::new(id: new PrimaryKey(1), name: 'Alice'),
+            recipient: Author::new(id: new PrimaryKey(2), name: 'Bob'),
+            reason: 'Collaboration',
+        );
+
+        $query = query(BookTransfer::class)
+            ->insert($transfer)
+            ->build();
+
+        $expected = $this->buildExpectedInsert('INSERT INTO `book_transfers` (`sender_id`, `recipient_id`, `reason`) VALUES (?, ?, ?)');
+
+        $this->assertSameWithoutBackticks($expected, $query->compile());
+        $this->assertSame(1, $query->bindings[0]);
+        $this->assertSame(2, $query->bindings[1]);
+        $this->assertSame('Collaboration', $query->bindings[2]);
+    }
+
+    public function test_insert_with_two_relations_to_same_model_one_null(): void
+    {
+        $transfer = BookTransfer::new(
+            sender: Author::new(id: new PrimaryKey(1), name: 'Alice'),
+            reason: 'Solo',
+        );
+
+        $query = query(BookTransfer::class)
+            ->insert($transfer)
+            ->build();
+
+        $expected = $this->buildExpectedInsert('INSERT INTO `book_transfers` (`sender_id`, `recipient_id`, `reason`) VALUES (?, ?, ?)');
+
+        $this->assertSameWithoutBackticks($expected, $query->compile());
+        $this->assertSame(1, $query->bindings[0]);
+        $this->assertNull($query->bindings[1]);
+        $this->assertSame('Solo', $query->bindings[2]);
     }
 
     public function test_insert_skips_has_one_through_property(): void

--- a/tests/Integration/Database/ModelInspector/BelongsToTest.php
+++ b/tests/Integration/Database/ModelInspector/BelongsToTest.php
@@ -35,7 +35,7 @@ final class BelongsToTest extends FrameworkIntegrationTestCase
         $this->assertInstanceOf(BelongsTo::class, $relation);
 
         $this->assertEquals(
-            'LEFT JOIN relation ON relation.overwritten_id = owner.relation_id',
+            'LEFT JOIN relation ON relation.overwritten_id = owner.relation_join_field_id',
             $relation->getJoinStatement()->compile(DatabaseDialect::SQLITE),
         );
     }
@@ -48,7 +48,7 @@ final class BelongsToTest extends FrameworkIntegrationTestCase
         $this->assertInstanceOf(BelongsTo::class, $relation);
 
         $this->assertEquals(
-            'LEFT JOIN relation ON overwritten.overwritten_id = owner.relation_id',
+            'LEFT JOIN relation ON overwritten.overwritten_id = owner.relation_join_field_and_table_id',
             $relation->getJoinStatement()->compile(DatabaseDialect::SQLITE),
         );
     }

--- a/tests/Integration/Database/ModelInspector/LatinPluralRelationTest.php
+++ b/tests/Integration/Database/ModelInspector/LatinPluralRelationTest.php
@@ -27,7 +27,7 @@ final class LatinPluralRelationTest extends FrameworkIntegrationTestCase
         );
 
         $this->assertSame(
-            expected: 'LEFT JOIN metadata ON metadata.id = products.metadata_id',
+            expected: 'LEFT JOIN metadata ON metadata.id = products.product_metadata_id',
             actual: $relation
                 ->getJoinStatement()
                 ->compile(dialect: DatabaseDialect::SQLITE),
@@ -65,7 +65,7 @@ final class LatinPluralRelationTest extends FrameworkIntegrationTestCase
         $fields = $model->getSelectFields()->toArray();
 
         $this->assertContains(
-            needle: 'metadata_id',
+            needle: 'product_metadata_id',
             haystack: $fields,
         );
         $this->assertNotContains(

--- a/tests/Integration/Database/ModelInspector/SnakeCaseRelationTest.php
+++ b/tests/Integration/Database/ModelInspector/SnakeCaseRelationTest.php
@@ -24,7 +24,7 @@ final class SnakeCaseRelationTest extends FrameworkIntegrationTestCase
             actual: $relation,
         );
         $this->assertSame(
-            expected: 'LEFT JOIN author ON author.id = book.author_id',
+            expected: 'LEFT JOIN author ON author.id = book.main_author_id',
             actual: $relation
                 ->getJoinStatement()
                 ->compile(dialect: DatabaseDialect::SQLITE),


### PR DESCRIPTION
related to https://github.com/tempestphp/tempest-framework/issues/2079 but on the insert side of things when no attribute is used