### PR TITLE
chore(deps): update phpunit to 12.5.22

### DIFF
--- a/.github/workflows/isolated-tests.yml
+++ b/.github/workflows/isolated-tests.yml
@@ -70,7 +70,7 @@ jobs:
         uses: supercharge/redis-github-action@1.8.1
 
       - name: Install PHPUnit
-        run: composer global require phpunit/phpunit:12.5.8
+        run: composer global require phpunit/phpunit:12.5.22
 
       - name: Setup problem matchers
         run: |

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "phpat/phpat": "^0.11.0",
         "phpbench/phpbench": "^1.4",
         "phpstan/phpstan": "2.1.40",
-        "phpunit/phpunit": "^12.5.8",
+        "phpunit/phpunit": "^12.5.22",
         "predis/predis": "^3.0.0",
         "riskio/oauth2-auth0": "^2.4",
         "smolblog/oauth2-twitter": "^1.0",

--- a/packages/generation/composer.json
+++ b/packages/generation/composer.json
@@ -24,6 +24,6 @@
     },
     "require-dev": {
         "spatie/phpunit-snapshot-assertions": "^5.1.8",
-        "phpunit/phpunit": "^12.5.8"
+        "phpunit/phpunit": "^12.5.22"
     }
 }

--- a/packages/http-client/composer.json
+++ b/packages/http-client/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "guzzlehttp/psr7": "^2.6.1",
-        "phpunit/phpunit": "^12.5.8"
+        "phpunit/phpunit": "^12.5.22"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
update phpunit to not affected version

Problem 1
    - Root composer.json requires phpunit/phpunit 12.5.8 (exact version match: 12.5.8 or 12.5.8.0), found phpunit/phpunit[12.5.8] but these were not loaded, because they are affected by security advisories ("PKSA-5jz8-6tcw-pbk4"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
    
https://packagist.org/packages/phpunit/phpunit/advisories?version=9715549
