### PR TITLE
fix(http): correct header presence check for falsy values

### DIFF
--- a/packages/http/src/RequestHeaders.php
+++ b/packages/http/src/RequestHeaders.php
@@ -53,7 +53,7 @@ final readonly class RequestHeaders implements ArrayAccess, IteratorAggregate
 
     public function has(string $name): bool
     {
-        return (bool) $this->get($name);
+        return $this->offsetExists($name);
     }
 
     public function getHeader(string $name): Header


### PR DESCRIPTION
`has()` shouldn't report `false` for existing headers that have falsy (eg. `0`, `''`, `null`) value.