### PR TITLE
fix(view): preserve zero attribute bindings

### DIFF
--- a/packages/view/src/Attributes/ExpressionAttribute.php
+++ b/packages/view/src/Attributes/ExpressionAttribute.php
@@ -66,14 +66,20 @@ final readonly class ExpressionAttribute implements Attribute
             return str($name)->kebab()->toString();
         }
 
-        if (! $value) {
+        if ($value === false || $value === null) {
+            return '';
+        }
+
+        $resolvedValue = self::resolveValue($value);
+
+        if ($resolvedValue === '') {
             return '';
         }
 
         return sprintf(
             '%s="%s"',
             str($name)->kebab(),
-            ExpressionAttribute::resolveValue($value),
+            $resolvedValue,
         );
     }
 

--- a/packages/view/src/Elements/ViewComponentElement.php
+++ b/packages/view/src/Elements/ViewComponentElement.php
@@ -60,7 +60,7 @@ final class ViewComponentElement implements Element, WithToken
         $this->expressionAttributes = arr($attributes)
             ->filter(fn (string $_, string $key) => str_starts_with($key, ':'))
             ->filter(fn (string $_, string $key) => ! in_array($key, [':if', ':else', ':elseif', ':foreach', ':forelse'], strict: true))
-            ->mapWithKeys(fn (string $value, string $key) => yield str($key)->camel()->ltrim(':')->toString() => $value ?: 'true');
+            ->mapWithKeys(fn (string $value, string $key) => yield str($key)->camel()->ltrim(':')->toString() => $value === '' ? 'true' : $value);
 
         $this->scopedVariables = arr();
     }
@@ -448,7 +448,7 @@ final class ViewComponentElement implements Element, WithToken
             $isExpression = isset($this->expressionAttributes[$camelKey]);
 
             $entries[] = $isExpression
-                ? sprintf("'%s' => %s", $key, $value ?: 'true')
+                ? sprintf("'%s' => %s", $key, $value === '' ? 'true' : $value)
                 : sprintf("'%s' => %s", $key, ViewObjectExporter::exportValue($value));
         }
 

--- a/tests/Integration/View/TempestViewRendererDataPassingTest.php
+++ b/tests/Integration/View/TempestViewRendererDataPassingTest.php
@@ -193,6 +193,25 @@ final class TempestViewRendererDataPassingTest extends FrameworkIntegrationTestC
         );
     }
 
+    public function test_zero_expression_attribute_literal_on_view_component(): void
+    {
+        $this->view->registerViewComponent(
+            'x-link',
+            <<<'HTML'
+            <a :href="$href" :data-start-percent="$attributes->get('data-start-percent')"><x-slot/></a>
+            HTML,
+        );
+
+        $this->assertSame(
+            '<a href="0" data-start-percent="0">a</a>',
+            $this->view->render(
+                <<<'HTML'
+                <x-link :href="0" :data-start-percent="0">a</x-link>
+                HTML,
+            ),
+        );
+    }
+
     public function test_normal_attribute_on_view_component(): void
     {
         // <x-button href="http://…" />      💯 always pass as variable, never set directly as attribute
@@ -270,7 +289,7 @@ final class TempestViewRendererDataPassingTest extends FrameworkIntegrationTestC
 
     #[TestWith(['false'])]
     #[TestWith(['null'])]
-    #[TestWith(['0'])]
+    #[TestWith(["''"])]
     #[TestWith(['$show'])]
     public function test_falsy_bool_attribute(mixed $value): void
     {
@@ -280,6 +299,20 @@ final class TempestViewRendererDataPassingTest extends FrameworkIntegrationTestC
 
         $this->assertStringEqualsStringIgnoringLineEndings(<<<'HTML'
         <div ></div>
+        HTML, $html);
+    }
+
+    #[TestWith([0])]
+    #[TestWith([0.0])]
+    #[TestWith(['0'])]
+    public function test_zero_expression_attribute_value_is_rendered(mixed $value): void
+    {
+        $html = $this->view->render(<<<'HTML'
+        <div :data-start-percent="$value"></div>
+        HTML, value: $value);
+
+        $this->assertStringEqualsStringIgnoringLineEndings(<<<'HTML'
+        <div data-start-percent="0"></div>
         HTML, $html);
     }
 


### PR DESCRIPTION
Expression attributes used a loose falsy check, so numeric zero values like `0`, `0.0`, and `"0"` were omitted from rendered attributes. That dropped meaningful data values such as `data-start-percent="0"`. The renderer now omits `false`, `null`, and values that normalize to an empty string, while preserving zero values.

Literal expression attributes passed into view components used the same loose fallback and could turn `:foo="0"` into `true`. That path now only falls back to `true` for empty shorthand attributes.

Fixes #2167