### PR TITLE
fix(database): model inspector `getSelectFields` returns duplicates

### DIFF
--- a/packages/database/src/Builder/ModelInspector.php
+++ b/packages/database/src/Builder/ModelInspector.php
@@ -582,7 +582,7 @@ final class ModelInspector
             }
         }
 
-        return $selectFields;
+        return $selectFields->unique();
     }
 
     public function resolveRelations(string $relationString, string $parent = '', array $visitedPaths = []): array

--- a/tests/Integration/Database/ModelInspector/ModelInspectorTest.php
+++ b/tests/Integration/Database/ModelInspector/ModelInspectorTest.php
@@ -4,6 +4,7 @@ namespace Tests\Tempest\Integration\Database\ModelInspector;
 
 use Tempest\Database\Casters\DataTransferObjectCaster;
 use Tempest\Database\IsDatabaseModel;
+use Tempest\Database\PrimaryKey;
 use Tempest\Database\Serializers\DataTransferObjectSerializer;
 use Tempest\Database\Virtual;
 use Tempest\Mapper\CastWith;
@@ -33,6 +34,35 @@ final class ModelInspectorTest extends IntegrationTestCase
     {
         $this->assertFalse(inspect(ModelInspectorTestModelWithSerializedDtoProperty::class)->isRelation('dto'));
     }
+
+    public function test_select_doesnt_contain_duplicate_fields(): void
+    {
+        $model = inspect(HasRelatedModelWithId::class);
+
+        $selectedFields = $model->getSelectFields();
+
+        $this->assertEqualsCanonicalizing(
+            expected: ['name', 'relation_id'],
+            actual: $selectedFields->toArray(),
+        );
+    }
+}
+
+final class RelationWithId
+{
+    public PrimaryKey $id;
+
+    public string $name;
+}
+
+final class HasRelatedModelWithId
+{
+    public RelationWithId $relation;
+
+    public function __construct(
+        public string $name,
+        public int $relation_id,
+    ) {}
 }
 
 final class ModelInspectorTestDtoForModelWithVirtual


### PR DESCRIPTION
This causes the mapper to fail "silently".

Example:

```php
// the credential here belongs to the user with id = 2
$passkey = query(Passkey::class)->find(credential_id: $publicKeyCredential->rawId)->first();

// validation logic

// here the user_id would always be 1, signing in the wrong user
$user = query(User::class)->findById($passkey->user_id);
```

After some digging I found out that the user_id returned from the database as an array [1,1] or [2,2] and so on, which the mapper always map to 1?

And the reason for this is that my model has both a relation and a relation_id field.

```php
final class Passkey
{
    public PrimaryKey $id;

    public User $user;

    public function __construct(
        ...
        public int $user_id,
        ...
    ){}
}
```

And since the model inspector appends relation ids to the select fields, there came duplicates which made pdo/sqlite(?) return a list for the user_id key.

Anyhow, very simple fix (unless Im missing something) `->unique()` on the fields.