### PR TITLE
perf(http): use keyed request header lookup

### DIFF
--- a/packages/http/src/RequestHeaders.php
+++ b/packages/http/src/RequestHeaders.php
@@ -43,12 +43,7 @@ final readonly class RequestHeaders implements ArrayAccess, IteratorAggregate
 
     public function get(string $name, ?string $default = null): ?string
     {
-        $header = array_find(
-            array: $this->headers,
-            callback: fn (mixed $_, string $header) => strcasecmp($header, $name) === 0,
-        );
-
-        return $header ?? $default;
+        return $this->headers[strtolower($name)] ?? $default;
     }
 
     public function has(string $name): bool


### PR DESCRIPTION
We don't need to iterate through all headers just to find one.