### PR TITLE
fix(discovery): ignore duplicate pest tests during discovery

### DIFF
--- a/packages/discovery/src/BootDiscovery.php
+++ b/packages/discovery/src/BootDiscovery.php
@@ -209,7 +209,8 @@ final class BootDiscovery
                 } elseif (class_exists($className)) {
                     $input = new ClassReflector($className);
                 }
-            // @phpstan-ignore-next-line
+
+                // @phpstan-ignore-next-line
             } catch (AssertionError|InvalidPestCommand|TestAlreadyExist) {
                 // Workaround for Pest test files autoloading.
                 // @mago-expect lint:no-empty-catch-clause

--- a/packages/discovery/src/BootDiscovery.php
+++ b/packages/discovery/src/BootDiscovery.php
@@ -209,7 +209,8 @@ final class BootDiscovery
                 } elseif (class_exists($className)) {
                     $input = new ClassReflector($className);
                 }
-            } catch (AssertionError|InvalidPestCommand|TestAlreadyExist) { // @phpstan-ignore class.notFound
+            // @phpstan-ignore-next-line
+            } catch (AssertionError|InvalidPestCommand|TestAlreadyExist) {
                 // Workaround for Pest test files autoloading.
                 // @mago-expect lint:no-empty-catch-clause
             }

--- a/packages/discovery/src/BootDiscovery.php
+++ b/packages/discovery/src/BootDiscovery.php
@@ -8,6 +8,7 @@ use ArgumentCountError;
 use AssertionError;
 use Closure;
 use Pest\Exceptions\InvalidPestCommand;
+use Pest\Exceptions\TestAlreadyExist;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Tempest\Discovery\Exceptions\DiscoveryClassCouldNotBeResolved;
@@ -208,7 +209,7 @@ final class BootDiscovery
                 } elseif (class_exists($className)) {
                     $input = new ClassReflector($className);
                 }
-            } catch (AssertionError|InvalidPestCommand) { // @phpstan-ignore class.notFound
+            } catch (AssertionError|InvalidPestCommand|TestAlreadyExist) { // @phpstan-ignore class.notFound
                 // Workaround for Pest test files autoloading.
                 // @mago-expect lint:no-empty-catch-clause
             }


### PR DESCRIPTION
Fixes #2174.