### PR TITLE
fix(http): recursively map nested uploaded files

### DIFF
--- a/packages/http/src/IsRequest.php
+++ b/packages/http/src/IsRequest.php
@@ -38,7 +38,7 @@ trait IsRequest
     #[SkipValidation]
     private(set) array $query;
 
-    /** @var \Tempest\Http\Upload[] */
+    /** @var array<array-key, \Tempest\Http\Upload|array> */
     #[SkipValidation]
     private(set) array $files;
 

--- a/packages/http/src/Mappers/PsrRequestToGenericRequestMapper.php
+++ b/packages/http/src/Mappers/PsrRequestToGenericRequestMapper.php
@@ -51,10 +51,7 @@ final readonly class PsrRequestToGenericRequestMapper implements Mapper
 
         parse_str($from->getUri()->getQuery(), $query);
 
-        $uploads = array_map(
-            fn (UploadedFileInterface $uploadedFile) => new Upload($uploadedFile),
-            $from->getUploadedFiles(),
-        );
+        $uploads = $this->createUploads($from->getUploadedFiles());
 
         return map([
             'method' => $this->requestMethod($from, $data),
@@ -86,6 +83,22 @@ final readonly class PsrRequestToGenericRequestMapper implements Mapper
             )),
         ])
             ->to(GenericRequest::class);
+    }
+
+    /**
+     * Array-style file inputs, such as `files[]`, are exposed by PSR-7 as nested arrays.
+     *
+     * @param array<array-key, UploadedFileInterface|array> $uploadedFiles
+     * @return array<array-key, Upload|array>
+     */
+    private function createUploads(array $uploadedFiles): array
+    {
+        return array_map(
+            fn (UploadedFileInterface|array $uploadedFile) => $uploadedFile instanceof UploadedFileInterface
+                ? new Upload($uploadedFile)
+                : $this->createUploads($uploadedFile),
+            $uploadedFiles,
+        );
     }
 
     private function requestMethod(PsrRequest $request, array $data): Method

--- a/packages/http/src/Request.php
+++ b/packages/http/src/Request.php
@@ -22,7 +22,7 @@ interface Request
 
     public array $query { get; }
 
-    /** @var \Tempest\Http\Upload[] $files */
+    /** @var array<array-key, \Tempest\Http\Upload|array> $files */
     public array $files { get; }
 
     /** @var Cookie[] $cookies */

--- a/packages/http/tests/Mappers/PsrRequestToGenericRequestMapperTest.php
+++ b/packages/http/tests/Mappers/PsrRequestToGenericRequestMapperTest.php
@@ -6,6 +6,7 @@ namespace Tempest\Http\Tests\Mappers;
 
 use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\Stream;
+use Laminas\Diactoros\UploadedFile;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -25,12 +26,15 @@ use Tempest\Http\Cookie\CookieConfig;
 use Tempest\Http\Cookie\CookieManager;
 use Tempest\Http\Mappers\PsrRequestToGenericRequestMapper;
 use Tempest\Http\Method;
+use Tempest\Http\Upload;
 
 final class PsrRequestToGenericRequestMapperTest extends TestCase
 {
     private PsrRequestToGenericRequestMapper $mapper;
 
     private ReflectionMethod $requestMethod;
+
+    private ReflectionMethod $createUploads;
 
     protected function setUp(): void
     {
@@ -47,6 +51,24 @@ final class PsrRequestToGenericRequestMapperTest extends TestCase
 
         $reflection = new ReflectionClass($this->mapper);
         $this->requestMethod = $reflection->getMethod('requestMethod');
+        $this->createUploads = $reflection->getMethod('createUploads');
+    }
+
+    #[Test]
+    public function nested_uploaded_files_are_mapped_to_uploads(): void
+    {
+        $files = $this->createUploads->invoke($this->mapper, [
+            'avatar' => $this->createUploadedFile('avatar.png'),
+            'documents' => [
+                $this->createUploadedFile('one.txt'),
+                'contract' => $this->createUploadedFile('contract.pdf'),
+            ],
+        ]);
+
+        $this->assertInstanceOf(Upload::class, $files['avatar']);
+        $this->assertSame('avatar.png', $files['avatar']->getClientFilename());
+        $this->assertSame('one.txt', $files['documents'][0]->getClientFilename());
+        $this->assertSame('contract.pdf', $files['documents']['contract']->getClientFilename());
     }
 
     #[DataProvider('nonPostMethodsProvider')]
@@ -155,5 +177,15 @@ final class PsrRequestToGenericRequestMapperTest extends TestCase
 
         $stream = new Stream('php://temp', 'r+');
         return $request->withBody($stream);
+    }
+
+    private function createUploadedFile(string $filename): UploadedFile
+    {
+        return new UploadedFile(
+            streamOrFile: new Stream('php://temp', 'r+'),
+            size: 0,
+            errorStatus: UPLOAD_ERR_OK,
+            clientFilename: $filename,
+        );
     }
 }

--- a/packages/http/tests/Mappers/PsrRequestToGenericRequestMapperTest.php
+++ b/packages/http/tests/Mappers/PsrRequestToGenericRequestMapperTest.php
@@ -6,7 +6,6 @@ namespace Tempest\Http\Tests\Mappers;
 
 use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\Stream;
-use Laminas\Diactoros\UploadedFile;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -26,15 +25,12 @@ use Tempest\Http\Cookie\CookieConfig;
 use Tempest\Http\Cookie\CookieManager;
 use Tempest\Http\Mappers\PsrRequestToGenericRequestMapper;
 use Tempest\Http\Method;
-use Tempest\Http\Upload;
 
 final class PsrRequestToGenericRequestMapperTest extends TestCase
 {
     private PsrRequestToGenericRequestMapper $mapper;
 
     private ReflectionMethod $requestMethod;
-
-    private ReflectionMethod $createUploads;
 
     protected function setUp(): void
     {
@@ -51,24 +47,6 @@ final class PsrRequestToGenericRequestMapperTest extends TestCase
 
         $reflection = new ReflectionClass($this->mapper);
         $this->requestMethod = $reflection->getMethod('requestMethod');
-        $this->createUploads = $reflection->getMethod('createUploads');
-    }
-
-    #[Test]
-    public function nested_uploaded_files_are_mapped_to_uploads(): void
-    {
-        $files = $this->createUploads->invoke($this->mapper, [
-            'avatar' => $this->createUploadedFile('avatar.png'),
-            'documents' => [
-                $this->createUploadedFile('one.txt'),
-                'contract' => $this->createUploadedFile('contract.pdf'),
-            ],
-        ]);
-
-        $this->assertInstanceOf(Upload::class, $files['avatar']);
-        $this->assertSame('avatar.png', $files['avatar']->getClientFilename());
-        $this->assertSame('one.txt', $files['documents'][0]->getClientFilename());
-        $this->assertSame('contract.pdf', $files['documents']['contract']->getClientFilename());
     }
 
     #[DataProvider('nonPostMethodsProvider')]
@@ -177,15 +155,5 @@ final class PsrRequestToGenericRequestMapperTest extends TestCase
 
         $stream = new Stream('php://temp', 'r+');
         return $request->withBody($stream);
-    }
-
-    private function createUploadedFile(string $filename): UploadedFile
-    {
-        return new UploadedFile(
-            streamOrFile: new Stream('php://temp', 'r+'),
-            size: 0,
-            errorStatus: UPLOAD_ERR_OK,
-            clientFilename: $filename,
-        );
     }
 }

--- a/tests/Integration/Route/PsrRequestToGenericRequestMapperTest.php
+++ b/tests/Integration/Route/PsrRequestToGenericRequestMapperTest.php
@@ -107,6 +107,31 @@ final class PsrRequestToGenericRequestMapperTest extends FrameworkIntegrationTes
     }
 
     #[Test]
+    public function nested_files(): void
+    {
+        /** @var GenericRequest $request */
+        $request = $this->mapper->map(
+            from: $this->http->makePsrRequest('/', files: [
+                'avatar' => $this->createUploadedFile('avatar.png'),
+                'documents' => [
+                    $this->createUploadedFile('one.txt'),
+                    'contract' => $this->createUploadedFile('contract.pdf'),
+                ],
+            ]),
+            to: Request::class,
+        );
+
+        $this->assertInstanceOf(Upload::class, $request->files['avatar']);
+        $this->assertSame('avatar.png', $request->files['avatar']->getClientFilename());
+
+        $this->assertInstanceOf(Upload::class, $request->files['documents'][0]);
+        $this->assertSame('one.txt', $request->files['documents'][0]->getClientFilename());
+
+        $this->assertInstanceOf(Upload::class, $request->files['documents']['contract']);
+        $this->assertSame('contract.pdf', $request->files['documents']['contract']->getClientFilename());
+    }
+
+    #[Test]
     public function body_field_in_body(): void
     {
         $request = $this->mapper->map(
@@ -143,5 +168,15 @@ final class PsrRequestToGenericRequestMapperTest extends FrameworkIntegrationTes
         $cookies = $this->cookies->all();
         $this->assertSame($cookies['foo']->expiresAt, -1);
         $this->assertSame($cookies['foo']->value, '');
+    }
+
+    private function createUploadedFile(string $filename): UploadedFile
+    {
+        return new UploadedFile(
+            streamOrFile: new Stream('php://temp', 'r+'),
+            size: 0,
+            errorStatus: UPLOAD_ERR_OK,
+            clientFilename: $filename,
+        );
     }
 }


### PR DESCRIPTION
PSR-7 exposes array-style file inputs, such as `files[]` or `files[avatar]`, as nested arrays. The mapper previously assumed a single-level array with a callback typed to `UploadedFileInterface`, so passing a nested array threw `TypeError`.

Uploaded files are now mapped recursively to preserve this nested structure, and the `$files` docblocks on `Request` and `IsRequest` have been widened to `array<array-key, Upload|array>`.

Runtime behaviour for standard file uploads is unchanged, though static analysis tools may report new notices in code that assumes `Upload[]`.