### PR TITLE
fix(router): use `Json\encode` for encoding when sending json responses

### DIFF
--- a/packages/router/src/GenericResponseSender.php
+++ b/packages/router/src/GenericResponseSender.php
@@ -104,7 +104,7 @@ final readonly class GenericResponseSender implements ResponseSender
         if ($response instanceof File || $response instanceof Download) {
             readfile($body);
         } elseif (is_array($body) || $body instanceof JsonSerializable) {
-            echo json_encode($body);
+            echo Json\encode($body);
         } elseif ($body instanceof View) {
             $this->renderView($response);
         } else {

--- a/tests/Integration/Http/GenericResponseSenderTest.php
+++ b/tests/Integration/Http/GenericResponseSenderTest.php
@@ -19,6 +19,7 @@ use Tempest\Http\ServerSentEvent;
 use Tempest\Http\ServerSentMessage;
 use Tempest\Http\Status;
 use Tempest\Router\GenericResponseSender;
+use Tempest\Support\Json\Exception\JsonCouldNotBeEncoded;
 use Tempest\View\ViewRenderer;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
@@ -115,6 +116,21 @@ final class GenericResponseSenderTest extends FrameworkIntegrationTestCase
         $output = ob_get_clean();
 
         $this->assertSame('{"key":"value"}', $output);
+    }
+
+    public function test_sending_invalid_json_throws_exception(): void
+    {
+        ob_start();
+        $response = new GenericResponse(
+            status: Status::CREATED,
+            body: ['key' => "\xB1\x31"],
+        );
+
+        $responseSender = $this->container->get(GenericResponseSender::class);
+
+        $this->assertException(JsonCouldNotBeEncoded::class, fn () => $responseSender->send($response));
+
+        ob_get_clean();
     }
 
     public function test_sending_of_json_serializable_to_json(): void


### PR DESCRIPTION
I got an issue where my json responses got no output, turns out it was because I had "binary strings" in my object, and since the json_encode didn't throw and I forgot those values existed it took forever for me to debug :3

I figured using the tempest encode function would be better than just adding the throw flag.