### PR TITLE
chore: upgrade PHPStan to 2.2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "php-di/php-di": "^7.0",
         "phpat/phpat": "^0.11.0",
         "phpbench/phpbench": "^1.4",
-        "phpstan/phpstan": "2.1.40",
+        "phpstan/phpstan": "2.2.6",
         "phpunit/phpunit": "^12.5.22",
         "predis/predis": "^3.0.0",
         "riskio/oauth2-auth0": "^2.4",

--- a/packages/console/src/Components/Option.php
+++ b/packages/console/src/Components/Option.php
@@ -19,9 +19,7 @@ final class Option
                 return $this->value;
             }
 
-            /** @phpstan-ignore-next-line */
             if (method_exists($this->value, 'toString')) {
-                /** @phpstan-ignore-next-line */
                 return $this->value->toString();
             }
 

--- a/packages/container/src/GenericContainer.php
+++ b/packages/container/src/GenericContainer.php
@@ -234,7 +234,7 @@ final class GenericContainer implements Container
             return $this->invokeClosure($method, ...$params);
         }
 
-        if (is_array($method) && count($method) === 2) {
+        if (is_array($method)) {
             return $this->invokeClosure($method(...), ...$params);
         }
 

--- a/packages/cryptography/tests/Signing/SignerTest.php
+++ b/packages/cryptography/tests/Signing/SignerTest.php
@@ -87,7 +87,7 @@ final class SignerTest extends TestCase
             minimumExecutionDuration: false,
         ));
 
-        $signer->sign('important data');
+        $signer->sign('important data'); // @phpstan-ignore method.resultUnused (call is expected to throw before returning)
     }
 
     public function test_empty_data(): void

--- a/packages/discovery/src/BootDiscovery.php
+++ b/packages/discovery/src/BootDiscovery.php
@@ -288,7 +288,7 @@ final class BootDiscovery
         if ($discovery === null) {
             try {
                 $discovery = new $discoveryClass();
-            } catch (ArgumentCountError) { // @phpstan-ignore catch.neverThrown
+            } catch (ArgumentCountError) {
                 throw DiscoveryClassCouldNotBeResolved::forDiscoveryClass($discoveryClass);
             }
         }

--- a/packages/http/src/Cookie/Cookie.php
+++ b/packages/http/src/Cookie/Cookie.php
@@ -123,13 +123,13 @@ final class Cookie implements Stringable
 
         return new Cookie(
             key: $cookie['name'],
-            value: $cookie['value'] ?? null,
+            value: $cookie['value'],
             expiresAt: isset($cookie['expires']) ? (int) $cookie['expires'] : null,
             maxAge: isset($cookie['max-age']) ? (int) $cookie['max-age'] : null,
             domain: $cookie['domain'] ?? null,
             path: $cookie['path'] ?? '/',
-            secure: isset($cookie['secure']) && $cookie['secure'] === true,
-            httpOnly: isset($cookie['httponly']) && $cookie['httponly'] === true,
+            secure: isset($cookie['secure']),
+            httpOnly: isset($cookie['httponly']),
             sameSite: isset($cookie['samesite']) ? SameSite::from($cookie['samesite']) : null,
         );
     }

--- a/packages/view/src/Parser/TempestViewLexer.php
+++ b/packages/view/src/Parser/TempestViewLexer.php
@@ -148,6 +148,7 @@ final class TempestViewLexer
                 );
 
                 if ($hasValue) {
+                    // @phpstan-ignore identical.alwaysFalse (seek() is stateful; consume() above advanced past '=', so it now returns the quote char)
                     $quote = $this->seek() === "'"
                         ? "'"
                         : '"';


### PR DESCRIPTION
## Summary

Upgrades `phpstan/phpstan` from 2.1.40 to 2.2.6.

## Why

Mainly speed. On this codebase (full `src`, `packages` and `tests`, level 5, single process, cold cache), 2.2.6 uses about 14% less CPU than 2.1.40, 63.9s against 74.6s as the min of three runs, and a little less peak memory (895 MB against 964 MB). CI runs in parallel, so in practice that is a shorter run and more room under the 1G limit.

Composer resolves it as a single-package upgrade. None of the PHPStan extensions here (phpat, disallowed-calls, deprecation-rules) need a version change.

## Findings addressed

2.2 reports nine things 2.1.40 did not. None are 2.2 bugs. Three kinds:

**Stale ignores** that 2.2 made unnecessary by fixing the false positives they suppressed, removed:

- `Option::displayValue`: two `@phpstan-ignore-next-line` on the `method_exists()` guard and the `toString()` call. 2.2 narrows `method_exists()`, so neither is needed.
- `BootDiscovery::resolveDiscovery()`: `@phpstan-ignore catch.neverThrown`. 2.2 sees `new $discoveryClass()` can throw `ArgumentCountError`, so the catch is reachable.

**Dead code**, removed (behavior unchanged):

- `GenericContainer::invoke()`: once `is_array($method)` narrows the `callable` to its two-element array form, `count($method) === 2` is always true.
- `Cookie::createFromString()`: `'value'` is always set, so `?? null` never fired; `secure` and `httponly` are only ever set to `true`, so `isset(...) && ... === true` is just `isset(...)`.

**False positives**, ignored with a reason:

- `SignerTest::test_no_signing_key()`: the `sign()` call is there to trigger the expected exception, so its result is unused on purpose.
- `TempestViewLexer::lexTag()`: `seek()` is stateful, and `consume()` moved the cursor past `=` earlier in the branch, so the `=== "'"` check is not actually always false. 2.2 does not track the mutation across the two calls.

## Checks

- `composer phpstan` green on 2.2.6, no baseline changes.
- `composer lint` (mago) and formatting clean.
- Full unit test suite green: 4660 tests, 14475 assertions, 1 skipped (pre-existing).
