### PR TITLE
perf(container): cache dynamic initializer instances

### DIFF
--- a/packages/container/src/GenericContainer.php
+++ b/packages/container/src/GenericContainer.php
@@ -450,9 +450,7 @@ final class GenericContainer implements Container
         // we have something to handle this class.
         foreach ($this->dynamicInitializers as $initializerClass) {
             if (! isset($this->resolvedDynamicInitializers[$initializerClass])) {
-                /** @var DynamicInitializer $initializer */
-                $initializer = $this->resolve($initializerClass);
-                $this->resolvedDynamicInitializers[$initializerClass] = $initializer;
+                $this->resolvedDynamicInitializers[$initializerClass] = $this->resolve($initializerClass);
             }
 
             $initializer = $this->resolvedDynamicInitializers[$initializerClass];

--- a/packages/container/src/GenericContainer.php
+++ b/packages/container/src/GenericContainer.php
@@ -28,6 +28,9 @@ final class GenericContainer implements Container
 {
     use HasInstance;
 
+    /** @var array<class-string<DynamicInitializer>, DynamicInitializer> */
+    private array $resolvedDynamicInitializers = [];
+
     public function __construct(
         /** @var ArrayIterator<array-key, mixed> $definitions */
         private(set) ArrayIterator $definitions = new ArrayIterator(),
@@ -81,6 +84,7 @@ final class GenericContainer implements Container
     public function setDynamicInitializers(array $dynamicInitializers): self
     {
         $this->dynamicInitializers = new ArrayIterator($dynamicInitializers);
+        $this->resolvedDynamicInitializers = [];
 
         return $this;
     }
@@ -330,6 +334,7 @@ final class GenericContainer implements Container
             );
 
             unset($this->dynamicInitializers[$index]);
+            unset($this->resolvedDynamicInitializers[$initializerClass->getName()]);
 
             return $this;
         }
@@ -444,8 +449,13 @@ final class GenericContainer implements Container
         // Loop through the registered initializers to see if
         // we have something to handle this class.
         foreach ($this->dynamicInitializers as $initializerClass) {
-            /** @var DynamicInitializer $initializer */
-            $initializer = $this->resolve($initializerClass);
+            if (! isset($this->resolvedDynamicInitializers[$initializerClass])) {
+                /** @var DynamicInitializer $initializer */
+                $initializer = $this->resolve($initializerClass);
+                $this->resolvedDynamicInitializers[$initializerClass] = $initializer;
+            }
+
+            $initializer = $this->resolvedDynamicInitializers[$initializerClass];
 
             if (! $initializer->canInitialize(class: $target, tag: $tag)) {
                 continue;
@@ -719,6 +729,7 @@ final class GenericContainer implements Container
     public function reset(): self
     {
         $this->resolvedSingletons = new ArrayIterator();
+        $this->resolvedDynamicInitializers = [];
 
         foreach ($this->resettables as $resettableClass) {
             /** @var Resettable $resettable */

--- a/packages/container/tests/ContainerTest.php
+++ b/packages/container/tests/ContainerTest.php
@@ -34,6 +34,7 @@ use Tempest\Container\Tests\Fixtures\ContainerObjectD;
 use Tempest\Container\Tests\Fixtures\ContainerObjectDInitializer;
 use Tempest\Container\Tests\Fixtures\ContainerObjectE;
 use Tempest\Container\Tests\Fixtures\ContainerObjectEInitializer;
+use Tempest\Container\Tests\Fixtures\CountingDynamicInitializer;
 use Tempest\Container\Tests\Fixtures\DecoratedClass;
 use Tempest\Container\Tests\Fixtures\DecoratedInterface;
 use Tempest\Container\Tests\Fixtures\DecoratorClass;
@@ -155,6 +156,19 @@ final class ContainerTest extends TestCase
         $return = $container->invoke(reflect($classToCall)->getMethod('method'), input: new ContainerObjectE('other'));
         $this->assertInstanceOf(ContainerObjectE::class, $return);
         $this->assertSame('other', $return->id);
+    }
+
+    public function test_dynamic_initializer_instances_are_reused(): void
+    {
+        CountingDynamicInitializer::reset();
+
+        $container = new GenericContainer();
+        $container->addInitializer(CountingDynamicInitializer::class);
+
+        $container->get(ContainerObjectA::class);
+        $container->get(ContainerObjectA::class);
+
+        $this->assertSame(1, CountingDynamicInitializer::$instances);
     }
 
     public function test_arrays_are_automatically_created(): void

--- a/packages/container/tests/Fixtures/CountingDynamicInitializer.php
+++ b/packages/container/tests/Fixtures/CountingDynamicInitializer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container\Tests\Fixtures;
+
+use Tempest\Container\Container;
+use Tempest\Container\DynamicInitializer;
+use Tempest\Reflection\ClassReflector;
+use UnitEnum;
+
+final class CountingDynamicInitializer implements DynamicInitializer
+{
+    public static int $instances = 0;
+
+    private bool $counted = false;
+
+    public static function reset(): void
+    {
+        self::$instances = 0;
+    }
+
+    public function canInitialize(ClassReflector $class, null|string|UnitEnum $tag): bool
+    {
+        if (! $this->counted) {
+            $this->counted = true;
+            self::$instances++;
+        }
+
+        return false;
+    }
+
+    public function initialize(ClassReflector $class, null|string|UnitEnum $tag, Container $container): object
+    {
+        throw new \LogicException('CountingDynamicInitializer should not initialize objects.');
+    }
+}


### PR DESCRIPTION
Dynamic initializers were resolved through the container every time an unresolved, non-singleton class was looked up. Because these initializer classes are not themselves singleton-cached, each lookup re-instantiated every registered dynamic initializer and repeated reflection/autowiring work just to call canInitialize().

## Reprod

```php
$container->addInitializer(DatabaseInitializer::class);
$container->addInitializer(CacheInitializer::class);

$container->get(Foo::class); // pass1
$container->get(Foo::class); // pass2
$container->get(Foo::class); // pass3
```

### Before

```php
// pass1
new DatabaseInitializer();
new CacheInitializer();

new Foo();

// pass2
new DatabaseInitializer();
new CacheInitializer();

new Foo();

// pass3
new DatabaseInitializer();
new CacheInitializer();

new Foo();
```

### After

```php
// pass1
new DatabaseInitializer();
new CacheInitializer();

new Foo();

// pass2
// DatabaseInitializer, CacheInitializer reused
new Foo();

// pass3
// DatabaseInitializer, CacheInitializer reused
new Foo();
```