### PR TITLE
perf(intl): avoid parser offset scans

### DIFF
--- a/packages/intl/src/MessageFormat/Parser/MessageFormatParser.php
+++ b/packages/intl/src/MessageFormat/Parser/MessageFormatParser.php
@@ -34,7 +34,8 @@ use Tempest\Intl\MessageFormat\Parser\Node\Variable;
 
 final class MessageFormatParser
 {
-    private string $input;
+    /** @var list<string> */
+    private array $chars;
 
     private int $pos = 0;
 
@@ -54,8 +55,8 @@ final class MessageFormatParser
 
     public function __construct(string $input)
     {
-        $this->input = str_replace("\r\n", "\n", $input);
-        $this->len = mb_strlen($this->input, 'UTF-8');
+        $this->chars = mb_str_split(str_replace("\r\n", "\n", $input), 1, 'UTF-8');
+        $this->len = count($this->chars);
     }
 
     /**
@@ -610,10 +611,7 @@ final class MessageFormatParser
             return '';
         }
 
-        $char = mb_substr($this->input, $this->pos, 1, 'UTF-8');
-        $this->pos++;
-
-        return $char;
+        return $this->chars[$this->pos++];
     }
 
     private function peek(int $length = 1): string
@@ -622,7 +620,14 @@ final class MessageFormatParser
             return '';
         }
 
-        return mb_substr($this->input, $this->pos, $length, 'UTF-8');
+        $peek = '';
+        $end = min($this->pos + $length, $this->len);
+
+        for ($offset = $this->pos; $offset < $end; $offset++) {
+            $peek .= $this->chars[$offset];
+        }
+
+        return $peek;
     }
 
     private function isEof(): bool


### PR DESCRIPTION
The parser used `mb_substr()` every time it read the next character. With UTF-8 strings, `mb_substr()` has to scan from the start of the string to reach that character, so long translations got much slower than they should.
In my benchmark, these numbers showed up:

| Characters | Original | New | Speedup |
| ---: | ---: | ---: | ---: |
| 2,000 | 4.568 ms | 0.275 ms | 16.6× |
| 4,000 | 17.252 ms | 0.545 ms | 31.7× |
| 8,000 | 62.975 ms | 1.082 ms | 58.2× |
| 16,000 | 239.825 ms | 2.141 ms | 112.0× |
| 32,000 | 936.264 ms | 4.258 ms | 219.9× |