### PR TITLE
ci: cache PHPStan's result cache between runs

### DIFF
--- a/.github/workflows/coding-conventions.yml
+++ b/.github/workflows/coding-conventions.yml
@@ -54,8 +54,23 @@ jobs:
       - name: Install composer dependencies
         uses: ramsey/composer-install@v3
 
+      - name: Restore PHPStan result cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .cache/phpstan
+          key: "phpstan-result-cache-${{ github.run_id }}"
+          restore-keys: |
+            phpstan-result-cache-
+
       - name: Run PHPStan
         run: vendor/bin/phpstan --error-format=github
+
+      - name: Save PHPStan result cache
+        uses: actions/cache/save@v4
+        if: ${{ !cancelled() }}
+        with:
+          path: .cache/phpstan
+          key: "phpstan-result-cache-${{ github.run_id }}"
 
 #  rector:
 #    name: "Run static analysis: Rector"


### PR DESCRIPTION
The PHPStan static-analysis job currently runs with a cold cache on every push and PR. It re-analyses the whole codebase each time, because PHPStan's `tmpDir` (`.cache/phpstan`) isn't persisted between runs.

This caches it with PHPStan's documented CI recipe: restore the cache before the run, and save it afterwards with `if: ${{ !cancelled() }}` so it's still written when PHPStan exits non-zero on findings. `.cache/` is already gitignored, so nothing else changes.

Effect:
- Incremental runs reuse the result cache and only re-analyse changed files and their dependents.
- Even after a `composer update` invalidates the result cache, PHPStan keeps a separate content-hash-keyed reflection cache in the same directory, so those runs stay faster too. (Locally, a result-cache-invalidated run of `packages/` still used about 18% less CPU; no-change runs become near-instant.)

Results are unchanged: PHPStan invalidates the cache per file by content hash, and wholesale on a PHP or PHPStan version change.

Ref: https://phpstan.org/user-guide/result-cache
