### PR TITLE
perf(event-bus): cache event propagation check

### DIFF
--- a/packages/event-bus/src/GenericEventBus.php
+++ b/packages/event-bus/src/GenericEventBus.php
@@ -61,15 +61,14 @@ final readonly class GenericEventBus implements EventBus
     private function getCallable(array $eventHandlers): EventBusMiddlewareCallable
     {
         $callable = new EventBusMiddlewareCallable(function (string|object $event) use ($eventHandlers): void {
+            $eventStopsPropagation = is_object($event) && reflect($event)->hasAttribute(StopsPropagation::class);
+
             foreach ($eventHandlers as $eventHandler) {
                 $callable = $eventHandler->normalizeCallable($this->container);
 
                 $callable($event);
 
-                if (
-                    is_object($event) && reflect($event)->hasAttribute(StopsPropagation::class)
-                    || ($eventHandler->handler->handler ?? null)?->hasAttribute(StopsPropagation::class)
-                ) {
+                if ($eventStopsPropagation || ($eventHandler->handler->handler ?? null)?->hasAttribute(StopsPropagation::class)) {
                     break;
                 }
             }


### PR DESCRIPTION
`GenericEventBus` checked whether the event class had `#[StopsPropagation]` inside the loop for every handler. So if one event had 50 handlers, it rebuilt reflection for the same unchanged event 50 times.