### PR TITLE
feat(validation): include error messages in ValidationFailed exception message

### DIFF
--- a/packages/validation/src/Exceptions/ValidationFailed.php
+++ b/packages/validation/src/Exceptions/ValidationFailed.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Tempest\Validation\Exceptions;
 
 use Exception;
+use Tempest\Core\ProvidesContext;
 use Tempest\Validation\FailingRule;
 use Tempest\Validation\Internal\MessageRule;
 
-use function Tempest\Support\Json\encode;
-
-final class ValidationFailed extends Exception
+final class ValidationFailed extends Exception implements ProvidesContext
 {
     /**
      * @template TKey of array-key
@@ -30,11 +29,18 @@ final class ValidationFailed extends Exception
             default => sprintf('Validation failed for %s.', is_object($subject) ? $subject::class : $subject),
         };
 
-        if ($errorMessages !== []) {
-            $message .= ' ' . encode($errorMessages);
+        foreach ($errorMessages as $field => $messages) {
+            $message .= PHP_EOL . sprintf('- %s: %s', $field, implode('; ', $messages));
         }
 
         parent::__construct($message);
+    }
+
+    public function context(): iterable
+    {
+        return array_filter([
+            'errors' => $this->errorMessages,
+        ]);
     }
 
     /**

--- a/packages/validation/src/Exceptions/ValidationFailed.php
+++ b/packages/validation/src/Exceptions/ValidationFailed.php
@@ -8,6 +8,8 @@ use Exception;
 use Tempest\Validation\FailingRule;
 use Tempest\Validation\Internal\MessageRule;
 
+use function Tempest\Support\Json\encode;
+
 final class ValidationFailed extends Exception
 {
     /**
@@ -23,10 +25,16 @@ final class ValidationFailed extends Exception
         private(set) array $errorMessages = [],
         private(set) ?string $targetClass = null,
     ) {
-        parent::__construct(match (true) {
+        $message = match (true) {
             is_null($subject) => 'Validation failed.',
             default => sprintf('Validation failed for %s.', is_object($subject) ? $subject::class : $subject),
-        });
+        };
+
+        if ($errorMessages !== []) {
+            $message .= ' ' . encode($errorMessages);
+        }
+
+        parent::__construct($message);
     }
 
     /**

--- a/packages/validation/src/Exceptions/ValidationFailed.php
+++ b/packages/validation/src/Exceptions/ValidationFailed.php
@@ -30,7 +30,7 @@ final class ValidationFailed extends Exception implements ProvidesContext
         };
 
         foreach ($errorMessages as $field => $messages) {
-            $message .= PHP_EOL . sprintf('- %s: %s', $field, implode('; ', $messages));
+            $message .= sprintf('%s- %s: %s', PHP_EOL, $field, implode('; ', $messages));
         }
 
         parent::__construct($message);

--- a/packages/validation/tests/ValidatorTest.php
+++ b/packages/validation/tests/ValidatorTest.php
@@ -144,7 +144,11 @@ final class ValidatorTest extends TestCase
         ]);
 
         $this->assertSame(
-            'Validation failed. {"credential":["Passkey not valid"],"email":["Email is already taken","Email domain is not allowed"]}',
+            implode(PHP_EOL, [
+                'Validation failed.',
+                '- credential: Passkey not valid',
+                '- email: Email is already taken; Email domain is not allowed',
+            ]),
             $validationFailed->getMessage(),
         );
     }
@@ -154,6 +158,16 @@ final class ValidatorTest extends TestCase
         $validationFailed = new ValidationFailed(failingRules: []);
 
         $this->assertSame('Validation failed.', $validationFailed->getMessage());
+    }
+
+    public function test_validation_failed_provides_error_messages_as_context(): void
+    {
+        $validationFailed = ValidationFailed::withMessages([
+            'email' => 'Email is already taken',
+        ]);
+
+        $this->assertSame(['errors' => ['email' => ['Email is already taken']]], $validationFailed->context());
+        $this->assertSame([], new ValidationFailed(failingRules: [])->context());
     }
 
     public function test_closure_passes_with_null_response(): void

--- a/packages/validation/tests/ValidatorTest.php
+++ b/packages/validation/tests/ValidatorTest.php
@@ -133,6 +133,29 @@ final class ValidatorTest extends TestCase
         $this->assertSame('Email domain is not allowed', $this->validator->getErrorMessage($validationFailed->failingRules['email'][1]));
     }
 
+    public function test_validation_failed_message_includes_error_messages(): void
+    {
+        $validationFailed = ValidationFailed::withMessages([
+            'credential' => 'Passkey not valid',
+            'email' => [
+                'Email is already taken',
+                'Email domain is not allowed',
+            ],
+        ]);
+
+        $this->assertSame(
+            'Validation failed. {"credential":["Passkey not valid"],"email":["Email is already taken","Email domain is not allowed"]}',
+            $validationFailed->getMessage(),
+        );
+    }
+
+    public function test_validation_failed_message_omits_error_messages_when_empty(): void
+    {
+        $validationFailed = new ValidationFailed(failingRules: []);
+
+        $this->assertSame('Validation failed.', $validationFailed->getMessage());
+    }
+
     public function test_closure_passes_with_null_response(): void
     {
         $validator = $this->validator;


### PR DESCRIPTION
**1. Implements `ProvidesContext`**, exposing the errors as structured context, so they show up in log context via `LoggingExceptionReporter` and on the development exception page, the same pattern as `QueryWasInvalid`, `EncryptionFailed`, and `ProcessExecutionWasForbidden`.

**2. Appends the failures to the message in a human-readable format:**

```
Validation failed for App\User.
- credential: Passkey not valid
- email: Email is already taken; Email domain is not allowed
```

The message stays untouched (`Validation failed.`) when there are no error messages.

Fixes #2189
