### PR TITLE
docs: replace outdated `--allow-dead-links` flag  with `--crawl`

### DIFF
--- a/docs/5-extra-topics/03-deployments.md
+++ b/docs/5-extra-topics/03-deployments.md
@@ -36,7 +36,7 @@ This `deploy.sh` script could look something like this:
 {:hl-keyword:tempest:} migrate:up --force
 {:hl-keyword:tempest:} static:clean --force
 {:hl-keyword:bun:} run build
-{:hl-keyword:tempest:} static:generate --allow-dead-links --verbose=true
+{:hl-keyword:tempest:} static:generate --crawl --verbose=true
 ```
 
 As you can see, there are a number of steps involved to deploying a Tempest project:


### PR DESCRIPTION
While reading docs I notices that --allow-dead-links was no available and the new option is --crawl, that is what I think tell if not is correct.