### PR TITLE
docs: fix typo on docs 1-essentials/03-database

### DIFF
--- a/docs/1-essentials/03-database.md
+++ b/docs/1-essentials/03-database.md
@@ -162,7 +162,7 @@ Beyond selecting models, any query builder can be used with model objects:
 use App\Models\Book;
 use Tempest\Database\PrimaryKey;
 
-;use function Tempest\Database\query;
+use function Tempest\Database\query;
 
 final class BookRepository
 {


### PR DESCRIPTION
A simple typo that I notice while reading the docs.