### PR TITLE
feat(http): client IP address behind trusted proxies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -193,6 +193,8 @@
             "packages/support/src/Comparison/functions.php",
             "packages/support/src/Filesystem/functions.php",
             "packages/support/src/Html/functions.php",
+            "packages/support/src/Ip/constants.php",
+            "packages/support/src/Ip/functions.php",
             "packages/support/src/Json/functions.php",
             "packages/support/src/Math/constants.php",
             "packages/support/src/Math/functions.php",

--- a/docs/1-essentials/01-routing.md
+++ b/docs/1-essentials/01-routing.md
@@ -466,6 +466,59 @@ final readonly class AircraftController
 }
 ```
 
+### Client IP address
+
+The address a request came from is available as the `ip` property of {b`Tempest\Http\Request`}. It is `null` when the server does not report one, such as for requests that were not made over a network.
+
+```php app/AircraftController.php
+use Tempest\Router\Get;
+use Tempest\Http\Request;
+
+final readonly class AircraftController
+{
+    #[Get(uri: '/aircraft')]
+    public function index(Request $request): View
+    {
+        $ip = $request->ip;
+    }
+}
+```
+
+Within tests, the address can be specified using the `fromIp()` method.
+
+```php
+$this->http
+    ->fromIp('203.0.113.9')
+    ->get('/aircraft')
+    ->assertOk();
+```
+
+#### Trusted proxies
+
+Forwarding headers are only read when the request came from a trusted proxy. None are trusted by default; they can be declared by creating a `trusted-proxies.config.php` file [anywhere](../1-essentials/06-configuration.md#configuration-files).
+
+```php app/trusted-proxies.config.php
+use Tempest\Http\Ip\TrustedProxiesConfig;
+
+return new TrustedProxiesConfig(
+    proxies: ['10.0.0.0/8'],
+    headers: ['x-forwarded-for'],
+);
+```
+
+Addresses and CIDR ranges are accepted, in IPv4 as well as IPv6, along with two constants for proxies that have no stable address:
+
+- `TrustedProxiesConfig::PRIVATE_RANGES` trusts the application's own network, which covers container platforms such as Docker, Railway or Fly.
+- `TrustedProxiesConfig::ANY` trusts whichever address connects, which covers a CDN such as Cloudflare.
+
+Headers are read in order of preference, each as a comma-separated chain of hops, of which the nearest one that is not itself a trusted proxy is the client.
+
+Note that only the client address is derived from a trusted proxy—the scheme and the host are not affected by this configuration. Headers that describe hops differently, such as the `{txt}Forwarded` header defined by RFC 7239, are not supported.
+
+:::warning
+Trusting a proxy that is not actually in front of the application allows any client to choose its own address, defeating anything built on top of it, such as rate limiting or allow-listing.
+:::
+
 ## Form validation
 
 When users submit forms—like updating profile settings, or posting comments—the data needs validation before processing. Tempest automatically validates request objects using type hints and validation attributes, then provides errors back to users when something is wrong.

--- a/docs/1-essentials/01-routing.md
+++ b/docs/1-essentials/01-routing.md
@@ -468,7 +468,7 @@ final readonly class AircraftController
 
 ### Client IP address
 
-The address a request came from is available as the `ip` property of {b`Tempest\Http\Request`}. It is `null` when the server does not report one, such as for requests that were not made over a network.
+The address a request came from is available as the `ip` property of {b`Tempest\Http\Request`}, an instance of {b`Tempest\Support\Ip\IpAddress`}. It is `null` when the server does not report one, such as for requests that were not made over a network.
 
 ```php app/AircraftController.php
 use Tempest\Router\Get;
@@ -480,9 +480,15 @@ final readonly class AircraftController
     public function index(Request $request): View
     {
         $ip = $request->ip;
+
+        $ip->equals('203.0.113.9');
+        $ip->matches('10.0.0.0/8');
+        $ip->isPrivate;
     }
 }
 ```
+
+The same address may be written in more than one notation, so addresses should be compared using `equals()` rather than as strings. [Read more about the `IpAddress` object](../1-essentials/08-primitive-utilities.md#ip-addresses).
 
 Within tests, the address can be specified using the `fromIp()` method.
 

--- a/docs/1-essentials/08-primitive-utilities.md
+++ b/docs/1-essentials/08-primitive-utilities.md
@@ -80,8 +80,8 @@ use Tempest\Support\Ip;
 use Tempest\Support\Ip\IpAddress;
 
 // Functional API
-Ip\ip_matches('10.0.1.24', '10.0.0.0/8');
-Ip\ip_is_private('10.0.1.24');
+Ip\matches('10.0.1.24', '10.0.0.0/8');
+Ip\is_private('10.0.1.24');
 
 // Object-oriented API
 $ip = IpAddress::from('10.0.1.24');

--- a/docs/1-essentials/08-primitive-utilities.md
+++ b/docs/1-essentials/08-primitive-utilities.md
@@ -71,6 +71,38 @@ $items = new ImmutableArray(glob(__DIR__ . '/content/*.md'))
 
 Note that you may use the `arr()` function as a shorthand to create an {b`\Tempest\Support\Arr\ImmutableArray`} instance.
 
+## IP addresses
+
+Tempest provides IP address utilities through [namespaced functions](https://github.com/tempestphp/tempest-framework/blob/main/packages/support/src/Ip/functions.php) or the {`\Tempest\Support\Ip\IpAddress`} object, which is what {b`Tempest\Http\Request`} uses for [the address a request came from](../1-essentials/01-routing.md#client-ip-address).
+
+```php
+use Tempest\Support\Ip;
+use Tempest\Support\Ip\IpAddress;
+
+// Functional API
+Ip\ip_matches('10.0.1.24', '10.0.0.0/8');
+Ip\ip_is_private('10.0.1.24');
+
+// Object-oriented API
+$ip = IpAddress::from('10.0.1.24');
+
+$ip->matches('10.0.0.0/8');
+$ip->matchesAny(['10.0.0.0/8', '2001:db8::/32']);
+$ip->isPrivate;
+$ip->isIpv4;
+```
+
+Both IPv4 and IPv6 are supported, as are CIDR ranges. Addresses are never matched across families, although IPv4-mapped IPv6 addresses such as `{txt}::ffff:127.0.0.1` are compared as IPv4.
+
+The same address may be written in more than one notation, so `equals()` should be used instead of comparing addresses as strings:
+
+```php
+IpAddress::from('::ffff:127.0.0.1')->equals('127.0.0.1'); // true
+IpAddress::from('2001:db8::1')->equals('2001:0db8:0000:0000:0000:0000:0000:0001'); // true
+```
+
+`{php}IpAddress::from()` throws {b`Tempest\Support\Ip\InvalidIpAddress`} when the given value is not an address. Use `{php}IpAddress::tryFrom()` to get `null` instead.
+
 ## Recommendations
 
 We recommend working with primitive utilities when possible instead of using PHP's built-in methods. For instance, you may read a file by using `Filesystem\read_file`:

--- a/docs/1-essentials/08-primitive-utilities.md
+++ b/docs/1-essentials/08-primitive-utilities.md
@@ -17,6 +17,7 @@ Most utilities provided by Tempest have a function-based implementation under th
 - [Filesystem paths](https://github.com/tempestphp/tempest-framework/blob/main/packages/support/src/Path/functions.php)
 - [Json manipulation](https://github.com/tempestphp/tempest-framework/blob/main/packages/support/src/Json/functions.php)
 - [Random values](https://github.com/tempestphp/tempest-framework/blob/main/packages/support/src/Random/functions.php)
+- [IP addresses](https://github.com/tempestphp/tempest-framework/blob/main/packages/support/src/Ip/functions.php)
 - [Pluralization](https://github.com/tempestphp/tempest-intl)
 - [PHP namespaces](https://github.com/tempestphp/tempest-framework/blob/main/packages/support/src/Namespace/functions.php)
 

--- a/packages/http/src/Ip/ClientIpResolver.php
+++ b/packages/http/src/Ip/ClientIpResolver.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Ip;
+
+use Tempest\Http\RequestHeaders;
+use Tempest\Support\Str;
+
+/**
+ * Resolves the address a request came from, reading forwarding headers only when it came from a proxy declared in {@see TrustedProxiesConfig}.
+ */
+final readonly class ClientIpResolver
+{
+    public function __construct(
+        private TrustedProxiesConfig $trustedProxies,
+    ) {}
+
+    public function resolve(?string $remoteAddress, RequestHeaders $headers): ?string
+    {
+        $remoteAddress = $this->parse($remoteAddress);
+
+        if ($remoteAddress === null || ! $this->trustedProxies->trusts($remoteAddress)) {
+            return $remoteAddress;
+        }
+
+        foreach ($this->trustedProxies->headers as $header) {
+            $chain = $this->parseChain($headers->get($header));
+
+            if ($chain === []) {
+                continue;
+            }
+
+            $client = array_find(
+                array_reverse($chain),
+                fn (string $candidate) => ! $this->trustedProxies->trusts($candidate),
+            );
+
+            // When every hop is trusted, the client is on the proxy network itself.
+            return $client ?? $chain[0];
+        }
+
+        return $remoteAddress;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function parseChain(?string $header): array
+    {
+        if ($header === null) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            $this->parse(...),
+            explode(',', $header),
+        )));
+    }
+
+    /**
+     * Strips the port a hop may carry, discarding anything that is not a valid address.
+     */
+    private function parse(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if (str_starts_with($value, '[')) {
+            // `[2001:db8::1]:8080`
+            $value = Str\before_last(Str\after_first($value, '['), ']');
+        } elseif (substr_count($value, ':') === 1) {
+            // `203.0.113.9:8080`, whereas multiple colons indicate an IPv6 address.
+            $value = Str\before_first($value, ':');
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_IP) === false) {
+            return null;
+        }
+
+        return $value;
+    }
+}

--- a/packages/http/src/Ip/ClientIpResolver.php
+++ b/packages/http/src/Ip/ClientIpResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Http\Ip;
 
 use Tempest\Http\RequestHeaders;
+use Tempest\Support\Ip\IpAddress;
 use Tempest\Support\Str;
 
 /**
@@ -16,7 +17,7 @@ final readonly class ClientIpResolver
         private TrustedProxiesConfig $trustedProxies,
     ) {}
 
-    public function resolve(?string $remoteAddress, RequestHeaders $headers): ?string
+    public function resolve(IpAddress|string|null $remoteAddress, RequestHeaders $headers): ?IpAddress
     {
         $remoteAddress = $this->parse($remoteAddress);
 
@@ -33,7 +34,7 @@ final readonly class ClientIpResolver
 
             $client = array_find(
                 array_reverse($chain),
-                fn (string $candidate) => ! $this->trustedProxies->trusts($candidate),
+                fn (IpAddress $candidate) => ! $this->trustedProxies->trusts($candidate),
             );
 
             // When every hop is trusted, the client is on the proxy network itself.
@@ -44,7 +45,7 @@ final readonly class ClientIpResolver
     }
 
     /**
-     * @return string[]
+     * @return IpAddress[]
      */
     private function parseChain(?string $header): array
     {
@@ -61,10 +62,10 @@ final readonly class ClientIpResolver
     /**
      * Strips the port a hop may carry, discarding anything that is not a valid address.
      */
-    private function parse(?string $value): ?string
+    private function parse(IpAddress|string|null $value): ?IpAddress
     {
-        if ($value === null) {
-            return null;
+        if ($value === null || $value instanceof IpAddress) {
+            return $value;
         }
 
         $value = trim($value);
@@ -77,10 +78,6 @@ final readonly class ClientIpResolver
             $value = Str\before_first($value, ':');
         }
 
-        if (filter_var($value, FILTER_VALIDATE_IP) === false) {
-            return null;
-        }
-
-        return $value;
+        return IpAddress::tryFrom($value);
     }
 }

--- a/packages/http/src/Ip/TrustedProxiesConfig.php
+++ b/packages/http/src/Ip/TrustedProxiesConfig.php
@@ -7,7 +7,7 @@ namespace Tempest\Http\Ip;
 use Tempest\Support\Ip;
 use Tempest\Support\Ip\IpAddress;
 
-use function Tempest\Support\Ip\ip_matches_any;
+use function Tempest\Support\Ip\matches_any;
 
 /**
  * Configures which reverse proxies may report the client address. No proxy is trusted by default.
@@ -37,6 +37,6 @@ final class TrustedProxiesConfig
 
     public function trusts(IpAddress|string $ip): bool
     {
-        return in_array(self::ANY, $this->proxies, strict: true) || ip_matches_any($ip, $this->proxies);
+        return in_array(self::ANY, $this->proxies, strict: true) || matches_any($ip, $this->proxies);
     }
 }

--- a/packages/http/src/Ip/TrustedProxiesConfig.php
+++ b/packages/http/src/Ip/TrustedProxiesConfig.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Tempest\Http\Ip;
 
 use Tempest\Support\Ip;
+use Tempest\Support\Ip\IpAddress;
 
-use function Tempest\Support\Ip\matches_any;
+use function Tempest\Support\Ip\ip_matches_any;
 
 /**
  * Configures which reverse proxies may report the client address. No proxy is trusted by default.
@@ -24,6 +25,8 @@ final class TrustedProxiesConfig
     public const array PRIVATE_RANGES = Ip\PRIVATE_RANGES;
 
     /**
+     * Note that proxies are declared as strings rather than as {@see IpAddress}, since a CIDR range is not itself an address.
+     *
      * @param string[] $proxies Addresses or CIDR ranges of the reverse proxies in front of the application, or one of {@see self::PRIVATE_RANGES} and {@see self::ANY} when they have no stable address.
      * @param string[] $headers Headers carrying the forwarded address, in order of preference. Each is read as a comma-separated chain of hops, so headers that describe them differently, such as the `Forwarded` header defined by RFC 7239, are not supported.
      */
@@ -32,8 +35,8 @@ final class TrustedProxiesConfig
         public array $headers = ['x-forwarded-for'],
     ) {}
 
-    public function trusts(string $ip): bool
+    public function trusts(IpAddress|string $ip): bool
     {
-        return in_array(self::ANY, $this->proxies, strict: true) || matches_any($ip, $this->proxies);
+        return in_array(self::ANY, $this->proxies, strict: true) || ip_matches_any($ip, $this->proxies);
     }
 }

--- a/packages/http/src/Ip/TrustedProxiesConfig.php
+++ b/packages/http/src/Ip/TrustedProxiesConfig.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Ip;
+
+use Tempest\Support\Ip;
+
+use function Tempest\Support\Ip\matches_any;
+
+/**
+ * Configures which reverse proxies may report the client address. No proxy is trusted by default.
+ */
+final class TrustedProxiesConfig
+{
+    /**
+     * Trusts whichever address the request came from.
+     */
+    public const string ANY = '*';
+
+    /**
+     * Trusts any address that is not routed on the public internet, such as a proxy on the application's own network.
+     */
+    public const array PRIVATE_RANGES = Ip\PRIVATE_RANGES;
+
+    /**
+     * @param string[] $proxies Addresses or CIDR ranges of the reverse proxies in front of the application, or one of {@see self::PRIVATE_RANGES} and {@see self::ANY} when they have no stable address.
+     * @param string[] $headers Headers carrying the forwarded address, in order of preference. Each is read as a comma-separated chain of hops, so headers that describe them differently, such as the `Forwarded` header defined by RFC 7239, are not supported.
+     */
+    public function __construct(
+        public array $proxies = [],
+        public array $headers = ['x-forwarded-for'],
+    ) {}
+
+    public function trusts(string $ip): bool
+    {
+        return in_array(self::ANY, $this->proxies, strict: true) || matches_any($ip, $this->proxies);
+    }
+}

--- a/packages/http/src/IsRequest.php
+++ b/packages/http/src/IsRequest.php
@@ -14,7 +14,11 @@ use function Tempest\Support\Arr\get_by_key;
 use function Tempest\Support\Arr\has_key;
 use function Tempest\Support\str;
 
-/** @phpstan-require-implements \Tempest\Http\Request */
+/**
+ * @phpstan-require-implements \Tempest\Http\Request
+ *
+ * @mago-expect lint:too-many-properties
+ */
 trait IsRequest
 {
     #[SkipValidation]
@@ -50,6 +54,9 @@ trait IsRequest
     #[SkipValidation]
     public array $cookies = [];
 
+    #[SkipValidation]
+    private(set) ?string $ip = null;
+
     public function __construct(
         Method $method,
         string $uri,
@@ -57,6 +64,7 @@ trait IsRequest
         array $headers = [],
         array $files = [],
         ?string $raw = null,
+        ?string $ip = null,
     ) {
         $this->method = $method;
         $this->uri = $uri;
@@ -64,6 +72,7 @@ trait IsRequest
         $this->headers = RequestHeaders::normalizeFromArray($headers);
         $this->files = $files;
         $this->raw = $raw;
+        $this->ip = $ip;
 
         if ($this->method === Method::CONNECT) {
             $this->path ??= '';

--- a/packages/http/src/IsRequest.php
+++ b/packages/http/src/IsRequest.php
@@ -6,6 +6,7 @@ namespace Tempest\Http;
 
 use Tempest\Http\Cookie\Cookie;
 use Tempest\Http\Session\Session;
+use Tempest\Support\Ip\IpAddress;
 use Tempest\Support\Uri\Uri;
 use Tempest\Validation\SkipValidation;
 
@@ -55,7 +56,7 @@ trait IsRequest
     public array $cookies = [];
 
     #[SkipValidation]
-    private(set) ?string $ip = null;
+    private(set) ?IpAddress $ip = null;
 
     public function __construct(
         Method $method,
@@ -64,7 +65,7 @@ trait IsRequest
         array $headers = [],
         array $files = [],
         ?string $raw = null,
-        ?string $ip = null,
+        IpAddress|string|null $ip = null,
     ) {
         $this->method = $method;
         $this->uri = $uri;
@@ -72,7 +73,7 @@ trait IsRequest
         $this->headers = RequestHeaders::normalizeFromArray($headers);
         $this->files = $files;
         $this->raw = $raw;
-        $this->ip = $ip;
+        $this->ip = IpAddress::tryFrom($ip);
 
         if ($this->method === Method::CONNECT) {
             $this->path ??= '';

--- a/packages/http/src/Mappers/PsrRequestToGenericRequestMapper.php
+++ b/packages/http/src/Mappers/PsrRequestToGenericRequestMapper.php
@@ -65,6 +65,7 @@ final readonly class PsrRequestToGenericRequestMapper implements Mapper
             'path' => $from->getUri()->getPath(),
             'query' => $query,
             'files' => $uploads,
+            'ip' => $from->getServerParams()['REMOTE_ADDR'] ?? null,
             'cookies' => Arr\filter(Arr\map(
                 array: $_COOKIE,
                 map: function (string $rawValue, string $key) {

--- a/packages/http/src/Mappers/PsrRequestToGenericRequestMapper.php
+++ b/packages/http/src/Mappers/PsrRequestToGenericRequestMapper.php
@@ -11,6 +11,7 @@ use Tempest\Http\Cookie\Cookie;
 use Tempest\Http\Cookie\CookieConfig;
 use Tempest\Http\Cookie\CookieManager;
 use Tempest\Http\GenericRequest;
+use Tempest\Http\Ip\ClientIpResolver;
 use Tempest\Http\Method;
 use Tempest\Http\RequestHeaders;
 use Tempest\Http\Upload;
@@ -27,6 +28,7 @@ final readonly class PsrRequestToGenericRequestMapper implements Mapper
         private Encrypter $encrypter,
         private CookieManager $cookies,
         private CookieConfig $cookieConfig,
+        private ClientIpResolver $clientIpResolver,
     ) {}
 
     public function canMap(mixed $from, mixed $to): bool
@@ -49,6 +51,8 @@ final readonly class PsrRequestToGenericRequestMapper implements Mapper
             $from->getHeaders(),
         );
 
+        $headers = RequestHeaders::normalizeFromArray($headersAsString);
+
         parse_str($from->getUri()->getQuery(), $query);
 
         $uploads = array_map(
@@ -61,11 +65,11 @@ final readonly class PsrRequestToGenericRequestMapper implements Mapper
             'uri' => (string) $from->getUri(),
             'raw' => $raw,
             'body' => $data,
-            'headers' => RequestHeaders::normalizeFromArray($headersAsString),
+            'headers' => $headers,
             'path' => $from->getUri()->getPath(),
             'query' => $query,
             'files' => $uploads,
-            'ip' => $from->getServerParams()['REMOTE_ADDR'] ?? null,
+            'ip' => $this->clientIpResolver->resolve($from->getServerParams()['REMOTE_ADDR'] ?? null, $headers),
             'cookies' => Arr\filter(Arr\map(
                 array: $_COOKIE,
                 map: function (string $rawValue, string $key) {

--- a/packages/http/src/Mappers/RequestToObjectMapper.php
+++ b/packages/http/src/Mappers/RequestToObjectMapper.php
@@ -50,6 +50,7 @@ final readonly class RequestToObjectMapper implements Mapper
                     'query' => $from->query,
                     'files' => $from->files,
                     'cookies' => $from->cookies,
+                    'ip' => $from->ip,
                 ],
                 ...$data,
             ];

--- a/packages/http/src/Mappers/RequestToPsrRequestMapper.php
+++ b/packages/http/src/Mappers/RequestToPsrRequestMapper.php
@@ -21,6 +21,7 @@ final readonly class RequestToPsrRequestMapper implements Mapper
     {
         /** @var Request $from */
         $request = new ServerRequest(
+            serverParams: $from->ip === null ? [] : ['REMOTE_ADDR' => $from->ip],
             uploadedFiles: $from->files,
             uri: $from->uri,
             method: $from->method->value,

--- a/packages/http/src/Mappers/RequestToPsrRequestMapper.php
+++ b/packages/http/src/Mappers/RequestToPsrRequestMapper.php
@@ -21,7 +21,7 @@ final readonly class RequestToPsrRequestMapper implements Mapper
     {
         /** @var Request $from */
         $request = new ServerRequest(
-            serverParams: $from->ip === null ? [] : ['REMOTE_ADDR' => $from->ip],
+            serverParams: $from->ip === null ? [] : ['REMOTE_ADDR' => $from->ip->toString()],
             uploadedFiles: $from->files,
             uri: $from->uri,
             method: $from->method->value,

--- a/packages/http/src/Request.php
+++ b/packages/http/src/Request.php
@@ -28,6 +28,8 @@ interface Request
     /** @var Cookie[] $cookies */
     public array $cookies { get; }
 
+    public ?string $ip { get; }
+
     public function has(string $key): bool;
 
     public function hasBody(?string $key = null): bool;

--- a/packages/http/src/Request.php
+++ b/packages/http/src/Request.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tempest\Http;
 
 use Tempest\Http\Cookie\Cookie;
+use Tempest\Support\Ip\IpAddress;
 
 interface Request
 {
@@ -31,7 +32,7 @@ interface Request
     /**
      * The address the request came from. Behind a reverse proxy, this is the proxy's address unless it is declared in {@see \Tempest\Http\Ip\TrustedProxiesConfig}.
      */
-    public ?string $ip { get; }
+    public ?IpAddress $ip { get; }
 
     public function has(string $key): bool;
 

--- a/packages/http/src/Request.php
+++ b/packages/http/src/Request.php
@@ -28,6 +28,9 @@ interface Request
     /** @var Cookie[] $cookies */
     public array $cookies { get; }
 
+    /**
+     * The address the request came from. Behind a reverse proxy, this is the proxy's address unless it is declared in {@see \Tempest\Http\Ip\TrustedProxiesConfig}.
+     */
     public ?string $ip { get; }
 
     public function has(string $key): bool;

--- a/packages/http/tests/Ip/ClientIpResolverTest.php
+++ b/packages/http/tests/Ip/ClientIpResolverTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Http\Tests\Ip;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Tempest\Http\Ip\ClientIpResolver;
+use Tempest\Http\Ip\TrustedProxiesConfig;
+use Tempest\Http\RequestHeaders;
+
+/**
+ * @internal
+ */
+final class ClientIpResolverTest extends TestCase
+{
+    #[Test]
+    public function connecting_address_is_used_when_no_proxy_is_trusted(): void
+    {
+        $ip = $this->resolve(
+            remoteAddress: '203.0.113.9',
+            headers: ['x-forwarded-for' => '198.51.100.7'],
+        );
+
+        $this->assertSame('203.0.113.9', $ip);
+    }
+
+    #[Test]
+    public function forwarded_address_is_used_when_the_proxy_is_trusted(): void
+    {
+        $ip = $this->resolve(
+            remoteAddress: '10.0.0.1',
+            headers: ['x-forwarded-for' => '198.51.100.7'],
+            proxies: ['10.0.0.0/8'],
+        );
+
+        $this->assertSame('198.51.100.7', $ip);
+    }
+
+    #[Test]
+    public function the_nearest_untrusted_hop_is_the_client(): void
+    {
+        // Two hops forged by the client, then a CDN, then the load balancer.
+        $ip = $this->resolve(
+            remoteAddress: '10.0.0.1',
+            headers: ['x-forwarded-for' => '1.1.1.1, 2.2.2.2, 198.51.100.7, 10.0.0.2'],
+            proxies: ['10.0.0.0/8'],
+        );
+
+        $this->assertSame('198.51.100.7', $ip);
+    }
+
+    #[Test]
+    public function chain_of_only_trusted_proxies_falls_back_to_the_outermost_hop(): void
+    {
+        $ip = $this->resolve(
+            remoteAddress: '10.0.0.1',
+            headers: ['x-forwarded-for' => '10.0.0.5, 10.0.0.2'],
+            proxies: ['10.0.0.0/8'],
+        );
+
+        $this->assertSame('10.0.0.5', $ip);
+    }
+
+    #[Test]
+    public function any_trusts_whichever_address_connects(): void
+    {
+        $ip = $this->resolve(
+            remoteAddress: '172.18.0.1',
+            headers: ['x-forwarded-for' => '198.51.100.7'],
+            proxies: [TrustedProxiesConfig::ANY],
+        );
+
+        $this->assertSame('198.51.100.7', $ip);
+    }
+
+    #[Test]
+    public function private_ranges_trust_a_proxy_on_the_same_network(): void
+    {
+        $ip = $this->resolve(
+            remoteAddress: '172.18.0.1',
+            headers: ['x-forwarded-for' => '198.51.100.7'],
+            proxies: TrustedProxiesConfig::PRIVATE_RANGES,
+        );
+
+        $this->assertSame('198.51.100.7', $ip);
+    }
+
+    #[Test]
+    public function private_ranges_do_not_trust_a_public_address(): void
+    {
+        $ip = $this->resolve(
+            remoteAddress: '203.0.113.9',
+            headers: ['x-forwarded-for' => '198.51.100.7'],
+            proxies: TrustedProxiesConfig::PRIVATE_RANGES,
+        );
+
+        $this->assertSame('203.0.113.9', $ip);
+    }
+
+    #[Test]
+    public function headers_are_consulted_in_order_of_preference(): void
+    {
+        $ip = $this->resolve(
+            remoteAddress: '10.0.0.1',
+            headers: [
+                'x-forwarded-for' => '198.51.100.7',
+                'cf-connecting-ip' => '198.51.100.8',
+            ],
+            proxies: ['10.0.0.0/8'],
+            headerNames: ['cf-connecting-ip', 'x-forwarded-for'],
+        );
+
+        $this->assertSame('198.51.100.8', $ip);
+    }
+
+    #[Test]
+    public function the_next_header_is_consulted_when_one_is_absent(): void
+    {
+        $ip = $this->resolve(
+            remoteAddress: '10.0.0.1',
+            headers: ['x-forwarded-for' => '198.51.100.7'],
+            proxies: ['10.0.0.0/8'],
+            headerNames: ['cf-connecting-ip', 'x-forwarded-for'],
+        );
+
+        $this->assertSame('198.51.100.7', $ip);
+    }
+
+    #[Test]
+    public function ports_are_stripped_from_hops(): void
+    {
+        $this->assertSame('198.51.100.7', $this->resolve(
+            remoteAddress: '10.0.0.1',
+            headers: ['x-forwarded-for' => '198.51.100.7:41234'],
+            proxies: ['10.0.0.0/8'],
+        ));
+
+        $this->assertSame('2001:db8::1', $this->resolve(
+            remoteAddress: '10.0.0.1',
+            headers: ['x-forwarded-for' => '[2001:db8::1]:41234'],
+            proxies: ['10.0.0.0/8'],
+        ));
+    }
+
+    #[Test]
+    #[TestWith(['not-an-address'])]
+    #[TestWith([''])]
+    #[TestWith([', ,'])]
+    public function forwarded_header_without_an_address_is_ignored(string $header): void
+    {
+        $ip = $this->resolve(
+            remoteAddress: '10.0.0.1',
+            headers: ['x-forwarded-for' => $header],
+            proxies: ['10.0.0.0/8'],
+        );
+
+        $this->assertSame('10.0.0.1', $ip);
+    }
+
+    #[Test]
+    public function invalid_hops_in_the_chain_are_discarded(): void
+    {
+        $ip = $this->resolve(
+            remoteAddress: '10.0.0.1',
+            headers: ['x-forwarded-for' => '198.51.100.7, not-an-address'],
+            proxies: ['10.0.0.0/8'],
+        );
+
+        $this->assertSame('198.51.100.7', $ip);
+    }
+
+    #[Test]
+    public function request_without_a_connecting_address_resolves_to_null(): void
+    {
+        $this->assertNull($this->resolve(remoteAddress: null, headers: []));
+        $this->assertNull($this->resolve(remoteAddress: '', headers: []));
+        $this->assertNull($this->resolve(remoteAddress: 'not-an-address', headers: []));
+    }
+
+    /**
+     * @param array<string, string> $headers
+     * @param string[] $proxies
+     * @param string[] $headerNames
+     */
+    private function resolve(
+        ?string $remoteAddress,
+        array $headers,
+        array $proxies = [],
+        array $headerNames = ['x-forwarded-for'],
+    ): ?string {
+        $resolver = new ClientIpResolver(new TrustedProxiesConfig(
+            proxies: $proxies,
+            headers: $headerNames,
+        ));
+
+        return $resolver->resolve($remoteAddress, RequestHeaders::normalizeFromArray($headers));
+    }
+}

--- a/packages/http/tests/Ip/ClientIpResolverTest.php
+++ b/packages/http/tests/Ip/ClientIpResolverTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Tempest\Http\Ip\ClientIpResolver;
 use Tempest\Http\Ip\TrustedProxiesConfig;
 use Tempest\Http\RequestHeaders;
+use Tempest\Support\Ip\IpAddress;
 
 /**
  * @internal
@@ -180,6 +181,17 @@ final class ClientIpResolverTest extends TestCase
         $this->assertNull($this->resolve(remoteAddress: 'not-an-address', headers: []));
     }
 
+    #[Test]
+    public function resolved_address_is_a_value_object(): void
+    {
+        $resolver = new ClientIpResolver(new TrustedProxiesConfig());
+
+        $ip = $resolver->resolve('::ffff:203.0.113.9', RequestHeaders::normalizeFromArray([]));
+
+        $this->assertInstanceOf(IpAddress::class, $ip);
+        $this->assertTrue($ip->equals('203.0.113.9'));
+    }
+
     /**
      * @param array<string, string> $headers
      * @param string[] $proxies
@@ -196,6 +208,6 @@ final class ClientIpResolverTest extends TestCase
             headers: $headerNames,
         ));
 
-        return $resolver->resolve($remoteAddress, RequestHeaders::normalizeFromArray($headers));
+        return $resolver->resolve($remoteAddress, RequestHeaders::normalizeFromArray($headers))?->toString();
     }
 }

--- a/packages/http/tests/Mappers/PsrRequestToGenericRequestMapperTest.php
+++ b/packages/http/tests/Mappers/PsrRequestToGenericRequestMapperTest.php
@@ -23,6 +23,8 @@ use Tempest\Cryptography\Signing\SigningConfig;
 use Tempest\Cryptography\Timelock;
 use Tempest\Http\Cookie\CookieConfig;
 use Tempest\Http\Cookie\CookieManager;
+use Tempest\Http\Ip\ClientIpResolver;
+use Tempest\Http\Ip\TrustedProxiesConfig;
 use Tempest\Http\Mappers\PsrRequestToGenericRequestMapper;
 use Tempest\Http\Method;
 
@@ -43,6 +45,7 @@ final class PsrRequestToGenericRequestMapperTest extends TestCase
                 new GenericClock(),
             ),
             new CookieConfig(),
+            new ClientIpResolver(new TrustedProxiesConfig()),
         );
 
         $reflection = new ReflectionClass($this->mapper);

--- a/packages/support/composer.json
+++ b/packages/support/composer.json
@@ -18,6 +18,8 @@
             "src/Str/constants.php",
             "src/Arr/functions.php",
             "src/Html/functions.php",
+            "src/Ip/constants.php",
+            "src/Ip/functions.php",
             "src/Random/functions.php",
             "src/Regex/functions.php",
             "src/Namespace/functions.php",

--- a/packages/support/src/Ip/InvalidIpAddress.php
+++ b/packages/support/src/Ip/InvalidIpAddress.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Ip;
+
+use Exception;
+
+final class InvalidIpAddress extends Exception
+{
+    public function __construct(string $ip)
+    {
+        parent::__construct(sprintf('The value `%s` is not a valid IP address.', $ip));
+    }
+}

--- a/packages/support/src/Ip/IpAddress.php
+++ b/packages/support/src/Ip/IpAddress.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Ip;
+
+use Stringable;
+use Tempest\Support\Comparison\Equable;
+
+/**
+ * An IPv4 or IPv6 address.
+ *
+ * Addresses are compared by their packed representation rather than as strings, so that the notations of the same address are equal.
+ *
+ * @implements Equable<self|string|null>
+ */
+final class IpAddress implements Stringable, Equable
+{
+    /**
+     * The packed representation of the address. IPv4-mapped IPv6 addresses, such as `::ffff:127.0.0.1`, are narrowed to their IPv4 form.
+     *
+     * @internal
+     */
+    private(set) string $bytes;
+
+    /**
+     * Whether the address is an IPv4 address.
+     */
+    public bool $isIpv4 {
+        get => strlen($this->bytes) === 4;
+    }
+
+    /**
+     * Whether the address is an IPv6 address that is not an IPv4-mapped one.
+     */
+    public bool $isIpv6 {
+        get => strlen($this->bytes) === 16;
+    }
+
+    /**
+     * Whether the address belongs to a range that is not routed on the public internet, such as a loopback or private-use address.
+     */
+    public bool $isPrivate {
+        get => $this->matchesAny(PRIVATE_RANGES);
+    }
+
+    private function __construct(
+        /**
+         * The address as it was given.
+         */
+        private(set) string $value,
+        string $bytes,
+    ) {
+        $this->bytes = $bytes;
+    }
+
+    /**
+     * Creates an address from the given notation, throwing when it is not an address.
+     *
+     * ### Example
+     * ```php
+     * IpAddress::from('203.0.113.9');
+     * IpAddress::from('2001:db8::1');
+     * ```
+     *
+     * @throws InvalidIpAddress
+     */
+    public static function from(self|string $ip): self
+    {
+        return self::tryFrom($ip) ?? throw new InvalidIpAddress((string) $ip);
+    }
+
+    /**
+     * Creates an address from the given notation, or returns `null` when it is not an address.
+     */
+    public static function tryFrom(self|string|null $ip): ?self
+    {
+        if ($ip === null) {
+            return null;
+        }
+
+        if ($ip instanceof self) {
+            return $ip;
+        }
+
+        $bytes = self::pack($ip);
+
+        if ($bytes === null) {
+            return null;
+        }
+
+        return new self($ip, $bytes);
+    }
+
+    /**
+     * Determines whether the address falls within the given address or CIDR range.
+     * Addresses are never matched across families, although IPv4-mapped IPv6 addresses such as `::ffff:127.0.0.1` are compared as IPv4.
+     *
+     * ### Example
+     * ```php
+     * IpAddress::from('10.0.1.24')->matches('10.0.0.0/8'); // true
+     * IpAddress::from('10.0.1.24')->matches('10.0.1.24'); // true
+     * IpAddress::from('10.0.1.24')->matches('::/0'); // false
+     * ```
+     */
+    public function matches(self|string $range): bool
+    {
+        $range = (string) $range;
+        $prefix = null;
+
+        if (str_contains($range, '/')) {
+            [$range, $length] = explode('/', $range, limit: 2);
+
+            if (! is_numeric($length)) {
+                return false;
+            }
+
+            $prefix = (int) $length;
+        }
+
+        $subnet = self::pack($range);
+
+        if ($subnet === null) {
+            return false;
+        }
+
+        // Different lengths indicate different families, which never match.
+        if (strlen($this->bytes) !== strlen($subnet)) {
+            return false;
+        }
+
+        $bits = strlen($subnet) * 8;
+        $prefix ??= $bits;
+
+        if ($prefix < 0 || $prefix > $bits) {
+            return false;
+        }
+
+        $wholeBytes = intdiv($prefix, 8);
+
+        if ($wholeBytes > 0 && substr($this->bytes, 0, $wholeBytes) !== substr($subnet, 0, $wholeBytes)) {
+            return false;
+        }
+
+        $remainingBits = $prefix % 8;
+
+        if ($remainingBits === 0) {
+            return true;
+        }
+
+        $mask = chr((0xFF << (8 - $remainingBits)) & 0xFF);
+
+        return ($this->bytes[$wholeBytes] & $mask) === ($subnet[$wholeBytes] & $mask);
+    }
+
+    /**
+     * Determines whether the address falls within any of the given addresses or CIDR ranges.
+     *
+     * @param iterable<self|string> $ranges
+     */
+    public function matchesAny(iterable $ranges): bool
+    {
+        foreach ($ranges as $range) {
+            if ($this->matches($range)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines whether the given address is the same as this one, regardless of the notation it is written in.
+     *
+     * ### Example
+     * ```php
+     * IpAddress::from('::ffff:127.0.0.1')->equals('127.0.0.1'); // true
+     * IpAddress::from('2001:db8::1')->equals('2001:0db8:0000:0000:0000:0000:0000:0001'); // true
+     * ```
+     */
+    public function equals(mixed $other): bool
+    {
+        if (! is_string($other) && ! $other instanceof self) {
+            return false;
+        }
+
+        return self::tryFrom($other)?->bytes === $this->bytes;
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * Converts an address to its packed representation, or `null` when it is not an address.
+     */
+    private static function pack(string $ip): ?string
+    {
+        if (filter_var($ip, FILTER_VALIDATE_IP) === false) {
+            return null;
+        }
+
+        $bytes = inet_pton($ip);
+
+        if ($bytes === false) {
+            return null;
+        }
+
+        if (strlen($bytes) === 16 && str_starts_with($bytes, "\0\0\0\0\0\0\0\0\0\0\xFF\xFF")) {
+            return substr($bytes, 12);
+        }
+
+        return $bytes;
+    }
+}

--- a/packages/support/src/Ip/constants.php
+++ b/packages/support/src/Ip/constants.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Ip;
+
+/**
+ * Ranges that are not routed on the public internet, and may only be reached from within the network the application runs on.
+ *
+ * @var string[]
+ */
+const PRIVATE_RANGES = [
+    '127.0.0.0/8', // Loopback (RFC 1122)
+    '10.0.0.0/8', // Private-use (RFC 1918)
+    '172.16.0.0/12', // Private-use (RFC 1918)
+    '192.168.0.0/16', // Private-use (RFC 1918)
+    '169.254.0.0/16', // Link local (RFC 3927)
+    '0.0.0.0/8', // This network (RFC 1122)
+    '240.0.0.0/4', // Reserved (RFC 1112)
+    '::1/128', // Loopback (RFC 4291)
+    'fc00::/7', // Unique local (RFC 4193)
+    'fe80::/10', // Link local (RFC 4291)
+    '::/128', // Unspecified (RFC 4291)
+];

--- a/packages/support/src/Ip/functions.php
+++ b/packages/support/src/Ip/functions.php
@@ -46,8 +46,6 @@ function ip_is_private(IpAddress|string $ip): bool
 
 /**
  * Converts an IP address to its packed representation, or `null` when it is not an address.
- *
- * @internal
  */
 function ip_to_bytes(IpAddress|string $ip): ?string
 {

--- a/packages/support/src/Ip/functions.php
+++ b/packages/support/src/Ip/functions.php
@@ -10,69 +10,24 @@ namespace Tempest\Support\Ip;
  *
  * ### Example
  * ```php
- * matches('10.0.1.24', '10.0.0.0/8'); // true
- * matches('10.0.1.24', '10.0.1.24'); // true
- * matches('10.0.1.24', '::/0'); // false
+ * ip_matches('10.0.1.24', '10.0.0.0/8'); // true
+ * ip_matches('10.0.1.24', '10.0.1.24'); // true
+ * ip_matches('10.0.1.24', '::/0'); // false
  * ```
  */
-function matches(string $ip, string $range): bool
+function ip_matches(IpAddress|string $ip, IpAddress|string $range): bool
 {
-    $prefix = null;
-
-    if (str_contains($range, '/')) {
-        [$range, $length] = explode('/', $range, limit: 2);
-
-        if (! is_numeric($length)) {
-            return false;
-        }
-
-        $prefix = (int) $length;
-    }
-
-    $address = to_bytes($ip);
-    $subnet = to_bytes($range);
-
-    if ($address === null || $subnet === null) {
-        return false;
-    }
-
-    // Different lengths indicate different families, which never match.
-    if (strlen($address) !== strlen($subnet)) {
-        return false;
-    }
-
-    $bits = strlen($subnet) * 8;
-    $prefix ??= $bits;
-
-    if ($prefix < 0 || $prefix > $bits) {
-        return false;
-    }
-
-    $wholeBytes = intdiv($prefix, 8);
-
-    if ($wholeBytes > 0 && substr($address, 0, $wholeBytes) !== substr($subnet, 0, $wholeBytes)) {
-        return false;
-    }
-
-    $remainingBits = $prefix % 8;
-
-    if ($remainingBits === 0) {
-        return true;
-    }
-
-    $mask = chr((0xFF << (8 - $remainingBits)) & 0xFF);
-
-    return ($address[$wholeBytes] & $mask) === ($subnet[$wholeBytes] & $mask);
+    return IpAddress::tryFrom($ip)?->matches($range) ?? false;
 }
 
 /**
  * Determines whether the given IP address falls within any of the given addresses or CIDR ranges.
  *
- * @param string[] $ranges
+ * @param iterable<IpAddress|string> $ranges
  */
-function matches_any(string $ip, array $ranges): bool
+function ip_matches_any(IpAddress|string $ip, iterable $ranges): bool
 {
-    return array_any($ranges, static fn (string $range) => matches($ip, $range));
+    return IpAddress::tryFrom($ip)?->matchesAny($ranges) ?? false;
 }
 
 /**
@@ -80,13 +35,13 @@ function matches_any(string $ip, array $ranges): bool
  *
  * ### Example
  * ```php
- * is_private('10.0.1.24'); // true
- * is_private('203.0.113.9'); // false
+ * ip_is_private('10.0.1.24'); // true
+ * ip_is_private('203.0.113.9'); // false
  * ```
  */
-function is_private(string $ip): bool
+function ip_is_private(IpAddress|string $ip): bool
 {
-    return matches_any($ip, PRIVATE_RANGES);
+    return IpAddress::tryFrom($ip)?->isPrivate === true;
 }
 
 /**
@@ -94,21 +49,7 @@ function is_private(string $ip): bool
  *
  * @internal
  */
-function to_bytes(string $ip): ?string
+function ip_to_bytes(IpAddress|string $ip): ?string
 {
-    if (filter_var($ip, FILTER_VALIDATE_IP) === false) {
-        return null;
-    }
-
-    $bytes = inet_pton($ip);
-
-    if ($bytes === false) {
-        return null;
-    }
-
-    if (strlen($bytes) === 16 && str_starts_with($bytes, "\0\0\0\0\0\0\0\0\0\0\xFF\xFF")) {
-        return substr($bytes, 12);
-    }
-
-    return $bytes;
+    return IpAddress::tryFrom($ip)?->bytes;
 }

--- a/packages/support/src/Ip/functions.php
+++ b/packages/support/src/Ip/functions.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Ip;
+
+/**
+ * Determines whether the given IP address falls within the given address or CIDR range.
+ * Addresses are never matched across families, although IPv4-mapped IPv6 addresses such as `::ffff:127.0.0.1` are compared as IPv4.
+ *
+ * ### Example
+ * ```php
+ * matches('10.0.1.24', '10.0.0.0/8'); // true
+ * matches('10.0.1.24', '10.0.1.24'); // true
+ * matches('10.0.1.24', '::/0'); // false
+ * ```
+ */
+function matches(string $ip, string $range): bool
+{
+    $prefix = null;
+
+    if (str_contains($range, '/')) {
+        [$range, $length] = explode('/', $range, limit: 2);
+
+        if (! is_numeric($length)) {
+            return false;
+        }
+
+        $prefix = (int) $length;
+    }
+
+    $address = to_bytes($ip);
+    $subnet = to_bytes($range);
+
+    if ($address === null || $subnet === null) {
+        return false;
+    }
+
+    // Different lengths indicate different families, which never match.
+    if (strlen($address) !== strlen($subnet)) {
+        return false;
+    }
+
+    $bits = strlen($subnet) * 8;
+    $prefix ??= $bits;
+
+    if ($prefix < 0 || $prefix > $bits) {
+        return false;
+    }
+
+    $wholeBytes = intdiv($prefix, 8);
+
+    if ($wholeBytes > 0 && substr($address, 0, $wholeBytes) !== substr($subnet, 0, $wholeBytes)) {
+        return false;
+    }
+
+    $remainingBits = $prefix % 8;
+
+    if ($remainingBits === 0) {
+        return true;
+    }
+
+    $mask = chr((0xFF << (8 - $remainingBits)) & 0xFF);
+
+    return ($address[$wholeBytes] & $mask) === ($subnet[$wholeBytes] & $mask);
+}
+
+/**
+ * Determines whether the given IP address falls within any of the given addresses or CIDR ranges.
+ *
+ * @param string[] $ranges
+ */
+function matches_any(string $ip, array $ranges): bool
+{
+    return array_any($ranges, static fn (string $range) => matches($ip, $range));
+}
+
+/**
+ * Determines whether the given IP address belongs to a range that is not routed on the public internet, such as a loopback or private-use address.
+ *
+ * ### Example
+ * ```php
+ * is_private('10.0.1.24'); // true
+ * is_private('203.0.113.9'); // false
+ * ```
+ */
+function is_private(string $ip): bool
+{
+    return matches_any($ip, PRIVATE_RANGES);
+}
+
+/**
+ * Converts an IP address to its packed representation, or `null` when it is not an address.
+ *
+ * @internal
+ */
+function to_bytes(string $ip): ?string
+{
+    if (filter_var($ip, FILTER_VALIDATE_IP) === false) {
+        return null;
+    }
+
+    $bytes = inet_pton($ip);
+
+    if ($bytes === false) {
+        return null;
+    }
+
+    if (strlen($bytes) === 16 && str_starts_with($bytes, "\0\0\0\0\0\0\0\0\0\0\xFF\xFF")) {
+        return substr($bytes, 12);
+    }
+
+    return $bytes;
+}

--- a/packages/support/src/Ip/functions.php
+++ b/packages/support/src/Ip/functions.php
@@ -10,12 +10,12 @@ namespace Tempest\Support\Ip;
  *
  * ### Example
  * ```php
- * ip_matches('10.0.1.24', '10.0.0.0/8'); // true
- * ip_matches('10.0.1.24', '10.0.1.24'); // true
- * ip_matches('10.0.1.24', '::/0'); // false
+ * matches('10.0.1.24', '10.0.0.0/8'); // true
+ * matches('10.0.1.24', '10.0.1.24'); // true
+ * matches('10.0.1.24', '::/0'); // false
  * ```
  */
-function ip_matches(IpAddress|string $ip, IpAddress|string $range): bool
+function matches(IpAddress|string $ip, IpAddress|string $range): bool
 {
     return IpAddress::tryFrom($ip)?->matches($range) ?? false;
 }
@@ -25,7 +25,7 @@ function ip_matches(IpAddress|string $ip, IpAddress|string $range): bool
  *
  * @param iterable<IpAddress|string> $ranges
  */
-function ip_matches_any(IpAddress|string $ip, iterable $ranges): bool
+function matches_any(IpAddress|string $ip, iterable $ranges): bool
 {
     return IpAddress::tryFrom($ip)?->matchesAny($ranges) ?? false;
 }
@@ -35,11 +35,11 @@ function ip_matches_any(IpAddress|string $ip, iterable $ranges): bool
  *
  * ### Example
  * ```php
- * ip_is_private('10.0.1.24'); // true
- * ip_is_private('203.0.113.9'); // false
+ * is_private('10.0.1.24'); // true
+ * is_private('203.0.113.9'); // false
  * ```
  */
-function ip_is_private(IpAddress|string $ip): bool
+function is_private(IpAddress|string $ip): bool
 {
     return IpAddress::tryFrom($ip)?->isPrivate === true;
 }
@@ -47,7 +47,7 @@ function ip_is_private(IpAddress|string $ip): bool
 /**
  * Converts an IP address to its packed representation, or `null` when it is not an address.
  */
-function ip_to_bytes(IpAddress|string $ip): ?string
+function to_bytes(IpAddress|string $ip): ?string
 {
     return IpAddress::tryFrom($ip)?->bytes;
 }

--- a/packages/support/tests/Ip/FunctionsTest.php
+++ b/packages/support/tests/Ip/FunctionsTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Tests\Ip;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Ip;
+
+/**
+ * @internal
+ */
+final class FunctionsTest extends TestCase
+{
+    #[Test]
+    #[TestWith(['203.0.113.9', '203.0.113.9'])]
+    #[TestWith(['10.0.1.24', '10.0.0.0/8'])]
+    #[TestWith(['10.0.1.24', '10.0.1.0/24'])]
+    #[TestWith(['192.168.1.1', '0.0.0.0/0'])]
+    #[TestWith(['2001:db8::1', '2001:db8::1'])]
+    #[TestWith(['2001:db8::1', '2001:db8::/32'])]
+    #[TestWith(['2001:db8::1', '::/0'])]
+    #[TestWith(['::ffff:10.0.1.24', '10.0.0.0/8'])]
+    public function matching_addresses(string $ip, string $range): void
+    {
+        $this->assertTrue(Ip\matches($ip, $range));
+    }
+
+    #[Test]
+    #[TestWith(['203.0.113.9', '203.0.113.10'])]
+    #[TestWith(['11.0.1.24', '10.0.0.0/8'])]
+    #[TestWith(['10.0.2.24', '10.0.1.0/24'])]
+    #[TestWith(['2001:db9::1', '2001:db8::/32'])]
+    public function non_matching_addresses(string $ip, string $range): void
+    {
+        $this->assertFalse(Ip\matches($ip, $range));
+    }
+
+    #[Test]
+    #[TestWith(['10.0.1.24', '::/0'])]
+    #[TestWith(['2001:db8::1', '0.0.0.0/0'])]
+    public function families_are_never_matched_against_each_other(string $ip, string $range): void
+    {
+        $this->assertFalse(Ip\matches($ip, $range));
+    }
+
+    #[Test]
+    #[TestWith(['not-an-address', '10.0.0.0/8'])]
+    #[TestWith(['10.0.1.24', 'not-a-range'])]
+    #[TestWith(['10.0.1.24', '10.0.0.0/mask'])]
+    #[TestWith(['10.0.1.24', '10.0.0.0/33'])]
+    #[TestWith(['10.0.1.24', '10.0.0.0/-1'])]
+    #[TestWith(['', ''])]
+    public function malformed_input_never_matches(string $ip, string $range): void
+    {
+        $this->assertFalse(Ip\matches($ip, $range));
+    }
+
+    #[Test]
+    public function matching_any_range(): void
+    {
+        $this->assertTrue(Ip\matches_any('10.0.1.24', ['203.0.113.9', '10.0.0.0/8']));
+        $this->assertFalse(Ip\matches_any('10.0.1.24', ['203.0.113.9', '192.168.0.0/16']));
+        $this->assertFalse(Ip\matches_any('10.0.1.24', []));
+    }
+
+    #[Test]
+    #[TestWith(['127.0.0.1'])]
+    #[TestWith(['10.0.1.24'])]
+    #[TestWith(['172.16.0.1'])]
+    #[TestWith(['192.168.1.1'])]
+    #[TestWith(['169.254.0.1'])]
+    #[TestWith(['::1'])]
+    #[TestWith(['fd00::1'])]
+    #[TestWith(['fe80::1'])]
+    #[TestWith(['::ffff:10.0.1.24'])]
+    public function private_addresses(string $ip): void
+    {
+        $this->assertTrue(Ip\is_private($ip));
+    }
+
+    #[Test]
+    #[TestWith(['203.0.113.9'])]
+    #[TestWith(['8.8.8.8'])]
+    #[TestWith(['172.32.0.1'])]
+    #[TestWith(['2001:db8::1'])]
+    #[TestWith(['::ffff:203.0.113.9'])]
+    #[TestWith(['not-an-address'])]
+    public function public_addresses(string $ip): void
+    {
+        $this->assertFalse(Ip\is_private($ip));
+    }
+}

--- a/packages/support/tests/Ip/FunctionsTest.php
+++ b/packages/support/tests/Ip/FunctionsTest.php
@@ -25,7 +25,7 @@ final class FunctionsTest extends TestCase
     #[TestWith(['::ffff:10.0.1.24', '10.0.0.0/8'])]
     public function matching_addresses(string $ip, string $range): void
     {
-        $this->assertTrue(Ip\ip_matches($ip, $range));
+        $this->assertTrue(Ip\matches($ip, $range));
     }
 
     #[Test]
@@ -35,7 +35,7 @@ final class FunctionsTest extends TestCase
     #[TestWith(['2001:db9::1', '2001:db8::/32'])]
     public function non_matching_addresses(string $ip, string $range): void
     {
-        $this->assertFalse(Ip\ip_matches($ip, $range));
+        $this->assertFalse(Ip\matches($ip, $range));
     }
 
     #[Test]
@@ -43,7 +43,7 @@ final class FunctionsTest extends TestCase
     #[TestWith(['2001:db8::1', '0.0.0.0/0'])]
     public function families_are_never_matched_against_each_other(string $ip, string $range): void
     {
-        $this->assertFalse(Ip\ip_matches($ip, $range));
+        $this->assertFalse(Ip\matches($ip, $range));
     }
 
     #[Test]
@@ -55,15 +55,15 @@ final class FunctionsTest extends TestCase
     #[TestWith(['', ''])]
     public function malformed_input_never_matches(string $ip, string $range): void
     {
-        $this->assertFalse(Ip\ip_matches($ip, $range));
+        $this->assertFalse(Ip\matches($ip, $range));
     }
 
     #[Test]
     public function matching_any_range(): void
     {
-        $this->assertTrue(Ip\ip_matches_any('10.0.1.24', ['203.0.113.9', '10.0.0.0/8']));
-        $this->assertFalse(Ip\ip_matches_any('10.0.1.24', ['203.0.113.9', '192.168.0.0/16']));
-        $this->assertFalse(Ip\ip_matches_any('10.0.1.24', []));
+        $this->assertTrue(Ip\matches_any('10.0.1.24', ['203.0.113.9', '10.0.0.0/8']));
+        $this->assertFalse(Ip\matches_any('10.0.1.24', ['203.0.113.9', '192.168.0.0/16']));
+        $this->assertFalse(Ip\matches_any('10.0.1.24', []));
     }
 
     #[Test]
@@ -78,7 +78,7 @@ final class FunctionsTest extends TestCase
     #[TestWith(['::ffff:10.0.1.24'])]
     public function private_addresses(string $ip): void
     {
-        $this->assertTrue(Ip\ip_is_private($ip));
+        $this->assertTrue(Ip\is_private($ip));
     }
 
     #[Test]
@@ -90,6 +90,6 @@ final class FunctionsTest extends TestCase
     #[TestWith(['not-an-address'])]
     public function public_addresses(string $ip): void
     {
-        $this->assertFalse(Ip\ip_is_private($ip));
+        $this->assertFalse(Ip\is_private($ip));
     }
 }

--- a/packages/support/tests/Ip/FunctionsTest.php
+++ b/packages/support/tests/Ip/FunctionsTest.php
@@ -25,7 +25,7 @@ final class FunctionsTest extends TestCase
     #[TestWith(['::ffff:10.0.1.24', '10.0.0.0/8'])]
     public function matching_addresses(string $ip, string $range): void
     {
-        $this->assertTrue(Ip\matches($ip, $range));
+        $this->assertTrue(Ip\ip_matches($ip, $range));
     }
 
     #[Test]
@@ -35,7 +35,7 @@ final class FunctionsTest extends TestCase
     #[TestWith(['2001:db9::1', '2001:db8::/32'])]
     public function non_matching_addresses(string $ip, string $range): void
     {
-        $this->assertFalse(Ip\matches($ip, $range));
+        $this->assertFalse(Ip\ip_matches($ip, $range));
     }
 
     #[Test]
@@ -43,7 +43,7 @@ final class FunctionsTest extends TestCase
     #[TestWith(['2001:db8::1', '0.0.0.0/0'])]
     public function families_are_never_matched_against_each_other(string $ip, string $range): void
     {
-        $this->assertFalse(Ip\matches($ip, $range));
+        $this->assertFalse(Ip\ip_matches($ip, $range));
     }
 
     #[Test]
@@ -55,15 +55,15 @@ final class FunctionsTest extends TestCase
     #[TestWith(['', ''])]
     public function malformed_input_never_matches(string $ip, string $range): void
     {
-        $this->assertFalse(Ip\matches($ip, $range));
+        $this->assertFalse(Ip\ip_matches($ip, $range));
     }
 
     #[Test]
     public function matching_any_range(): void
     {
-        $this->assertTrue(Ip\matches_any('10.0.1.24', ['203.0.113.9', '10.0.0.0/8']));
-        $this->assertFalse(Ip\matches_any('10.0.1.24', ['203.0.113.9', '192.168.0.0/16']));
-        $this->assertFalse(Ip\matches_any('10.0.1.24', []));
+        $this->assertTrue(Ip\ip_matches_any('10.0.1.24', ['203.0.113.9', '10.0.0.0/8']));
+        $this->assertFalse(Ip\ip_matches_any('10.0.1.24', ['203.0.113.9', '192.168.0.0/16']));
+        $this->assertFalse(Ip\ip_matches_any('10.0.1.24', []));
     }
 
     #[Test]
@@ -78,7 +78,7 @@ final class FunctionsTest extends TestCase
     #[TestWith(['::ffff:10.0.1.24'])]
     public function private_addresses(string $ip): void
     {
-        $this->assertTrue(Ip\is_private($ip));
+        $this->assertTrue(Ip\ip_is_private($ip));
     }
 
     #[Test]
@@ -90,6 +90,6 @@ final class FunctionsTest extends TestCase
     #[TestWith(['not-an-address'])]
     public function public_addresses(string $ip): void
     {
-        $this->assertFalse(Ip\is_private($ip));
+        $this->assertFalse(Ip\ip_is_private($ip));
     }
 }

--- a/packages/support/tests/Ip/IpAddressTest.php
+++ b/packages/support/tests/Ip/IpAddressTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Support\Tests\Ip;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Tempest\Support\Ip\InvalidIpAddress;
+use Tempest\Support\Ip\IpAddress;
+
+/**
+ * @internal
+ */
+final class IpAddressTest extends TestCase
+{
+    #[Test]
+    #[TestWith(['203.0.113.9'])]
+    #[TestWith(['2001:db8::1'])]
+    #[TestWith(['::ffff:127.0.0.1'])]
+    public function creating_from_a_valid_address(string $ip): void
+    {
+        $this->assertSame($ip, IpAddress::from($ip)->toString());
+        $this->assertSame($ip, (string) IpAddress::from($ip));
+    }
+
+    #[Test]
+    #[TestWith(['not-an-address'])]
+    #[TestWith([''])]
+    #[TestWith(['10.0.0.0/8'])]
+    #[TestWith(['203.0.113.9:8080'])]
+    public function creating_from_an_invalid_address_throws(string $ip): void
+    {
+        $this->expectException(InvalidIpAddress::class);
+
+        IpAddress::from($ip);
+    }
+
+    #[Test]
+    public function try_from_returns_null_for_an_invalid_address(): void
+    {
+        $this->assertNull(IpAddress::tryFrom('not-an-address'));
+        $this->assertNull(IpAddress::tryFrom(null));
+    }
+
+    #[Test]
+    public function try_from_passes_an_address_through(): void
+    {
+        $ip = IpAddress::from('203.0.113.9');
+
+        $this->assertSame($ip, IpAddress::tryFrom($ip));
+    }
+
+    #[Test]
+    #[TestWith(['127.0.0.1', '::ffff:127.0.0.1'])]
+    #[TestWith(['2001:db8::1', '2001:0db8:0000:0000:0000:0000:0000:0001'])]
+    #[TestWith(['203.0.113.9', '203.0.113.9'])]
+    public function equality_is_determined_by_the_address_rather_than_the_notation(string $ip, string $other): void
+    {
+        $this->assertTrue(IpAddress::from($ip)->equals($other));
+        $this->assertTrue(IpAddress::from($ip)->equals(IpAddress::from($other)));
+        $this->assertTrue(IpAddress::from($other)->equals($ip));
+    }
+
+    #[Test]
+    #[TestWith(['203.0.113.9', '203.0.113.10'])]
+    #[TestWith(['2001:db8::1', '2001:db8::2'])]
+    #[TestWith(['127.0.0.1', '::1'])]
+    public function different_addresses_are_not_equal(string $ip, string $other): void
+    {
+        $this->assertFalse(IpAddress::from($ip)->equals($other));
+    }
+
+    #[Test]
+    public function non_addresses_are_never_equal(): void
+    {
+        $ip = IpAddress::from('203.0.113.9');
+
+        $this->assertFalse($ip->equals('not-an-address'));
+        $this->assertFalse($ip->equals(''));
+        $this->assertFalse($ip->equals(null));
+    }
+
+    #[Test]
+    public function address_families(): void
+    {
+        $this->assertTrue(IpAddress::from('203.0.113.9')->isIpv4);
+        $this->assertFalse(IpAddress::from('203.0.113.9')->isIpv6);
+
+        $this->assertTrue(IpAddress::from('2001:db8::1')->isIpv6);
+        $this->assertFalse(IpAddress::from('2001:db8::1')->isIpv4);
+
+        // IPv4-mapped addresses are narrowed to IPv4.
+        $this->assertTrue(IpAddress::from('::ffff:127.0.0.1')->isIpv4);
+    }
+
+    #[Test]
+    public function matching_a_range(): void
+    {
+        $this->assertTrue(IpAddress::from('10.0.1.24')->matches('10.0.0.0/8'));
+        $this->assertFalse(IpAddress::from('10.0.1.24')->matches('192.168.0.0/16'));
+    }
+
+    #[Test]
+    public function matching_any_range(): void
+    {
+        $ip = IpAddress::from('10.0.1.24');
+
+        $this->assertTrue($ip->matchesAny(['203.0.113.9', '10.0.0.0/8']));
+        $this->assertFalse($ip->matchesAny(['203.0.113.9', '192.168.0.0/16']));
+        $this->assertFalse($ip->matchesAny([]));
+    }
+
+    #[Test]
+    public function private_addresses(): void
+    {
+        $this->assertTrue(IpAddress::from('10.0.1.24')->isPrivate);
+        $this->assertTrue(IpAddress::from('::1')->isPrivate);
+        $this->assertFalse(IpAddress::from('203.0.113.9')->isPrivate);
+    }
+}

--- a/src/Tempest/Framework/Testing/Http/HttpRouterTester.php
+++ b/src/Tempest/Framework/Testing/Http/HttpRouterTester.php
@@ -39,6 +39,8 @@ final class HttpRouterTester
 
     private(set) bool $throwExceptions = false;
 
+    private(set) ?string $ip = null;
+
     public function __construct(
         private Container $container,
     ) {}
@@ -125,6 +127,16 @@ final class HttpRouterTester
     }
 
     /**
+     * Specifies the IP address that subsequent requests are made from.
+     */
+    public function fromIp(string $ip): self
+    {
+        $this->ip = $ip;
+
+        return $this;
+    }
+
+    /**
      * Specifies that subsequent requests should be sent without Sec-Fetch headers.
      */
     public function withoutSecFetchHeaders(): self
@@ -141,6 +153,7 @@ final class HttpRouterTester
             uri: Uri\merge_query($uri, ...$query),
             body: [],
             headers: $this->createHeaders($headers),
+            ip: $this->ip,
         ));
     }
 
@@ -151,6 +164,7 @@ final class HttpRouterTester
             uri: Uri\merge_query($uri, ...$query),
             body: [],
             headers: $this->createHeaders($headers),
+            ip: $this->ip,
         ));
     }
 
@@ -162,6 +176,7 @@ final class HttpRouterTester
             body: is_string($body) ? [] : $body,
             headers: $this->createHeaders($headers),
             raw: is_string($body) ? $body : null,
+            ip: $this->ip,
         ));
     }
 
@@ -173,6 +188,7 @@ final class HttpRouterTester
             body: is_string($body) ? [] : $body,
             headers: $this->createHeaders($headers),
             raw: is_string($body) ? $body : null,
+            ip: $this->ip,
         ));
     }
 
@@ -184,6 +200,7 @@ final class HttpRouterTester
             body: is_string($body) ? [] : $body,
             headers: $this->createHeaders($headers),
             raw: is_string($body) ? $body : null,
+            ip: $this->ip,
         ));
     }
 
@@ -195,6 +212,7 @@ final class HttpRouterTester
             body: is_string($body) ? [] : $body,
             headers: $this->createHeaders($headers),
             raw: is_string($body) ? $body : null,
+            ip: $this->ip,
         ));
     }
 
@@ -205,6 +223,7 @@ final class HttpRouterTester
             uri: Uri\merge_query($uri, ...$query),
             body: [],
             headers: $this->createHeaders($headers),
+            ip: $this->ip,
         ));
     }
 
@@ -215,6 +234,7 @@ final class HttpRouterTester
             uri: Uri\merge_query($uri, ...$query),
             body: [],
             headers: $this->createHeaders($headers),
+            ip: $this->ip,
         ));
     }
 
@@ -225,6 +245,7 @@ final class HttpRouterTester
             uri: Uri\merge_query($uri, ...$query),
             body: [],
             headers: $this->createHeaders($headers),
+            ip: $this->ip,
         ));
     }
 
@@ -236,6 +257,7 @@ final class HttpRouterTester
             body: is_string($body) ? [] : $body,
             headers: $this->createHeaders($headers),
             raw: is_string($body) ? $body : null,
+            ip: $this->ip,
         ));
     }
 
@@ -291,7 +313,9 @@ final class HttpRouterTester
 
         $_POST = is_array($body) ? $body : [];
 
-        return ServerRequestFactory::fromGlobals()->withUploadedFiles($files);
+        $server = $this->ip === null ? $_SERVER : [...$_SERVER, 'REMOTE_ADDR' => $this->ip];
+
+        return ServerRequestFactory::fromGlobals($server)->withUploadedFiles($files);
     }
 
     private function createHeaders(array $headers = []): array

--- a/src/Tempest/Framework/Testing/Http/HttpRouterTester.php
+++ b/src/Tempest/Framework/Testing/Http/HttpRouterTester.php
@@ -26,6 +26,7 @@ use Tempest\Router\SecFetchMode;
 use Tempest\Router\SecFetchSite;
 use Tempest\Router\Static\StaticPageConfig;
 use Tempest\Router\StaticPage;
+use Tempest\Support\Ip\IpAddress;
 use Tempest\Support\Uri;
 use Throwable;
 
@@ -39,7 +40,7 @@ final class HttpRouterTester
 
     private(set) bool $throwExceptions = false;
 
-    private(set) ?string $ip = null;
+    private(set) ?IpAddress $ip = null;
 
     public function __construct(
         private Container $container,
@@ -129,9 +130,9 @@ final class HttpRouterTester
     /**
      * Specifies the IP address that subsequent requests are made from.
      */
-    public function fromIp(string $ip): self
+    public function fromIp(IpAddress|string $ip): self
     {
-        $this->ip = $ip;
+        $this->ip = IpAddress::from($ip);
 
         return $this;
     }
@@ -313,7 +314,7 @@ final class HttpRouterTester
 
         $_POST = is_array($body) ? $body : [];
 
-        $server = $this->ip === null ? $_SERVER : [...$_SERVER, 'REMOTE_ADDR' => $this->ip];
+        $server = $this->ip === null ? $_SERVER : [...$_SERVER, 'REMOTE_ADDR' => $this->ip->toString()];
 
         return ServerRequestFactory::fromGlobals($server)->withUploadedFiles($files);
     }

--- a/tests/Fixtures/Controllers/IpController.php
+++ b/tests/Fixtures/Controllers/IpController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Fixtures\Controllers;
+
+use Tempest\Http\Request;
+use Tempest\Http\Response;
+use Tempest\Http\Responses\Ok;
+use Tempest\Router\Get;
+
+final readonly class IpController
+{
+    #[Get('/ip')]
+    public function __invoke(Request $request): Response
+    {
+        return new Ok($request->ip ?? 'unknown');
+    }
+}

--- a/tests/Fixtures/Controllers/IpController.php
+++ b/tests/Fixtures/Controllers/IpController.php
@@ -14,6 +14,6 @@ final readonly class IpController
     #[Get('/ip')]
     public function __invoke(Request $request): Response
     {
-        return new Ok($request->ip ?? 'unknown');
+        return new Ok($request->ip?->toString() ?? 'unknown');
     }
 }

--- a/tests/Integration/Http/RequestIpTest.php
+++ b/tests/Integration/Http/RequestIpTest.php
@@ -10,6 +10,7 @@ use Tempest\Http\Ip\TrustedProxiesConfig;
 use Tempest\Http\Mappers\PsrRequestToGenericRequestMapper;
 use Tempest\Http\Mappers\RequestToPsrRequestMapper;
 use Tempest\Http\Method;
+use Tempest\Support\Ip\IpAddress;
 use Tests\Tempest\Fixtures\Requests\BookRequest;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
@@ -27,7 +28,8 @@ final class RequestIpTest extends FrameworkIntegrationTestCase
 
         $request = map($psrRequest)->with(PsrRequestToGenericRequestMapper::class)->do();
 
-        $this->assertSame('203.0.113.9', $request->ip);
+        $this->assertInstanceOf(IpAddress::class, $request->ip);
+        $this->assertTrue($request->ip->equals('203.0.113.9'));
     }
 
     #[Test]
@@ -61,7 +63,24 @@ final class RequestIpTest extends FrameworkIntegrationTestCase
 
         $bookRequest = map($request)->to(BookRequest::class);
 
-        $this->assertSame('203.0.113.9', $bookRequest->ip);
+        $this->assertInstanceOf(IpAddress::class, $bookRequest->ip);
+        $this->assertTrue($bookRequest->ip->equals('203.0.113.9'));
+    }
+
+    #[Test]
+    public function ip_is_accepted_as_a_value_object(): void
+    {
+        $request = new GenericRequest(method: Method::GET, uri: '/', ip: IpAddress::from('203.0.113.9'));
+
+        $this->assertTrue($request->ip->equals('203.0.113.9'));
+    }
+
+    #[Test]
+    public function ip_is_compared_regardless_of_notation(): void
+    {
+        $request = new GenericRequest(method: Method::GET, uri: '/', ip: '::ffff:203.0.113.9');
+
+        $this->assertTrue($request->ip->equals('203.0.113.9'));
     }
 
     #[Test]

--- a/tests/Integration/Http/RequestIpTest.php
+++ b/tests/Integration/Http/RequestIpTest.php
@@ -6,9 +6,11 @@ namespace Tests\Tempest\Integration\Http;
 
 use PHPUnit\Framework\Attributes\Test;
 use Tempest\Http\GenericRequest;
+use Tempest\Http\Ip\TrustedProxiesConfig;
 use Tempest\Http\Mappers\PsrRequestToGenericRequestMapper;
 use Tempest\Http\Mappers\RequestToPsrRequestMapper;
 use Tempest\Http\Method;
+use Tests\Tempest\Fixtures\Requests\BookRequest;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
 
 use function Tempest\Mapper\map;
@@ -53,8 +55,38 @@ final class RequestIpTest extends FrameworkIntegrationTestCase
     }
 
     #[Test]
+    public function ip_is_carried_over_to_a_custom_request(): void
+    {
+        $request = new GenericRequest(method: Method::POST, uri: '/', body: ['title' => 'Timeline Taxi'], ip: '203.0.113.9');
+
+        $bookRequest = map($request)->to(BookRequest::class);
+
+        $this->assertSame('203.0.113.9', $bookRequest->ip);
+    }
+
+    #[Test]
     public function requests_without_an_ip_are_dispatched_normally(): void
     {
         $this->http->get('/ip')->assertSee('unknown');
+    }
+
+    #[Test]
+    public function forwarding_headers_are_ignored_by_default(): void
+    {
+        $this->http
+            ->fromIp('10.0.0.1')
+            ->get('/ip', headers: ['X-Forwarded-For' => '198.51.100.7'])
+            ->assertSee('10.0.0.1');
+    }
+
+    #[Test]
+    public function forwarding_headers_are_read_from_a_trusted_proxy(): void
+    {
+        $this->container->config(new TrustedProxiesConfig(proxies: ['10.0.0.0/8']));
+
+        $this->http
+            ->fromIp('10.0.0.1')
+            ->get('/ip', headers: ['X-Forwarded-For' => '198.51.100.7'])
+            ->assertSee('198.51.100.7');
     }
 }

--- a/tests/Integration/Http/RequestIpTest.php
+++ b/tests/Integration/Http/RequestIpTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Http;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Http\GenericRequest;
+use Tempest\Http\Mappers\PsrRequestToGenericRequestMapper;
+use Tempest\Http\Mappers\RequestToPsrRequestMapper;
+use Tempest\Http\Method;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+use function Tempest\Mapper\map;
+
+/**
+ * @internal
+ */
+final class RequestIpTest extends FrameworkIntegrationTestCase
+{
+    #[Test]
+    public function ip_is_read_from_the_server_parameters(): void
+    {
+        $psrRequest = $this->http->fromIp('203.0.113.9')->makePsrRequest('/');
+
+        $request = map($psrRequest)->with(PsrRequestToGenericRequestMapper::class)->do();
+
+        $this->assertSame('203.0.113.9', $request->ip);
+    }
+
+    #[Test]
+    public function ip_is_null_when_the_server_does_not_report_one(): void
+    {
+        $request = map($this->http->makePsrRequest('/'))->with(PsrRequestToGenericRequestMapper::class)->do();
+
+        $this->assertNull($request->ip);
+    }
+
+    #[Test]
+    public function ip_survives_the_round_trip_to_a_psr_request(): void
+    {
+        $request = new GenericRequest(method: Method::GET, uri: '/', ip: '203.0.113.9');
+
+        $psrRequest = map($request)->with(RequestToPsrRequestMapper::class)->do();
+
+        $this->assertSame('203.0.113.9', $psrRequest->getServerParams()['REMOTE_ADDR']);
+    }
+
+    #[Test]
+    public function ip_is_available_to_a_controller(): void
+    {
+        $this->http->fromIp('203.0.113.9')->get('/ip')->assertSee('203.0.113.9');
+    }
+
+    #[Test]
+    public function requests_without_an_ip_are_dispatched_normally(): void
+    {
+        $this->http->get('/ip')->assertSee('unknown');
+    }
+}

--- a/tests/Integration/Route/PsrRequestToGenericRequestMapperTest.php
+++ b/tests/Integration/Route/PsrRequestToGenericRequestMapperTest.php
@@ -13,6 +13,8 @@ use Tempest\Cryptography\Encryption\Encrypter;
 use Tempest\Http\Cookie\CookieConfig;
 use Tempest\Http\Cookie\CookieManager;
 use Tempest\Http\GenericRequest;
+use Tempest\Http\Ip\ClientIpResolver;
+use Tempest\Http\Ip\TrustedProxiesConfig;
 use Tempest\Http\Mappers\PsrRequestToGenericRequestMapper;
 use Tempest\Http\Request;
 use Tempest\Http\Upload;
@@ -32,7 +34,7 @@ final class PsrRequestToGenericRequestMapperTest extends FrameworkIntegrationTes
     }
 
     private PsrRequestToGenericRequestMapper $mapper {
-        get => new PsrRequestToGenericRequestMapper($this->encrypter, $this->cookies, new CookieConfig());
+        get => new PsrRequestToGenericRequestMapper($this->encrypter, $this->cookies, new CookieConfig(), new ClientIpResolver(new TrustedProxiesConfig()));
     }
 
     #[Test]


### PR DESCRIPTION
Right now, getting the IP address a request came from means digging into `$_SERVER` yourself. The PSR request has it in `REMOTE_ADDR`, but the mapper to `GenericRequest` throws the server params away.

This PR adds `Request::$ip`:

```php
#[Get(uri: '/aircraft')]
public function index(Request $request): View
{
    $ip = $request->ip;
}
```

It's `null` when the server doesn't report an address. In tests, `fromIp` sets it:

```php
$this->http
    ->fromIp('203.0.113.9')
    ->get('/aircraft')
    ->assertOk();
```

## Trusted proxies

Behind a reverse proxy you get the proxy's address, and the client's real one sits in a header like `X-Forwarded-For`. Anyone can set that header, so it's only read if the request came through a proxy you've declared. Nothing is trusted by default:

```php app/trusted-proxies.config.php
use Tempest\Http\Ip\TrustedProxiesConfig;

return new TrustedProxiesConfig(
    proxies: ['10.0.0.0/8'], // or PRIVATE_RANGES, or ANY
);
```

Addresses and CIDR ranges both work, IPv4 and IPv6. In a chain of hops, the closest one that isn't a trusted proxy is the client. Header names are configurable too, for the likes of Cloudflare. Docs included, under routing.

## Notes

- `ip` is now a reserved request parameter name, since it's a property on the `Request` interface. If a payload has a field called `ip` and gets mapped onto a custom request object, it'll throw `RequestParametersIncludedReservedNames`, same as it already does for `path`, `query` and so on. Probably worth a line in the release notes.
- Went with `ip` rather than `clientIp` to keep it short, like Laravel's `$request->ip()`.
- The range matching lives in `Tempest\Support\Ip` rather than the HTTP package, since it seemed generally useful: `matches()`, `matches_any()`, `is_private()`.

### Included changes

- `Request::$ip` on the interface and in `IsRequest`
- `TrustedProxiesConfig` and `ClientIpResolver` in `Tempest\Http\Ip`, `Tempest\Support\Ip` functions and `PRIVATE_RANGES`
- `PsrRequestToGenericRequestMapper` resolves the address, `RequestToPsrRequestMapper` writes it back for the tester's dispatch, and `RequestToObjectMapper` carries it onto custom request objects
- `HttpRouterTester::fromIp()`, across all verb methods and `makePsrRequest`
- Docs and tests
