### PR TITLE
fix(database): delete rolled back migration records

### DIFF
--- a/packages/database/src/Migrations/MigrationManager.php
+++ b/packages/database/src/Migrations/MigrationManager.php
@@ -267,10 +267,9 @@ final class MigrationManager
 
         try {
             $this->database->execute(
-                new Query(
-                    'DELETE FROM Migration WHERE name = :name',
-                    ['name' => $migration->name],
-                ),
+                query(Migration::class)
+                    ->delete()
+                    ->whereRaw('name = ?', $migration->name),
             );
         } catch (QueryWasInvalid) { // @mago-expect lint:no-empty-catch-clause
             /**

--- a/tests/Integration/Database/MigrationManagerTest.php
+++ b/tests/Integration/Database/MigrationManagerTest.php
@@ -4,9 +4,17 @@ declare(strict_types=1);
 
 namespace Tests\Tempest\Integration\Database;
 
+use Tempest\Database\MigratesDown;
+use Tempest\Database\MigratesUp;
+use Tempest\Database\Migrations\CreateMigrationsTable;
 use Tempest\Database\Migrations\Migration;
 use Tempest\Database\Migrations\MigrationManager;
+use Tempest\Database\QueryStatement;
+use Tempest\Database\QueryStatements\CreateTableStatement;
+use Tempest\Database\QueryStatements\DropTableStatement;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\Database\query;
 
 /**
  * @internal
@@ -28,5 +36,43 @@ final class MigrationManagerTest extends FrameworkIntegrationTestCase
         $migrations = Migration::all();
         $this->assertNotEmpty($migrations);
         $this->assertSame($oldCount, count($migrations));
+    }
+
+    public function test_execute_down_removes_rolled_back_migration_record(): void
+    {
+        $migrationManager = $this->container->get(MigrationManager::class);
+        $migration = new MigrationManagerTestRollbackMigration();
+
+        $migrationManager->executeUp(new CreateMigrationsTable());
+        $migrationManager->executeUp($migration);
+
+        $this->assertSame(1, $this->countMigrationRecords($migration));
+
+        $migrationManager->executeDown($migration);
+
+        $this->assertSame(0, $this->countMigrationRecords($migration));
+    }
+
+    private function countMigrationRecords(MigrationManagerTestRollbackMigration $migration): int
+    {
+        return query(Migration::class)
+            ->count()
+            ->whereRaw('name = ?', $migration->name)
+            ->execute();
+    }
+}
+
+final class MigrationManagerTestRollbackMigration implements MigratesUp, MigratesDown
+{
+    public string $name = '0000-00-00_create_migration_manager_test_table';
+
+    public function up(): QueryStatement
+    {
+        return new CreateTableStatement('migration_manager_test_table')->primary();
+    }
+
+    public function down(): QueryStatement
+    {
+        return new DropTableStatement('migration_manager_test_table');
     }
 }


### PR DESCRIPTION
If you rolled back a migration, it would try to delete its tracking row with `DELETE FROM Migration`, but since the real table could be different based on the naming strategy, the delete could silently fail and the row would be left behind. That stale row could then cause a later migration to be skipped.