### PR TITLE
chore: bump `oauth2-apple` to allow `php-jwt` 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "mikey179/vfsstream": "^2.0@dev",
         "nesbot/carbon": "^3.8",
         "nyholm/psr7": "^1.8",
-        "patrickbussmann/oauth2-apple": "^0.3",
+        "patrickbussmann/oauth2-apple": "^0.4",
         "php-di/php-di": "^7.0",
         "phpat/phpat": "^0.11.0",
         "phpbench/phpbench": "^1.4",


### PR DESCRIPTION
I suggests to update `patrickbussmann/oauth2-apple` dependency to 0.4

**Why ?** 

While running a composer update, Composer reported a security vulnerability advisory about `firebase/php-jwt` package
[See Github advisory](https://github.com/advisories/GHSA-2x45-7fc3-mxwq)

A composer why later, I found this package was stick to `firebase/php-jwt 6.0` but [0.4 solves this](https://github.com/patrickbussmann/oauth2-apple/releases/tag/0.4.0) without introducing BC