### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# TempestPHP Security Policy
+
+## Reporting a Security Issue
+
+If you think you have found a Security Issue within one or more of the TempestPHP repositories, don't use the Issues and don't publish a PR with proof of concept. In the first instance, report issues to **security (at) tempestphp (dot) com**, with as much information as you can provide, ideally including steps-to-recreate. Emails sent to this address are forwarded to the core maintainers.
+
+The core maintainers will determine whether this is classified as a Security Issue, and address it accordingly, or whether it is classified as a regular bug, and may ask you to raise a GitHub Issue instead, at this time.
+
+## Resolution Process
+
+The core maintainers will aim to acknowledge and validate any reported Security Issue promptly.
+
+Following the validation of a Security Issue, the core maintainers will broadly:
+
+1. Work on a patch and commit it to the repository via GitHub following the usual processes.
+
+2. Issue a release containing the security release.
+
+3. Consider offering a Rector automated fix within the release, where appropriate.
+
+4. Notify all subscribed TempestPHP parties via the usual channels (discord, blog, etc) that the updated is published.
+
+## Keeping TempestPHP Secure
+
+Several controls are in place to ensure that TempestPHP code releases are kept secure.
+
+1. All maintainers with write access to the repository (currently, just core maintainers) utilise Multi-Factor Authentication.
+
+2. Branch protection is configured on the repository.
+
+3. All access rights and privileges (including automated accounts, API keys) are assigned on a Principle of Least Privilege basis.
+
+4. Every Pull Request requires the successful completion of code quality and static analysis checks, and is reviewed by a core maintainer.
+
+5. TempestPHP actively upgrades dependencies based on deprecations and notices from upstream packages where used.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,16 +1,16 @@
-# TempestPHP Security Policy
+# Tempest security policy
 
-## Reporting a Security Issue
+## Reporting a security issue
 
-If you think you have found a Security Issue within one or more of the TempestPHP repositories, don't use the Issues and don't publish a PR with proof of concept. In the first instance, report issues using [GitHub's security advisory reporting mechanism](https://github.com/tempestphp/tempest-framework/security/advisories/new), with as much information as you can provide, ideally including steps-to-recreate. Security reports submitted on this page are forwarded to the core maintainers, only.
+If you think you have found a security issue within Tempest, don't create a GitHub issue and don't publish a pull request with proof of concept. In the first instance, report issues using [GitHub's security advisory reporting mechanism](https://github.com/tempestphp/tempest-framework/security/advisories/new), with as much information as you can provide, ideally including steps-to-recreate. Security reports submitted on this page are forwarded to the core maintainers only.
 
-The core maintainers will determine whether this is classified as a Security Issue, and address it accordingly, or whether it is classified as a regular bug, and may ask you to raise a GitHub Issue instead, at this time.
+The core maintainers will determine whether this is classified as a security issue, and address it accordingly, or whether it is classified as a regular bug, and may ask you to raise a GitHub issue instead, at this time.
 
-## Resolution Process
+## Resolution process
 
-The core maintainers will aim to acknowledge and validate any reported Security Issue promptly.
+The core maintainers will aim to acknowledge and validate any reported security issue promptly.
 
-Following the validation of a Security Issue, the core maintainers will broadly:
+Following the validation of a security issue, the core maintainers will broadly:
 
 1. Work on a patch and commit it to the repository via GitHub following the usual processes.
 
@@ -18,18 +18,18 @@ Following the validation of a Security Issue, the core maintainers will broadly:
 
 3. Consider offering a Rector automated fix within the release, where appropriate.
 
-4. Notify all subscribed TempestPHP parties via the usual channels (discord, blog, etc) that the updated is published.
+4. Notify all subscribed Tempest parties via the usual channels (discord, blog, etc) that the updated is published.
 
-## Keeping TempestPHP Secure
+## Keeping Tempest secure
 
-Several controls are in place to ensure that TempestPHP code releases are kept secure.
+Several controls are in place to ensure that Tempest code releases are kept secure.
 
-1. All maintainers with write access to the repository (currently, just core maintainers) utilise Multi-Factor Authentication.
+1. All maintainers with write access to the repository use multi-factor authentication.
 
 2. Branch protection is configured on the repository.
 
 3. All access rights and privileges (including automated accounts, API keys) are assigned on a Principle of Least Privilege basis.
 
-4. Every Pull Request requires the successful completion of code quality and static analysis checks, and is reviewed by a core maintainer.
+4. Every pull request requires the successful completion of code quality and static analysis checks, and is reviewed by a core maintainer.
 
-5. TempestPHP actively upgrades dependencies based on deprecations and notices from upstream packages where used.
+5. Tempest actively upgrades dependencies based on deprecations and notices from upstream packages where used.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Security Issue
 
-If you think you have found a Security Issue within one or more of the TempestPHP repositories, don't use the Issues and don't publish a PR with proof of concept. In the first instance, report issues to **security (at) tempestphp (dot) com**, with as much information as you can provide, ideally including steps-to-recreate. Emails sent to this address are forwarded to the core maintainers.
+If you think you have found a Security Issue within one or more of the TempestPHP repositories, don't use the Issues and don't publish a PR with proof of concept. In the first instance, report issues using [GitHub's security advisory reporting mechanism](https://github.com/tempestphp/tempest-framework/security/advisories/new), with as much information as you can provide, ideally including steps-to-recreate. Security reports submitted on this page are forwarded to the core maintainers, only.
 
 The core maintainers will determine whether this is classified as a Security Issue, and address it accordingly, or whether it is classified as a regular bug, and may ask you to raise a GitHub Issue instead, at this time.
 


### PR DESCRIPTION
I offered to type this up in the Discord a while ago, Aidan said to go ahead, so now committing this for review.

It's just a light touch and from what I can see outwardly just covers off what you're already doing.

I drew guidance from the following:

- https://symfony.com/doc/current/contributing/code/security.html

- https://github.com/github/opensource.guide/blob/main/_articles/security-best-practices-for-your-project.md

- Personal knowledge (I'm an InfoSec Consultant)

If you'd like me to go into more detail or add anything else, I'm happy to work on it.

You may also need to manually link it in the "Security and quality" tab if it's not automatically detected.

In the initial commit I did suggest a security shared email address, but as GH has a private submission form which goes to core maintainers, I just updated to use that link.