### PR TITLE
fix(router): skip sessions for stateless routes

### DIFF
--- a/packages/router/src/HandleRouteExceptionMiddleware.php
+++ b/packages/router/src/HandleRouteExceptionMiddleware.php
@@ -9,7 +9,7 @@ use Tempest\Http\Responses\NotFound;
 use Tempest\Router\Exceptions\RouteBindingFailed;
 use Tempest\Support\Priority;
 
-#[Priority(Priority::FRAMEWORK - 10)]
+#[Priority(Priority::FRAMEWORK - 30)]
 final readonly class HandleRouteExceptionMiddleware implements HttpMiddleware
 {
     public function __invoke(Request $request, HttpMiddlewareCallable $next): Response

--- a/packages/router/src/MatchRouteMiddleware.php
+++ b/packages/router/src/MatchRouteMiddleware.php
@@ -4,7 +4,6 @@ namespace Tempest\Router;
 
 use Tempest\Container\Container;
 use Tempest\Http\GenericRequest;
-use Tempest\Http\Mappers\RequestToObjectMapper;
 use Tempest\Http\Method;
 use Tempest\Http\Request;
 use Tempest\Http\Response;
@@ -12,9 +11,7 @@ use Tempest\Http\Responses\NotFound;
 use Tempest\Router\Routing\Matching\RouteMatcher;
 use Tempest\Support\Priority;
 
-use function Tempest\Mapper\map;
-
-#[Priority(Priority::FRAMEWORK - 9)]
+#[Priority(Priority::FRAMEWORK - 29)]
 final readonly class MatchRouteMiddleware implements HttpMiddleware
 {
     public function __construct(
@@ -37,38 +34,6 @@ final readonly class MatchRouteMiddleware implements HttpMiddleware
         // We register the matched route in the container, some internal framework components will need it
         $this->container->singleton(MatchedRoute::class, fn () => $matchedRoute);
 
-        // Convert the request to a specific request implementation, if needed
-        $request = $this->resolveRequest($request, $matchedRoute);
-
-        // We register this newly created request object in the container
-        // This makes it so that RequestInitializer is bypassed entirely when the controller action needs the request class
-        // Making it so that we don't need to set any $_SERVER variables and stuff like that
-        $this->container->singleton($request::class, fn () => $request);
-
         return $next($request);
-    }
-
-    private function resolveRequest(Request $request, MatchedRoute $matchedRoute): Request
-    {
-        // Let's find out if our input request data matches what the route's action needs
-        $requestClass = GenericRequest::class;
-
-        // We'll loop over all the handler's parameters
-        foreach ($matchedRoute->route->handler->getParameters() as $parameter) {
-            // If the parameter's type is an instance of Request…
-            if (! $parameter->getType()->matches(Request::class)) {
-                continue;
-            }
-
-            $requestClass = $parameter->getType()->getName();
-
-            break;
-        }
-
-        if ($requestClass !== Request::class && $requestClass !== GenericRequest::class) {
-            return map($request)->with(RequestToObjectMapper::class)->to($requestClass);
-        }
-
-        return $request;
     }
 }

--- a/packages/router/src/ResolveRouteRequestMiddleware.php
+++ b/packages/router/src/ResolveRouteRequestMiddleware.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Router;
+
+use Tempest\Container\Container;
+use Tempest\Http\GenericRequest;
+use Tempest\Http\Mappers\RequestToObjectMapper;
+use Tempest\Http\Request;
+use Tempest\Http\Response;
+use Tempest\Support\Priority;
+
+use function Tempest\Mapper\map;
+
+#[Priority(Priority::FRAMEWORK - 9)]
+final readonly class ResolveRouteRequestMiddleware implements HttpMiddleware
+{
+    public function __construct(
+        private MatchedRoute $matchedRoute,
+        private Container $container,
+    ) {}
+
+    public function __invoke(Request $request, HttpMiddlewareCallable $next): Response
+    {
+        $request = $this->resolveRequest($request);
+
+        // We register this newly created request object in the container
+        // This makes it so that RequestInitializer is bypassed entirely when the controller action needs the request class
+        // Making it so that we don't need to set any $_SERVER variables and stuff like that
+        $this->container->singleton($request::class, fn () => $request);
+
+        return $next($request);
+    }
+
+    private function resolveRequest(Request $request): Request
+    {
+        // Let's find out if our input request data matches what the route's action needs
+        $requestClass = GenericRequest::class;
+
+        // We'll loop over all the handler's parameters
+        foreach ($this->matchedRoute
+            ->route
+            ->handler
+            ->getParameters() as $parameter) {
+            // If the parameter's type is an instance of Request…
+            if (! $parameter->getType()->matches(Request::class)) {
+                continue;
+            }
+
+            $requestClass = $parameter->getType()->getName();
+
+            break;
+        }
+
+        if ($requestClass !== Request::class && $requestClass !== GenericRequest::class) {
+            return map($request)->with(RequestToObjectMapper::class)->to($requestClass);
+        }
+
+        return $request;
+    }
+}

--- a/packages/router/src/RouteConfig.php
+++ b/packages/router/src/RouteConfig.php
@@ -31,6 +31,7 @@ final class RouteConfig
         public Middleware $middleware = new Middleware(
             HandleRouteExceptionMiddleware::class,
             MatchRouteMiddleware::class,
+            ResolveRouteRequestMiddleware::class,
             SetCookieHeadersMiddleware::class,
             HandleRouteSpecificMiddleware::class,
         ),

--- a/packages/router/src/Stateless.php
+++ b/packages/router/src/Stateless.php
@@ -4,6 +4,7 @@ namespace Tempest\Router;
 
 use Attribute;
 use Tempest\Http\Session\ManageSessionMiddleware;
+use Tempest\Http\Session\TrackPreviousUrlMiddleware;
 
 /**
  * Mark a route handler as stateless, causing all cookie and session-related middleware to be skipped.
@@ -17,6 +18,7 @@ final class Stateless implements RouteDecorator
             ...$route->without,
             PreventCrossSiteRequestsMiddleware::class,
             ManageSessionMiddleware::class,
+            TrackPreviousUrlMiddleware::class,
             SetCookieHeadersMiddleware::class,
         ];
 

--- a/tests/Integration/Route/RouterTest.php
+++ b/tests/Integration/Route/RouterTest.php
@@ -7,9 +7,13 @@ namespace Tests\Tempest\Integration\Route;
 use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\Stream;
 use Laminas\Diactoros\Uri;
+use Tempest\Clock\Clock;
 use Tempest\Database\Migrations\CreateMigrationsTable;
 use Tempest\Http\ContentType;
 use Tempest\Http\Responses\Ok;
+use Tempest\Http\Session\Session;
+use Tempest\Http\Session\SessionId;
+use Tempest\Http\Session\SessionManager;
 use Tempest\Http\Status;
 use Tempest\Router\GenericRouter;
 use Tempest\Router\RouteConfig;
@@ -260,6 +264,20 @@ final class RouterTest extends FrameworkIntegrationTestCase
             ->assertDoesNotHaveCookie('tempest_session_id');
     }
 
+    public function test_stateless_decorator_does_not_manage_session(): void
+    {
+        $sessionManager = new RouteTestingSessionManager($this->container->get(Clock::class));
+
+        $this->container->singleton(SessionManager::class, fn () => $sessionManager);
+
+        $this->http
+            ->get('/stateless')
+            ->assertOk();
+
+        $this->assertSame(0, $sessionManager->createdSessions);
+        $this->assertSame(0, $sessionManager->savedSessions);
+    }
+
     public function test_prefix_decorator(): void
     {
         $this->http
@@ -326,4 +344,42 @@ final class RouterTest extends FrameworkIntegrationTestCase
             ->assertOk()
             ->assertSee('Post 789 in category tech');
     }
+}
+
+final class RouteTestingSessionManager implements SessionManager
+{
+    public int $createdSessions = 0;
+
+    public int $savedSessions = 0;
+
+    public function __construct(
+        private readonly Clock $clock,
+    ) {}
+
+    public function getOrCreate(SessionId $id): Session
+    {
+        $this->createdSessions++;
+
+        $now = $this->clock->now();
+
+        return new Session(
+            id: $id,
+            createdAt: $now,
+            lastActiveAt: $now,
+        );
+    }
+
+    public function save(Session $session): void
+    {
+        $this->savedSessions++;
+    }
+
+    public function delete(Session $session): void {}
+
+    public function isValid(Session $session): bool
+    {
+        return true;
+    }
+
+    public function deleteExpiredSessions(): void {}
 }


### PR DESCRIPTION
Fixes #2065.

Note: this makes it so sessions won't run for unmatched/404 routes, because the matcher now short-circuits before the session middleware. Not sure if this is acceptable.