### PR TITLE
feat(database): add option to get underlying query for property relation

### DIFF
--- a/docs/1-essentials/03-database.md
+++ b/docs/1-essentials/03-database.md
@@ -757,6 +757,35 @@ query(model: Author::class)->delete()->whereDoesntHave(relation: 'books')->execu
 query(model: Author::class)->update(verified: true)->whereHas(relation: 'books')->execute();
 ```
 
+### Querying relation properties
+
+Use `query()` on a model instance to get a query builder scoped to a collection relation. This is similar to Laravel's `$author->books()` pattern:
+
+```php
+// Select with constraints
+$books = $author->query('books')->select()->whereField(field: 'title', value: 'Timeline Taxi')->all();
+$books = $author->query('books')->select()->limit(limit: 5)->all();
+
+// Count related records
+$count = $author->query('books')->count()->execute();
+
+// Update scoped to relation
+$author->query('books')->update(title: 'Updated')->execute();
+
+// Delete scoped to relation
+$author->query('books')->delete()->execute();
+```
+
+The `query()` method works with `HasMany`, `HasManyThrough`, and `BelongsToMany` relations — any relation that returns a collection. Calling it on a singular relation like `BelongsTo` or `HasOne` will throw an exception.
+
+```php
+// HasManyThrough
+$tag->query('reviewers')->select()->all();
+
+// BelongsToMany
+$tag->query('books')->select()->all();
+```
+
 ## Migrations
 
 When persisting objects to the database, a table is required to store the data. A migration is a file that instructs the framework how to manage the database schema.

--- a/docs/1-essentials/03-database.md
+++ b/docs/1-essentials/03-database.md
@@ -759,7 +759,7 @@ query(model: Author::class)->update(verified: true)->whereHas(relation: 'books')
 
 ### Querying relation properties
 
-While the global `query(Model::class)` function creates a query builder for any model, calling `query()` on a model _instance_ returns a query builder scoped to a specific relation. The returned `QueryBuilder` is pre-filtered to only include records belonging to that model instance:
+While the global `query(Model::class)` function creates a query builder for any model, models using the `IsDatabaseModel` trait also have a `query()` method that returns a query builder scoped to a specific relation. The returned `QueryBuilder` is pre-filtered to only include records belonging to that model:
 
 ```php
 // Select with constraints

--- a/docs/1-essentials/03-database.md
+++ b/docs/1-essentials/03-database.md
@@ -776,13 +776,21 @@ $author->query('books')->update(title: 'Updated')->execute();
 $author->query('books')->delete()->execute();
 ```
 
-The `query()` method works with `HasMany`, `HasManyThrough`, and `BelongsToMany` relations — any relation that returns a collection. Calling it on a singular relation like `BelongsTo` or `HasOne` will throw an exception.
+The `query()` method works with all relation types:
 
 ```php
-// HasManyThrough
-$tag->query('reviewers')->select()->all();
+// HasMany / HasOne — simple FK on related table
+$author->query('books')->select()->all();
+$book->query('isbn')->select()->first();
 
-// BelongsToMany
+// BelongsTo — subquery through owner's FK
+$book->query('author')->select()->first();
+
+// HasManyThrough / HasOneThrough — subquery through intermediate table
+$tag->query('reviewers')->select()->all();
+$tag->query('topReviewer')->select()->first();
+
+// BelongsToMany — subquery through pivot table
 $tag->query('books')->select()->all();
 ```
 

--- a/docs/1-essentials/03-database.md
+++ b/docs/1-essentials/03-database.md
@@ -759,7 +759,7 @@ query(model: Author::class)->update(verified: true)->whereHas(relation: 'books')
 
 ### Querying relation properties
 
-Use `query()` on a model instance to get a query builder scoped to a collection relation. This is similar to Laravel's `$author->books()` pattern:
+While the global `query(Model::class)` function creates a query builder for any model, calling `query()` on a model _instance_ returns a query builder scoped to a specific relation. The returned `QueryBuilder` is pre-filtered to only include records belonging to that model instance:
 
 ```php
 // Select with constraints

--- a/packages/database/src/BelongsTo.php
+++ b/packages/database/src/BelongsTo.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tempest\Database;
 
 use Attribute;
-use BadMethodCallException;
 use Tempest\Database\Builder\ModelInspector;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
+use Tempest\Database\Builder\QueryBuilders\WhereRawScope;
 use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\QueryStatements\FieldStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
@@ -16,6 +16,7 @@ use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
 use UnitEnum;
 
+use function Tempest\Database\query;
 use function Tempest\Support\str;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
@@ -197,6 +198,28 @@ final class BelongsTo implements Relation
 
     public function query(PrimaryKey $primaryKey, null|string|UnitEnum $onDatabase = null): QueryBuilder
     {
-        throw new BadMethodCallException(message: 'Cannot query a BelongsTo relation. Use HasMany on the inverse side.');
+        $relatedClassName = $this->property->getType()->getName();
+        $relatedModel = inspect(model: $this->property->getType()->asClass());
+        $ownerModel = inspect(model: $this->property->getClass());
+        $relatedTable = $relatedModel->getTableName();
+        $relatedPK = $relatedModel->getPrimaryKey();
+        $ownerTable = $ownerModel->getTableName();
+        $ownerPK = $ownerModel->getPrimaryKey();
+        $fk = $this->getOwnerFieldName();
+
+        return query(model: $relatedClassName)
+            ->onDatabase(databaseTag: $onDatabase)
+            ->scope(scope: new WhereRawScope(
+                statement: sprintf(
+                    '%s.%s = (SELECT %s FROM %s WHERE %s.%s = ?)',
+                    $relatedTable,
+                    $relatedPK,
+                    $fk,
+                    $ownerTable,
+                    $ownerTable,
+                    $ownerPK,
+                ),
+                binding: $primaryKey,
+            ));
     }
 }

--- a/packages/database/src/BelongsTo.php
+++ b/packages/database/src/BelongsTo.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Tempest\Database;
 
 use Attribute;
+use BadMethodCallException;
 use Tempest\Database\Builder\ModelInspector;
+use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
+use UnitEnum;
 use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\QueryStatements\FieldStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
@@ -190,5 +193,10 @@ final class BelongsTo implements Relation
             $ownerTable,
             $this->getOwnerFieldName(),
         );
+    }
+
+    public function query(PrimaryKey $primaryKey, null|string|UnitEnum $onDatabase = null): QueryBuilder
+    {
+        throw new BadMethodCallException(message: 'Cannot query a BelongsTo relation. Use HasMany on the inverse side.');
     }
 }

--- a/packages/database/src/BelongsTo.php
+++ b/packages/database/src/BelongsTo.php
@@ -16,7 +16,6 @@ use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
 use UnitEnum;
 
-use function Tempest\Database\query;
 use function Tempest\Support\str;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]

--- a/packages/database/src/BelongsTo.php
+++ b/packages/database/src/BelongsTo.php
@@ -8,13 +8,13 @@ use Attribute;
 use BadMethodCallException;
 use Tempest\Database\Builder\ModelInspector;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
-use UnitEnum;
 use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\QueryStatements\FieldStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
 use Tempest\Database\QueryStatements\WhereExistsStatement;
 use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
+use UnitEnum;
 
 use function Tempest\Support\str;
 

--- a/packages/database/src/BelongsToMany.php
+++ b/packages/database/src/BelongsToMany.php
@@ -16,7 +16,6 @@ use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
 use UnitEnum;
 
-use function Tempest\Database\query;
 use function Tempest\Support\arr;
 use function Tempest\Support\str;
 
@@ -415,7 +414,7 @@ final class BelongsToMany implements Relation
 
         return query(model: $relatedClassName)
             ->onDatabase(databaseTag: $onDatabase)
-            ->scope(new WhereRawScope(
+            ->scope(scope: new WhereRawScope(
                 statement: sprintf(
                     '%s.%s IN (SELECT %s FROM %s WHERE %s = ?)',
                     $targetTable,

--- a/packages/database/src/BelongsToMany.php
+++ b/packages/database/src/BelongsToMany.php
@@ -6,13 +6,17 @@ namespace Tempest\Database;
 
 use Attribute;
 use Tempest\Database\Builder\ModelInspector;
+use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
+use Tempest\Database\Builder\QueryBuilders\WhereRawScope;
 use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\QueryStatements\FieldStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
 use Tempest\Database\QueryStatements\WhereExistsStatement;
 use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
+use UnitEnum;
 
+use function Tempest\Database\query;
 use function Tempest\Support\arr;
 use function Tempest\Support\str;
 
@@ -393,5 +397,34 @@ final class BelongsToMany implements Relation
                 statement: "INNER JOIN {$targetTable} ON {$targetTable}.{$targetPK} = {$pivotTable}.{$targetFK}",
             ),
         );
+    }
+
+    public function query(PrimaryKey $primaryKey, null|string|UnitEnum $onDatabase = null): QueryBuilder
+    {
+        $ownerModel = inspect(model: $this->property->getClass());
+        $targetModel = inspect(model: $this->property->getIterableType()->asClass());
+        $relatedClassName = $this->property->getIterableType()->getName();
+        $ownerTable = $ownerModel->getTableName();
+        $ownerPK = $ownerModel->getPrimaryKey();
+        $targetTable = $targetModel->getTableName();
+        $targetPK = $targetModel->getPrimaryKey();
+
+        $pivotTable = $this->pivot ?? arr([$ownerTable, $targetTable])->sort()->implode('_')->toString();
+        $ownerFK = $this->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
+        $targetFK = $this->relatedOwnerJoin ?? str(string: $targetTable)->singularizeLastWord() . '_' . $targetPK;
+
+        return query(model: $relatedClassName)
+            ->onDatabase(databaseTag: $onDatabase)
+            ->scope(new WhereRawScope(
+                statement: sprintf(
+                    '%s.%s IN (SELECT %s FROM %s WHERE %s = ?)',
+                    $targetTable,
+                    $targetPK,
+                    $targetFK,
+                    $pivotTable,
+                    $ownerFK,
+                ),
+                binding: $primaryKey,
+            ));
     }
 }

--- a/packages/database/src/BelongsToMany.php
+++ b/packages/database/src/BelongsToMany.php
@@ -408,7 +408,7 @@ final class BelongsToMany implements Relation
         $targetTable = $targetModel->getTableName();
         $targetPK = $targetModel->getPrimaryKey();
 
-        $pivotTable = $this->pivot ?? arr([$ownerTable, $targetTable])->sort()->implode('_')->toString();
+        $pivotTable = $this->resolvePivotTable(ownerModel: $ownerModel, targetModel: $targetModel);
         $ownerFK = $this->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
         $targetFK = $this->relatedOwnerJoin ?? str(string: $targetTable)->singularizeLastWord() . '_' . $targetPK;
 

--- a/packages/database/src/Builder/QueryBuilders/HasWhereQueryBuilderMethods.php
+++ b/packages/database/src/Builder/QueryBuilders/HasWhereQueryBuilderMethods.php
@@ -15,6 +15,18 @@ trait HasWhereQueryBuilderMethods
     use HasConvenientWhereMethods;
     use HasWhereRelationMethods;
 
+    /**
+     * @param QueryScope[] $scopes
+     */
+    public function applyScopes(array $scopes): self
+    {
+        foreach ($scopes as $scope) {
+            $scope->apply(builder: $this);
+        }
+
+        return $this;
+    }
+
     protected function appendWhere(WhereStatement|WhereGroupStatement|WhereExistsStatement $where): void
     {
         $this->wheres->offsetSet(null, $where);

--- a/packages/database/src/Builder/QueryBuilders/QueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/QueryBuilder.php
@@ -39,7 +39,6 @@ final class QueryBuilder
         return $this;
     }
 
-
     /**
      * Creates a `SELECT` query builder for retrieving records from the database.
      *
@@ -57,7 +56,9 @@ final class QueryBuilder
         return new SelectQueryBuilder(
             model: $this->model,
             fields: $columns !== [] ? arr($columns)->unique() : null,
-        )->onDatabase(databaseTag: $this->onDatabase)->applyScopes(scopes: $this->scopes);
+        )
+            ->onDatabase(databaseTag: $this->onDatabase)
+            ->applyScopes(scopes: $this->scopes);
     }
 
     /**
@@ -104,7 +105,9 @@ final class QueryBuilder
             model: $this->model,
             values: $values,
             serializerFactory: get(SerializerFactory::class),
-        )->onDatabase(databaseTag: $this->onDatabase)->applyScopes(scopes: $this->scopes);
+        )
+            ->onDatabase(databaseTag: $this->onDatabase)
+            ->applyScopes(scopes: $this->scopes);
     }
 
     /**
@@ -122,7 +125,9 @@ final class QueryBuilder
      */
     public function delete(): DeleteQueryBuilder
     {
-        return new DeleteQueryBuilder(model: $this->model)->onDatabase(databaseTag: $this->onDatabase)->applyScopes(scopes: $this->scopes);
+        return new DeleteQueryBuilder(model: $this->model)
+            ->onDatabase(databaseTag: $this->onDatabase)
+            ->applyScopes(scopes: $this->scopes);
     }
 
     /**
@@ -140,7 +145,9 @@ final class QueryBuilder
         return new CountQueryBuilder(
             model: $this->model,
             column: $column,
-        )->onDatabase(databaseTag: $this->onDatabase)->applyScopes(scopes: $this->scopes);
+        )
+            ->onDatabase(databaseTag: $this->onDatabase)
+            ->applyScopes(scopes: $this->scopes);
     }
 
     /**

--- a/packages/database/src/Builder/QueryBuilders/QueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/QueryBuilder.php
@@ -19,10 +19,26 @@ final class QueryBuilder
 {
     use OnDatabase;
 
+    /** @var QueryScope[] */
+    private array $scopes = [];
+
     /** @param class-string<TModel>|TModel|string $model */
     public function __construct(
         private readonly string|object $model,
     ) {}
+
+    /**
+     * Adds a scope that will be applied to any query builder created from this instance.
+     *
+     * @return self<TModel>
+     */
+    public function scope(QueryScope $scope): self
+    {
+        $this->scopes[] = $scope;
+
+        return $this;
+    }
+
 
     /**
      * Creates a `SELECT` query builder for retrieving records from the database.
@@ -41,7 +57,7 @@ final class QueryBuilder
         return new SelectQueryBuilder(
             model: $this->model,
             fields: $columns !== [] ? arr($columns)->unique() : null,
-        )->onDatabase($this->onDatabase);
+        )->onDatabase($this->onDatabase)->applyScopes($this->scopes);
     }
 
     /**
@@ -88,7 +104,7 @@ final class QueryBuilder
             model: $this->model,
             values: $values,
             serializerFactory: get(SerializerFactory::class),
-        )->onDatabase($this->onDatabase);
+        )->onDatabase($this->onDatabase)->applyScopes($this->scopes);
     }
 
     /**
@@ -106,7 +122,7 @@ final class QueryBuilder
      */
     public function delete(): DeleteQueryBuilder
     {
-        return new DeleteQueryBuilder($this->model)->onDatabase($this->onDatabase);
+        return new DeleteQueryBuilder($this->model)->onDatabase($this->onDatabase)->applyScopes($this->scopes);
     }
 
     /**
@@ -124,7 +140,7 @@ final class QueryBuilder
         return new CountQueryBuilder(
             model: $this->model,
             column: $column,
-        )->onDatabase($this->onDatabase);
+        )->onDatabase($this->onDatabase)->applyScopes($this->scopes);
     }
 
     /**

--- a/packages/database/src/Builder/QueryBuilders/QueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/QueryBuilder.php
@@ -57,7 +57,7 @@ final class QueryBuilder
         return new SelectQueryBuilder(
             model: $this->model,
             fields: $columns !== [] ? arr($columns)->unique() : null,
-        )->onDatabase($this->onDatabase)->applyScopes($this->scopes);
+        )->onDatabase(databaseTag: $this->onDatabase)->applyScopes(scopes: $this->scopes);
     }
 
     /**
@@ -104,7 +104,7 @@ final class QueryBuilder
             model: $this->model,
             values: $values,
             serializerFactory: get(SerializerFactory::class),
-        )->onDatabase($this->onDatabase)->applyScopes($this->scopes);
+        )->onDatabase(databaseTag: $this->onDatabase)->applyScopes(scopes: $this->scopes);
     }
 
     /**
@@ -122,7 +122,7 @@ final class QueryBuilder
      */
     public function delete(): DeleteQueryBuilder
     {
-        return new DeleteQueryBuilder($this->model)->onDatabase($this->onDatabase)->applyScopes($this->scopes);
+        return new DeleteQueryBuilder(model: $this->model)->onDatabase(databaseTag: $this->onDatabase)->applyScopes(scopes: $this->scopes);
     }
 
     /**
@@ -140,7 +140,7 @@ final class QueryBuilder
         return new CountQueryBuilder(
             model: $this->model,
             column: $column,
-        )->onDatabase($this->onDatabase)->applyScopes($this->scopes);
+        )->onDatabase(databaseTag: $this->onDatabase)->applyScopes(scopes: $this->scopes);
     }
 
     /**

--- a/packages/database/src/Builder/QueryBuilders/QueryScope.php
+++ b/packages/database/src/Builder/QueryBuilders/QueryScope.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Builder\QueryBuilders;
+
+interface QueryScope
+{
+    public function apply(SupportsWhereStatements $builder): void;
+}

--- a/packages/database/src/Builder/QueryBuilders/SupportsWhereStatements.php
+++ b/packages/database/src/Builder/QueryBuilders/SupportsWhereStatements.php
@@ -32,4 +32,11 @@ interface SupportsWhereStatements
      * @return self<TModel>
      */
     public function orWhere(string $field, mixed $value, WhereOperator $operator = WhereOperator::EQUALS): self;
+
+    /**
+     * Adds a raw WHERE condition to the query.
+     *
+     * @return self<TModel>
+     */
+    public function whereRaw(string $statement, mixed ...$bindings): self;
 }

--- a/packages/database/src/Builder/QueryBuilders/WhereFieldScope.php
+++ b/packages/database/src/Builder/QueryBuilders/WhereFieldScope.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Builder\QueryBuilders;
+
+final readonly class WhereFieldScope implements QueryScope
+{
+    public function __construct(
+        private string $field,
+        private mixed $value,
+    ) {}
+
+    public function apply(SupportsWhereStatements $builder): void
+    {
+        $builder->whereField(field: $this->field, value: $this->value);
+    }
+}

--- a/packages/database/src/Builder/QueryBuilders/WhereRawScope.php
+++ b/packages/database/src/Builder/QueryBuilders/WhereRawScope.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Builder\QueryBuilders;
+
+final readonly class WhereRawScope implements QueryScope
+{
+    public function __construct(
+        private string $statement,
+        private mixed $binding,
+    ) {}
+
+    public function apply(SupportsWhereStatements $builder): void
+    {
+        $builder->whereRaw($this->statement, $this->binding);
+    }
+}

--- a/packages/database/src/Exceptions/PrimaryKeyWasNotInitialized.php
+++ b/packages/database/src/Exceptions/PrimaryKeyWasNotInitialized.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Exceptions;
+
+use Exception;
+
+final class PrimaryKeyWasNotInitialized extends Exception
+{
+    public function __construct(
+        public readonly string $model,
+    ) {
+        parent::__construct("Cannot query relations on `{$model}` without a primary key value.");
+    }
+}

--- a/packages/database/src/Exceptions/PropertyWasNotARelation.php
+++ b/packages/database/src/Exceptions/PropertyWasNotARelation.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Database\Exceptions;
+
+use Exception;
+
+final class PropertyWasNotARelation extends Exception
+{
+    public function __construct(
+        public readonly string $property,
+        public readonly string $model,
+    ) {
+        parent::__construct("Property `{$property}` is not a relation on `{$model}`.");
+    }
+}

--- a/packages/database/src/HasMany.php
+++ b/packages/database/src/HasMany.php
@@ -7,7 +7,7 @@ namespace Tempest\Database;
 use Attribute;
 use Tempest\Database\Builder\ModelInspector;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
-use Tempest\Database\Builder\QueryBuilders\WhereRawScope;
+use Tempest\Database\Builder\QueryBuilders\WhereFieldScope;
 use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\QueryStatements\FieldStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
@@ -190,14 +190,9 @@ final class HasMany implements Relation
         $parentPK = $parentModel->getPrimaryKey();
         $fk = $this->ownerJoin ?? str(string: $parentTable)->singularizeLastWord() . '_' . $parentPK;
 
-        $relatedTable = inspect(model: $relatedClassName)->getTableName();
-
         return query(model: $relatedClassName)
             ->onDatabase(databaseTag: $onDatabase)
-            ->scope(new WhereRawScope(
-                statement: sprintf('%s.%s = ?', $relatedTable, $fk),
-                binding: $primaryKey,
-            ));
+            ->scope(new WhereFieldScope(field: $fk, value: $primaryKey));
     }
 
     private function isSelfReferencing(): bool

--- a/packages/database/src/HasMany.php
+++ b/packages/database/src/HasMany.php
@@ -16,7 +16,6 @@ use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
 use UnitEnum;
 
-use function Tempest\Database\query;
 use function Tempest\Support\str;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
@@ -192,7 +191,7 @@ final class HasMany implements Relation
 
         return query(model: $relatedClassName)
             ->onDatabase(databaseTag: $onDatabase)
-            ->scope(new WhereFieldScope(field: $fk, value: $primaryKey));
+            ->scope(scope: new WhereFieldScope(field: $fk, value: $primaryKey));
     }
 
     private function isSelfReferencing(): bool

--- a/packages/database/src/HasMany.php
+++ b/packages/database/src/HasMany.php
@@ -6,13 +6,17 @@ namespace Tempest\Database;
 
 use Attribute;
 use Tempest\Database\Builder\ModelInspector;
+use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
+use Tempest\Database\Builder\QueryBuilders\WhereRawScope;
 use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\QueryStatements\FieldStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
 use Tempest\Database\QueryStatements\WhereExistsStatement;
 use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
+use UnitEnum;
 
+use function Tempest\Database\query;
 use function Tempest\Support\str;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
@@ -176,6 +180,24 @@ final class HasMany implements Relation
             relatedModelName: $relatedModel->getName(),
             condition: "{$relatedTable}.{$fk} = {$parentTable}.{$parentPK}",
         );
+    }
+
+    public function query(PrimaryKey $primaryKey, null|string|UnitEnum $onDatabase = null): QueryBuilder
+    {
+        $relatedClassName = $this->property->getIterableType()->getName();
+        $parentModel = inspect(model: $this->property->getClass());
+        $parentTable = $parentModel->getTableName();
+        $parentPK = $parentModel->getPrimaryKey();
+        $fk = $this->ownerJoin ?? str(string: $parentTable)->singularizeLastWord() . '_' . $parentPK;
+
+        $relatedTable = inspect(model: $relatedClassName)->getTableName();
+
+        return query(model: $relatedClassName)
+            ->onDatabase(databaseTag: $onDatabase)
+            ->scope(new WhereRawScope(
+                statement: sprintf('%s.%s = ?', $relatedTable, $fk),
+                binding: $primaryKey,
+            ));
     }
 
     private function isSelfReferencing(): bool

--- a/packages/database/src/HasManyThrough.php
+++ b/packages/database/src/HasManyThrough.php
@@ -16,7 +16,6 @@ use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
 use UnitEnum;
 
-use function Tempest\Database\query;
 use function Tempest\Support\str;
 
 #[Attribute(flags: Attribute::TARGET_PROPERTY)]
@@ -381,7 +380,7 @@ final class HasManyThrough implements Relation
 
         return query(model: $relatedClassName)
             ->onDatabase(databaseTag: $onDatabase)
-            ->scope(new WhereRawScope(
+            ->scope(scope: new WhereRawScope(
                 statement: sprintf(
                     '%s IN (SELECT %s FROM %s WHERE %s = ?)',
                     $relatedTable . '.' . $targetFK,

--- a/packages/database/src/HasManyThrough.php
+++ b/packages/database/src/HasManyThrough.php
@@ -6,13 +6,17 @@ namespace Tempest\Database;
 
 use Attribute;
 use Tempest\Database\Builder\ModelInspector;
+use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
+use Tempest\Database\Builder\QueryBuilders\WhereRawScope;
 use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\QueryStatements\FieldStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
 use Tempest\Database\QueryStatements\WhereExistsStatement;
 use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
+use UnitEnum;
 
+use function Tempest\Database\query;
 use function Tempest\Support\str;
 
 #[Attribute(flags: Attribute::TARGET_PROPERTY)]
@@ -359,5 +363,33 @@ final class HasManyThrough implements Relation
                 statement: "INNER JOIN {$targetTable} ON {$targetTable}.{$targetFK} = {$intermediateTable}.{$intermediatePK}",
             ),
         );
+    }
+
+    public function query(PrimaryKey $primaryKey, null|string|UnitEnum $onDatabase = null): QueryBuilder
+    {
+        $relatedClassName = $this->property->getIterableType()->getName();
+        $ownerModel = inspect(model: $this->property->getClass());
+        $intermediateModel = inspect(model: $this->through);
+        $intermediateTable = $intermediateModel->getTableName();
+        $ownerTable = $ownerModel->getTableName();
+        $ownerPK = $ownerModel->getPrimaryKey();
+        $intermediatePK = $intermediateModel->getPrimaryKey();
+        $relatedTable = inspect(model: $relatedClassName)->getTableName();
+
+        $ownerFK = $this->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
+        $targetFK = $this->throughOwnerJoin ?? str(string: $intermediateTable)->singularizeLastWord() . '_' . $intermediatePK;
+
+        return query(model: $relatedClassName)
+            ->onDatabase(databaseTag: $onDatabase)
+            ->scope(new WhereRawScope(
+                statement: sprintf(
+                    '%s IN (SELECT %s FROM %s WHERE %s = ?)',
+                    $relatedTable . '.' . $targetFK,
+                    $intermediatePK,
+                    $intermediateTable,
+                    $ownerFK,
+                ),
+                binding: $primaryKey,
+            ));
     }
 }

--- a/packages/database/src/HasOne.php
+++ b/packages/database/src/HasOne.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tempest\Database;
 
 use Attribute;
-use BadMethodCallException;
 use Tempest\Database\Builder\ModelInspector;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
+use Tempest\Database\Builder\QueryBuilders\WhereFieldScope;
 use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\QueryStatements\FieldStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
@@ -16,6 +16,7 @@ use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
 use UnitEnum;
 
+use function Tempest\Database\query;
 use function Tempest\Support\str;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
@@ -195,6 +196,14 @@ final class HasOne implements Relation
 
     public function query(PrimaryKey $primaryKey, null|string|UnitEnum $onDatabase = null): QueryBuilder
     {
-        throw new BadMethodCallException(message: 'Cannot query a HasOne relation.');
+        $relatedClassName = $this->property->getType()->getName();
+        $parentModel = inspect(model: $this->property->getClass());
+        $parentTable = $parentModel->getTableName();
+        $parentPK = $parentModel->getPrimaryKey();
+        $fk = $this->ownerJoin ?? str(string: $parentTable)->singularizeLastWord() . '_' . $parentPK;
+
+        return query(model: $relatedClassName)
+            ->onDatabase(databaseTag: $onDatabase)
+            ->scope(scope: new WhereFieldScope(field: $fk, value: $primaryKey));
     }
 }

--- a/packages/database/src/HasOne.php
+++ b/packages/database/src/HasOne.php
@@ -16,7 +16,6 @@ use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
 use UnitEnum;
 
-use function Tempest\Database\query;
 use function Tempest\Support\str;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]

--- a/packages/database/src/HasOne.php
+++ b/packages/database/src/HasOne.php
@@ -8,13 +8,13 @@ use Attribute;
 use BadMethodCallException;
 use Tempest\Database\Builder\ModelInspector;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
-use UnitEnum;
 use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\QueryStatements\FieldStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
 use Tempest\Database\QueryStatements\WhereExistsStatement;
 use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
+use UnitEnum;
 
 use function Tempest\Support\str;
 

--- a/packages/database/src/HasOne.php
+++ b/packages/database/src/HasOne.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Tempest\Database;
 
 use Attribute;
+use BadMethodCallException;
 use Tempest\Database\Builder\ModelInspector;
+use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
+use UnitEnum;
 use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\QueryStatements\FieldStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
@@ -188,5 +191,10 @@ final class HasOne implements Relation
             $ownerTable,
             $primaryKey,
         );
+    }
+
+    public function query(PrimaryKey $primaryKey, null|string|UnitEnum $onDatabase = null): QueryBuilder
+    {
+        throw new BadMethodCallException(message: 'Cannot query a HasOne relation.');
     }
 }

--- a/packages/database/src/HasOneThrough.php
+++ b/packages/database/src/HasOneThrough.php
@@ -16,7 +16,6 @@ use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
 use UnitEnum;
 
-use function Tempest\Database\query;
 use function Tempest\Support\str;
 
 #[Attribute(flags: Attribute::TARGET_PROPERTY)]

--- a/packages/database/src/HasOneThrough.php
+++ b/packages/database/src/HasOneThrough.php
@@ -8,13 +8,13 @@ use Attribute;
 use BadMethodCallException;
 use Tempest\Database\Builder\ModelInspector;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
-use UnitEnum;
 use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\QueryStatements\FieldStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
 use Tempest\Database\QueryStatements\WhereExistsStatement;
 use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
+use UnitEnum;
 
 use function Tempest\Support\str;
 

--- a/packages/database/src/HasOneThrough.php
+++ b/packages/database/src/HasOneThrough.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Tempest\Database;
 
 use Attribute;
+use BadMethodCallException;
 use Tempest\Database\Builder\ModelInspector;
+use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
+use UnitEnum;
 use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\QueryStatements\FieldStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
@@ -316,5 +319,10 @@ final class HasOneThrough implements Relation
                 statement: "INNER JOIN {$targetTable} ON {$targetTable}.{$targetFK} = {$intermediateTable}.{$intermediatePK}",
             ),
         );
+    }
+
+    public function query(PrimaryKey $primaryKey, null|string|UnitEnum $onDatabase = null): QueryBuilder
+    {
+        throw new BadMethodCallException(message: 'Cannot query a HasOneThrough relation.');
     }
 }

--- a/packages/database/src/HasOneThrough.php
+++ b/packages/database/src/HasOneThrough.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Tempest\Database;
 
 use Attribute;
-use BadMethodCallException;
 use Tempest\Database\Builder\ModelInspector;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
+use Tempest\Database\Builder\QueryBuilders\WhereRawScope;
 use Tempest\Database\Exceptions\ModelDidNotHavePrimaryColumn;
 use Tempest\Database\QueryStatements\FieldStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
@@ -16,6 +16,7 @@ use Tempest\Reflection\PropertyReflector;
 use Tempest\Support\Arr\ImmutableArray;
 use UnitEnum;
 
+use function Tempest\Database\query;
 use function Tempest\Support\str;
 
 #[Attribute(flags: Attribute::TARGET_PROPERTY)]
@@ -323,6 +324,30 @@ final class HasOneThrough implements Relation
 
     public function query(PrimaryKey $primaryKey, null|string|UnitEnum $onDatabase = null): QueryBuilder
     {
-        throw new BadMethodCallException(message: 'Cannot query a HasOneThrough relation.');
+        $relatedClassName = $this->property->getType()->getName();
+        $ownerModel = inspect(model: $this->property->getClass());
+        $intermediateModel = inspect(model: $this->through);
+        $intermediateTable = $intermediateModel->getTableName();
+        $ownerTable = $ownerModel->getTableName();
+        $ownerPK = $ownerModel->getPrimaryKey();
+        $intermediatePK = $intermediateModel->getPrimaryKey();
+        $relatedTable = inspect(model: $relatedClassName)->getTableName();
+
+        $ownerFK = $this->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
+        $targetFK = $this->throughOwnerJoin ?? str(string: $intermediateTable)->singularizeLastWord() . '_' . $intermediatePK;
+
+        return query(model: $relatedClassName)
+            ->onDatabase(databaseTag: $onDatabase)
+            ->scope(scope: new WhereRawScope(
+                statement: sprintf(
+                    '%s.%s IN (SELECT %s FROM %s WHERE %s = ?)',
+                    $relatedTable,
+                    $targetFK,
+                    $intermediatePK,
+                    $intermediateTable,
+                    $ownerFK,
+                ),
+                binding: $primaryKey,
+            ));
     }
 }

--- a/packages/database/src/IsDatabaseModel.php
+++ b/packages/database/src/IsDatabaseModel.php
@@ -266,29 +266,57 @@ trait IsDatabaseModel
     }
 
     /**
-     * Returns a query builder scoped to a HasMany relation on this model.
+     * Returns a query builder scoped to a collection relation on this model.
      */
     public function query(string $relation): SelectQueryBuilder
     {
-        $model = inspect($this);
-        $hasMany = $model->getHasMany($relation);
+        $model = inspect(model: $this);
+        $primaryKeyValue = $model->getPrimaryKeyProperty()->getValue(object: $this);
 
-        if (! $hasMany instanceof HasMany) {
-            throw new InvalidArgumentException(
-                sprintf('Property "%s" is not a HasMany relation on %s.', $relation, $model->getName()),
-            );
+        $hasMany = $model->getHasMany(name: $relation);
+
+        if ($hasMany instanceof HasMany) {
+            $relatedClassName = $hasMany->property->getIterableType()->getName();
+            $parentTable = $model->getTableName();
+            $parentPK = $model->getPrimaryKey();
+            $fk = $hasMany->ownerJoin ?? str(string: $parentTable)->singularizeLastWord() . '_' . $parentPK;
+
+            return query(model: $relatedClassName)
+                ->onDatabase(databaseTag: $this->onDatabase)
+                ->select()
+                ->whereField(field: $fk, value: $primaryKeyValue);
         }
 
-        $relatedClassName = $hasMany->property->getIterableType()->getName();
-        $parentTable = $model->getTableName();
-        $parentPK = $model->getPrimaryKey();
-        $fk = $hasMany->ownerJoin ?? str($parentTable)->singularizeLastWord() . '_' . $parentPK;
-        $primaryKeyValue = $model->getPrimaryKeyProperty()->getValue($this);
+        $hasManyThrough = $model->getHasManyThrough(name: $relation);
 
-        return query($relatedClassName)
-            ->onDatabase($this->onDatabase)
-            ->select()
-            ->whereField($fk, $primaryKeyValue);
+        if ($hasManyThrough instanceof HasManyThrough) {
+            $relatedClassName = $hasManyThrough->property->getIterableType()->getName();
+            $intermediateModel = inspect(model: $hasManyThrough->through);
+            $intermediateTable = $intermediateModel->getTableName();
+            $ownerTable = $model->getTableName();
+            $ownerPK = $model->getPrimaryKey();
+            $intermediatePK = $intermediateModel->getPrimaryKey();
+
+            $ownerFK = $hasManyThrough->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
+            $targetFK = $hasManyThrough->throughOwnerJoin ?? str(string: $intermediateTable)->singularizeLastWord() . '_' . $intermediatePK;
+
+            return query(model: $relatedClassName)
+                ->onDatabase(databaseTag: $this->onDatabase)
+                ->select()
+                ->join(sprintf(
+                    'INNER JOIN %s ON %s.%s = %s.%s',
+                    $intermediateTable,
+                    inspect(model: $relatedClassName)->getTableName(),
+                    $targetFK,
+                    $intermediateTable,
+                    $intermediatePK,
+                ))
+                ->whereRaw(sprintf('%s.%s = ?', $intermediateTable, $ownerFK), $primaryKeyValue);
+        }
+
+        throw new InvalidArgumentException(
+            message: sprintf('Property "%s" is not a collection relation on %s.', $relation, $model->getName()),
+        );
     }
 
     /**

--- a/packages/database/src/IsDatabaseModel.php
+++ b/packages/database/src/IsDatabaseModel.php
@@ -272,15 +272,13 @@ trait IsDatabaseModel
     {
         $model = inspect(model: $this);
 
-        $primaryKeyProperty = $model->getPrimaryKeyProperty();
-
-        if ($primaryKeyProperty === null || ! $primaryKeyProperty->isInitialized(object: $this)) {
+        if (! $model->hasPrimaryKey() || ! $model->getPrimaryKeyProperty()->isInitialized(object: $this)) {
             throw new InvalidArgumentException(
                 message: sprintf('Cannot query relations on %s without a primary key value.', $model->getName()),
             );
         }
 
-        $primaryKeyValue = $primaryKeyProperty->getValue(object: $this);
+        $primaryKeyValue = $model->getPrimaryKeyValue();
 
         $relationObj = $model->getRelation(name: $relation);
         $ownerTable = $model->getTableName();

--- a/packages/database/src/IsDatabaseModel.php
+++ b/packages/database/src/IsDatabaseModel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Database;
 
+use InvalidArgumentException;
 use Tempest\Database\Builder\QueryBuilders\CountQueryBuilder;
 use Tempest\Database\Builder\QueryBuilders\InsertQueryBuilder;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
@@ -13,7 +14,6 @@ use Tempest\Database\Exceptions\ValueWasMissing;
 use Tempest\Reflection\PropertyReflector;
 use Tempest\Router\IsBindingValue;
 use Tempest\Validation\SkipValidation;
-use InvalidArgumentException;
 use UnitEnum;
 
 use function Tempest\Support\arr;

--- a/packages/database/src/IsDatabaseModel.php
+++ b/packages/database/src/IsDatabaseModel.php
@@ -282,13 +282,13 @@ trait IsDatabaseModel
 
         $primaryKeyValue = $primaryKeyProperty->getValue(object: $this);
 
-        $hasMany = $model->getHasMany(name: $relation);
+        $relationObj = $model->getRelation(name: $relation);
+        $ownerTable = $model->getTableName();
+        $ownerPK = $model->getPrimaryKey();
 
-        if ($hasMany instanceof HasMany) {
-            $relatedClassName = $hasMany->property->getIterableType()->getName();
-            $parentTable = $model->getTableName();
-            $parentPK = $model->getPrimaryKey();
-            $fk = $hasMany->ownerJoin ?? str(string: $parentTable)->singularizeLastWord() . '_' . $parentPK;
+        if ($relationObj instanceof HasMany) {
+            $relatedClassName = $relationObj->property->getIterableType()->getName();
+            $fk = $relationObj->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
 
             return query(model: $relatedClassName)
                 ->onDatabase(databaseTag: $this->onDatabase)
@@ -296,18 +296,14 @@ trait IsDatabaseModel
                 ->whereField(field: $fk, value: $primaryKeyValue);
         }
 
-        $hasManyThrough = $model->getHasManyThrough(name: $relation);
-
-        if ($hasManyThrough instanceof HasManyThrough) {
-            $relatedClassName = $hasManyThrough->property->getIterableType()->getName();
-            $intermediateModel = inspect(model: $hasManyThrough->through);
+        if ($relationObj instanceof HasManyThrough) {
+            $relatedClassName = $relationObj->property->getIterableType()->getName();
+            $intermediateModel = inspect(model: $relationObj->through);
             $intermediateTable = $intermediateModel->getTableName();
-            $ownerTable = $model->getTableName();
-            $ownerPK = $model->getPrimaryKey();
             $intermediatePK = $intermediateModel->getPrimaryKey();
 
-            $ownerFK = $hasManyThrough->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
-            $targetFK = $hasManyThrough->throughOwnerJoin ?? str(string: $intermediateTable)->singularizeLastWord() . '_' . $intermediatePK;
+            $ownerFK = $relationObj->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
+            $targetFK = $relationObj->throughOwnerJoin ?? str(string: $intermediateTable)->singularizeLastWord() . '_' . $intermediatePK;
 
             return query(model: $relatedClassName)
                 ->onDatabase(databaseTag: $this->onDatabase)
@@ -323,19 +319,15 @@ trait IsDatabaseModel
                 ->whereRaw(sprintf('%s.%s = ?', $intermediateTable, $ownerFK), $primaryKeyValue);
         }
 
-        $belongsToMany = $model->getBelongsToMany(name: $relation);
-
-        if ($belongsToMany instanceof BelongsToMany) {
-            $relatedClassName = $belongsToMany->property->getIterableType()->getName();
+        if ($relationObj instanceof BelongsToMany) {
+            $relatedClassName = $relationObj->property->getIterableType()->getName();
             $targetModel = inspect(model: $relatedClassName);
-            $ownerTable = $model->getTableName();
-            $ownerPK = $model->getPrimaryKey();
             $targetTable = $targetModel->getTableName();
             $targetPK = $targetModel->getPrimaryKey();
 
-            $pivotTable = $belongsToMany->pivot ?? arr([$ownerTable, $targetTable])->sort()->implode('_')->toString();
-            $ownerFK = $belongsToMany->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
-            $targetFK = $belongsToMany->relatedOwnerJoin ?? str(string: $targetTable)->singularizeLastWord() . '_' . $targetPK;
+            $pivotTable = $relationObj->pivot ?? arr([$ownerTable, $targetTable])->sort()->implode('_')->toString();
+            $ownerFK = $relationObj->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
+            $targetFK = $relationObj->relatedOwnerJoin ?? str(string: $targetTable)->singularizeLastWord() . '_' . $targetPK;
 
             return query(model: $relatedClassName)
                 ->onDatabase(databaseTag: $this->onDatabase)

--- a/packages/database/src/IsDatabaseModel.php
+++ b/packages/database/src/IsDatabaseModel.php
@@ -268,7 +268,7 @@ trait IsDatabaseModel
     /**
      * Returns a query builder scoped to a collection relation on this model.
      */
-    public function query(string $relation): SelectQueryBuilder
+    public function query(string $relation): QueryBuilder
     {
         $model = inspect(model: $this);
 
@@ -278,79 +278,18 @@ trait IsDatabaseModel
             );
         }
 
-        $primaryKeyValue = $model->getPrimaryKeyValue();
-        $ownerTable = $model->getTableName();
-        $ownerPK = $model->getPrimaryKey();
         $resolved = $model->getRelation(name: $relation);
 
-        return match (true) {
-            $resolved instanceof HasMany => $this->buildHasManyQuery($resolved, $ownerTable, $ownerPK, $primaryKeyValue),
-            $resolved instanceof HasManyThrough => $this->buildHasManyThroughQuery($resolved, $ownerTable, $ownerPK, $primaryKeyValue),
-            $resolved instanceof BelongsToMany => $this->buildBelongsToManyQuery($resolved, $ownerTable, $ownerPK, $primaryKeyValue),
-            default => throw new InvalidArgumentException(
-                message: sprintf('Property "%s" is not a collection relation on %s.', $relation, $model->getName()),
-            ),
-        };
-    }
+        if ($resolved === null) {
+            throw new InvalidArgumentException(
+                message: sprintf('Property "%s" is not a relation on %s.', $relation, $model->getName()),
+            );
+        }
 
-    private function buildHasManyQuery(HasMany $relation, string $ownerTable, string $ownerPK, PrimaryKey $primaryKeyValue): SelectQueryBuilder
-    {
-        $relatedClassName = $relation->property->getIterableType()->getName();
-        $fk = $relation->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
-
-        return query(model: $relatedClassName)
-            ->onDatabase(databaseTag: $this->onDatabase)
-            ->select()
-            ->whereField(field: $fk, value: $primaryKeyValue);
-    }
-
-    private function buildHasManyThroughQuery(HasManyThrough $relation, string $ownerTable, string $ownerPK, PrimaryKey $primaryKeyValue): SelectQueryBuilder
-    {
-        $relatedClassName = $relation->property->getIterableType()->getName();
-        $intermediateModel = inspect(model: $relation->through);
-        $intermediateTable = $intermediateModel->getTableName();
-        $intermediatePK = $intermediateModel->getPrimaryKey();
-
-        $ownerFK = $relation->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
-        $targetFK = $relation->throughOwnerJoin ?? str(string: $intermediateTable)->singularizeLastWord() . '_' . $intermediatePK;
-
-        return query(model: $relatedClassName)
-            ->onDatabase(databaseTag: $this->onDatabase)
-            ->select()
-            ->join(sprintf(
-                'INNER JOIN %s ON %s.%s = %s.%s',
-                $intermediateTable,
-                inspect(model: $relatedClassName)->getTableName(),
-                $targetFK,
-                $intermediateTable,
-                $intermediatePK,
-            ))
-            ->whereRaw(sprintf('%s.%s = ?', $intermediateTable, $ownerFK), $primaryKeyValue);
-    }
-
-    private function buildBelongsToManyQuery(BelongsToMany $relation, string $ownerTable, string $ownerPK, PrimaryKey $primaryKeyValue): SelectQueryBuilder
-    {
-        $relatedClassName = $relation->property->getIterableType()->getName();
-        $targetModel = inspect(model: $relatedClassName);
-        $targetTable = $targetModel->getTableName();
-        $targetPK = $targetModel->getPrimaryKey();
-
-        $pivotTable = $relation->pivot ?? arr([$ownerTable, $targetTable])->sort()->implode('_')->toString();
-        $ownerFK = $relation->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
-        $targetFK = $relation->relatedOwnerJoin ?? str(string: $targetTable)->singularizeLastWord() . '_' . $targetPK;
-
-        return query(model: $relatedClassName)
-            ->onDatabase(databaseTag: $this->onDatabase)
-            ->select()
-            ->join(sprintf(
-                'INNER JOIN %s ON %s.%s = %s.%s',
-                $pivotTable,
-                $pivotTable,
-                $targetFK,
-                $targetTable,
-                $targetPK,
-            ))
-            ->whereRaw(sprintf('%s.%s = ?', $pivotTable, $ownerFK), $primaryKeyValue);
+        return $resolved->query(
+            primaryKey: $model->getPrimaryKeyValue(),
+            onDatabase: $this->onDatabase,
+        );
     }
 
     /**

--- a/packages/database/src/IsDatabaseModel.php
+++ b/packages/database/src/IsDatabaseModel.php
@@ -271,7 +271,16 @@ trait IsDatabaseModel
     public function query(string $relation): SelectQueryBuilder
     {
         $model = inspect(model: $this);
-        $primaryKeyValue = $model->getPrimaryKeyProperty()->getValue(object: $this);
+
+        $primaryKeyProperty = $model->getPrimaryKeyProperty();
+
+        if ($primaryKeyProperty === null || ! $primaryKeyProperty->isInitialized(object: $this)) {
+            throw new InvalidArgumentException(
+                message: sprintf('Cannot query relations on %s without a primary key value.', $model->getName()),
+            );
+        }
+
+        $primaryKeyValue = $primaryKeyProperty->getValue(object: $this);
 
         $hasMany = $model->getHasMany(name: $relation);
 
@@ -312,6 +321,34 @@ trait IsDatabaseModel
                     $intermediatePK,
                 ))
                 ->whereRaw(sprintf('%s.%s = ?', $intermediateTable, $ownerFK), $primaryKeyValue);
+        }
+
+        $belongsToMany = $model->getBelongsToMany(name: $relation);
+
+        if ($belongsToMany instanceof BelongsToMany) {
+            $relatedClassName = $belongsToMany->property->getIterableType()->getName();
+            $targetModel = inspect(model: $relatedClassName);
+            $ownerTable = $model->getTableName();
+            $ownerPK = $model->getPrimaryKey();
+            $targetTable = $targetModel->getTableName();
+            $targetPK = $targetModel->getPrimaryKey();
+
+            $pivotTable = $belongsToMany->pivot ?? arr([$ownerTable, $targetTable])->sort()->implode('_')->toString();
+            $ownerFK = $belongsToMany->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
+            $targetFK = $belongsToMany->relatedOwnerJoin ?? str(string: $targetTable)->singularizeLastWord() . '_' . $targetPK;
+
+            return query(model: $relatedClassName)
+                ->onDatabase(databaseTag: $this->onDatabase)
+                ->select()
+                ->join(sprintf(
+                    'INNER JOIN %s ON %s.%s = %s.%s',
+                    $pivotTable,
+                    $pivotTable,
+                    $targetFK,
+                    $targetTable,
+                    $targetPK,
+                ))
+                ->whereRaw(sprintf('%s.%s = ?', $pivotTable, $ownerFK), $primaryKeyValue);
         }
 
         throw new InvalidArgumentException(

--- a/packages/database/src/IsDatabaseModel.php
+++ b/packages/database/src/IsDatabaseModel.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Tempest\Database;
 
-use InvalidArgumentException;
 use Tempest\Database\Builder\QueryBuilders\CountQueryBuilder;
 use Tempest\Database\Builder\QueryBuilders\InsertQueryBuilder;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
 use Tempest\Database\Builder\QueryBuilders\SelectQueryBuilder;
+use Tempest\Database\Exceptions\PrimaryKeyWasNotInitialized;
+use Tempest\Database\Exceptions\PropertyWasNotARelation;
 use Tempest\Database\Exceptions\RelationWasMissing;
 use Tempest\Database\Exceptions\ValueWasMissing;
 use Tempest\Reflection\PropertyReflector;
@@ -273,17 +274,13 @@ trait IsDatabaseModel
         $model = inspect(model: $this);
 
         if (! $model->hasPrimaryKey() || ! $model->getPrimaryKeyProperty()->isInitialized(object: $this)) {
-            throw new InvalidArgumentException(
-                message: sprintf('Cannot query relations on %s without a primary key value.', $model->getName()),
-            );
+            throw new PrimaryKeyWasNotInitialized(model: $model->getName());
         }
 
         $resolved = $model->getRelation(name: $relation);
 
         if ($resolved === null) {
-            throw new InvalidArgumentException(
-                message: sprintf('Property "%s" is not a relation on %s.', $relation, $model->getName()),
-            );
+            throw new PropertyWasNotARelation(property: $relation, model: $model->getName());
         }
 
         return $resolved->query(

--- a/packages/database/src/IsDatabaseModel.php
+++ b/packages/database/src/IsDatabaseModel.php
@@ -13,6 +13,7 @@ use Tempest\Database\Exceptions\ValueWasMissing;
 use Tempest\Reflection\PropertyReflector;
 use Tempest\Router\IsBindingValue;
 use Tempest\Validation\SkipValidation;
+use InvalidArgumentException;
 use UnitEnum;
 
 use function Tempest\Support\arr;
@@ -262,6 +263,32 @@ trait IsDatabaseModel
         }
 
         return $this;
+    }
+
+    /**
+     * Returns a query builder scoped to a HasMany relation on this model.
+     */
+    public function query(string $relation): SelectQueryBuilder
+    {
+        $model = inspect($this);
+        $hasMany = $model->getHasMany($relation);
+
+        if (! $hasMany instanceof HasMany) {
+            throw new InvalidArgumentException(
+                sprintf('Property "%s" is not a HasMany relation on %s.', $relation, $model->getName()),
+            );
+        }
+
+        $relatedClassName = $hasMany->property->getIterableType()->getName();
+        $parentTable = $model->getTableName();
+        $parentPK = $model->getPrimaryKey();
+        $fk = $hasMany->ownerJoin ?? str($parentTable)->singularizeLastWord() . '_' . $parentPK;
+        $primaryKeyValue = $model->getPrimaryKeyProperty()->getValue($this);
+
+        return query($relatedClassName)
+            ->onDatabase($this->onDatabase)
+            ->select()
+            ->whereField($fk, $primaryKeyValue);
     }
 
     /**

--- a/packages/database/src/IsDatabaseModel.php
+++ b/packages/database/src/IsDatabaseModel.php
@@ -279,71 +279,77 @@ trait IsDatabaseModel
         }
 
         $primaryKeyValue = $model->getPrimaryKeyValue();
-
-        $relationObj = $model->getRelation(name: $relation);
         $ownerTable = $model->getTableName();
         $ownerPK = $model->getPrimaryKey();
 
-        if ($relationObj instanceof HasMany) {
-            $relatedClassName = $relationObj->property->getIterableType()->getName();
-            $fk = $relationObj->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
+        return match (true) {
+            ($resolved = $model->getRelation(name: $relation)) instanceof HasMany => $this->buildHasManyQuery($resolved, $ownerTable, $ownerPK, $primaryKeyValue),
+            $resolved instanceof HasManyThrough => $this->buildHasManyThroughQuery($resolved, $ownerTable, $ownerPK, $primaryKeyValue),
+            $resolved instanceof BelongsToMany => $this->buildBelongsToManyQuery($resolved, $ownerTable, $ownerPK, $primaryKeyValue),
+            default => throw new InvalidArgumentException(
+                message: sprintf('Property "%s" is not a collection relation on %s.', $relation, $model->getName()),
+            ),
+        };
+    }
 
-            return query(model: $relatedClassName)
-                ->onDatabase(databaseTag: $this->onDatabase)
-                ->select()
-                ->whereField(field: $fk, value: $primaryKeyValue);
-        }
+    private function buildHasManyQuery(HasMany $relation, string $ownerTable, string $ownerPK, PrimaryKey $primaryKeyValue): SelectQueryBuilder
+    {
+        $relatedClassName = $relation->property->getIterableType()->getName();
+        $fk = $relation->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
 
-        if ($relationObj instanceof HasManyThrough) {
-            $relatedClassName = $relationObj->property->getIterableType()->getName();
-            $intermediateModel = inspect(model: $relationObj->through);
-            $intermediateTable = $intermediateModel->getTableName();
-            $intermediatePK = $intermediateModel->getPrimaryKey();
+        return query(model: $relatedClassName)
+            ->onDatabase(databaseTag: $this->onDatabase)
+            ->select()
+            ->whereField(field: $fk, value: $primaryKeyValue);
+    }
 
-            $ownerFK = $relationObj->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
-            $targetFK = $relationObj->throughOwnerJoin ?? str(string: $intermediateTable)->singularizeLastWord() . '_' . $intermediatePK;
+    private function buildHasManyThroughQuery(HasManyThrough $relation, string $ownerTable, string $ownerPK, PrimaryKey $primaryKeyValue): SelectQueryBuilder
+    {
+        $relatedClassName = $relation->property->getIterableType()->getName();
+        $intermediateModel = inspect(model: $relation->through);
+        $intermediateTable = $intermediateModel->getTableName();
+        $intermediatePK = $intermediateModel->getPrimaryKey();
 
-            return query(model: $relatedClassName)
-                ->onDatabase(databaseTag: $this->onDatabase)
-                ->select()
-                ->join(sprintf(
-                    'INNER JOIN %s ON %s.%s = %s.%s',
-                    $intermediateTable,
-                    inspect(model: $relatedClassName)->getTableName(),
-                    $targetFK,
-                    $intermediateTable,
-                    $intermediatePK,
-                ))
-                ->whereRaw(sprintf('%s.%s = ?', $intermediateTable, $ownerFK), $primaryKeyValue);
-        }
+        $ownerFK = $relation->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
+        $targetFK = $relation->throughOwnerJoin ?? str(string: $intermediateTable)->singularizeLastWord() . '_' . $intermediatePK;
 
-        if ($relationObj instanceof BelongsToMany) {
-            $relatedClassName = $relationObj->property->getIterableType()->getName();
-            $targetModel = inspect(model: $relatedClassName);
-            $targetTable = $targetModel->getTableName();
-            $targetPK = $targetModel->getPrimaryKey();
+        return query(model: $relatedClassName)
+            ->onDatabase(databaseTag: $this->onDatabase)
+            ->select()
+            ->join(sprintf(
+                'INNER JOIN %s ON %s.%s = %s.%s',
+                $intermediateTable,
+                inspect(model: $relatedClassName)->getTableName(),
+                $targetFK,
+                $intermediateTable,
+                $intermediatePK,
+            ))
+            ->whereRaw(sprintf('%s.%s = ?', $intermediateTable, $ownerFK), $primaryKeyValue);
+    }
 
-            $pivotTable = $relationObj->pivot ?? arr([$ownerTable, $targetTable])->sort()->implode('_')->toString();
-            $ownerFK = $relationObj->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
-            $targetFK = $relationObj->relatedOwnerJoin ?? str(string: $targetTable)->singularizeLastWord() . '_' . $targetPK;
+    private function buildBelongsToManyQuery(BelongsToMany $relation, string $ownerTable, string $ownerPK, PrimaryKey $primaryKeyValue): SelectQueryBuilder
+    {
+        $relatedClassName = $relation->property->getIterableType()->getName();
+        $targetModel = inspect(model: $relatedClassName);
+        $targetTable = $targetModel->getTableName();
+        $targetPK = $targetModel->getPrimaryKey();
 
-            return query(model: $relatedClassName)
-                ->onDatabase(databaseTag: $this->onDatabase)
-                ->select()
-                ->join(sprintf(
-                    'INNER JOIN %s ON %s.%s = %s.%s',
-                    $pivotTable,
-                    $pivotTable,
-                    $targetFK,
-                    $targetTable,
-                    $targetPK,
-                ))
-                ->whereRaw(sprintf('%s.%s = ?', $pivotTable, $ownerFK), $primaryKeyValue);
-        }
+        $pivotTable = $relation->pivot ?? arr([$ownerTable, $targetTable])->sort()->implode('_')->toString();
+        $ownerFK = $relation->ownerJoin ?? str(string: $ownerTable)->singularizeLastWord() . '_' . $ownerPK;
+        $targetFK = $relation->relatedOwnerJoin ?? str(string: $targetTable)->singularizeLastWord() . '_' . $targetPK;
 
-        throw new InvalidArgumentException(
-            message: sprintf('Property "%s" is not a collection relation on %s.', $relation, $model->getName()),
-        );
+        return query(model: $relatedClassName)
+            ->onDatabase(databaseTag: $this->onDatabase)
+            ->select()
+            ->join(sprintf(
+                'INNER JOIN %s ON %s.%s = %s.%s',
+                $pivotTable,
+                $pivotTable,
+                $targetFK,
+                $targetTable,
+                $targetPK,
+            ))
+            ->whereRaw(sprintf('%s.%s = ?', $pivotTable, $ownerFK), $primaryKeyValue);
     }
 
     /**

--- a/packages/database/src/IsDatabaseModel.php
+++ b/packages/database/src/IsDatabaseModel.php
@@ -281,9 +281,10 @@ trait IsDatabaseModel
         $primaryKeyValue = $model->getPrimaryKeyValue();
         $ownerTable = $model->getTableName();
         $ownerPK = $model->getPrimaryKey();
+        $resolved = $model->getRelation(name: $relation);
 
         return match (true) {
-            ($resolved = $model->getRelation(name: $relation)) instanceof HasMany => $this->buildHasManyQuery($resolved, $ownerTable, $ownerPK, $primaryKeyValue),
+            $resolved instanceof HasMany => $this->buildHasManyQuery($resolved, $ownerTable, $ownerPK, $primaryKeyValue),
             $resolved instanceof HasManyThrough => $this->buildHasManyThroughQuery($resolved, $ownerTable, $ownerPK, $primaryKeyValue),
             $resolved instanceof BelongsToMany => $this->buildBelongsToManyQuery($resolved, $ownerTable, $ownerPK, $primaryKeyValue),
             default => throw new InvalidArgumentException(

--- a/packages/database/src/Relation.php
+++ b/packages/database/src/Relation.php
@@ -2,10 +2,12 @@
 
 namespace Tempest\Database;
 
+use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
 use Tempest\Database\QueryStatements\JoinStatement;
 use Tempest\Database\QueryStatements\WhereExistsStatement;
 use Tempest\Reflection\PropertyAttribute;
 use Tempest\Support\Arr\ImmutableArray;
+use UnitEnum;
 
 interface Relation extends PropertyAttribute
 {
@@ -22,4 +24,6 @@ interface Relation extends PropertyAttribute
     public function getJoinStatement(): JoinStatement;
 
     public function getExistsStatement(): WhereExistsStatement;
+
+    public function query(PrimaryKey $primaryKey, null|string|UnitEnum $onDatabase = null): QueryBuilder;
 }

--- a/packages/upgrade/tests/Tempest20/Tempest20RectorTest.php
+++ b/packages/upgrade/tests/Tempest20/Tempest20RectorTest.php
@@ -2,9 +2,11 @@
 
 namespace Tempest\Upgrade\Tests\Tempest20;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
 use Tempest\Upgrade\Tests\RectorTester;
 
+#[RunTestsInSeparateProcesses]
 final class Tempest20RectorTest extends TestCase
 {
     private RectorTester $rector {

--- a/packages/upgrade/tests/Tempest28/Tempest28RectorTest.php
+++ b/packages/upgrade/tests/Tempest28/Tempest28RectorTest.php
@@ -2,9 +2,11 @@
 
 namespace Tempest\Upgrade\Tests\Tempest28;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
 use Tempest\Upgrade\Tests\RectorTester;
 
+#[RunTestsInSeparateProcesses]
 final class Tempest28RectorTest extends TestCase
 {
     private RectorTester $rector {

--- a/packages/upgrade/tests/Tempest3/Tempest3RectorTest.php
+++ b/packages/upgrade/tests/Tempest3/Tempest3RectorTest.php
@@ -2,9 +2,11 @@
 
 namespace Tempest\Upgrade\Tests\Tempest3;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
 use Tempest\Upgrade\Tests\RectorTester;
 
+#[RunTestsInSeparateProcesses]
 final class Tempest3RectorTest extends TestCase
 {
     private RectorTester $rector {

--- a/packages/upgrade/tests/Tempest34/Tempest34RectorTest.php
+++ b/packages/upgrade/tests/Tempest34/Tempest34RectorTest.php
@@ -2,9 +2,11 @@
 
 namespace Tempest\Upgrade\Tests\Tempest34;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
 use Tempest\Upgrade\Tests\RectorTester;
 
+#[RunTestsInSeparateProcesses]
 final class Tempest34RectorTest extends TestCase
 {
     private RectorTester $rector {

--- a/tests/Fixtures/Migrations/CreateBookTagTable.php
+++ b/tests/Fixtures/Migrations/CreateBookTagTable.php
@@ -6,10 +6,10 @@ namespace Tests\Tempest\Fixtures\Migrations;
 
 use Tempest\Database\MigratesDown;
 use Tempest\Database\MigratesUp;
-use Tempest\Database\QueryStatements\OnDelete;
 use Tempest\Database\QueryStatement;
 use Tempest\Database\QueryStatements\CreateTableStatement;
 use Tempest\Database\QueryStatements\DropTableStatement;
+use Tempest\Database\QueryStatements\OnDelete;
 
 final class CreateBookTagTable implements MigratesUp, MigratesDown
 {

--- a/tests/Fixtures/Migrations/CreateBookTagTable.php
+++ b/tests/Fixtures/Migrations/CreateBookTagTable.php
@@ -6,6 +6,7 @@ namespace Tests\Tempest\Fixtures\Migrations;
 
 use Tempest\Database\MigratesDown;
 use Tempest\Database\MigratesUp;
+use Tempest\Database\QueryStatements\OnDelete;
 use Tempest\Database\QueryStatement;
 use Tempest\Database\QueryStatements\CreateTableStatement;
 use Tempest\Database\QueryStatements\DropTableStatement;
@@ -18,8 +19,8 @@ final class CreateBookTagTable implements MigratesUp, MigratesDown
     {
         return new CreateTableStatement(tableName: 'books_tags')
             ->primary()
-            ->belongsTo(local: 'books_tags.book_id', foreign: 'books.id')
-            ->belongsTo(local: 'books_tags.tag_id', foreign: 'tags.id');
+            ->belongsTo(local: 'books_tags.book_id', foreign: 'books.id', onDelete: OnDelete::CASCADE)
+            ->belongsTo(local: 'books_tags.tag_id', foreign: 'tags.id', onDelete: OnDelete::CASCADE);
     }
 
     public function down(): QueryStatement

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -701,6 +701,119 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         $this->assertSame(2, $tag->query('books')->count()->execute());
     }
 
+    public function test_query_has_many_through_update(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreateTagTable::class,
+            CreateBookReviewTable::class,
+            CreateReviewerTable::class,
+        );
+
+        $tagA = Tag::create(label: 'fantasy');
+        $tagB = Tag::create(label: 'sci-fi');
+
+        $reviewA = BookReview::create(content: 'Great', tag: $tagA);
+        $reviewB = BookReview::create(content: 'Meh', tag: $tagB);
+
+        Reviewer::create(name: 'Alice', bookReview: $reviewA);
+        Reviewer::create(name: 'Bob', bookReview: $reviewB);
+
+        $tagA->query('reviewers')->update(name: 'Updated')->execute();
+
+        $reviewersA = $tagA->query('reviewers')->select()->all();
+        $reviewersB = $tagB->query('reviewers')->select()->all();
+
+        $this->assertSame('Updated', $reviewersA[0]->name);
+        $this->assertSame('Bob', $reviewersB[0]->name);
+    }
+
+    public function test_query_has_many_through_delete(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreateTagTable::class,
+            CreateBookReviewTable::class,
+            CreateReviewerTable::class,
+        );
+
+        $tagA = Tag::create(label: 'fantasy');
+        $tagB = Tag::create(label: 'sci-fi');
+
+        $reviewA = BookReview::create(content: 'Great', tag: $tagA);
+        $reviewB = BookReview::create(content: 'Meh', tag: $tagB);
+
+        Reviewer::create(name: 'Alice', bookReview: $reviewA);
+        Reviewer::create(name: 'Bob', bookReview: $reviewB);
+
+        $tagA->query('reviewers')->delete()->execute();
+
+        $this->assertSame(0, $tagA->query('reviewers')->count()->execute());
+        $this->assertSame(1, $tagB->query('reviewers')->count()->execute());
+    }
+
+    public function test_query_belongs_to_many_delete(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+            CreateTagTable::class,
+            CreateBookTagTable::class,
+        );
+
+        $author = Author::create(name: 'Author', type: AuthorType::A);
+        $book1 = Book::create(title: 'Book 1', author: $author);
+        $book2 = Book::create(title: 'Book 2', author: $author);
+        $book3 = Book::create(title: 'Book 3', author: $author);
+
+        $tagA = Tag::create(label: 'fantasy');
+        $tagB = Tag::create(label: 'sci-fi');
+
+        query(model: 'books_tags')->insert(['book_id' => $book1->id->value, 'tag_id' => $tagA->id->value])->execute();
+        query(model: 'books_tags')->insert(['book_id' => $book2->id->value, 'tag_id' => $tagA->id->value])->execute();
+        query(model: 'books_tags')->insert(['book_id' => $book3->id->value, 'tag_id' => $tagB->id->value])->execute();
+
+        $tagA->query('books')->delete()->execute();
+
+        $this->assertSame(0, $tagA->query('books')->count()->execute());
+        $this->assertSame(1, $tagB->query('books')->count()->execute());
+    }
+
+    public function test_query_belongs_to_many_update(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+            CreateTagTable::class,
+            CreateBookTagTable::class,
+        );
+
+        $author = Author::create(name: 'Author', type: AuthorType::A);
+        $book1 = Book::create(title: 'Old 1', author: $author);
+        $book2 = Book::create(title: 'Old 2', author: $author);
+        $book3 = Book::create(title: 'Keep', author: $author);
+
+        $tagA = Tag::create(label: 'fantasy');
+        $tagB = Tag::create(label: 'sci-fi');
+
+        query(model: 'books_tags')->insert(['book_id' => $book1->id->value, 'tag_id' => $tagA->id->value])->execute();
+        query(model: 'books_tags')->insert(['book_id' => $book2->id->value, 'tag_id' => $tagA->id->value])->execute();
+        query(model: 'books_tags')->insert(['book_id' => $book3->id->value, 'tag_id' => $tagB->id->value])->execute();
+
+        $tagA->query('books')->update(title: 'Updated')->execute();
+
+        $booksA = $tagA->query('books')->select()->all();
+        $booksB = $tagB->query('books')->select()->all();
+
+        $this->assertSame('Updated', $booksA[0]->title);
+        $this->assertSame('Updated', $booksA[1]->title);
+        $this->assertSame('Keep', $booksB[0]->title);
+    }
+
     public function test_has_many_through_relation(): void
     {
         $this->database->migrate(

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -7,6 +7,7 @@ namespace Tests\Tempest\Integration\Database\Builder;
 use Carbon\Carbon;
 use DateTime as NativeDateTime;
 use DateTimeImmutable;
+use BadMethodCallException;
 use InvalidArgumentException;
 use Tempest\Database\BelongsTo;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
@@ -341,7 +342,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Book::create(title: 'Book 3', author: $authorA);
         Book::create(title: 'Other Book', author: $authorB);
 
-        $books = $authorA->query( 'books')->all();
+        $books = $authorA->query('books')->select()->all();
 
         $this->assertCount(3, $books);
         $this->assertContainsOnlyInstancesOf(Book::class, $books);
@@ -365,7 +366,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Book::create(title: 'Beta', author: $author);
         Book::create(title: 'Gamma', author: $author);
 
-        $books = $author->query( 'books')
+        $books = $author->query('books')->select()
             ->whereField(field: 'title', value: 'Beta')
             ->all();
 
@@ -391,7 +392,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Book::create(title: 'Book 2', author: $author);
         Book::create(title: 'Book 3', author: $author);
 
-        $books = $author->query( 'books')->limit(limit: 2)->all();
+        $books = $author->query('books')->select()->limit(limit: 2)->all();
 
         $this->assertCount(2, $books);
     }
@@ -416,7 +417,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Reviewer::create(name: 'Bob', bookReview: $reviewA2);
         Reviewer::create(name: 'Charlie', bookReview: $reviewB1);
 
-        $reviewers = $tagA->query( 'reviewers')->all();
+        $reviewers = $tagA->query('reviewers')->select()->all();
 
         $this->assertCount(2, $reviewers);
         $this->assertContainsOnlyInstancesOf(Reviewer::class, $reviewers);
@@ -439,7 +440,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Reviewer::create(name: 'Alice', bookReview: $review1);
         Reviewer::create(name: 'Bob', bookReview: $review2);
 
-        $reviewers = $tag->query( 'reviewers')
+        $reviewers = $tag->query('reviewers')->select()
             ->whereField(field: 'name', value: 'Alice')
             ->all();
 
@@ -470,7 +471,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         query(model: 'books_tags')->insert(['book_id' => $book2->id->value, 'tag_id' => $tagA->id->value])->execute();
         query(model: 'books_tags')->insert(['book_id' => $book3->id->value, 'tag_id' => $tagB->id->value])->execute();
 
-        $books = $tagA->query( 'books')->all();
+        $books = $tagA->query('books')->select()->all();
 
         $this->assertCount(2, $books);
         $this->assertContainsOnlyInstancesOf(Book::class, $books);
@@ -496,7 +497,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         query(model: 'books_tags')->insert(['book_id' => $book1->id->value, 'tag_id' => $tag->id->value])->execute();
         query(model: 'books_tags')->insert(['book_id' => $book2->id->value, 'tag_id' => $tag->id->value])->execute();
 
-        $books = $tag->query( 'books')
+        $books = $tag->query('books')->select()
             ->whereField(field: 'title', value: 'Alpha')
             ->all();
 
@@ -521,7 +522,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
             ->insert(['title' => 'Post 2', 'body' => 'Body 2', 'test_user_id' => $user->id->value])
             ->execute();
 
-        $posts = $user->query( 'posts')->all();
+        $posts = $user->query('posts')->select()->all();
 
         $this->assertCount(2, $posts);
         $this->assertContainsOnlyInstancesOf(TestPost::class, $posts);
@@ -538,9 +539,9 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
         $book = Book::create(title: 'Test');
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(BadMethodCallException::class);
 
-        $book->query( 'author');
+        $book->query('author');
     }
 
     public function test_query_throws_for_nonexistent_property(): void
@@ -555,7 +556,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
         $this->expectException(InvalidArgumentException::class);
 
-        $author->query( 'nonexistent');
+        $author->query('nonexistent');
     }
 
     public function test_query_throws_for_unsaved_model(): void
@@ -564,7 +565,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
         $this->expectException(InvalidArgumentException::class);
 
-        $author->query( 'books');
+        $author->query('books');
     }
 
     public function test_query_has_many_returns_empty_for_no_results(): void
@@ -578,7 +579,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
         $author = Author::create(name: 'Author', type: AuthorType::A);
 
-        $books = $author->query( 'books')->all();
+        $books = $author->query('books')->select()->all();
 
         $this->assertCount(0, $books);
     }

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -7,6 +7,7 @@ namespace Tests\Tempest\Integration\Database\Builder;
 use Carbon\Carbon;
 use DateTime as NativeDateTime;
 use DateTimeImmutable;
+use InvalidArgumentException;
 use Tempest\Database\BelongsTo;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
 use Tempest\Database\Exceptions\DeleteStatementWasInvalid;
@@ -46,6 +47,7 @@ use Tests\Tempest\Fixtures\Models\AWithVirtual;
 use Tests\Tempest\Fixtures\Models\B;
 use Tests\Tempest\Fixtures\Models\C;
 use Tests\Tempest\Fixtures\Migrations\CreateBookReviewTable;
+use Tests\Tempest\Fixtures\Migrations\CreateBookTagTable;
 use Tests\Tempest\Fixtures\Migrations\CreateReviewerTable;
 use Tests\Tempest\Fixtures\Migrations\CreateTagTable;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
@@ -443,6 +445,142 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
         $this->assertCount(1, $reviewers);
         $this->assertSame('Alice', $reviewers[0]->name);
+    }
+
+    public function test_query_belongs_to_many_returns_scoped_results(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+            CreateTagTable::class,
+            CreateBookTagTable::class,
+        );
+
+        $author = Author::create(name: 'Author', type: AuthorType::A);
+        $book1 = Book::create(title: 'Book 1', author: $author);
+        $book2 = Book::create(title: 'Book 2', author: $author);
+        $book3 = Book::create(title: 'Book 3', author: $author);
+
+        $tagA = Tag::create(label: 'fantasy');
+        $tagB = Tag::create(label: 'sci-fi');
+
+        query(model: 'books_tags')->insert(['book_id' => $book1->id->value, 'tag_id' => $tagA->id->value])->execute();
+        query(model: 'books_tags')->insert(['book_id' => $book2->id->value, 'tag_id' => $tagA->id->value])->execute();
+        query(model: 'books_tags')->insert(['book_id' => $book3->id->value, 'tag_id' => $tagB->id->value])->execute();
+
+        $books = $tagA->query(relation: 'books')->all();
+
+        $this->assertCount(2, $books);
+        $this->assertContainsOnlyInstancesOf(Book::class, $books);
+    }
+
+    public function test_query_belongs_to_many_supports_where(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+            CreateTagTable::class,
+            CreateBookTagTable::class,
+        );
+
+        $author = Author::create(name: 'Author', type: AuthorType::A);
+        $book1 = Book::create(title: 'Alpha', author: $author);
+        $book2 = Book::create(title: 'Beta', author: $author);
+
+        $tag = Tag::create(label: 'fantasy');
+
+        query(model: 'books_tags')->insert(['book_id' => $book1->id->value, 'tag_id' => $tag->id->value])->execute();
+        query(model: 'books_tags')->insert(['book_id' => $book2->id->value, 'tag_id' => $tag->id->value])->execute();
+
+        $books = $tag->query(relation: 'books')
+            ->whereField(field: 'title', value: 'Alpha')
+            ->all();
+
+        $this->assertCount(1, $books);
+        $this->assertSame('Alpha', $books[0]->title);
+    }
+
+    public function test_query_has_many_with_explicit_attribute(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreateTestUserMigration::class,
+            CreateTestPostMigration::class,
+        );
+
+        $user = TestUser::create(name: 'Alice');
+
+        query(model: 'test_posts')
+            ->insert(['title' => 'Post 1', 'body' => 'Body 1', 'test_user_id' => $user->id->value])
+            ->execute();
+        query(model: 'test_posts')
+            ->insert(['title' => 'Post 2', 'body' => 'Body 2', 'test_user_id' => $user->id->value])
+            ->execute();
+
+        $posts = $user->query(relation: 'posts')->all();
+
+        $this->assertCount(2, $posts);
+        $this->assertContainsOnlyInstancesOf(TestPost::class, $posts);
+    }
+
+    public function test_query_throws_for_non_collection_relation(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+        );
+
+        $book = Book::create(title: 'Test');
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $book->query(relation: 'author');
+    }
+
+    public function test_query_throws_for_nonexistent_property(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+        );
+
+        $author = Author::create(name: 'Author', type: AuthorType::A);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $author->query(relation: 'nonexistent');
+    }
+
+    public function test_query_throws_for_unsaved_model(): void
+    {
+        $author = new Author(name: 'Unsaved');
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $author->query(relation: 'books');
+    }
+
+    public function test_query_has_many_returns_empty_for_no_results(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+        );
+
+        $author = Author::create(name: 'Author', type: AuthorType::A);
+
+        $books = $author->query(relation: 'books')->all();
+
+        $this->assertCount(0, $books);
     }
 
     public function test_has_many_through_relation(): void

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -567,6 +567,86 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         $this->assertSame(1, $book->query('author')->count()->execute());
     }
 
+    public function test_query_has_one_select(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+            CreateIsbnTable::class,
+        );
+
+        $book = Book::create(title: 'Test Book');
+        Isbn::new(value: '978-123', book: $book)->save();
+
+        $result = $book->query('isbn')->select()->first();
+
+        $this->assertInstanceOf(Isbn::class, $result);
+        $this->assertSame('978-123', $result->value);
+    }
+
+    public function test_query_has_one_count(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+            CreateIsbnTable::class,
+        );
+
+        $book = Book::create(title: 'Test Book');
+        Isbn::new(value: '978-123', book: $book)->save();
+
+        $this->assertSame(1, $book->query('isbn')->count()->execute());
+    }
+
+    public function test_query_has_one_update(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+            CreateIsbnTable::class,
+        );
+
+        $bookA = Book::create(title: 'Book A');
+        $bookB = Book::create(title: 'Book B');
+        Isbn::new(value: 'old-isbn', book: $bookA)->save();
+        Isbn::new(value: 'keep-isbn', book: $bookB)->save();
+
+        $bookA->query('isbn')->update(value: 'new-isbn')->execute();
+
+        $isbnA = $bookA->query('isbn')->select()->first();
+        $isbnB = $bookB->query('isbn')->select()->first();
+
+        $this->assertSame('new-isbn', $isbnA->value);
+        $this->assertSame('keep-isbn', $isbnB->value);
+    }
+
+    public function test_query_has_one_delete(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+            CreateIsbnTable::class,
+        );
+
+        $bookA = Book::create(title: 'Book A');
+        $bookB = Book::create(title: 'Book B');
+        Isbn::new(value: 'isbn-a', book: $bookA)->save();
+        Isbn::new(value: 'isbn-b', book: $bookB)->save();
+
+        $bookA->query('isbn')->delete()->execute();
+
+        $this->assertSame(0, $bookA->query('isbn')->count()->execute());
+        $this->assertSame(1, $bookB->query('isbn')->count()->execute());
+    }
+
     public function test_query_throws_for_nonexistent_property(): void
     {
         $this->database->migrate(

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -10,6 +10,7 @@ use DateTimeImmutable;
 use InvalidArgumentException;
 use Tempest\Database\BelongsTo;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
+use Tempest\Database\Builder\QueryBuilders\SelectQueryBuilder;
 use Tempest\Database\Exceptions\DeleteStatementWasInvalid;
 use Tempest\Database\Exceptions\RelationWasMissing;
 use Tempest\Database\Exceptions\ValueWasMissing;
@@ -54,6 +55,7 @@ use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Fixtures\Modules\Books\Models\AuthorType;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
 use Tests\Tempest\Fixtures\Modules\Books\Models\BookReview;
+use Tests\Tempest\Fixtures\Modules\Books\Models\Chapter;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Isbn;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Reviewer;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Tag;
@@ -726,6 +728,117 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
         $this->assertSame(0, $tagA->query('topReviewer')->count()->execute());
         $this->assertSame(1, $tagB->query('topReviewer')->count()->execute());
+    }
+
+    public function test_query_has_many_with_where_has(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+            CreateChapterTable::class,
+        );
+
+        $author = Author::create(name: 'Author', type: AuthorType::A);
+        $bookWithChapters = Book::create(title: 'With Chapters', author: $author);
+        Book::create(title: 'No Chapters', author: $author);
+
+        Chapter::new(title: 'Chapter 1', contents: 'Content', book: $bookWithChapters)->save();
+
+        $books = $author
+            ->query('books')
+            ->select()
+            ->whereHas(relation: 'chapters')
+            ->all();
+
+        $this->assertCount(1, $books);
+        $this->assertSame('With Chapters', $books[0]->title);
+    }
+
+    public function test_query_has_many_with_where_doesnt_have_and_where_field(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+            CreateChapterTable::class,
+        );
+
+        $author = Author::create(name: 'Author', type: AuthorType::A);
+        $bookA = Book::create(title: 'Alpha', author: $author);
+        Book::create(title: 'Beta', author: $author);
+        Book::create(title: 'Gamma', author: $author);
+
+        Chapter::new(title: 'Ch 1', contents: 'Content', book: $bookA)->save();
+
+        $books = $author
+            ->query('books')
+            ->select()
+            ->whereDoesntHave(relation: 'chapters')
+            ->whereField(field: 'title', value: 'Beta')
+            ->all();
+
+        $this->assertCount(1, $books);
+        $this->assertSame('Beta', $books[0]->title);
+    }
+
+    public function test_query_has_many_with_where_has_callback(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+            CreateChapterTable::class,
+        );
+
+        $author = Author::create(name: 'Author', type: AuthorType::A);
+        $bookA = Book::create(title: 'Book A', author: $author);
+        $bookB = Book::create(title: 'Book B', author: $author);
+
+        Chapter::new(title: 'Intro', contents: 'Content', book: $bookA)->save();
+        Chapter::new(title: 'Advanced Topics', contents: 'Content', book: $bookB)->save();
+
+        $books = $author
+            ->query('books')
+            ->select()
+            ->whereHas(relation: 'chapters', callback: function (SelectQueryBuilder $q): void {
+                $q->whereField(field: 'title', value: 'Advanced Topics');
+            })
+            ->all();
+
+        $this->assertCount(1, $books);
+        $this->assertSame('Book B', $books[0]->title);
+    }
+
+    public function test_query_has_many_with_where_doesnt_have_callback(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+            CreateChapterTable::class,
+        );
+
+        $author = Author::create(name: 'Author', type: AuthorType::A);
+        $bookA = Book::create(title: 'Book A', author: $author);
+        Book::create(title: 'Book B', author: $author);
+
+        Chapter::new(title: 'Draft', contents: 'WIP', book: $bookA)->save();
+
+        $books = $author
+            ->query('books')
+            ->select()
+            ->whereDoesntHave(relation: 'chapters', callback: function (SelectQueryBuilder $q): void {
+                $q->whereField(field: 'title', value: 'Draft');
+            })
+            ->all();
+
+        $this->assertCount(1, $books);
+        $this->assertSame('Book B', $books[0]->title);
     }
 
     public function test_query_throws_for_nonexistent_property(): void

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -45,10 +45,16 @@ use Tests\Tempest\Fixtures\Models\AWithValue;
 use Tests\Tempest\Fixtures\Models\AWithVirtual;
 use Tests\Tempest\Fixtures\Models\B;
 use Tests\Tempest\Fixtures\Models\C;
+use Tests\Tempest\Fixtures\Migrations\CreateBookReviewTable;
+use Tests\Tempest\Fixtures\Migrations\CreateReviewerTable;
+use Tests\Tempest\Fixtures\Migrations\CreateTagTable;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Fixtures\Modules\Books\Models\AuthorType;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
+use Tests\Tempest\Fixtures\Modules\Books\Models\BookReview;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Isbn;
+use Tests\Tempest\Fixtures\Modules\Books\Models\Reviewer;
+use Tests\Tempest\Fixtures\Modules\Books\Models\Tag;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 use function Tempest\Database\query;
@@ -333,7 +339,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Book::create(title: 'Book 3', author: $authorA);
         Book::create(title: 'Other Book', author: $authorB);
 
-        $books = $authorA->query('books')->all();
+        $books = $authorA->query(relation: 'books')->all();
 
         $this->assertCount(3, $books);
         $this->assertContainsOnlyInstancesOf(Book::class, $books);
@@ -357,8 +363,8 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Book::create(title: 'Beta', author: $author);
         Book::create(title: 'Gamma', author: $author);
 
-        $books = $author->query('books')
-            ->whereField('title', 'Beta')
+        $books = $author->query(relation: 'books')
+            ->whereField(field: 'title', value: 'Beta')
             ->all();
 
         $this->assertCount(1, $books);
@@ -383,9 +389,60 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Book::create(title: 'Book 2', author: $author);
         Book::create(title: 'Book 3', author: $author);
 
-        $books = $author->query('books')->limit(2)->all();
+        $books = $author->query(relation: 'books')->limit(limit: 2)->all();
 
         $this->assertCount(2, $books);
+    }
+
+    public function test_query_has_many_through_returns_scoped_results(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreateTagTable::class,
+            CreateBookReviewTable::class,
+            CreateReviewerTable::class,
+        );
+
+        $tagA = Tag::create(label: 'fantasy');
+        $tagB = Tag::create(label: 'sci-fi');
+
+        $reviewA1 = BookReview::create(content: 'Great', tag: $tagA);
+        $reviewA2 = BookReview::create(content: 'Good', tag: $tagA);
+        $reviewB1 = BookReview::create(content: 'Meh', tag: $tagB);
+
+        Reviewer::create(name: 'Alice', bookReview: $reviewA1);
+        Reviewer::create(name: 'Bob', bookReview: $reviewA2);
+        Reviewer::create(name: 'Charlie', bookReview: $reviewB1);
+
+        $reviewers = $tagA->query(relation: 'reviewers')->all();
+
+        $this->assertCount(2, $reviewers);
+        $this->assertContainsOnlyInstancesOf(Reviewer::class, $reviewers);
+    }
+
+    public function test_query_has_many_through_supports_where(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreateTagTable::class,
+            CreateBookReviewTable::class,
+            CreateReviewerTable::class,
+        );
+
+        $tag = Tag::create(label: 'fantasy');
+
+        $review1 = BookReview::create(content: 'Great', tag: $tag);
+        $review2 = BookReview::create(content: 'Good', tag: $tag);
+
+        Reviewer::create(name: 'Alice', bookReview: $review1);
+        Reviewer::create(name: 'Bob', bookReview: $review2);
+
+        $reviewers = $tag->query(relation: 'reviewers')
+            ->whereField(field: 'name', value: 'Alice')
+            ->all();
+
+        $this->assertCount(1, $reviewers);
+        $this->assertSame('Alice', $reviewers[0]->name);
     }
 
     public function test_has_many_through_relation(): void

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -7,11 +7,12 @@ namespace Tests\Tempest\Integration\Database\Builder;
 use Carbon\Carbon;
 use DateTime as NativeDateTime;
 use DateTimeImmutable;
-use InvalidArgumentException;
 use Tempest\Database\BelongsTo;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
 use Tempest\Database\Builder\QueryBuilders\SelectQueryBuilder;
 use Tempest\Database\Exceptions\DeleteStatementWasInvalid;
+use Tempest\Database\Exceptions\PrimaryKeyWasNotInitialized;
+use Tempest\Database\Exceptions\PropertyWasNotARelation;
 use Tempest\Database\Exceptions\RelationWasMissing;
 use Tempest\Database\Exceptions\ValueWasMissing;
 use Tempest\Database\HasMany;
@@ -851,7 +852,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
         $author = Author::create(name: 'Author', type: AuthorType::A);
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(PropertyWasNotARelation::class);
 
         $author->query('nonexistent');
     }
@@ -860,7 +861,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
     {
         $author = new Author(name: 'Unsaved');
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(PrimaryKeyWasNotInitialized::class);
 
         $author->query('books');
     }

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -341,7 +341,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Book::create(title: 'Book 3', author: $authorA);
         Book::create(title: 'Other Book', author: $authorB);
 
-        $books = $authorA->query(relation: 'books')->all();
+        $books = $authorA->query( 'books')->all();
 
         $this->assertCount(3, $books);
         $this->assertContainsOnlyInstancesOf(Book::class, $books);
@@ -365,7 +365,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Book::create(title: 'Beta', author: $author);
         Book::create(title: 'Gamma', author: $author);
 
-        $books = $author->query(relation: 'books')
+        $books = $author->query( 'books')
             ->whereField(field: 'title', value: 'Beta')
             ->all();
 
@@ -391,7 +391,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Book::create(title: 'Book 2', author: $author);
         Book::create(title: 'Book 3', author: $author);
 
-        $books = $author->query(relation: 'books')->limit(limit: 2)->all();
+        $books = $author->query( 'books')->limit(limit: 2)->all();
 
         $this->assertCount(2, $books);
     }
@@ -416,7 +416,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Reviewer::create(name: 'Bob', bookReview: $reviewA2);
         Reviewer::create(name: 'Charlie', bookReview: $reviewB1);
 
-        $reviewers = $tagA->query(relation: 'reviewers')->all();
+        $reviewers = $tagA->query( 'reviewers')->all();
 
         $this->assertCount(2, $reviewers);
         $this->assertContainsOnlyInstancesOf(Reviewer::class, $reviewers);
@@ -439,7 +439,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Reviewer::create(name: 'Alice', bookReview: $review1);
         Reviewer::create(name: 'Bob', bookReview: $review2);
 
-        $reviewers = $tag->query(relation: 'reviewers')
+        $reviewers = $tag->query( 'reviewers')
             ->whereField(field: 'name', value: 'Alice')
             ->all();
 
@@ -470,7 +470,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         query(model: 'books_tags')->insert(['book_id' => $book2->id->value, 'tag_id' => $tagA->id->value])->execute();
         query(model: 'books_tags')->insert(['book_id' => $book3->id->value, 'tag_id' => $tagB->id->value])->execute();
 
-        $books = $tagA->query(relation: 'books')->all();
+        $books = $tagA->query( 'books')->all();
 
         $this->assertCount(2, $books);
         $this->assertContainsOnlyInstancesOf(Book::class, $books);
@@ -496,7 +496,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         query(model: 'books_tags')->insert(['book_id' => $book1->id->value, 'tag_id' => $tag->id->value])->execute();
         query(model: 'books_tags')->insert(['book_id' => $book2->id->value, 'tag_id' => $tag->id->value])->execute();
 
-        $books = $tag->query(relation: 'books')
+        $books = $tag->query( 'books')
             ->whereField(field: 'title', value: 'Alpha')
             ->all();
 
@@ -521,7 +521,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
             ->insert(['title' => 'Post 2', 'body' => 'Body 2', 'test_user_id' => $user->id->value])
             ->execute();
 
-        $posts = $user->query(relation: 'posts')->all();
+        $posts = $user->query( 'posts')->all();
 
         $this->assertCount(2, $posts);
         $this->assertContainsOnlyInstancesOf(TestPost::class, $posts);
@@ -540,7 +540,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
         $this->expectException(InvalidArgumentException::class);
 
-        $book->query(relation: 'author');
+        $book->query( 'author');
     }
 
     public function test_query_throws_for_nonexistent_property(): void
@@ -555,7 +555,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
         $this->expectException(InvalidArgumentException::class);
 
-        $author->query(relation: 'nonexistent');
+        $author->query( 'nonexistent');
     }
 
     public function test_query_throws_for_unsaved_model(): void
@@ -564,7 +564,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
         $this->expectException(InvalidArgumentException::class);
 
-        $author->query(relation: 'books');
+        $author->query( 'books');
     }
 
     public function test_query_has_many_returns_empty_for_no_results(): void
@@ -578,7 +578,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
 
         $author = Author::create(name: 'Author', type: AuthorType::A);
 
-        $books = $author->query(relation: 'books')->all();
+        $books = $author->query( 'books')->all();
 
         $this->assertCount(0, $books);
     }

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -534,7 +534,7 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         $this->assertContainsOnlyInstancesOf(TestPost::class, $posts);
     }
 
-    public function test_query_throws_for_non_collection_relation(): void
+    public function test_query_belongs_to_select(): void
     {
         $this->database->migrate(
             CreateMigrationsTable::class,
@@ -543,11 +543,28 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
             CreateBookTable::class,
         );
 
-        $book = Book::create(title: 'Test');
+        $author = Author::create(name: 'Target Author', type: AuthorType::A);
+        $book = Book::create(title: 'Test', author: $author);
 
-        $this->expectException(BadMethodCallException::class);
+        $result = $book->query('author')->select()->first();
 
-        $book->query('author');
+        $this->assertInstanceOf(Author::class, $result);
+        $this->assertSame('Target Author', $result->name);
+    }
+
+    public function test_query_belongs_to_count(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+        );
+
+        $author = Author::create(name: 'Author', type: AuthorType::A);
+        $book = Book::create(title: 'Test', author: $author);
+
+        $this->assertSame(1, $book->query('author')->count()->execute());
     }
 
     public function test_query_throws_for_nonexistent_property(): void

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -309,6 +309,85 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         $this->assertCount(2, $author->books);
     }
 
+    public function test_query_has_many_returns_scoped_results(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+        );
+
+        $authorA = Author::create(
+            name: 'Author A',
+            type: AuthorType::A,
+        );
+
+        $authorB = Author::create(
+            name: 'Author B',
+            type: AuthorType::B,
+        );
+
+        Book::create(title: 'Book 1', author: $authorA);
+        Book::create(title: 'Book 2', author: $authorA);
+        Book::create(title: 'Book 3', author: $authorA);
+        Book::create(title: 'Other Book', author: $authorB);
+
+        $books = $authorA->query('books')->all();
+
+        $this->assertCount(3, $books);
+        $this->assertContainsOnlyInstancesOf(Book::class, $books);
+    }
+
+    public function test_query_has_many_supports_where(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+        );
+
+        $author = Author::create(
+            name: 'Author A',
+            type: AuthorType::A,
+        );
+
+        Book::create(title: 'Alpha', author: $author);
+        Book::create(title: 'Beta', author: $author);
+        Book::create(title: 'Gamma', author: $author);
+
+        $books = $author->query('books')
+            ->whereField('title', 'Beta')
+            ->all();
+
+        $this->assertCount(1, $books);
+        $this->assertSame('Beta', $books[0]->title);
+    }
+
+    public function test_query_has_many_supports_limit(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+        );
+
+        $author = Author::create(
+            name: 'Author A',
+            type: AuthorType::A,
+        );
+
+        Book::create(title: 'Book 1', author: $author);
+        Book::create(title: 'Book 2', author: $author);
+        Book::create(title: 'Book 3', author: $author);
+
+        $books = $author->query('books')->limit(2)->all();
+
+        $this->assertCount(2, $books);
+    }
+
     public function test_has_many_through_relation(): void
     {
         $this->database->migrate(

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -647,6 +647,88 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         $this->assertSame(1, $bookB->query('isbn')->count()->execute());
     }
 
+    public function test_query_has_one_through_select(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreateTagTable::class,
+            CreateBookReviewTable::class,
+            CreateReviewerTable::class,
+        );
+
+        $tag = Tag::create(label: 'fantasy');
+        $review = BookReview::create(content: 'Great', tag: $tag);
+        Reviewer::create(name: 'Alice', bookReview: $review);
+
+        $result = $tag->query('topReviewer')->select()->first();
+
+        $this->assertInstanceOf(Reviewer::class, $result);
+        $this->assertSame('Alice', $result->name);
+    }
+
+    public function test_query_has_one_through_count(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreateTagTable::class,
+            CreateBookReviewTable::class,
+            CreateReviewerTable::class,
+        );
+
+        $tag = Tag::create(label: 'fantasy');
+        $review = BookReview::create(content: 'Great', tag: $tag);
+        Reviewer::create(name: 'Alice', bookReview: $review);
+
+        $this->assertSame(1, $tag->query('topReviewer')->count()->execute());
+    }
+
+    public function test_query_has_one_through_update(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreateTagTable::class,
+            CreateBookReviewTable::class,
+            CreateReviewerTable::class,
+        );
+
+        $tagA = Tag::create(label: 'fantasy');
+        $tagB = Tag::create(label: 'sci-fi');
+        $reviewA = BookReview::create(content: 'Great', tag: $tagA);
+        $reviewB = BookReview::create(content: 'Meh', tag: $tagB);
+        Reviewer::create(name: 'Alice', bookReview: $reviewA);
+        Reviewer::create(name: 'Bob', bookReview: $reviewB);
+
+        $tagA->query('topReviewer')->update(name: 'Updated')->execute();
+
+        $resultA = $tagA->query('topReviewer')->select()->first();
+        $resultB = $tagB->query('topReviewer')->select()->first();
+
+        $this->assertSame('Updated', $resultA->name);
+        $this->assertSame('Bob', $resultB->name);
+    }
+
+    public function test_query_has_one_through_delete(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreateTagTable::class,
+            CreateBookReviewTable::class,
+            CreateReviewerTable::class,
+        );
+
+        $tagA = Tag::create(label: 'fantasy');
+        $tagB = Tag::create(label: 'sci-fi');
+        $reviewA = BookReview::create(content: 'Great', tag: $tagA);
+        $reviewB = BookReview::create(content: 'Meh', tag: $tagB);
+        Reviewer::create(name: 'Alice', bookReview: $reviewA);
+        Reviewer::create(name: 'Bob', bookReview: $reviewB);
+
+        $tagA->query('topReviewer')->delete()->execute();
+
+        $this->assertSame(0, $tagA->query('topReviewer')->count()->execute());
+        $this->assertSame(1, $tagB->query('topReviewer')->count()->execute());
+    }
+
     public function test_query_throws_for_nonexistent_property(): void
     {
         $this->database->migrate(

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Database\Builder;
 
-use BadMethodCallException;
 use Carbon\Carbon;
 use DateTime as NativeDateTime;
 use DateTimeImmutable;

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -584,6 +584,123 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         $this->assertCount(0, $books);
     }
 
+    public function test_query_has_many_count(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+        );
+
+        $authorA = Author::create(name: 'Author A', type: AuthorType::A);
+        $authorB = Author::create(name: 'Author B', type: AuthorType::B);
+
+        Book::create(title: 'Book 1', author: $authorA);
+        Book::create(title: 'Book 2', author: $authorA);
+        Book::create(title: 'Book 3', author: $authorA);
+        Book::create(title: 'Other', author: $authorB);
+
+        $count = $authorA->query('books')->count()->execute();
+
+        $this->assertSame(3, $count);
+    }
+
+    public function test_query_has_many_update(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+        );
+
+        $authorA = Author::create(name: 'Author A', type: AuthorType::A);
+        $authorB = Author::create(name: 'Author B', type: AuthorType::B);
+
+        Book::create(title: 'Old Title 1', author: $authorA);
+        Book::create(title: 'Old Title 2', author: $authorA);
+        Book::create(title: 'Keep This', author: $authorB);
+
+        $authorA->query('books')->update(title: 'Updated')->execute();
+
+        $booksA = $authorA->query('books')->select()->all();
+        $booksB = $authorB->query('books')->select()->all();
+
+        $this->assertSame('Updated', $booksA[0]->title);
+        $this->assertSame('Updated', $booksA[1]->title);
+        $this->assertSame('Keep This', $booksB[0]->title);
+    }
+
+    public function test_query_has_many_delete(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+        );
+
+        $authorA = Author::create(name: 'Author A', type: AuthorType::A);
+        $authorB = Author::create(name: 'Author B', type: AuthorType::B);
+
+        Book::create(title: 'Book 1', author: $authorA);
+        Book::create(title: 'Book 2', author: $authorA);
+        Book::create(title: 'Keep This', author: $authorB);
+
+        $authorA->query('books')->delete()->execute();
+
+        $this->assertSame(0, $authorA->query('books')->count()->execute());
+        $this->assertSame(1, $authorB->query('books')->count()->execute());
+    }
+
+    public function test_query_has_many_through_count(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreateTagTable::class,
+            CreateBookReviewTable::class,
+            CreateReviewerTable::class,
+        );
+
+        $tagA = Tag::create(label: 'fantasy');
+        $tagB = Tag::create(label: 'sci-fi');
+
+        $reviewA1 = BookReview::create(content: 'Great', tag: $tagA);
+        $reviewA2 = BookReview::create(content: 'Good', tag: $tagA);
+        $reviewB1 = BookReview::create(content: 'Meh', tag: $tagB);
+
+        Reviewer::create(name: 'Alice', bookReview: $reviewA1);
+        Reviewer::create(name: 'Bob', bookReview: $reviewA2);
+        Reviewer::create(name: 'Charlie', bookReview: $reviewB1);
+
+        $this->assertSame(2, $tagA->query('reviewers')->count()->execute());
+        $this->assertSame(1, $tagB->query('reviewers')->count()->execute());
+    }
+
+    public function test_query_belongs_to_many_count(): void
+    {
+        $this->database->migrate(
+            CreateMigrationsTable::class,
+            CreatePublishersTable::class,
+            CreateAuthorTable::class,
+            CreateBookTable::class,
+            CreateTagTable::class,
+            CreateBookTagTable::class,
+        );
+
+        $author = Author::create(name: 'Author', type: AuthorType::A);
+        $book1 = Book::create(title: 'Book 1', author: $author);
+        $book2 = Book::create(title: 'Book 2', author: $author);
+
+        $tag = Tag::create(label: 'fantasy');
+
+        query(model: 'books_tags')->insert(['book_id' => $book1->id->value, 'tag_id' => $tag->id->value])->execute();
+        query(model: 'books_tags')->insert(['book_id' => $book2->id->value, 'tag_id' => $tag->id->value])->execute();
+
+        $this->assertSame(2, $tag->query('books')->count()->execute());
+    }
+
     public function test_has_many_through_relation(): void
     {
         $this->database->migrate(

--- a/tests/Integration/Database/Builder/IsDatabaseModelTest.php
+++ b/tests/Integration/Database/Builder/IsDatabaseModelTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Database\Builder;
 
+use BadMethodCallException;
 use Carbon\Carbon;
 use DateTime as NativeDateTime;
 use DateTimeImmutable;
-use BadMethodCallException;
 use InvalidArgumentException;
 use Tempest\Database\BelongsTo;
 use Tempest\Database\Builder\QueryBuilders\QueryBuilder;
@@ -36,10 +36,14 @@ use Tempest\Mapper\Serializer;
 use Tempest\Validation\Rules\IsBetween;
 use Tempest\Validation\SkipValidation;
 use Tests\Tempest\Fixtures\Migrations\CreateAuthorTable;
+use Tests\Tempest\Fixtures\Migrations\CreateBookReviewTable;
 use Tests\Tempest\Fixtures\Migrations\CreateBookTable;
+use Tests\Tempest\Fixtures\Migrations\CreateBookTagTable;
 use Tests\Tempest\Fixtures\Migrations\CreateChapterTable;
 use Tests\Tempest\Fixtures\Migrations\CreateIsbnTable;
 use Tests\Tempest\Fixtures\Migrations\CreatePublishersTable;
+use Tests\Tempest\Fixtures\Migrations\CreateReviewerTable;
+use Tests\Tempest\Fixtures\Migrations\CreateTagTable;
 use Tests\Tempest\Fixtures\Models\A;
 use Tests\Tempest\Fixtures\Models\AWithEager;
 use Tests\Tempest\Fixtures\Models\AWithLazy;
@@ -47,10 +51,6 @@ use Tests\Tempest\Fixtures\Models\AWithValue;
 use Tests\Tempest\Fixtures\Models\AWithVirtual;
 use Tests\Tempest\Fixtures\Models\B;
 use Tests\Tempest\Fixtures\Models\C;
-use Tests\Tempest\Fixtures\Migrations\CreateBookReviewTable;
-use Tests\Tempest\Fixtures\Migrations\CreateBookTagTable;
-use Tests\Tempest\Fixtures\Migrations\CreateReviewerTable;
-use Tests\Tempest\Fixtures\Migrations\CreateTagTable;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Author;
 use Tests\Tempest\Fixtures\Modules\Books\Models\AuthorType;
 use Tests\Tempest\Fixtures\Modules\Books\Models\Book;
@@ -366,7 +366,9 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Book::create(title: 'Beta', author: $author);
         Book::create(title: 'Gamma', author: $author);
 
-        $books = $author->query('books')->select()
+        $books = $author
+            ->query('books')
+            ->select()
             ->whereField(field: 'title', value: 'Beta')
             ->all();
 
@@ -440,7 +442,9 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         Reviewer::create(name: 'Alice', bookReview: $review1);
         Reviewer::create(name: 'Bob', bookReview: $review2);
 
-        $reviewers = $tag->query('reviewers')->select()
+        $reviewers = $tag
+            ->query('reviewers')
+            ->select()
             ->whereField(field: 'name', value: 'Alice')
             ->all();
 
@@ -497,7 +501,9 @@ final class IsDatabaseModelTest extends FrameworkIntegrationTestCase
         query(model: 'books_tags')->insert(['book_id' => $book1->id->value, 'tag_id' => $tag->id->value])->execute();
         query(model: 'books_tags')->insert(['book_id' => $book2->id->value, 'tag_id' => $tag->id->value])->execute();
 
-        $books = $tag->query('books')->select()
+        $books = $tag
+            ->query('books')
+            ->select()
             ->whereField(field: 'title', value: 'Alpha')
             ->all();
 


### PR DESCRIPTION
pr to add option to have similar behavior to laravels author->books() to get underlying query for property relation we can chain into

```php
// select with constraints
$author->query('books')->select()->whereField(field: 'title', value: 'Timeline Taxi')->all();
$author->query('books')->select()->limit(limit: 5)->all();

// count
$author->query('books')->count()->execute();

// update scoped to relation
$author->query('books')->update(title: 'Updated')->execute();

// delete scoped to relation
$author->query('books')->delete()->execute();
```

works with all relation types:

```php
// HasMany / HasOne
$author->query('books')->select()->all();
$book->query('isbn')->select()->first();

// BelongsTo
$book->query('author')->select()->first();

// HasManyThrough / HasOneThrough
$tag->query('reviewers')->select()->all();
$tag->query('topReviewer')->select()->first();

// BelongsToMany
$tag->query('books')->select()->all();
```

now, I wasnt sure about naming it but opted in for `query` since it returns querybuilder same as query() helper just scoped to model property