### PR TITLE
docs: fix syntax in mapper

### DIFF
--- a/docs/2-features/01-mapper.md
+++ b/docs/2-features/01-mapper.md
@@ -102,7 +102,7 @@ $json = map($user)->toJson();
 ```
 
 :::info
-The {b`#[Hidden]`} attribute also excludes properties from database SELECT queries. See the [database documentation](../1-essentials/03-database.md#hidden-properties) for more information.
+The {b`#[Tempest\Mapper\Hidden]`} attribute also excludes properties from database SELECT queries. See the [database documentation](../1-essentials/03-database.md#hidden-properties) for more information.
 :::
 
 ### Overriding field names


### PR DESCRIPTION
While reading Mapper doc I noticed in [this part](https://github.com/tempestphp/tempest-framework/blob/580b059a0b40dc6c1ac0cc9e26a99f7396ec1faf/packages/router/src/functions.php#L23) a malformed ref to point to attribute file on Github