### PR TITLE
fix(session): age flash values at the start of the request

### DIFF
--- a/packages/http/src/Session/ManageSessionMiddleware.php
+++ b/packages/http/src/Session/ManageSessionMiddleware.php
@@ -24,10 +24,14 @@ final readonly class ManageSessionMiddleware implements HttpMiddleware
 
     public function __invoke(Request $request, HttpMiddlewareCallable $next): Response
     {
+        // Flash values are aged at the start of the request, before the response
+        // body is rendered, so a value flashed on the previous request stays
+        // readable this request and is expired on the next one.
+        $this->session->cleanup();
+
         try {
             return $next($request);
         } finally {
-            $this->session->cleanup();
             $this->sessionManager->save($this->session);
 
             match ($this->config->cleanupStrategy) {

--- a/packages/http/src/Session/Session.php
+++ b/packages/http/src/Session/Session.php
@@ -124,9 +124,11 @@ final class Session
         $this->expiredKeys = [];
 
         foreach ($this->data as $key => $value) {
-            if ($value instanceof FlashValue) {
-                $this->expiredKeys[$key] = $key;
+            if (! $value instanceof FlashValue) {
+                continue;
             }
+
+            $this->expiredKeys[$key] = $key;
         }
     }
 

--- a/packages/http/src/Session/Session.php
+++ b/packages/http/src/Session/Session.php
@@ -65,11 +65,9 @@ final class Session
      */
     public function get(string|UnitEnum $key, mixed $default = null): mixed
     {
-        $key = Str\parse($key);
-        $value = $this->data[$key] ?? $default;
+        $value = $this->data[Str\parse($key)] ?? $default;
 
         if ($value instanceof FlashValue) {
-            $this->expiredKeys[$key] = $key;
             $value = $value->value;
         }
 
@@ -110,12 +108,25 @@ final class Session
     }
 
     /**
-     * Cleans up expired session values.
+     * Expires flash values by one request. Values flashed on the previous request
+     * are removed; values flashed since are marked to expire on the next request.
+     *
+     * This runs once, at the start of the request, so that flash values remain
+     * readable while the request is handled - including while the response body
+     * (e.g. a view) is being rendered - regardless of whether they are read.
      */
     public function cleanup(): void
     {
         foreach ($this->expiredKeys as $key) {
             $this->remove($key);
+        }
+
+        $this->expiredKeys = [];
+
+        foreach ($this->data as $key => $value) {
+            if ($value instanceof FlashValue) {
+                $this->expiredKeys[$key] = $key;
+            }
         }
     }
 

--- a/tests/Fixtures/Controllers/FlashViewController.php
+++ b/tests/Fixtures/Controllers/FlashViewController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Controllers;
+
+use Tempest\Http\Responses\Redirect;
+use Tempest\Http\Session\Session;
+use Tempest\Router\Get;
+use Tempest\Router\Post;
+use Tempest\View\View;
+
+use function Tempest\View\view;
+
+final readonly class FlashViewController
+{
+    public function __construct(
+        private Session $session,
+    ) {}
+
+    #[Post('/flash-view')]
+    public function flash(): Redirect
+    {
+        $this->session->flash('message', 'flashed-message');
+
+        return new Redirect('/flash-view');
+    }
+
+    #[Get('/flash-view')]
+    public function show(): View
+    {
+        return view('./flash-view.view.php');
+    }
+}

--- a/tests/Fixtures/Controllers/flash-view.view.php
+++ b/tests/Fixtures/Controllers/flash-view.view.php
@@ -1,0 +1,12 @@
+<?php
+
+use Tempest\Http\Session\Session;
+
+use function Tempest\Container\get;
+
+// The flash value is consumed while the view renders, i.e. after the session
+// middleware has run. It must still expire for the following request.
+$message = get(Session::class)->get('message');
+?>
+
+<div id="flash">{{ $message }}</div>

--- a/tests/Integration/Http/FlashInViewTest.php
+++ b/tests/Integration/Http/FlashInViewTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Http;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+/**
+ * @internal
+ */
+final class FlashInViewTest extends FrameworkIntegrationTestCase
+{
+    #[Test]
+    public function flash_value_consumed_while_rendering_a_view_is_shown_once(): void
+    {
+        // A request flashes a value and redirects.
+        $this->http
+            ->post('/flash-view')
+            ->assertRedirect('/flash-view');
+
+        // The redirected request reads the flash value while rendering the view.
+        $this->http
+            ->get('/flash-view')
+            ->assertOk()
+            ->assertSee('flashed-message');
+
+        // The following request no longer sees it: it was aged out at the start of
+        // this request, even though it was only ever read while rendering the view.
+        $this->http
+            ->get('/flash-view')
+            ->assertOk()
+            ->assertNotSee('flashed-message');
+    }
+}

--- a/tests/Integration/Http/FormSessionTest.php
+++ b/tests/Integration/Http/FormSessionTest.php
@@ -166,10 +166,12 @@ final class FormSessionTest extends FrameworkIntegrationTestCase
         // First access - errors exist
         $this->assertTrue($this->formSession->hasErrors());
 
-        // Simulate cleanup after request
+        // Start of the next request: still available to display.
         $this->session->cleanup();
+        $this->assertTrue($this->formSession->hasErrors());
 
-        // Second access - errors cleared
+        // Start of the request after that: cleared.
+        $this->session->cleanup();
         $this->assertFalse($this->formSession->hasErrors());
     }
 
@@ -183,10 +185,12 @@ final class FormSessionTest extends FrameworkIntegrationTestCase
         // First access - values exist
         $this->assertEquals('John Doe', $this->formSession->getOriginalValueFor('name'));
 
-        // Simulate cleanup after request
+        // Start of the next request: still available to display.
         $this->session->cleanup();
+        $this->assertEquals('John Doe', $this->formSession->getOriginalValueFor('name'));
 
-        // Second access - values cleared
+        // Start of the request after that: cleared.
+        $this->session->cleanup();
         $this->assertEquals('', $this->formSession->getOriginalValueFor('name'));
     }
 }

--- a/tests/Integration/Http/SessionTest.php
+++ b/tests/Integration/Http/SessionTest.php
@@ -74,7 +74,25 @@ final class SessionTest extends FrameworkIntegrationTestCase
         $this->session->flash('message', 'success');
         $this->assertEquals('success', $this->session->get('message'));
 
+        // Start of the next request: the value is still available (e.g. to render).
         $this->session->cleanup();
+        $this->assertEquals('success', $this->session->get('message'));
+
+        // Start of the request after that: it has expired.
+        $this->session->cleanup();
+        $this->assertNull($this->session->get('message'));
+    }
+
+    #[Test]
+    public function flash_value_expires_even_when_never_read(): void
+    {
+        $this->session->flash('message', 'success');
+
+        // Aging is independent of reads: two request boundaries expire the value
+        // without it ever being retrieved.
+        $this->session->cleanup();
+        $this->session->cleanup();
+
         $this->assertNull($this->session->get('message'));
     }
 


### PR DESCRIPTION
Closes #1734. Addresses #210.

### Problem

A flash value is meant to live for one request and then go away.

The old logic removed a flash value once it was read. But the cleanup happened before the view was rendered - and views are often where the value is actually read (for example, the default form and input components). By then it was too late: the value was already saved back into the session, so it showed up again on the next request.

And if a flash value was never read, it was never removed at all.

### Fix

Instead of expiring flash values at the end of the request, expire them at the start:

- values flashed on the previous request are removed;
- values flashed since then are marked to go on the next request.

Reads no longer affect this, so a flash value stays readable for the whole request, including whilst the view renders, and is reliably gone on the next one.

The session is still saved right away. This is a bit different from the idea in #210 (removing once the response is sent): expiring at the start of the next request gives the same result without deferring any work, and doesn't change the public API.

### Notes

Three tests checked the old read-based timing (`flash()` then a single `cleanup()`); they now check the two-request lifecycle. A new test covers a flash value expiring even when it's never read.
