### PR TITLE
refactor(mapper): replace tempest/core with direct package dependencies

### DIFF
--- a/packages/mapper/composer.json
+++ b/packages/mapper/composer.json
@@ -5,8 +5,10 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^8.5",
-        "tempest/validation": "3.x-dev",
-        "tempest/core": "3.x-dev"
+        "tempest/container": "3.x-dev",
+        "tempest/reflection": "3.x-dev",
+        "tempest/support": "3.x-dev",
+        "tempest/validation": "3.x-dev"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
PR for #2241, im not sure about including the `tempest/discovery` package, since it's optional. The `tempest/container` provides Discovery, but also does not include it in its dependencies.
