### PR TITLE
fix(validator): improve validateObject and validateValueForProperty methods

### DIFF
--- a/packages/validation/src/Validator.php
+++ b/packages/validation/src/Validator.php
@@ -49,11 +49,15 @@ final readonly class Validator
 
             $value = $property->getValue($object);
 
-            $failingRules[$property->getName()] = $this->validateValueForProperty($property, $value);
+            $failingRulesForProperty = $this->validateValueForProperty($property, $value);
+
+            if ($failingRulesForProperty !== []) {
+                $failingRules[$property->getName()] = $failingRulesForProperty;
+            }
         }
 
         if ($failingRules !== []) {
-            throw $this->createValidationFailureException($failingRules, $object);
+            throw $this->createValidationFailureException($failingRules, $object, $object::class);
         }
     }
 
@@ -153,9 +157,11 @@ final readonly class Validator
 
         $key = $property->getAttribute(TranslationKey::class)?->key;
 
+        $field = $property->getName();
+
         return Arr\map(
             array: $this->validateValue($value, $rules),
-            map: fn (FailingRule $rule) => $rule->withKey($key),
+            map: fn (FailingRule $rule) => $rule->withField($field)->withKey($key),
         );
     }
 

--- a/packages/validation/tests/ValidatorTest.php
+++ b/packages/validation/tests/ValidatorTest.php
@@ -60,7 +60,7 @@ final class ValidatorTest extends TestCase
 
     public function test_validate_value_for_property_sets_field_and_value(): void
     {
-        $property = (new ClassReflector(ValidateObjectA::class))->getProperty('title');
+        $property = new ClassReflector(ValidateObjectA::class)->getProperty('title');
 
         $failingRules = $this->validator->validateValueForProperty($property, 123);
 

--- a/packages/validation/tests/ValidatorTest.php
+++ b/packages/validation/tests/ValidatorTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Tempest\Reflection\ClassReflector;
 use Tempest\Validation\Exceptions\ValidationFailed;
 use Tempest\Validation\HasErrorMessage;
+use Tempest\Validation\Rules\HasLength;
 use Tempest\Validation\Rules\IsBoolean;
 use Tempest\Validation\Rules\IsEmail;
 use Tempest\Validation\Rules\IsEnum;
@@ -37,9 +38,35 @@ final class ValidatorTest extends TestCase
 
     public function test_validate(): void
     {
-        $this->expectException(ValidationFailed::class);
+        try {
+            $this->validator->validateObject(new ObjectToBeValidated(name: 'a'));
+            $this->fail('Expected ValidationFailed to be thrown.');
+        } catch (ValidationFailed $e) {
+            $this->assertArrayHasKey('name', $e->failingRules);
+            $this->assertCount(1, $e->failingRules['name']);
+            $this->assertInstanceOf(HasLength::class, $e->failingRules['name'][0]->rule);
+            $this->assertSame('name', $e->failingRules['name'][0]->field);
+            $this->assertSame('a', $e->failingRules['name'][0]->value);
+            $this->assertSame(ObjectToBeValidated::class, $e->targetClass);
+        }
+    }
 
-        $this->validator->validateObject(new ObjectToBeValidated(name: 'a'));
+    public function test_validate_passes_with_valid_object(): void
+    {
+        $this->validator->validateObject(new ObjectToBeValidated(name: 'ab'));
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function test_validate_value_for_property_sets_field_and_value(): void
+    {
+        $property = (new ClassReflector(ValidateObjectA::class))->getProperty('title');
+
+        $failingRules = $this->validator->validateValueForProperty($property, 123);
+
+        $this->assertCount(1, $failingRules);
+        $this->assertSame('title', $failingRules[0]->field);
+        $this->assertSame(123, $failingRules[0]->value);
     }
 
     public function test_validate_value(): void

--- a/tests/Integration/Validator/TranslationKeyTest.php
+++ b/tests/Integration/Validator/TranslationKeyTest.php
@@ -27,6 +27,7 @@ final class TranslationKeyTest extends FrameworkIntegrationTestCase
             $this->assertArrayHasKey('title', $validationFailed->failingRules);
             $this->assertSame('book_title', $validationFailed->failingRules['title'][0]->key);
             $this->assertSame('foo', $validationFailed->failingRules['title'][0]->value);
+            $this->assertSame('title', $validationFailed->failingRules['title'][0]->field);
             $this->assertSame('The length of the title of the book is invalid.', $validator->getErrorMessage($validationFailed->failingRules['title'][0]));
         }
     }

--- a/tests/Integration/Validator/TranslationKeyTest.php
+++ b/tests/Integration/Validator/TranslationKeyTest.php
@@ -27,7 +27,6 @@ final class TranslationKeyTest extends FrameworkIntegrationTestCase
             $this->assertArrayHasKey('title', $validationFailed->failingRules);
             $this->assertSame('book_title', $validationFailed->failingRules['title'][0]->key);
             $this->assertSame('foo', $validationFailed->failingRules['title'][0]->value);
-            $this->assertNull($validationFailed->failingRules['title'][0]->field);
             $this->assertSame('The length of the title of the book is invalid.', $validator->getErrorMessage($validationFailed->failingRules['title'][0]));
         }
     }


### PR DESCRIPTION
Fix #2131.

I added several assertions for the exception. 
Let me know if they're okay, or should be moved in a specific test inside `tests/Integration/Validator`.