### PR TITLE
fix(view): data attribute handling for x-component

### DIFF
--- a/packages/view/src/Components/x-component.view.php
+++ b/packages/view/src/Components/x-component.view.php
@@ -10,9 +10,20 @@ use Tempest\View\Slot;
 use function Tempest\Container\get;
 use function Tempest\View\view;
 
-$attributeString = $attributes
-    ->map(fn (string $value, string $key) => "{$key}=\"{$value}\"")
-    ->implode(' ');
+$htmlAttributes = [];
+$dataVariables = [];
+
+foreach ($attributes as $key => $value) {
+    if (is_object($value) || is_array($value)) {
+        $dataVariables[$key] = $value;
+    } elseif ($value === true) {
+        $htmlAttributes[] = $key;
+    } elseif ($value !== false && $value !== null) {
+        $htmlAttributes[] = "{$key}=\"{$value}\"";
+    }
+}
+
+$attributeString = implode(' ', $htmlAttributes);
 
 $content = $slots[Slot::DEFAULT]->content ?? '';
 
@@ -24,6 +35,7 @@ HTML, $is, $attributeString, $content, $is);
 
 $data = $scopedVariables ?? $_data ?? [];
 $data = is_array($data) ? $data : [];
+$data = array_merge($data, $dataVariables);
 $html = get(TempestViewRenderer::class)->render(view($template, ...$data));
 ?>
 

--- a/tests/Integration/View/ViewComponentTest.php
+++ b/tests/Integration/View/ViewComponentTest.php
@@ -870,6 +870,43 @@ final class ViewComponentTest extends FrameworkIntegrationTestCase
         $this->assertSame('<div>test</div>', $html);
     }
 
+    public function test_dynamic_view_component_with_object_attribute_forwarded_as_data(): void
+    {
+        $this->view->registerViewComponent('x-field', '<label>{{ $field->label }}</label>');
+
+        $field = new class {
+            public string $label = 'Email';
+        };
+
+        $html = $this->view->render(<<<'HTML'
+        <x-component :is="'x-field'" :field="$field" />
+        HTML, field: $field);
+
+        $this->assertSame('<label>Email</label>', $html);
+    }
+
+    public function test_dynamic_view_component_with_boolean_true_renders_bare_attribute(): void
+    {
+        $this->view->registerViewComponent('x-test', '<span>{{ isset($disabled) ? "yes" : "no" }}</span>');
+
+        $html = $this->view->render(<<<'HTML'
+        <x-component :is="'x-test'" :disabled="true" />
+        HTML);
+
+        $this->assertSame('<span>yes</span>', $html);
+    }
+
+    public function test_dynamic_view_component_with_boolean_false_omits_attribute(): void
+    {
+        $this->view->registerViewComponent('x-test', '<span>{{ isset($disabled) ? "yes" : "no" }}</span>');
+
+        $html = $this->view->render(<<<'HTML'
+        <x-component :is="'x-test'" :disabled="false" />
+        HTML);
+
+        $this->assertSame('<span>no</span>', $html);
+    }
+
     public function test_dynamic_view_component_with_slot(): void
     {
         $this->view->registerViewComponent('x-test', '<div><x-slot/></div>');


### PR DESCRIPTION
Closes #2000 

- Extended `x-component` to ensure it handles data, boolean and stringable attribute spread.
- Added tests.