### PR TITLE
perf(command-bus): store pending commands in a single Redis hash

### DIFF
--- a/packages/command-bus/src/AsyncCommandRepositories/RedisCommandRepository.php
+++ b/packages/command-bus/src/AsyncCommandRepositories/RedisCommandRepository.php
@@ -9,13 +9,34 @@ use Tempest\CommandBus\Exceptions\PendingCommandCouldNotBeResolved;
 use Tempest\KeyValue\Redis\Redis;
 use Throwable;
 
-use function Tempest\Support\Str\after_first;
-
-final class RedisCommandRepository implements CommandRepository
+final readonly class RedisCommandRepository implements CommandRepository
 {
-    private const string PENDING_PREFIX = 'command:pending:';
+    private const string PENDING_KEY = 'command:pending';
 
-    private const string FAILED_PREFIX = 'command:failed:';
+    private const string FAILED_KEY = 'command:failed';
+
+    /**
+     * How many fields to read per `HSCAN` batch. Bigger batches mean fewer round trips but larger
+     * replies; 500 measured as a good middle ground.
+     */
+    private const string SCAN_COUNT = '500';
+
+    /**
+     * Moves a command from the pending hash to the failed one. Runs as a script so the two writes
+     * cannot be interrupted halfway.
+     */
+    private const string MARK_AS_FAILED_SCRIPT = <<<'LUA'
+    local command = redis.call('HGET', KEYS[1], ARGV[1])
+
+    if not command then
+        return 0
+    end
+
+    redis.call('HSET', KEYS[2], ARGV[1], command)
+    redis.call('HDEL', KEYS[1], ARGV[1])
+
+    return 1
+    LUA;
 
     public function __construct(
         private Redis $redis,
@@ -23,80 +44,105 @@ final class RedisCommandRepository implements CommandRepository
 
     public function store(string $uuid, object $command): void
     {
-        $this->redis->set(
-            key: self::PENDING_PREFIX . $uuid,
-            value: serialize($command),
-        );
+        $this->redis->command('HSET', self::PENDING_KEY, $uuid, serialize($command));
     }
 
     public function getPendingCommands(): array
     {
         $commands = [];
-        $cursor = '0';
 
-        do {
-            /** @var array<int,string> $keys */
-            [$cursor, $keys] = $this->redis->command('SCAN', $cursor, 'MATCH', self::PENDING_PREFIX . '*', 'COUNT', '100');
+        foreach ($this->scanHash(self::PENDING_KEY) as $uuid => $payload) {
+            $command = $this->unserializeCommand($payload);
 
-            foreach ($keys as $key) {
-                $value = $this->redis->get($key);
-
-                if (! is_string($value)) {
-                    continue;
-                }
-
-                try {
-                    $command = unserialize($value);
-                } catch (Throwable) {
-                    continue;
-                }
-
-                if (! is_object($command)) {
-                    continue;
-                }
-
-                $uuid = after_first($key, self::PENDING_PREFIX);
-                $commands[$uuid] = $command;
+            if ($command === null) {
+                continue;
             }
-        } while ($cursor !== '0');
+
+            $commands[$uuid] = $command;
+        }
 
         return $commands;
     }
 
     public function findPendingCommand(string $uuid): object
     {
-        $value = $this->redis->get(self::PENDING_PREFIX . $uuid);
+        $value = $this->redis->command('HGET', self::PENDING_KEY, $uuid);
 
         if (! is_string($value)) {
             throw new PendingCommandCouldNotBeResolved($uuid);
         }
 
-        try {
-            $command = unserialize($value);
-        } catch (Throwable) {
-            throw new PendingCommandCouldNotBeResolved($uuid);
-        }
-
-        if (! is_object($command)) {
-            throw new PendingCommandCouldNotBeResolved($uuid);
-        }
-
-        return $command;
+        return $this->unserializeCommand($value) ?? throw new PendingCommandCouldNotBeResolved($uuid);
     }
 
     public function markAsDone(string $uuid): void
     {
-        $this->redis->command('UNLINK', self::PENDING_PREFIX . $uuid);
+        $this->redis->command('HDEL', self::PENDING_KEY, $uuid);
     }
 
     public function markAsFailed(string $uuid): void
     {
-        $pendingKey = self::PENDING_PREFIX . $uuid;
+        $this->redis->command('EVAL', self::MARK_AS_FAILED_SCRIPT, '2', self::PENDING_KEY, self::FAILED_KEY, $uuid);
+    }
 
-        if (! $this->redis->command('EXISTS', $pendingKey)) {
-            return;
+    /**
+     * Reads a hash in batches, instead of using `HGETALL`, which would make every other client
+     * wait while Redis reads a large backlog.
+     *
+     * @return iterable<string, string>
+     */
+    private function scanHash(string $key): iterable
+    {
+        $cursor = '0';
+
+        do {
+            $response = $this->redis->command('HSCAN', $key, $cursor, 'COUNT', self::SCAN_COUNT);
+
+            if (! is_array($response) || count($response) !== 2) {
+                return;
+            }
+
+            [$cursor, $fields] = $response;
+
+            yield from $this->parseHash($fields);
+        } while ((string) $cursor !== '0');
+    }
+
+    /**
+     * The clients pass raw commands straight through, so a hash comes back as a flat list:
+     * field, value, field, value. This pairs them up again.
+     *
+     * @return array<string, string>
+     */
+    private function parseHash(mixed $fields): array
+    {
+        if (! is_array($fields)) {
+            return [];
         }
 
-        $this->redis->command('RENAME', $pendingKey, self::FAILED_PREFIX . $uuid);
+        if (! array_is_list($fields)) {
+            return $fields;
+        }
+
+        $hash = [];
+
+        for ($i = 0; $i < (count($fields) - 1); $i += 2) {
+            $hash[$fields[$i]] = $fields[$i + 1];
+        }
+
+        return $hash;
+    }
+
+    private function unserializeCommand(string $value): ?object
+    {
+        try {
+            // A corrupted payload warns and returns `false` instead of throwing, but a custom
+            // `__wakeup()` or `__unserialize()` can still throw
+            $command = @unserialize($value);
+        } catch (Throwable) {
+            return null;
+        }
+
+        return is_object($command) ? $command : null;
     }
 }

--- a/packages/command-bus/src/AsyncCommandRepositories/RedisCommandRepository.php
+++ b/packages/command-bus/src/AsyncCommandRepositories/RedisCommandRepository.php
@@ -16,6 +16,13 @@ final readonly class RedisCommandRepository implements CommandRepository
     private const string FAILED_KEY = 'command:failed';
 
     /**
+     * Set once the old one key per command layout has been migrated, so the keyspace is scanned once.
+     *
+     * @deprecated Remove in 4.0, along with the key itself.
+     */
+    private const string MIGRATION_KEY = 'command:migrated';
+
+    /**
      * How many fields to read per `HSCAN` batch. Bigger batches mean fewer round trips but larger
      * replies; 500 measured as a good middle ground.
      */
@@ -34,6 +41,24 @@ final readonly class RedisCommandRepository implements CommandRepository
 
     redis.call('HSET', KEYS[2], ARGV[1], command)
     redis.call('HDEL', KEYS[1], ARGV[1])
+
+    return 1
+    LUA;
+
+    /**
+     * Moves one command from its own key into the matching hash, as a script so it ends up in exactly one.
+     *
+     * @deprecated Remove in 4.0.
+     */
+    private const string MIGRATE_COMMAND_SCRIPT = <<<'LUA'
+    local command = redis.call('GET', KEYS[1])
+
+    if not command then
+        return 0
+    end
+
+    redis.call('HSET', KEYS[2], ARGV[1], command)
+    redis.call('UNLINK', KEYS[1])
 
     return 1
     LUA;
@@ -83,6 +108,54 @@ final readonly class RedisCommandRepository implements CommandRepository
     public function markAsFailed(string $uuid): void
     {
         $this->redis->command('EVAL', self::MARK_AS_FAILED_SCRIPT, '2', self::PENDING_KEY, self::FAILED_KEY, $uuid);
+    }
+
+    /**
+     * Moves commands that earlier versions stored under their own key into the hashes, and returns how many.
+     *
+     * @deprecated Remove in 4.0.
+     */
+    public function migrateStoredCommands(): int
+    {
+        if ((int) $this->redis->command('EXISTS', self::MIGRATION_KEY) === 1) {
+            return 0;
+        }
+
+        $migrated = $this->migrateLegacyKeys(self::PENDING_KEY) + $this->migrateLegacyKeys(self::FAILED_KEY);
+
+        $this->redis->command('SET', self::MIGRATION_KEY, '1');
+
+        return $migrated;
+    }
+
+    /**
+     * Scans from the client, since Redis before 7 refuses to write after a `SCAN`.
+     *
+     * @deprecated Remove in 4.0.
+     */
+    private function migrateLegacyKeys(string $hash): int
+    {
+        $prefix = $hash . ':';
+        $migrated = 0;
+        $cursor = '0';
+
+        do {
+            $response = $this->redis->command('SCAN', $cursor, 'MATCH', $prefix . '*', 'COUNT', self::SCAN_COUNT);
+
+            if (! is_array($response) || count($response) !== 2) {
+                return $migrated;
+            }
+
+            [$cursor, $keys] = $response;
+
+            foreach (is_array($keys) ? $keys : [] as $key) {
+                $uuid = substr((string) $key, strlen($prefix));
+
+                $migrated += (int) $this->redis->command('EVAL', self::MIGRATE_COMMAND_SCRIPT, '2', (string) $key, $hash, $uuid);
+            }
+        } while ((string) $cursor !== '0');
+
+        return $migrated;
     }
 
     /**

--- a/packages/command-bus/src/MonitorAsyncCommands.php
+++ b/packages/command-bus/src/MonitorAsyncCommands.php
@@ -6,6 +6,7 @@ namespace Tempest\CommandBus;
 
 use DateTimeImmutable;
 use Symfony\Component\Process\Process;
+use Tempest\CommandBus\AsyncCommandRepositories\RedisCommandRepository;
 use Tempest\Console\Console;
 use Tempest\Console\ConsoleCommand;
 use Tempest\Console\HasConsole;
@@ -27,6 +28,8 @@ if (class_exists(ConsoleCommand::class)) {
         #[ConsoleCommand(name: 'command:monitor', description: 'Monitors and executes pending async commands')]
         public function __invoke(): void
         {
+            $this->migrateStoredCommands();
+
             $this->info('Monitoring for new commands. Press <em>Ctrl+C</em> to stop.');
             $this->writeln();
 
@@ -101,6 +104,26 @@ if (class_exists(ConsoleCommand::class)) {
 
                 $processes[$uuid] = $process;
             }
+        }
+
+        /**
+         * Moves Redis commands stored by an older version over, on the first start after the upgrade.
+         *
+         * @deprecated Remove in 4.0.
+         */
+        private function migrateStoredCommands(): void
+        {
+            if (! $this->repository instanceof RedisCommandRepository) {
+                return;
+            }
+
+            $migrated = $this->repository->migrateStoredCommands();
+
+            if ($migrated === 0) {
+                return;
+            }
+
+            $this->info("Migrated <em>{$migrated}</em> stored commands to the current storage format.");
         }
 
         private function sleep(float $seconds): void

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
         displayDetailsOnTestsThatTriggerErrors="true"
         displayDetailsOnTestsThatTriggerNotices="true"
         displayDetailsOnTestsThatTriggerWarnings="true"
+        failOnWarning="true"
         bootstrap="./tests/bootstrap.php"
         cacheDirectory=".cache/phpunit"
 >

--- a/tests/Integration/CommandBus/RedisCommandRepositoryTest.php
+++ b/tests/Integration/CommandBus/RedisCommandRepositoryTest.php
@@ -85,4 +85,99 @@ final class RedisCommandRepositoryTest extends FrameworkIntegrationTestCase
         $this->expectException(PendingCommandCouldNotBeResolved::class);
         $repository->findPendingCommand($uuid);
     }
+
+    #[Test]
+    public function stores_all_pending_commands_in_a_single_hash(): void
+    {
+        $repository = $this->container->get(RedisCommandRepository::class);
+        $redis = $this->container->get(Redis::class);
+
+        $repository->store($first = uuid(), new MyCommand());
+        $repository->store($second = uuid(), new MyCommand());
+
+        $this->assertSame(2, (int) $redis->command('HLEN', 'command:pending'));
+
+        // `HSCAN` does not promise any order once the hash grows past a certain size
+        $this->assertEqualsCanonicalizing([$first, $second], array_keys($repository->getPendingCommands()));
+    }
+
+    #[Test]
+    public function retrieves_a_backlog_larger_than_a_single_scan_batch(): void
+    {
+        $repository = $this->container->get(RedisCommandRepository::class);
+
+        $uuids = [];
+
+        // Redis treats `COUNT` as a hint, so this just needs to be well above the batch size to
+        // make sure the scan takes more than one round
+        for ($i = 0; $i < 1_200; $i++) {
+            $repository->store($uuids[] = uuid(), new MyCommand());
+        }
+
+        $this->assertEqualsCanonicalizing($uuids, array_keys($repository->getPendingCommands()));
+    }
+
+    #[Test]
+    public function marking_as_failed_moves_the_command_to_the_failed_hash(): void
+    {
+        $repository = $this->container->get(RedisCommandRepository::class);
+        $redis = $this->container->get(Redis::class);
+
+        $repository->store($uuid = uuid(), $command = new MyCommand());
+        $repository->markAsFailed($uuid);
+
+        $this->assertSame(0, (int) $redis->command('HEXISTS', 'command:pending', $uuid));
+        $this->assertEquals($command, unserialize($redis->command('HGET', 'command:failed', $uuid)));
+    }
+
+    #[Test]
+    public function marking_an_unknown_command_as_failed_does_nothing(): void
+    {
+        $repository = $this->container->get(RedisCommandRepository::class);
+        $redis = $this->container->get(Redis::class);
+
+        $repository->markAsFailed(uuid());
+
+        $this->assertSame(0, (int) $redis->command('EXISTS', 'command:failed'));
+    }
+
+    #[Test]
+    public function ignores_unrelated_keys(): void
+    {
+        $repository = $this->container->get(RedisCommandRepository::class);
+        $redis = $this->container->get(Redis::class);
+
+        $redis->set('cache:unrelated', 'value');
+        $repository->store($uuid = uuid(), new MyCommand());
+
+        $this->assertSame([$uuid], array_keys($repository->getPendingCommands()));
+        $this->assertSame('value', $redis->get('cache:unrelated'));
+    }
+
+    #[Test]
+    public function skips_commands_that_cannot_be_unserialized(): void
+    {
+        $repository = $this->container->get(RedisCommandRepository::class);
+        $redis = $this->container->get(Redis::class);
+
+        $redis->command('HSET', 'command:pending', $corrupted = uuid(), 'not-a-serialized-command');
+        $repository->store($uuid = uuid(), new MyCommand());
+
+        $pending = $repository->getPendingCommands();
+
+        $this->assertArrayHasKey($uuid, $pending);
+        $this->assertArrayNotHasKey($corrupted, $pending);
+    }
+
+    #[Test]
+    public function cant_find_a_command_that_cannot_be_unserialized(): void
+    {
+        $repository = $this->container->get(RedisCommandRepository::class);
+        $redis = $this->container->get(Redis::class);
+
+        $redis->command('HSET', 'command:pending', $uuid = uuid(), 'not-a-serialized-command');
+
+        $this->expectException(PendingCommandCouldNotBeResolved::class);
+        $repository->findPendingCommand($uuid);
+    }
 }

--- a/tests/Integration/CommandBus/RedisCommandRepositoryTest.php
+++ b/tests/Integration/CommandBus/RedisCommandRepositoryTest.php
@@ -149,6 +149,51 @@ final class RedisCommandRepositoryTest extends FrameworkIntegrationTestCase
         $this->assertArrayNotHasKey($corrupted, $pending);
     }
 
+    /**
+     * @deprecated Remove in 4.0, together with the migration itself.
+     */
+    #[Test]
+    public function migrates_commands_stored_under_their_own_key(): void
+    {
+        $this->redis->command('SET', 'command:pending:' . ($pending = uuid()), serialize($command = new MyCommand()));
+        $this->redis->command('SET', 'command:failed:' . ($failed = uuid()), serialize(new MyCommand()));
+
+        $this->assertSame(2, $this->repository->migrateStoredCommands());
+
+        $this->assertSame(0, (int) $this->redis->command('EXISTS', 'command:pending:' . $pending));
+        $this->assertSame(0, (int) $this->redis->command('EXISTS', 'command:failed:' . $failed));
+
+        $this->assertEquals([$pending => $command], $this->repository->getPendingCommands());
+        $this->assertSame(1, (int) $this->redis->command('HEXISTS', 'command:failed', $failed));
+    }
+
+    /**
+     * @deprecated Remove in 4.0, together with the migration itself.
+     */
+    #[Test]
+    public function migrating_leaves_commands_already_stored_in_the_hash_alone(): void
+    {
+        $this->repository->store($uuid = uuid(), $command = new MyCommand());
+
+        $this->assertSame(0, $this->repository->migrateStoredCommands());
+        $this->assertEquals([$uuid => $command], $this->repository->getPendingCommands());
+    }
+
+    /**
+     * @deprecated Remove in 4.0, together with the migration itself.
+     */
+    #[Test]
+    public function migrating_only_scans_the_keyspace_once(): void
+    {
+        $this->assertSame(0, $this->repository->migrateStoredCommands());
+
+        // Not picked up again, which is what keeps later boots from walking the keyspace
+        $this->redis->command('SET', 'command:pending:' . ($uuid = uuid()), serialize(new MyCommand()));
+
+        $this->assertSame(0, $this->repository->migrateStoredCommands());
+        $this->assertSame(1, (int) $this->redis->command('EXISTS', 'command:pending:' . $uuid));
+    }
+
     #[Test]
     public function cant_find_a_command_that_cannot_be_unserialized(): void
     {

--- a/tests/Integration/CommandBus/RedisCommandRepositoryTest.php
+++ b/tests/Integration/CommandBus/RedisCommandRepositoryTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\PreCondition;
 use PHPUnit\Framework\Attributes\Test;
 use Tempest\CommandBus\AsyncCommandRepositories\RedisCommandRepository;
 use Tempest\CommandBus\Exceptions\PendingCommandCouldNotBeResolved;
+use Tempest\KeyValue\Redis\Config\RedisConfig;
 use Tempest\KeyValue\Redis\Redis;
 use Tests\Tempest\Fixtures\Commands\MyCommand;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
@@ -21,11 +22,26 @@ use function Tempest\Support\Random\uuid;
  */
 final class RedisCommandRepositoryTest extends FrameworkIntegrationTestCase
 {
+    private Redis $redis;
+
+    private RedisCommandRepository $repository;
+
     #[PreCondition]
     protected function configure(): void
     {
+        $this->eventBus->preventEventHandling();
+
+        $this->container->config(new RedisConfig(
+            prefix: 'tempest_test:',
+            database: 6,
+            connectionTimeOut: .2,
+        ));
+
+        $this->redis = $this->container->get(Redis::class);
+        $this->repository = $this->container->get(RedisCommandRepository::class);
+
         try {
-            $this->container->get(Redis::class)->connect();
+            $this->redis->connect();
         } catch (Throwable) {
             $this->markTestSkipped('Could not connect to Redis.');
         }
@@ -35,7 +51,7 @@ final class RedisCommandRepositoryTest extends FrameworkIntegrationTestCase
     protected function cleanup(): void
     {
         try {
-            $this->container->get(Redis::class)->flush();
+            $this->redis->flush();
         } catch (Throwable) { // @mago-expect lint:no-empty-catch-clause
         }
     }
@@ -43,127 +59,91 @@ final class RedisCommandRepositoryTest extends FrameworkIntegrationTestCase
     #[Test]
     public function store_and_retrieve(): void
     {
-        $repository = $this->container->get(RedisCommandRepository::class);
         $command = new MyCommand();
 
-        $repository->store($uuid = uuid(), $command);
+        $this->repository->store($uuid = uuid(), $command);
 
-        $pending = $repository->getPendingCommands();
+        $pending = $this->repository->getPendingCommands();
         $this->assertArrayHasKey($uuid, $pending);
         $this->assertEquals($command, $pending[$uuid]);
-        $this->assertEquals($command, $repository->findPendingCommand($uuid));
+        $this->assertEquals($command, $this->repository->findPendingCommand($uuid));
 
-        $repository->markAsFailed($uuid);
-        $this->assertArrayNotHasKey($uuid, $repository->getPendingCommands());
+        $this->repository->markAsFailed($uuid);
+        $this->assertArrayNotHasKey($uuid, $this->repository->getPendingCommands());
 
         $this->expectException(PendingCommandCouldNotBeResolved::class);
-        $repository->findPendingCommand($uuid);
+        $this->repository->findPendingCommand($uuid);
     }
 
     #[Test]
     public function marking_as_done_removes_record(): void
     {
-        $repository = $this->container->get(RedisCommandRepository::class);
-        $command = new MyCommand();
+        $this->repository->store($uuid = uuid(), new MyCommand());
+        $this->assertArrayHasKey($uuid, $this->repository->getPendingCommands());
 
-        $repository->store($uuid = uuid(), $command);
-        $pending = $repository->getPendingCommands();
-        $this->assertArrayHasKey($uuid, $pending);
+        $this->repository->markAsDone($uuid);
 
-        $repository->markAsDone($uuid);
-
-        $this->assertArrayNotHasKey($uuid, $repository->getPendingCommands());
+        $this->assertArrayNotHasKey($uuid, $this->repository->getPendingCommands());
     }
 
     #[Test]
     public function cant_find_not_stored_command(): void
     {
-        $repository = $this->container->get(RedisCommandRepository::class);
-
-        $uuid = uuid();
-
         $this->expectException(PendingCommandCouldNotBeResolved::class);
-        $repository->findPendingCommand($uuid);
+        $this->repository->findPendingCommand(uuid());
     }
 
     #[Test]
     public function stores_all_pending_commands_in_a_single_hash(): void
     {
-        $repository = $this->container->get(RedisCommandRepository::class);
-        $redis = $this->container->get(Redis::class);
+        $this->repository->store($first = uuid(), new MyCommand());
+        $this->repository->store($second = uuid(), new MyCommand());
 
-        $repository->store($first = uuid(), new MyCommand());
-        $repository->store($second = uuid(), new MyCommand());
-
-        $this->assertSame(2, (int) $redis->command('HLEN', 'command:pending'));
+        $this->assertSame(2, (int) $this->redis->command('HLEN', 'command:pending'));
 
         // `HSCAN` does not promise any order once the hash grows past a certain size
-        $this->assertEqualsCanonicalizing([$first, $second], array_keys($repository->getPendingCommands()));
+        $this->assertEqualsCanonicalizing([$first, $second], array_keys($this->repository->getPendingCommands()));
     }
 
     #[Test]
     public function retrieves_a_backlog_larger_than_a_single_scan_batch(): void
     {
-        $repository = $this->container->get(RedisCommandRepository::class);
-
         $uuids = [];
 
         // Redis treats `COUNT` as a hint, so this just needs to be well above the batch size to
         // make sure the scan takes more than one round
         for ($i = 0; $i < 1_200; $i++) {
-            $repository->store($uuids[] = uuid(), new MyCommand());
+            $this->repository->store($uuids[] = uuid(), new MyCommand());
         }
 
-        $this->assertEqualsCanonicalizing($uuids, array_keys($repository->getPendingCommands()));
+        $this->assertEqualsCanonicalizing($uuids, array_keys($this->repository->getPendingCommands()));
     }
 
     #[Test]
     public function marking_as_failed_moves_the_command_to_the_failed_hash(): void
     {
-        $repository = $this->container->get(RedisCommandRepository::class);
-        $redis = $this->container->get(Redis::class);
+        $this->repository->store($uuid = uuid(), $command = new MyCommand());
+        $this->repository->markAsFailed($uuid);
 
-        $repository->store($uuid = uuid(), $command = new MyCommand());
-        $repository->markAsFailed($uuid);
-
-        $this->assertSame(0, (int) $redis->command('HEXISTS', 'command:pending', $uuid));
-        $this->assertEquals($command, unserialize($redis->command('HGET', 'command:failed', $uuid)));
+        $this->assertSame(0, (int) $this->redis->command('HEXISTS', 'command:pending', $uuid));
+        $this->assertEquals($command, unserialize($this->redis->command('HGET', 'command:failed', $uuid)));
     }
 
     #[Test]
     public function marking_an_unknown_command_as_failed_does_nothing(): void
     {
-        $repository = $this->container->get(RedisCommandRepository::class);
-        $redis = $this->container->get(Redis::class);
+        $this->repository->markAsFailed(uuid());
 
-        $repository->markAsFailed(uuid());
-
-        $this->assertSame(0, (int) $redis->command('EXISTS', 'command:failed'));
-    }
-
-    #[Test]
-    public function ignores_unrelated_keys(): void
-    {
-        $repository = $this->container->get(RedisCommandRepository::class);
-        $redis = $this->container->get(Redis::class);
-
-        $redis->set('cache:unrelated', 'value');
-        $repository->store($uuid = uuid(), new MyCommand());
-
-        $this->assertSame([$uuid], array_keys($repository->getPendingCommands()));
-        $this->assertSame('value', $redis->get('cache:unrelated'));
+        $this->assertSame(0, (int) $this->redis->command('EXISTS', 'command:failed'));
     }
 
     #[Test]
     public function skips_commands_that_cannot_be_unserialized(): void
     {
-        $repository = $this->container->get(RedisCommandRepository::class);
-        $redis = $this->container->get(Redis::class);
+        $this->redis->command('HSET', 'command:pending', $corrupted = uuid(), 'not-a-serialized-command');
+        $this->repository->store($uuid = uuid(), new MyCommand());
 
-        $redis->command('HSET', 'command:pending', $corrupted = uuid(), 'not-a-serialized-command');
-        $repository->store($uuid = uuid(), new MyCommand());
-
-        $pending = $repository->getPendingCommands();
+        $pending = $this->repository->getPendingCommands();
 
         $this->assertArrayHasKey($uuid, $pending);
         $this->assertArrayNotHasKey($corrupted, $pending);
@@ -172,12 +152,9 @@ final class RedisCommandRepositoryTest extends FrameworkIntegrationTestCase
     #[Test]
     public function cant_find_a_command_that_cannot_be_unserialized(): void
     {
-        $repository = $this->container->get(RedisCommandRepository::class);
-        $redis = $this->container->get(Redis::class);
-
-        $redis->command('HSET', 'command:pending', $uuid = uuid(), 'not-a-serialized-command');
+        $this->redis->command('HSET', 'command:pending', $uuid = uuid(), 'not-a-serialized-command');
 
         $this->expectException(PendingCommandCouldNotBeResolved::class);
-        $repository->findPendingCommand($uuid);
+        $this->repository->findPendingCommand($uuid);
     }
 }


### PR DESCRIPTION
Follow-up on https://github.com/tempestphp/tempest-framework/pull/2247 (redis implementation). `RedisCommandRepository` kept one key per command, so every read ran `SCAN ... MATCH command:pending:*` - which walks **every key in Redis**. `command:monitor` does that twice a second, and `kv-store` shares one Redis with the cache, so most of the work was stepping over unrelated cache keys.

Pending and failed commands now live in one hash each, read with `HSCAN`. The public `CommandRepository` interface is unchanged.

| Operation              | Before                          | After                               |
| ---------------------- | ------------------------------- | ----------------------------------- |
| `store()`              | `SET command:pending:{uuid}`    | `HSET`                              |
| `getPendingCommands()` | `SCAN` + one `GET` per command  | `HSCAN` loop (`COUNT 500`)          |
| `findPendingCommand()` | `GET command:pending:{uuid}`    | `HGET`                              |
| `markAsDone()`         | `UNLINK command:pending:{uuid}` | `HDEL`                              |
| `markAsFailed()`       | `EXISTS` + `RENAME`             | Lua script (`HGET` + `HSET`/`HDEL`) |

Two fixes came along with it:

- `markAsFailed()` sent `EXISTS` then `RENAME` as two calls, and threw if a `markAsDone()` landed in between. It is now one script.
- `unserialize()` warns and returns `false` on a corrupted payload rather than throwing, so the old `catch (Throwable)` never caught anything. Handled in `unserializeCommand()`, with `failOnWarning="true"` added to `phpunit.xml.dist`.

## Benchmarks

| Pending | Unrelated keys | Before      | After    | Speedup  |
| ------- | -------------- | ----------- | -------- | -------- |
| 100     | 0              | 55.09 ms    | 0.71 ms  | **78×**  |
| 1,000   | 0              | 542.08 ms   | 3.38 ms  | **160×** |
| 10,000  | 0              | 5,344.95 ms | 35.24 ms | **152×** |
| 1,000   | 100,000        | 1,083.15 ms | 3.11 ms  | **348×** |

Rows 2 and 4 are the point: same backlog, but 100,000 unrelated cache keys make the old version twice as slow.

_Redis 7 in Docker on macOS, median of 15 runs, ~0.5 ms round trip._

<details>
<summary>redis-command-repository-bench.php</summary>

Requires `ext-redis` and a throwaway Redis server on `127.0.0.1:6399` (**calls `FLUSHALL`**):

```bash
docker run --rm -p 6399:6379 redis:7-alpine
php redis-command-repository-bench.php
```

```php
<?php

declare(strict_types=1);

final class DummyCommand
{
    public function __construct(
        public string $id,
        public array $payload,
    ) {}
}

const HASH_KEY = 'command:pending';

function connect(): Redis
{
    $r = new Redis();
    $r->connect('127.0.0.1', 6399, 3);

    return $r;
}

function seed(Redis $r, int $pending, int $noise): void
{
    $r->flushAll();

    $pipe = $r->multi(Redis::PIPELINE);

    for ($i = 0; $i < $pending; $i++) {
        $uuid = sprintf('%08x-0000-4000-8000-%012x', $i, $i);
        $value = serialize(new DummyCommand($uuid, ['attempt' => 1, 'data' => str_repeat('x', 64)]));

        $pipe->set('command:pending:' . $uuid, $value);
        $pipe->hSet(HASH_KEY, $uuid, $value);
    }

    for ($i = 0; $i < $noise; $i++) {
        $pipe->set('cache:some:other:key:' . $i, 'noise');
    }

    $pipe->exec();
}

// Old implementation: SCAN over the keyspace + one GET per match.
function readCurrent(Redis $r): int
{
    $commands = [];
    $cursor = null;

    while (($keys = $r->scan($cursor, 'command:pending:*', 100)) !== false) {
        foreach ($keys as $key) {
            $value = $r->get($key);

            if (! is_string($value)) {
                continue;
            }

            $command = @unserialize($value);

            if (! is_object($command)) {
                continue;
            }

            $commands[substr($key, strlen('command:pending:'))] = $command;
        }

        if ((int) $cursor === 0) {
            break;
        }
    }

    return count($commands);
}

// Shipped implementation: incremental HSCAN over a single hash.
function readHscan(Redis $r): int
{
    $commands = [];
    $cursor = null;

    while (($fields = $r->hScan(HASH_KEY, $cursor, null, 500)) !== false) {
        foreach ($fields as $uuid => $value) {
            $command = @unserialize($value);

            if (! is_object($command)) {
                continue;
            }

            $commands[$uuid] = $command;
        }

        if ((int) $cursor === 0) {
            break;
        }
    }

    return count($commands);
}

// Rejected variant, kept to show what the incremental read costs.
function readHgetall(Redis $r): int
{
    $commands = [];

    foreach ($r->hGetAll(HASH_KEY) as $uuid => $value) {
        $command = @unserialize($value);

        if (! is_object($command)) {
            continue;
        }

        $commands[$uuid] = $command;
    }

    return count($commands);
}

function bench(callable $fn, Redis $r, int $runs): float
{
    $fn($r); // warm up

    $times = [];

    for ($i = 0; $i < $runs; $i++) {
        $start = hrtime(true);
        $fn($r);
        $times[] = (hrtime(true) - $start) / 1e6;
    }

    sort($times);

    return $times[intdiv(count($times), 2)]; // median, in ms
}

$redis = connect();
$runs = 15;

$scenarios = [[100, 0], [1_000, 0], [10_000, 0], [1_000, 100_000]];

printf("%-10s %-10s %12s %12s %12s %10s %8s\n", 'pending', 'noise', 'scan (ms)', 'hgetall (ms)', 'hscan (ms)', 'speedup', 'found');

foreach ($scenarios as [$pending, $noise]) {
    seed($redis, $pending, $noise);

    $found = readHscan($redis);
    $current = bench('readCurrent', $redis, $runs);
    $hgetall = bench('readHgetall', $redis, $runs);
    $hscan = bench('readHscan', $redis, $runs);

    printf(
        "%-10s %-10s %12.2f %12.2f %12.2f %9.1fx %8d\n",
        number_format($pending),
        number_format($noise),
        $current,
        $hgetall,
        $hscan,
        $current / $hscan,
        $found,
    );
}

$redis->flushAll();
```

</details>

## Migration

Needed only if the queue isn't empty when you deploy:

```bash
# `command:pending:{uuid}` string keys become fields of the `command:pending` hash
migrate() {
  redis-cli --scan --pattern "$1:*" | while read -r key; do
    redis-cli EVAL '
      local value = redis.call("GET", KEYS[1])
      if not value then return 0 end
      redis.call("HSET", KEYS[2], ARGV[1], value)
      redis.call("UNLINK", KEYS[1])
      return 1
    ' 2 "$key" "$1" "${key#"$1":}"
  done
}

migrate command:pending
migrate command:failed
```

_Scanning is client-side so each move stays atomic without a script that blocks the server, and
also because Redis before 7 refuses to write after a `SCAN`._

## Notes

- **Went with `HSCAN` instead `HGETALL`.** `HGETALL` is ~2× faster, but it reads the whole hash in one command, and Redis is single threaded - a big backlog makes every other client wait. `HSCAN` reads in batches of 500 that others can be served between.
- **No per-command TTLs.** Hash fields can't expire individually before Redis 7.4. The old keys had no TTL either.
- **Still no way to claim a command,** so a killed monitor leaves a command pending forever. Equally true before this PR; fixing it means a breaking interface change, so it needs its own RFC.

## Tests

Integration tests alongside the three existing ones, which now share a pinned Redis database, hoisted fixtures, and suppressed event handling: the single-hash layout, the atomic move to the failed hash, marking an unknown uuid as failed, corrupted payloads on both read paths, and a 1,200-command backlog that forces `HSCAN` through more than one batch. Skipped when Redis isn't reachable.

