### PR TITLE
fix(discovery): support PSR-4 paths defined as arrays in composer.json

### DIFF
--- a/packages/discovery/src/Composer.php
+++ b/packages/discovery/src/Composer.php
@@ -36,15 +36,10 @@ final class Composer
     {
         $this->composerPath = Path\normalize($this->root, 'composer.json');
         $this->composer = $this->loadComposerFile($this->composerPath);
-        $this->namespaces = arr($this->composer)
-            ->get('autoload.psr-4', default: arr())
-            ->map(fn (string $path, string $namespace) => new Psr4Namespace($namespace, $path))
-            ->sortByCallback(fn (Psr4Namespace $ns1, Psr4Namespace $ns2) => strlen($ns1->path) <=> strlen($ns2->path))
-            ->values()
-            ->toArray();
+        $this->namespaces = $this->resolvePsr4Namespaces('autoload.psr-4');
 
         foreach ($this->namespaces as $namespace) {
-            if (! Str\starts_with(Str\ensure_ends_with($namespace->path, '/'), ['app/', 'src/', 'source/', 'lib/'])) {
+            if (! Str\starts_with(Str\ensure_ends_with($namespace->path, '/'), needles: ['app/', 'src/', 'source/', 'lib/'])) {
                 continue;
             }
 
@@ -57,20 +52,12 @@ final class Composer
             $this->mainNamespace = $this->namespaces[0];
         }
 
-        $this->namespaces = arr([
-            $this->mainNamespace,
-            ...$this->namespaces,
-        ])
+        $this->namespaces = new Arr\ImmutableArray([$this->mainNamespace, ...$this->namespaces])
             ->filter()
-            ->unique(fn (Psr4Namespace $ns) => $ns->namespace)
+            ->unique(fn (Psr4Namespace $ns) => "{$ns->namespace}:{$ns->path}")
             ->toArray();
 
-        $this->devNamespaces = arr($this->composer)
-            ->get('autoload-dev.psr-4', default: arr())
-            ->map(fn (string $path, string $namespace) => new Psr4Namespace($namespace, $path))
-            ->sortByCallback(fn (Psr4Namespace $ns1, Psr4Namespace $ns2) => strlen($ns1->path) <=> strlen($ns2->path))
-            ->values()
-            ->toArray();
+        $this->devNamespaces = $this->resolvePsr4Namespaces('autoload-dev.psr-4');
 
         return $this;
     }
@@ -130,5 +117,16 @@ final class Composer
         }
 
         return Filesystem\read_json($path);
+    }
+
+    /** @return array<Psr4Namespace> */
+    private function resolvePsr4Namespaces(string $path): array
+    {
+        return new Arr\ImmutableArray($this->composer)
+            ->get($path, default: new Arr\ImmutableArray())
+            ->flatMap(fn (string|iterable $paths, string $namespace) => Arr\map(Arr\wrap($paths), fn (string $path) => new Psr4Namespace($namespace, $path)))
+            ->sortByCallback(fn (Psr4Namespace $ns1, Psr4Namespace $ns2) => strlen($ns1->path) <=> strlen($ns2->path))
+            ->values()
+            ->toArray();
     }
 }

--- a/packages/discovery/src/Composer.php
+++ b/packages/discovery/src/Composer.php
@@ -11,8 +11,6 @@ use Tempest\Support\Namespace\Psr4Namespace;
 use Tempest\Support\Path;
 use Tempest\Support\Str;
 
-use function Tempest\Support\arr;
-
 final class Composer
 {
     /** @var array<Psr4Namespace> */

--- a/tests/Integration/Core/ComposerTest.php
+++ b/tests/Integration/Core/ComposerTest.php
@@ -164,4 +164,40 @@ final class ComposerTest extends FrameworkIntegrationTestCase
         $this->assertSame('Foo\\', $composer->devNamespaces[0]->namespace);
         $this->assertSame('foo/', $composer->devNamespaces[0]->path);
     }
+
+    #[Test]
+    public function supports_psr4_paths_as_array(): void
+    {
+        $composer = $this->initializeComposer([
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => 'src/',
+                    'Other\\' => ['other/src/', 'other/lib/'],
+                ],
+            ],
+            'autoload-dev' => [
+                'psr-4' => [
+                    'Tests\\' => ['tests/', 'spec/'],
+                ],
+            ],
+        ]);
+
+        $this->assertSame('App\\', $composer->mainNamespace->namespace);
+        $this->assertSame('src/', $composer->mainNamespace->path);
+
+        $this->assertCount(3, $composer->namespaces);
+        $this->assertSame('App\\', $composer->namespaces[0]->namespace);
+        $this->assertSame('src/', $composer->namespaces[0]->path);
+        $this->assertSame('Other\\', $composer->namespaces[1]->namespace);
+        $this->assertSame('other/src/', $composer->namespaces[1]->path);
+        $this->assertSame('Other\\', $composer->namespaces[2]->namespace);
+        $this->assertSame('other/lib/', $composer->namespaces[2]->path);
+
+        $this->assertCount(2, $composer->devNamespaces);
+        // sorting is based on path length, putting spec/ before tests/
+        $this->assertSame('Tests\\', $composer->devNamespaces[0]->namespace);
+        $this->assertSame('spec/', $composer->devNamespaces[0]->path);
+        $this->assertSame('Tests\\', $composer->devNamespaces[1]->namespace);
+        $this->assertSame('tests/', $composer->devNamespaces[1]->path);
+    }
 }


### PR DESCRIPTION
This reproduces the error I'm seeing in a project using tempest/discovery standalone.

The issue most likely affects the main framework as well due to a assumption in the [Discovery Composer.php](https://github.com/tempestphp/tempest-framework/blob/6c8b9fefdf1a7c7cde6cecdfe9ae902883cc05c7/packages/discovery/src/Composer.php#L41) class that PSR-4 namespaces only map to a single path, even though Composer's schema allows both `string` and `list<string>`:

https://getcomposer.org/doc/04-schema.md#psr-4
> If you need to search for a same prefix in multiple directories, you can specify them as an array as such:
```json
{
    "autoload": {
        "psr-4": { "Monolog\\": ["src/", "lib/"] }
    }
}
```

As per the contribution guidelines I've only submitted the failing test, even though I gave a fix a shot already. 

You'll find the patch in the following Gist: https://gist.github.com/nayleen/1696e073c98c98f7b822ed51927e3350

The test reproduces the exact error I'm seeing:
> Tests\Tempest\Integration\Core\ComposerTest::supports_psr4_paths_as_array
> TypeError: Tempest\Discovery\Composer::{closure:Tempest\Discovery\Composer::load():41}(): Argument #1 ($path) must > be of type string, array given, called in /app/src/packages/support/src/Arr/functions.php on line 862