### PR TITLE
perf(intl): lazy load catalog fallback

### DIFF
--- a/packages/intl/src/Catalog/GenericCatalog.php
+++ b/packages/intl/src/Catalog/GenericCatalog.php
@@ -21,14 +21,7 @@ final class GenericCatalog implements Catalog
 
     public function get(Locale $locale, string $key): ?string
     {
-        return Arr\get_by_key(
-            array: $this->catalog,
-            key: "{$locale->value}.{$key}",
-            default: Arr\get_by_key(
-                array: $this->catalog,
-                key: "{$locale->getLanguage()}.{$key}",
-            ),
-        );
+        return Arr\get_by_key($this->catalog, "{$locale->value}.{$key}") ?? Arr\get_by_key($this->catalog, "{$locale->getLanguage()}.{$key}");
     }
 
     public function add(Locale $locale, string $key, string $message): self


### PR DESCRIPTION
The fallback lookup was passed on the `default` value, so PHP eagerly executed the default route as well, even if the exact translation existed. The new way is about 2.5x faster based on my benchmark.