### PR TITLE
feat(discovery): improve autoloading of discovery paths

### DIFF
--- a/docs/3-packages/02-console.md
+++ b/docs/3-packages/02-console.md
@@ -35,7 +35,7 @@ You may read more about building commands in the [dedicated documentation](../1-
 Tempest will automatically discover all console commands from multiple sources:
 
 1. **Core Tempest packages** — Built-in commands from Tempest itself
-2. **Vendor packages** — Third-party packages that require `tempest/framework` or `tempest/core`
+2. **Vendor packages** — Packages that require any `tempest/*` package,or opt in via `extra.tempest.can-discover`
 3. **App namespaces** — All namespaces configured as PSR-4 autoload paths in your `composer.json`
 
 ```json

--- a/docs/5-extra-topics/01-package-development.md
+++ b/docs/5-extra-topics/01-package-development.md
@@ -5,9 +5,25 @@ description: "Tempest comes with a handful of tools to help third-party package 
 
 ## Overview
 
-Creating a package for Tempest is as simple as adding `tempest/core` as a dependency. When this happens, [discovery](../1-essentials/05-discovery.md) will find the package thanks to composer metadata and register discoverable classes.
+Creating a package for Tempest consists of creating a typical PHP package, except it should depend on the relevant Tempest dependency. When you install a dependency that depends on any `tempest/*` package, [discovery](../1-essentials/05-discovery.md) will find it through Composer metadata and register discoverable classes.
 
 Unlike Symfony or Laravel, Tempest doesn't have a dedicated "service provider" concept. Instead, you're encouraged to rely on [discovery](../1-essentials/05-discovery.md) and [initializers](../1-essentials/05-container#dependency-initializers).
+
+## Optional Tempest support
+
+If your package is a normal package but has optional support for Tempest, you can opt-in for discovery by providing metadata in `composer.json`:
+
+```json composer.json
+{
+	"extra": {
+		"tempest": {
+			"can-discover": true
+		}
+	}
+}
+```
+
+The `extra.tempest.can-discover` property marks your package as discoverable even without a Tempest dependency.
 
 ## Preventing discovery
 
@@ -22,6 +38,20 @@ use Tempest\Discovery\SkipDiscovery;
 final readonly class UserMigration implements Migration
 {
     // …
+}
+```
+
+Alternatively, you may use composer metadata to completely exclude any path from discovery. This is mostly useful when the package has optional dependencies, since discovery use Reflection and will throw errors when encountering unknown classes or interfaces.
+
+```json composer.json
+{
+	"extra": {
+		"tempest": {
+			"ignore": [
+				"src/OptionalDependency.php"
+			]
+		}
+	}
 }
 ```
 

--- a/packages/discovery/src/AutoloadDiscoveryLocations.php
+++ b/packages/discovery/src/AutoloadDiscoveryLocations.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Discovery;
 
 use Tempest\Support\Filesystem;
-
-use function Tempest\Support\Path\normalize;
+use Tempest\Support\Path;
 
 final readonly class AutoloadDiscoveryLocations
 {
@@ -27,42 +26,47 @@ final readonly class AutoloadDiscoveryLocations
     /** @return \Tempest\Discovery\DiscoveryLocation[] */
     public function __invoke(): array
     {
+        $composerPath = Path\normalize($this->rootPath, 'vendor/composer');
+        $installed = $this->loadJsonFile(Path\normalize($composerPath, 'installed.json'));
+        $packages = $installed['packages'] ?? [];
+
         return [
-            ...$this->discoverCorePackages(),
-            ...$this->discoverVendorPackages(),
+            ...$this->discoverInstalledPackages($composerPath, $packages),
             ...$this->discoverAppNamespaces(),
         ];
     }
 
-    /**
-     * @return DiscoveryLocation[]
-     */
-    private function discoverCorePackages(): array
+    /** @return array{core: DiscoveryLocation[], vendor: DiscoveryLocation[], optIn: DiscoveryLocation[]} */
+    private function discoverInstalledPackages(string $composerPath, array $packages): array
     {
-        $composerPath = normalize($this->rootPath, 'vendor/composer');
-        $installed = $this->loadJsonFile(normalize($composerPath, 'installed.json'));
-        $packages = $installed['packages'] ?? [];
-
-        $discoveredLocations = [];
+        $core = [];
+        $vendor = [];
+        $optIn = [];
 
         foreach ($packages as $package) {
-            $packageName = $package['name'] ?? '';
-            $isTempest = str_starts_with($packageName, 'tempest');
-
-            if (! $isTempest) {
+            if (! isset($package['autoload']['psr-4'])) {
                 continue;
             }
 
-            $packagePath = normalize($composerPath, $package['install-path'] ?? '');
+            $packagePath = Path\normalize($composerPath, $package['install-path'] ?? '');
 
-            foreach ($package['autoload']['psr-4'] as $namespace => $namespacePath) {
-                $namespacePath = normalize($packagePath, $namespacePath);
+            if (str_starts_with($package['name'] ?? '', needle: 'tempest/')) {
+                $core = [...$core, ...$this->discoverPackageLocations($packagePath, $package['autoload']['psr-4'])];
+                continue;
+            }
 
-                $discoveredLocations[] = new DiscoveryLocation($namespace, $namespacePath);
+            if (array_find($package['require'] ?? [], static fn ($_, string $package) => str_starts_with($package, needle: 'tempest/'))) {
+                $vendor = [...$vendor, ...$this->discoverPackageLocations($packagePath, $package['autoload']['psr-4'])];
+                continue;
+            }
+
+            if ($package['extra']['tempest']['can-discover'] ?? false) {
+                $optIn = [...$optIn, ...$this->discoverPackageLocations($packagePath, $package['autoload']['psr-4'])];
+                continue;
             }
         }
 
-        return $discoveredLocations;
+        return [...$core, ...$vendor, ...$optIn];
     }
 
     /**
@@ -73,7 +77,7 @@ final readonly class AutoloadDiscoveryLocations
         $discoveredLocations = [];
 
         foreach ($this->composer->namespaces as $namespace) {
-            $path = normalize($this->rootPath, $namespace->path);
+            $path = Path\normalize($this->rootPath, $namespace->path);
 
             $discoveredLocations[] = new DiscoveryLocation($namespace->namespace, $path);
         }
@@ -81,35 +85,26 @@ final readonly class AutoloadDiscoveryLocations
         return $discoveredLocations;
     }
 
-    /**
-     * @return DiscoveryLocation[]
-     */
-    private function discoverVendorPackages(): array
+    /** @return DiscoveryLocation[] */
+    private function discoverPackageLocations(string $packagePath, array $psr4Namespaces): array
     {
-        $composerPath = normalize($this->rootPath, 'vendor/composer');
-        $installed = $this->loadJsonFile(normalize($composerPath, 'installed.json'));
-        $packages = $installed['packages'] ?? [];
-
         $discoveredLocations = [];
 
-        foreach ($packages as $package) {
-            $packageName = $package['name'] ?? '';
-            $isTempest = str_starts_with($packageName, 'tempest');
+        foreach ($psr4Namespaces as $namespace => $namespacePath) {
+            if (is_array($namespacePath)) {
+                foreach ($namespacePath as $path) {
+                    if (! is_string($path)) {
+                        continue;
+                    }
 
-            if ($isTempest) {
+                    $discoveredLocations[] = new DiscoveryLocation($namespace, Path\normalize($packagePath, $path));
+                }
+
                 continue;
             }
 
-            $packagePath = normalize($composerPath, $package['install-path'] ?? '');
-            $requiresTempest = isset($package['require']['tempest/discovery']) || isset($package['require']['tempest/framework']) || isset($package['require']['tempest/core']);
-            $hasPsr4Namespaces = isset($package['autoload']['psr-4']);
-
-            if (! ($requiresTempest && $hasPsr4Namespaces)) {
-                continue;
-            }
-
-            foreach ($package['autoload']['psr-4'] as $namespace => $namespacePath) {
-                $path = normalize($packagePath, $namespacePath);
+            if (is_string($namespacePath)) {
+                $path = Path\normalize($packagePath, $namespacePath);
 
                 $discoveredLocations[] = new DiscoveryLocation($namespace, $path);
             }

--- a/packages/discovery/src/AutoloadDiscoveryLocations.php
+++ b/packages/discovery/src/AutoloadDiscoveryLocations.php
@@ -89,6 +89,7 @@ final readonly class AutoloadDiscoveryLocations
     private function discoverPackageLocations(string $packagePath, array $psr4Namespaces, array $ignore = []): array
     {
         $discoveredLocations = [];
+        $ignore = array_map(static fn (string $path) => Filesystem\normalize_path(Path\normalize($packagePath, $path)), $ignore);
 
         foreach ($psr4Namespaces as $namespace => $namespacePath) {
             if (is_array($namespacePath)) {

--- a/packages/discovery/src/AutoloadDiscoveryLocations.php
+++ b/packages/discovery/src/AutoloadDiscoveryLocations.php
@@ -61,7 +61,7 @@ final readonly class AutoloadDiscoveryLocations
             }
 
             if ($package['extra']['tempest']['can-discover'] ?? false) {
-                $optIn = [...$optIn, ...$this->discoverPackageLocations($packagePath, $package['autoload']['psr-4'])];
+                $optIn = [...$optIn, ...$this->discoverPackageLocations($packagePath, $package['autoload']['psr-4'], $package['extra']['tempest']['ignore'] ?? [])];
                 continue;
             }
         }
@@ -86,7 +86,7 @@ final readonly class AutoloadDiscoveryLocations
     }
 
     /** @return DiscoveryLocation[] */
-    private function discoverPackageLocations(string $packagePath, array $psr4Namespaces): array
+    private function discoverPackageLocations(string $packagePath, array $psr4Namespaces, array $ignore = []): array
     {
         $discoveredLocations = [];
 
@@ -97,16 +97,14 @@ final readonly class AutoloadDiscoveryLocations
                         continue;
                     }
 
-                    $discoveredLocations[] = new DiscoveryLocation($namespace, Path\normalize($packagePath, $path));
+                    $discoveredLocations[] = new DiscoveryLocation($namespace, Path\normalize($packagePath, $path), $ignore);
                 }
 
                 continue;
             }
 
             if (is_string($namespacePath)) {
-                $path = Path\normalize($packagePath, $namespacePath);
-
-                $discoveredLocations[] = new DiscoveryLocation($namespace, $path);
+                $discoveredLocations[] = new DiscoveryLocation($namespace, Path\normalize($packagePath, $namespacePath), $ignore);
             }
         }
 

--- a/packages/discovery/src/AutoloadDiscoveryLocations.php
+++ b/packages/discovery/src/AutoloadDiscoveryLocations.php
@@ -36,7 +36,7 @@ final readonly class AutoloadDiscoveryLocations
         ];
     }
 
-    /** @return array{core: DiscoveryLocation[], vendor: DiscoveryLocation[], optIn: DiscoveryLocation[]} */
+    /** @return DiscoveryLocation[] */
     private function discoverInstalledPackages(string $composerPath, array $packages): array
     {
         $core = [];

--- a/packages/discovery/src/BootDiscovery.php
+++ b/packages/discovery/src/BootDiscovery.php
@@ -150,6 +150,10 @@ final class BootDiscovery
             return;
         }
 
+        if ($location->isIgnored($input)) {
+            return;
+        }
+
         if (is_file($input)) {
             $this->discoverPath($input, $location, $discoveries);
             return;

--- a/packages/discovery/src/DiscoveryLocation.php
+++ b/packages/discovery/src/DiscoveryLocation.php
@@ -18,6 +18,7 @@ final class DiscoveryLocation
     public function __construct(
         public readonly string $namespace,
         string $path,
+        private(set) array $ignore = [],
     ) {
         $this->path = Filesystem\normalize_path(rtrim($path, '\\/'));
     }
@@ -35,6 +36,11 @@ final class DiscoveryLocation
     public function isVendor(): bool
     {
         return str_contains($this->path, '/vendor/') || str_contains($this->path, '\\vendor\\') || $this->isTempest();
+    }
+
+    public function isIgnored(string $path): bool
+    {
+        return array_any($this->ignore, fn (string $ignore) => str_starts_with($path, $ignore));
     }
 
     public function toClassName(string $path): string


### PR DESCRIPTION
This pull requests slightly improves the performance of the building of discovery by only reading `installed.json` once, and looping on the installed packages once instead of three times.

Additionally:
- I made it so all `tempest/` packages were included in Discovery, not just core/framework/discovery
- I added the ability for a package to define a `extra.tempest.can-discover` property to its `composer.json`, so it can opt in for Discovery without requiring a Tempest package
- I also added the ability for a package that has opted in for Discovery to ignore specific files through `extra.tempest.ignore`, mostly to prevent issues with optional dependencies