### PR TITLE
ci: fix PHPStan not using result cache

### DIFF
--- a/.github/workflows/coding-conventions.yml
+++ b/.github/workflows/coding-conventions.yml
@@ -1,6 +1,8 @@
 name: Coding Conventions
 
 on:
+  push:
+    branches: [3.x]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/coding-conventions.yml
+++ b/.github/workflows/coding-conventions.yml
@@ -63,7 +63,7 @@ jobs:
             phpstan-result-cache-
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan --error-format=github
+        run: vendor/bin/phpstan --error-format=github -vv
 
       - name: Save PHPStan result cache
         uses: actions/cache/save@v4

--- a/.github/workflows/coding-conventions.yml
+++ b/.github/workflows/coding-conventions.yml
@@ -63,7 +63,7 @@ jobs:
             phpstan-result-cache-
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan --error-format=github -vv
+        run: vendor/bin/phpstan --error-format=github -vv 
 
       - name: Save PHPStan result cache
         uses: actions/cache/save@v4

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "php-di/php-di": "^7.0",
         "phpat/phpat": "^0.11.0",
         "phpbench/phpbench": "^1.4",
-        "phpstan/phpstan": "2.1.40",
+        "phpstan/phpstan": "2.2.x-dev",
         "phpunit/phpunit": "^12.5.22",
         "predis/predis": "^3.0.0",
         "riskio/oauth2-auth0": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0|^2.0",
         "psr/log": "^3.0.0",
-        "rector/rector": "^2.5.8",
+        "rector/rector": "2.5.8",
         "symfony/cache": "^7.3|^8.0",
         "symfony/filesystem": "^7.3|^8.0",
         "symfony/mailer": "^7.2.6|^8.0",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0|^2.0",
         "psr/log": "^3.0.0",
-        "rector/rector": "2.3.8",
+        "rector/rector": "^2.5.8",
         "symfony/cache": "^7.3|^8.0",
         "symfony/filesystem": "^7.3|^8.0",
         "symfony/mailer": "^7.2.6|^8.0",

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "php-di/php-di": "^7.0",
         "phpat/phpat": "^0.11.0",
         "phpbench/phpbench": "^1.4",
-        "phpstan/phpstan": "2.2.x-dev",
+        "phpstan/phpstan": "2.2.6",
         "phpunit/phpunit": "^12.5.22",
         "predis/predis": "^3.0.0",
         "riskio/oauth2-auth0": "^2.4",

--- a/packages/console/src/Components/InteractiveComponentRenderer.php
+++ b/packages/console/src/Components/InteractiveComponentRenderer.php
@@ -28,6 +28,7 @@ final class InteractiveComponentRenderer
 
     /** @var list<string> */
     private array $pendingKeys = [];
+
     private string $pendingInput = '';
 
     public function __construct(

--- a/packages/console/src/Components/Option.php
+++ b/packages/console/src/Components/Option.php
@@ -19,15 +19,12 @@ final class Option
                 return $this->value;
             }
 
-            /** @phpstan-ignore-next-line */
             if (method_exists($this->value, 'toString')) {
-                /** @phpstan-ignore-next-line */
                 return $this->value->toString();
             }
 
             $reflection = new ReflectionEnum($this->value::class);
 
-            /** @phpstan-ignore-next-line */
             if (! $reflection->isBacked()) {
                 return $this->value->name;
             }

--- a/packages/console/src/Input/ConsoleArgumentBag.php
+++ b/packages/console/src/Input/ConsoleArgumentBag.php
@@ -177,10 +177,12 @@ final class ConsoleArgumentBag
 
         // Otherwise, $arguments is an array of flags or positional argument.
         foreach ($arguments as $key => $argument) {
-            if (! (str_starts_with($argument, '-') && ! str_starts_with($argument, '--'))) {
+            if (!str_starts_with($argument, '-')) {
                 continue;
             }
-
+            if (str_starts_with($argument, '--')) {
+                continue;
+            }
             $flags = str_split($argument);
             unset($flags[0]);
 

--- a/packages/console/src/Input/ConsoleArgumentBag.php
+++ b/packages/console/src/Input/ConsoleArgumentBag.php
@@ -177,12 +177,14 @@ final class ConsoleArgumentBag
 
         // Otherwise, $arguments is an array of flags or positional argument.
         foreach ($arguments as $key => $argument) {
-            if (!str_starts_with($argument, '-')) {
+            if (! str_starts_with($argument, '-')) {
                 continue;
             }
+
             if (str_starts_with($argument, '--')) {
                 continue;
             }
+
             $flags = str_split($argument);
             unset($flags[0]);
 

--- a/packages/container/src/GenericContainer.php
+++ b/packages/container/src/GenericContainer.php
@@ -234,7 +234,7 @@ final class GenericContainer implements Container
             return $this->invokeClosure($method, ...$params);
         }
 
-        if (is_array($method) && count($method) === 2) {
+        if (is_array($method)) {
             return $this->invokeClosure($method(...), ...$params);
         }
 

--- a/packages/core/src/PublishesFiles.php
+++ b/packages/core/src/PublishesFiles.php
@@ -251,12 +251,14 @@ if (trait_exists(HasConsole::class)) {
                     // PHP will output empty arrays for empty dependencies,
                     // which is invalid and will make package managers crash.
                     foreach (['dependencies', 'devDependencies', 'peerDependencies'] as $key) {
-                        if (!isset($json[$key])) {
+                        if (! isset($json[$key])) {
                             continue;
                         }
+
                         if ($json[$key]) {
                             continue;
                         }
+
                         unset($json[$key]);
                     }
 

--- a/packages/core/src/PublishesFiles.php
+++ b/packages/core/src/PublishesFiles.php
@@ -251,10 +251,12 @@ if (trait_exists(HasConsole::class)) {
                     // PHP will output empty arrays for empty dependencies,
                     // which is invalid and will make package managers crash.
                     foreach (['dependencies', 'devDependencies', 'peerDependencies'] as $key) {
-                        if (! (isset($json[$key]) && ! $json[$key])) {
+                        if (!isset($json[$key])) {
                             continue;
                         }
-
+                        if ($json[$key]) {
+                            continue;
+                        }
                         unset($json[$key]);
                     }
 

--- a/packages/cryptography/src/Signing/SigningKey.php
+++ b/packages/cryptography/src/Signing/SigningKey.php
@@ -7,6 +7,9 @@ use Tempest\Cryptography\Signing\Exceptions\SigningKeyWasInvalid;
 
 final readonly class SigningKey implements Stringable
 {
+    /**
+     * @throws SigningKeyWasInvalid
+     */
     public function __construct(
         private(set) string $value,
     ) {
@@ -17,6 +20,8 @@ final readonly class SigningKey implements Stringable
 
     /**
      * Creates a signing key from a string.
+     *
+     * @throws SigningKeyWasInvalid
      */
     public static function fromString(?string $key): self
     {

--- a/packages/cryptography/tests/Signing/SignerTest.php
+++ b/packages/cryptography/tests/Signing/SignerTest.php
@@ -91,6 +91,8 @@ final class SignerTest extends TestCase
             key: '', // @phpstan-ignore argument.type
             minimumExecutionDuration: false,
         ));
+
+        $signed = $signer->sign('important data');
     }
 
     #[Test]

--- a/packages/cryptography/tests/Signing/SignerTest.php
+++ b/packages/cryptography/tests/Signing/SignerTest.php
@@ -91,8 +91,6 @@ final class SignerTest extends TestCase
             key: '', // @phpstan-ignore argument.type
             minimumExecutionDuration: false,
         ));
-
-        $signer->sign('important data');
     }
 
     #[Test]

--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -404,7 +404,7 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
             $dialect->quoteIdentifier($this->tableName),
             arr($this->statements)
                 // Remove BelongsTo for sqlLite as it does not support those queries
-                ->filter(fn (QueryStatement $queryStatement) => $dialect !== DatabaseDialect::SQLITE || !$queryStatement instanceof BelongsToStatement)
+                ->filter(fn (QueryStatement $queryStatement) => $dialect !== DatabaseDialect::SQLITE || ! $queryStatement instanceof BelongsToStatement)
                 ->map(fn (QueryStatement $queryStatement) => str($queryStatement->compile($dialect))->trim()->replace('  ', ' '))
                 ->filter(fn (ImmutableString $str) => $str->isNotEmpty())
                 ->implode(', ' . PHP_EOL . '    ')

--- a/packages/database/src/QueryStatements/CreateTableStatement.php
+++ b/packages/database/src/QueryStatements/CreateTableStatement.php
@@ -404,7 +404,7 @@ final class CreateTableStatement implements QueryStatement, HasTrailingStatement
             $dialect->quoteIdentifier($this->tableName),
             arr($this->statements)
                 // Remove BelongsTo for sqlLite as it does not support those queries
-                ->filter(fn (QueryStatement $queryStatement) => ! ($dialect === DatabaseDialect::SQLITE && $queryStatement instanceof BelongsToStatement))
+                ->filter(fn (QueryStatement $queryStatement) => $dialect !== DatabaseDialect::SQLITE || !$queryStatement instanceof BelongsToStatement)
                 ->map(fn (QueryStatement $queryStatement) => str($queryStatement->compile($dialect))->trim()->replace('  ', ' '))
                 ->filter(fn (ImmutableString $str) => $str->isNotEmpty())
                 ->implode(', ' . PHP_EOL . '    ')

--- a/packages/datetime/src/functions.php
+++ b/packages/datetime/src/functions.php
@@ -150,7 +150,7 @@ function high_resolution_time(): array
     if ($offset === null) {
         $offset = hrtime();
 
-        if ($offset === false) { // @phpstan-ignore-line identical.alwaysFalse
+        if ($offset === false) {
             throw new RuntimeException('The system does not provide a monotonic timer.');
         }
 
@@ -243,7 +243,7 @@ function to_intl_timezone(Timezone $timezone): IntlTimeZone
 
     $tz = IntlTimeZone::createTimeZone($value);
 
-    if ($tz === null) { // @phpstan-ignore-line identical.alwaysFalse
+    if ($tz === null) {
         throw new RuntimeException(sprintf(
             'Failed to create intl timezone from timezone "%s" ("%s" / "%s").',
             $timezone->name,

--- a/packages/discovery/src/BootDiscovery.php
+++ b/packages/discovery/src/BootDiscovery.php
@@ -288,7 +288,7 @@ final class BootDiscovery
         if ($discovery === null) {
             try {
                 $discovery = new $discoveryClass();
-            } catch (ArgumentCountError) { // @phpstan-ignore catch.neverThrown
+            } catch (ArgumentCountError) {
                 throw DiscoveryClassCouldNotBeResolved::forDiscoveryClass($discoveryClass);
             }
         }

--- a/packages/event-bus/tests/EventBusTest.php
+++ b/packages/event-bus/tests/EventBusTest.php
@@ -218,7 +218,7 @@ final class EventBusTest extends TestCase
 
         $eventBus->dispatch(EventEnum::TWO);
 
-        /** @var bool $hasHappened */
+        /** @phpstan-ignore method.impossibleType */
         $this->assertTrue($hasHappened);
     }
 }

--- a/packages/generation/src/Php/SimplifiesClassNames.php
+++ b/packages/generation/src/Php/SimplifiesClassNames.php
@@ -136,10 +136,12 @@ trait SimplifiesClassNames
                     }
 
                     foreach ($type->getTypes() as $subtype) {
-                        if (! ($subtype->isClass() && ! $subtype->isClassKeyword())) {
+                        if (!$subtype->isClass()) {
                             continue;
                         }
-
+                        if ($subtype->isClassKeyword()) {
+                            continue;
+                        }
                         $namespace->addUse((string) $subtype);
                     }
                 }

--- a/packages/generation/src/Php/SimplifiesClassNames.php
+++ b/packages/generation/src/Php/SimplifiesClassNames.php
@@ -136,12 +136,14 @@ trait SimplifiesClassNames
                     }
 
                     foreach ($type->getTypes() as $subtype) {
-                        if (!$subtype->isClass()) {
+                        if (! $subtype->isClass()) {
                             continue;
                         }
+
                         if ($subtype->isClassKeyword()) {
                             continue;
                         }
+
                         $namespace->addUse((string) $subtype);
                     }
                 }

--- a/packages/generation/src/Php/StubFileGenerator.php
+++ b/packages/generation/src/Php/StubFileGenerator.php
@@ -60,7 +60,6 @@ final class StubFileGenerator
                 ->setClassName($classname);
 
             foreach ($replacements as $placeholder => $replacement) {
-                // @phpstan-ignore function.alreadyNarrowedType
                 if (! is_string($replacement)) {
                     continue;
                 }
@@ -117,7 +116,6 @@ final class StubFileGenerator
             $fileContent = Filesystem\read_file($stubFile->filePath);
 
             foreach ($replacements as $placeholder => $replacement) {
-                // @phpstan-ignore function.alreadyNarrowedType
                 if (! is_string($replacement)) {
                     continue;
                 }

--- a/packages/http/src/Cookie/Cookie.php
+++ b/packages/http/src/Cookie/Cookie.php
@@ -128,10 +128,8 @@ final class Cookie implements Stringable
             maxAge: isset($cookie['max-age']) ? (int) $cookie['max-age'] : null,
             domain: $cookie['domain'] ?? null,
             path: $cookie['path'] ?? '/',
-            // @phpstan-ignore identical.alwaysTrue
-            secure: isset($cookie['secure']) && $cookie['secure'] === true,
-            // @phpstan-ignore identical.alwaysTrue
-            httpOnly: isset($cookie['httponly']) && $cookie['httponly'] === true,
+            secure: isset($cookie['secure']),
+            httpOnly: isset($cookie['httponly']),
             sameSite: isset($cookie['samesite']) ? SameSite::from($cookie['samesite']) : null,
         );
     }

--- a/packages/http/src/Cookie/Cookie.php
+++ b/packages/http/src/Cookie/Cookie.php
@@ -123,12 +123,14 @@ final class Cookie implements Stringable
 
         return new Cookie(
             key: $cookie['name'],
-            value: $cookie['value'] ?? null,
+            value: $cookie['value'],
             expiresAt: isset($cookie['expires']) ? (int) $cookie['expires'] : null,
             maxAge: isset($cookie['max-age']) ? (int) $cookie['max-age'] : null,
             domain: $cookie['domain'] ?? null,
             path: $cookie['path'] ?? '/',
+            // @phpstan-ignore identical.alwaysTrue
             secure: isset($cookie['secure']) && $cookie['secure'] === true,
+            // @phpstan-ignore identical.alwaysTrue
             httpOnly: isset($cookie['httponly']) && $cookie['httponly'] === true,
             sameSite: isset($cookie['samesite']) ? SameSite::from($cookie['samesite']) : null,
         );

--- a/packages/support/tests/IsEnumHelperTest.php
+++ b/packages/support/tests/IsEnumHelperTest.php
@@ -106,7 +106,6 @@ final class IsEnumHelperTest extends TestCase
         );
 
         // It's case sensitive
-        // @phpstan-ignore method.alreadyNarrowedType ( Because it's a regression test )
         $this->assertNull(
             SampleStatusBackedEnum::tryFrom('PUBLISH'),
         );

--- a/packages/validation/src/Rules/IsPassword.php
+++ b/packages/validation/src/Rules/IsPassword.php
@@ -48,7 +48,7 @@ final readonly class IsPassword implements Rule, HasTranslationVariables
             return false;
         }
 
-        return !$this->symbols || preg_match('/\p{Z}|\p{S}|\p{P}/u', $value);
+        return ! $this->symbols || preg_match('/\p{Z}|\p{S}|\p{P}/u', $value);
     }
 
     public function getTranslationVariables(): array

--- a/packages/validation/src/Rules/IsPassword.php
+++ b/packages/validation/src/Rules/IsPassword.php
@@ -48,7 +48,7 @@ final readonly class IsPassword implements Rule, HasTranslationVariables
             return false;
         }
 
-        return ! ($this->symbols && ! preg_match('/\p{Z}|\p{S}|\p{P}/u', $value));
+        return !$this->symbols || preg_match('/\p{Z}|\p{S}|\p{P}/u', $value);
     }
 
     public function getTranslationVariables(): array

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -42,16 +42,6 @@ parameters:
                 - packages/**/tests/**/*.php
                 - packages/**/tests/*.php
         -
-            identifier: smaller.alwaysFalse
-            path: packages/support/src/Arr/functions.php
-            count: 1
-            # Runtime guard: positive-int type guarantees $number >= 1, but we keep the check for safety
-        -
-            identifier: instanceof.alwaysTrue
-            path: packages/support/src/Arr/functions.php
-            count: 1
-            # Runtime guard: closure return type guarantees Generator, but we validate for a clear error message
-        -
             identifier: disallowed.function
             path: packages/clock/src/MockClock.php
             count: 1
@@ -82,21 +72,6 @@ parameters:
             count: 2
             # Intentional: dd() is the purpose of TemporalInterface::dd()
         -
-            identifier: identical.alwaysFalse
-            path: packages/datetime/src/DateTime.php
-            count: 6
-            # Runtime guard: IntlCalendar::get() returns false at runtime for extreme year values
-        -
-            identifier: booleanOr.alwaysFalse
-            path: packages/datetime/src/DateTime.php
-            count: 5
-            # Runtime guard: IntlCalendar::get() returns false at runtime for extreme year values
-        -
-            identifier: instanceof.alwaysTrue
-            path: packages/datetime/src/DateTime.php
-            count: 1
-            # Runtime guard: DateTimeInterface::getTimezone() can return false at runtime
-        -
             identifier: disallowed.function
             path: packages/console/src/Testing/ConsoleTester.php
             count: 1
@@ -121,11 +96,6 @@ parameters:
             path: packages/support/tests/Fixtures/Phar/normalize_path.php
             count: 1
             # Intentional: require_once target exists only inside generated Phar archive at runtime
-        -
-            identifier: function.alreadyNarrowedType
-            path: packages/console/src/GenericConsole.php
-            count: 1
-            # Runtime guard: PHPDoc narrows string to class-string<BackedEnum>, but is_a() check is needed at runtime
         -
             identifier: argument.type
             path: packages/validation/tests/Rules/IsEnumTest.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -22,8 +22,8 @@ services:
 parameters:
     level: 5
     tmpDir: .cache/phpstan
-    tips:
-        treatPhpDocTypesAsCertain: false
+    treatPhpDocTypesAsCertain: false
+
     paths:
         - src
         - packages

--- a/rector.php
+++ b/rector.php
@@ -18,6 +18,7 @@ use Rector\Php82\Rector\Param\AddSensitiveParameterAttributeRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\Php85\Rector\FuncCall\ArrayKeyExistsNullToEmptyStringRector;
 use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
 use Tempest\Rector\ImportClassNamesRector;
 
 return RectorConfig::configure()
@@ -54,6 +55,7 @@ return RectorConfig::configure()
         ArrayKeyExistsNullToEmptyStringRector::class,
         StringClassNameToClassConstantRector::class,
         ReturnBinaryOrToEarlyReturnRector::class,
+        SafeDeclareStrictTypesRector::class,
     ])
     ->withConfiguredRule(ImportClassNamesRector::class, [
         'importShortClasses' => true,

--- a/tests/Integration/Cache/LockTest.php
+++ b/tests/Integration/Cache/LockTest.php
@@ -88,7 +88,7 @@ final class LockTest extends FrameworkIntegrationTestCase
 
         $lock = $cache->lock('processing');
 
-        $this->assertTrue($lock->execute(fn () => true)); // @phpstan-ignore method.alreadyNarrowedType
+        $this->assertTrue($lock->execute(fn () => true));
         $this->assertFalse($lock->release());
     }
 
@@ -121,7 +121,6 @@ final class LockTest extends FrameworkIntegrationTestCase
         $clock->plus(Duration::hours(1));
 
         // Try executing a callback for the specified duration
-        /** @phpstan-ignore-next-line */
         $this->assertTrue($cache->lock('processing')->execute(fn () => true, wait: Duration::hours(1)));
     }
 


### PR DESCRIPTION
~~CI debug first, why it doesn't work.. than we will see how a fix looks like~~

ok, findings are
- we had a bug in PHPStan result cache handling, when projects had composer.lock on gitignore, which we fixed with https://github.com/phpstan/phpstan/issues/14984
- CI should build the cache on the 3.x branch, so new PRs immediately benefit from a warm cache
- updating to latest PHPStan unlocks new performance level (cold cache takes 10 seconds on my local machine to scan ~2600 files; previosly PHPStan 2.1.40 took 20s)
- after updating PHPStan, I fixed upcoming new errors and cleaned up no longer necessary ignore rules

---

relevant changes are in 
- `.github/workflows/coding-conventions.yml`
- `composer.json`

everything else is handling of PHPStan errors to get the build green