### PR TITLE
feat: allows `get` to resolve services as singletons

### DIFF
--- a/packages/container/src/Container.php
+++ b/packages/container/src/Container.php
@@ -25,6 +25,13 @@ interface Container extends ContainerInterface
      * @param class-string<TClassName> $className
      * @return TClassName
      */
+    public function make(string $className, mixed ...$params): mixed;
+
+    /**
+     * @template TClassName of object
+     * @param class-string<TClassName> $className
+     * @return TClassName
+     */
     public function get(string $className, string|UnitEnum|null $tag = null, mixed ...$params): mixed;
 
     public function has(string $className, string|UnitEnum|null $tag = null): bool;

--- a/packages/container/src/GenericContainer.php
+++ b/packages/container/src/GenericContainer.php
@@ -54,6 +54,8 @@ final class GenericContainer implements Container
         private(set) ArrayIterator $resettables = new ArrayIterator(),
 
         private(set) ?DependencyChain $chain = null,
+
+        private(set) bool $getClassAsSingletonByDefault = false,
     ) {
         $this->singleton(Container::class, $this);
         $this->singleton(ContainerInterface::class, $this);
@@ -203,6 +205,17 @@ final class GenericContainer implements Container
      * @param class-string<TClassName> $className
      * @return TClassName
      * @throws CircularDependencyEncountered
+     */
+    public function make(string $className, ...$params): mixed
+    {
+        return $this->resolve($className, null, ...$params);
+    }
+
+    /**
+     * @template TClassName of object
+     * @param class-string<TClassName> $className
+     * @return TClassName
+     * @throws CircularDependencyEncountered
      * @throws TaggedDependencyCouldNotBeResolved
      */
     public function get(string $className, string|UnitEnum|null $tag = null, mixed ...$params): object
@@ -212,6 +225,10 @@ final class GenericContainer implements Container
         $dependency = $this->resolve($className, $tag, ...$params);
 
         $this->stopChain();
+
+        if ($this->getClassAsSingletonByDefault) {
+            $this->singleton($className, $dependency, $tag);
+        }
 
         return $dependency;
     }


### PR DESCRIPTION
Based on the conversations with @crell in the Tempest discord, this PR allows services to be shared by default and adds a secondary `make` method that always retrieves a new instance of the class.

Note the definition of the `make` method that PHP-DI has:

> The make() method works like get() except it will resolve the entry every time it is called. Depending on the type of the entry this means:
>
> - if the entry is an object, an new instance will be created every time
> - if the entry is a factory, the factory will be called every time
> - if the entry is an alias, the alias will be resolved every time
>
> Please note that only the entry you ask for will be resolved every time: all the dependencies of the entry will not! That means that if the entry is an alias, the entry the alias points to will be resolved only once.



https://php-di.org/doc/container.html#make