### PR TITLE
fix(support): shuffle random array values

### DIFF
--- a/packages/support/src/Arr/functions.php
+++ b/packages/support/src/Arr/functions.php
@@ -285,7 +285,7 @@ function random(iterable $array, int $number = 1, bool $preserveKey = false): mi
     }
 
     if ($preserveKey === false) {
-        shuffle($randomValues);
+        $randomValues = shuffle($randomValues);
     }
 
     return count($randomValues) > 1

--- a/packages/support/tests/Arr/ManipulatesArrayTest.php
+++ b/packages/support/tests/Arr/ManipulatesArrayTest.php
@@ -1142,6 +1142,15 @@ final class ManipulatesArrayTest extends TestCase
         $this->assertCount(3, $randoms);
     }
 
+    public function test_random_without_preserving_keys_shuffles_selected_values(): void
+    {
+        $randoms = arr(range(1, 1_000))->random(100)->toArray();
+        $ordered = $randoms;
+        sort($ordered);
+
+        $this->assertNotEquals($randoms, $ordered);
+    }
+
     public function test_random_with_preserve_keys(): void
     {
         $collection = arr([


### PR DESCRIPTION
This PR fixes `shuffle` not shuffling. PHP’s native `shuffle()` mutates the input array, but this file defines its own `shuffle()` function, which returns a shuffled array instead. The return value was being discarded, making the call a no-op and leaving values in their original order.