### PR TITLE
fix(router): preserve development exception status

### DIFF
--- a/packages/router/src/Exceptions/DevelopmentException.php
+++ b/packages/router/src/Exceptions/DevelopmentException.php
@@ -10,7 +10,6 @@ use Tempest\Debug\Stacktrace\Stacktrace;
 use Tempest\Http\IsResponse;
 use Tempest\Http\Request;
 use Tempest\Http\Response;
-use Tempest\Http\Status;
 use Tempest\Support\Filesystem;
 use Tempest\View\Exceptions\ViewCompilationFailed;
 use Tempest\View\GenericView;
@@ -27,7 +26,7 @@ final class DevelopmentException implements Response
 
     public function __construct(Throwable $throwable, Response $response, Request $request)
     {
-        $this->status = Status::INTERNAL_SERVER_ERROR;
+        $this->status = $response->status;
 
         if (! Filesystem\exists(__DIR__ . '/local/dist/main.js')) {
             $this->body = 'The development exception interface is not built.';

--- a/tests/Integration/Http/Exceptions/HtmlExceptionRendererTest.php
+++ b/tests/Integration/Http/Exceptions/HtmlExceptionRendererTest.php
@@ -121,6 +121,21 @@ final class HtmlExceptionRendererTest extends FrameworkIntegrationTestCase
     }
 
     #[Test]
+    public function development_exception_preserves_http_request_failed_status(): void
+    {
+        $this->container->singleton(Environment::class, Environment::LOCAL);
+        $this->container->singleton(GenericRequest::class, new GenericRequest(
+            method: Method::GET,
+            uri: '/',
+        ));
+
+        $response = $this->renderer->render(new HttpRequestFailed(Status::NOT_ACCEPTABLE));
+
+        $this->assertInstanceOf(DevelopmentException::class, $response);
+        $this->assertSame(Status::NOT_ACCEPTABLE, $response->status);
+    }
+
+    #[Test]
     public function does_not_render_development_exception_for_not_found_in_local(): void
     {
         $this->container->singleton(Environment::class, Environment::LOCAL);


### PR DESCRIPTION
This PR ensures the local development exception page preserves the underlying HTTP error status instead of always responding with 500.