### PR TITLE
fix(router): prevent exception ui build from watching

### DIFF
--- a/packages/router/src/Exceptions/local/vite.config.ts
+++ b/packages/router/src/Exceptions/local/vite.config.ts
@@ -42,11 +42,11 @@ export default defineConfig({
 		viteSingleFile(),
 	],
 	build: {
-		watch: {
-			exclude: 'dist/**', // prevent infinite loops while using --watch
-		},
 		rollupOptions: {
 			input: ['./src/entrypoint/main.ts'],
+			watch: {
+				exclude: 'dist/**', // prevent infinite loops while using --watch
+			},
 			output: {
 				inlineDynamicImports: true,
 				assetFileNames: '[name][extname]',


### PR DESCRIPTION
Prevents `composer exceptions:build` from watching and "hanging" `composer qa`.