### PR TITLE
feat(auth): add scopeSeparator parameter to GenericOAuthConfig

### DIFF
--- a/docs/2-features/17-oauth.md
+++ b/docs/2-features/17-oauth.md
@@ -204,6 +204,7 @@ return new GenericOAuthConfig(
     urlAccessToken: 'https://provider.com/oauth/token',
     urlResourceOwnerDetails: 'https://provider.com/api/user',
     scopes: ['read:user'],
+    scopeSeparator: ' ', // Optional: If omitted the default `,` will be used. OIDC uses a space as separator.
 );
 ```
 

--- a/packages/auth/src/OAuth/Config/GenericOAuthConfig.php
+++ b/packages/auth/src/OAuth/Config/GenericOAuthConfig.php
@@ -58,6 +58,11 @@ final class GenericOAuthConfig implements OAuthConfig
          * Identifier for this OAuth configuration.
          */
         public null|string|UnitEnum $tag = null,
+
+        /**
+         * Separator for the scopes, defaults to `,` if omitted.
+         */
+        public ?string $scopeSeparator = null,
     ) {}
 
     public function createProvider(): AbstractProvider
@@ -68,6 +73,7 @@ final class GenericOAuthConfig implements OAuthConfig
             'urlAuthorize' => $this->urlAuthorize,
             'urlAccessToken' => $this->urlAccessToken,
             'urlResourceOwnerDetails' => $this->urlResourceOwnerDetails,
+            'scopeSeparator' => $this->scopeSeparator,
         ]);
     }
 

--- a/packages/auth/tests/OAuthTest.php
+++ b/packages/auth/tests/OAuthTest.php
@@ -232,6 +232,43 @@ final class OAuthTest extends TestCase
         $this->assertSame('https://example.com/himmel.jpg', $user->avatar);
         $this->assertSame('generic', $user->provider);
     }
+
+    #[Test]
+    public function generic_config_creates_provider_correctly(): void
+    {
+        $config = new GenericOAuthConfig(
+            clientId: 'client-123',
+            clientSecret: 'secret-456', // @mago-expect lint:no-literal-password
+            redirectTo: 'https://example.com/callback',
+            urlAuthorize: 'https://provider.com/authorize',
+            urlAccessToken: 'https://provider.com/token', // @mago-expect lint:no-literal-password
+            urlResourceOwnerDetails: 'https://provider.com/user',
+        );
+
+        $provider = $config->createProvider();
+
+        $url = $provider->getAuthorizationUrl(['scope' => ['scope1', 'scope2']]);
+        $this->assertStringContainsString('https://provider.com/authorize?', $url);
+        $this->assertStringContainsString('scope=scope1%2Cscope2', $url);
+        $this->assertStringContainsString('client_id=client-123', $url);
+
+        $config = new GenericOAuthConfig(
+            clientId: 'client-123',
+            clientSecret: 'secret-456', // @mago-expect lint:no-literal-password
+            redirectTo: 'https://example.com/callback',
+            urlAuthorize: 'https://provider.com/authorize',
+            urlAccessToken: 'https://provider.com/token', // @mago-expect lint:no-literal-password
+            urlResourceOwnerDetails: 'https://provider.com/user',
+            scopeSeparator: ' ',
+        );
+
+        $provider = $config->createProvider();
+
+        $url = $provider->getAuthorizationUrl(['scope' => ['scope1', 'scope2']]);
+        $this->assertStringContainsString('https://provider.com/authorize?', $url);
+        $this->assertStringContainsString('scope=scope1%20scope2', $url);
+        $this->assertStringContainsString('client_id=client-123', $url);
+    }
 }
 
 final class ResourceOwner implements ResourceOwnerInterface


### PR DESCRIPTION
Currently the `scopeSeperator` option of the `\League\OAuth2\Client\Provider\GenericProvider` is not configurable using `\Tempest\Auth\OAuth\Config\GenericOAuthConfig`.

To support OIDC login correctly (e.g. providing additional scope data) the separator for scopes has to be a space `%20` instead of a `%2C`.

I added a test to verify behavior if the option is omitted and when the option is different from the default.

Also updated the docs to include the parameter, if this is unwanted I can update the PR reverting the doc change.

Fixes #2118 