### PR TITLE
fix(database): make `orderBy` support all dialects

### DIFF
--- a/packages/database/src/Builder/QueryBuilders/SelectQueryBuilder.php
+++ b/packages/database/src/Builder/QueryBuilders/SelectQueryBuilder.php
@@ -229,7 +229,7 @@ final class SelectQueryBuilder implements BuildsQuery, SupportsWhereStatements, 
             return $this->orderByRaw($field);
         }
 
-        $this->select->orderBy[] = new OrderByStatement("`{$field}` {$direction->value}");
+        $this->select->orderBy[] = new OrderByStatement(field: $field, direction: $direction);
 
         return $this;
     }
@@ -241,7 +241,7 @@ final class SelectQueryBuilder implements BuildsQuery, SupportsWhereStatements, 
      */
     public function orderByRaw(string $statement): self
     {
-        $this->select->orderBy[] = new OrderByStatement($statement);
+        $this->select->orderBy[] = new RawStatement($statement);
 
         return $this;
     }

--- a/packages/database/src/QueryStatements/OrderByStatement.php
+++ b/packages/database/src/QueryStatements/OrderByStatement.php
@@ -3,16 +3,25 @@
 namespace Tempest\Database\QueryStatements;
 
 use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\Direction;
 use Tempest\Database\QueryStatement;
+
+use function Tempest\Support\str;
 
 final readonly class OrderByStatement implements QueryStatement
 {
     public function __construct(
-        private string $orderBy,
+        private string $field,
+        private Direction $direction = Direction::ASC,
     ) {}
 
     public function compile(DatabaseDialect $dialect): string
     {
-        return $this->orderBy;
+        $quoted = str($this->field)
+            ->explode(separator: '.')
+            ->map($dialect->quoteIdentifier(...))
+            ->implode(glue: '.');
+
+        return "{$quoted} {$this->direction->value}";
     }
 }

--- a/packages/database/src/QueryStatements/SelectStatement.php
+++ b/packages/database/src/QueryStatements/SelectStatement.php
@@ -96,7 +96,7 @@ final class SelectStatement implements QueryStatement, HasWhereStatements
 
         if ($this->orderBy->isNotEmpty()) {
             $query[] = 'ORDER BY ' . $this->orderBy
-                ->map(fn (OrderByStatement $orderBy) => $orderBy->compile($dialect))
+                ->map(fn (OrderByStatement|RawStatement $orderBy) => $orderBy->compile($dialect))
                 ->implode(', ');
         }
 

--- a/packages/database/tests/QueryStatements/SelectStatementTest.php
+++ b/packages/database/tests/QueryStatements/SelectStatementTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Tempest\Database\Builder\FieldDefinition;
 use Tempest\Database\Builder\TableDefinition;
 use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\Direction;
 use Tempest\Database\QueryStatements\GroupByStatement;
 use Tempest\Database\QueryStatements\HavingStatement;
 use Tempest\Database\QueryStatements\JoinStatement;
@@ -26,7 +27,7 @@ final class SelectStatementTest extends TestCase
             fields: arr(['`a`', 'b', 'c', new FieldDefinition($tableDefinition, 'd', 'd_alias')]),
             join: arr(new JoinStatement('INNER JOIN foo ON bar.id = foo.id')),
             where: arr(new WhereStatement('`foo` = "bar"')),
-            orderBy: arr(new OrderByStatement('`foo` DESC')),
+            orderBy: arr(new OrderByStatement(field: 'foo', direction: Direction::DESC)),
             groupBy: arr(new GroupByStatement('`foo`')),
             having: arr(new HavingStatement('`foo` = "bar"')),
             limit: 10,

--- a/tests/Integration/Database/QueryStatements/OrderByStatementTest.php
+++ b/tests/Integration/Database/QueryStatements/OrderByStatementTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Database\QueryStatements;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\Direction;
+use Tempest\Database\QueryStatements\OrderByStatement;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+/**
+ * @internal
+ */
+final class OrderByStatementTest extends FrameworkIntegrationTestCase
+{
+    #[Test]
+    #[TestWith([DatabaseDialect::MYSQL, '`books`.`title` ASC'])]
+    #[TestWith([DatabaseDialect::SQLITE, '`books`.`title` ASC'])]
+    #[TestWith([DatabaseDialect::POSTGRESQL, '"books"."title" ASC'])]
+    public function qualified_field_is_quoted_per_dialect(DatabaseDialect $dialect, string $expected): void
+    {
+        $statement = new OrderByStatement(field: 'books.title', direction: Direction::ASC);
+
+        $this->assertSame(expected: $expected, actual: $statement->compile(dialect: $dialect));
+    }
+
+    #[Test]
+    #[TestWith([DatabaseDialect::MYSQL, '`title` DESC'])]
+    #[TestWith([DatabaseDialect::SQLITE, '`title` DESC'])]
+    #[TestWith([DatabaseDialect::POSTGRESQL, '"title" DESC'])]
+    public function bare_column_is_quoted_per_dialect(DatabaseDialect $dialect, string $expected): void
+    {
+        $statement = new OrderByStatement(field: 'title', direction: Direction::DESC);
+
+        $this->assertSame(expected: $expected, actual: $statement->compile(dialect: $dialect));
+    }
+}


### PR DESCRIPTION
 `orderBy('table.column')` emitted `` ORDER BY `table.column` `` instead of `` ORDER BY `table`.`column` ``
 
 for orderbyraw I wasnt sure if we want separate class so I used RawStatement
 
 OrderByStatement|RawStatement
 
 but if you prefer creating something like OrderByRawStatement let me know