### PR TITLE
fix(router)!: block all cross-site unsafe requests when using `PreventCrossSiteRequestsMiddleware`

### DIFF
--- a/packages/router/src/PreventCrossSiteRequestsMiddleware.php
+++ b/packages/router/src/PreventCrossSiteRequestsMiddleware.php
@@ -15,11 +15,10 @@ use Tempest\Support\Priority;
  *
  * - Safe HTTP methods are always allowed
  * - Requests from same-origin or same-site are allowed
- * - Cross-site requests that aren't navigation are blocked
+ * - Cross-site requests using unsafe methods are blocked
  * - Requests without Sec-Fetch-Site headers are blocked
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site
- * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode
  * @see https://web.dev/articles/fetch-metadata
  */
 #[Priority(Priority::FRAMEWORK - 8)]
@@ -59,16 +58,10 @@ final readonly class PreventCrossSiteRequestsMiddleware implements HttpMiddlewar
     private function isValidRequest(Request $request): bool
     {
         $secFetchSite = SecFetchSite::tryFrom($request->headers->get('sec-fetch-site', default: ''));
-        $secFetchMode = SecFetchMode::tryFrom($request->headers->get('sec-fetch-mode', default: ''));
 
         // prevent the request if there is no `sec-fetch-site` header
         if ($secFetchSite === null) {
             return false;
-        }
-
-        // allow cross-site only on navigation requests
-        if ($secFetchSite === SecFetchSite::CROSS_SITE && $secFetchMode === SecFetchMode::NAVIGATE) {
-            return true;
         }
 
         // same origin, same site and user-originated requests are always allowed

--- a/tests/Integration/Router/PreventCrossSiteRequestsMiddlewareTest.php
+++ b/tests/Integration/Router/PreventCrossSiteRequestsMiddlewareTest.php
@@ -67,14 +67,14 @@ final class PreventCrossSiteRequestsMiddlewareTest extends FrameworkIntegrationT
     }
 
     #[Test]
-    public function post_with_cross_site_navigation_is_allowed(): void
+    public function post_with_cross_site_navigation_is_blocked(): void
     {
         $this->http
             ->post('/test', headers: [
                 'sec-fetch-site' => SecFetchSite::CROSS_SITE,
                 'sec-fetch-mode' => SecFetchMode::NAVIGATE,
             ])
-            ->assertOk();
+            ->assertForbidden();
     }
 
     #[Test]


### PR DESCRIPTION
I initially implemented this with the idea that Tempest defaults to using LAX cookies, so sessions are not carried during cross-site POST requests.

However, it's better to special-case the routes that need support for this instead of it being allowed by default, so this PR changes that.

Marking as breaking because technically it is, payment provider flows might be affected and related routes will need to get hand-rolled protection.