### PR TITLE
refactor(generation): remove `tempest/container` dependency

### DIFF
--- a/packages/generation/composer.json
+++ b/packages/generation/composer.json
@@ -11,6 +11,11 @@
         "tempest/support": "3.x-dev",
         "psr/container": "^2.0"
     },
+    "require-dev": {
+        "spatie/phpunit-snapshot-assertions": "^5.1.8",
+        "phpunit/phpunit": "^12.5.22",
+        "tempest/container": "3.x-dev"
+    },
     "autoload": {
         "psr-4": {
             "Tempest\\Generation\\": "src"
@@ -20,9 +25,5 @@
         "psr-4": {
             "Tempest\\Generation\\Tests\\": "tests"
         }
-    },
-    "require-dev": {
-        "spatie/phpunit-snapshot-assertions": "^5.1.8",
-        "phpunit/phpunit": "^12.5.22"
     }
 }

--- a/packages/generation/composer.json
+++ b/packages/generation/composer.json
@@ -8,7 +8,6 @@
         "nette/php-generator": "4.2.1",
         "nette/schema": "^1.3.4",
         "nikic/php-parser": "^5.3",
-        "tempest/container": "3.x-dev",
         "tempest/support": "3.x-dev",
         "psr/container": "^2.0"
     },

--- a/packages/generation/src/TypeScript/GenerateTypesCommand.php
+++ b/packages/generation/src/TypeScript/GenerateTypesCommand.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tempest\Generation\TypeScript;
 
+use Psr\Container\ContainerInterface;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\HasConsole;
-use Tempest\Container\Container;
 
 final readonly class GenerateTypesCommand
 {
@@ -15,7 +15,7 @@ final readonly class GenerateTypesCommand
     public function __construct(
         private TypeScriptGenerationConfig $config,
         private TypeScriptGenerator $generator,
-        private Container $container,
+        private ContainerInterface $container,
     ) {}
 
     #[ConsoleCommand(

--- a/packages/generation/src/TypeScript/StructureResolvers/ClassStructureResolver.php
+++ b/packages/generation/src/TypeScript/StructureResolvers/ClassStructureResolver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tempest\Generation\TypeScript\StructureResolvers;
 
-use Tempest\Container\Container;
+use Psr\Container\ContainerInterface;
 use Tempest\Generation\TypeScript\InterfaceDefinition;
 use Tempest\Generation\TypeScript\PropertyDefinition;
 use Tempest\Generation\TypeScript\StructureResolver;
@@ -25,7 +25,7 @@ final readonly class ClassStructureResolver implements StructureResolver
 {
     public function __construct(
         private TypeScriptGenerationConfig $config,
-        private Container $container,
+        private ContainerInterface $container,
     ) {}
 
     public function resolve(TypeReflector $type, TypeScriptGenerator $generator): InterfaceDefinition

--- a/packages/generation/src/TypeScript/StructureResolvers/EnumStructureResolver.php
+++ b/packages/generation/src/TypeScript/StructureResolvers/EnumStructureResolver.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tempest\Generation\TypeScript\StructureResolvers;
 
+use Psr\Container\ContainerInterface;
 use ReflectionEnumBackedCase;
 use ReflectionEnumUnitCase;
 use RuntimeException;
-use Tempest\Container\Container;
 use Tempest\Generation\TypeScript\StructureResolver;
 use Tempest\Generation\TypeScript\TypeDefinition;
 use Tempest\Generation\TypeScript\TypeNodes\TypeNode;
@@ -23,7 +23,7 @@ final readonly class EnumStructureResolver implements StructureResolver
 {
     public function __construct(
         private TypeScriptGenerationConfig $config,
-        private Container $container,
+        private ContainerInterface $container,
     ) {}
 
     public function resolve(TypeReflector $type, TypeScriptGenerator $generator): TypeDefinition


### PR DESCRIPTION
Depends on https://github.com/tempestphp/tempest-framework/pull/2116, will update this PR when merged

## What

This pull request removes the dependency of `tempest/generation` on `tempest/container` by using PSR-11 instead. This makes the package usable outside of Tempest in applications that user other containers.

## Why

With `tempest/container` as a dependency, Discovery will find many discoveries depending on Tempest's own container, which is obviously not registered (and should not be alongside another container), so it will fail at the `BootDiscovery` step.

I'm thinking that for all packages that we want to be usable standalone, we probably want to do the same.