### PR TITLE
perf(mapper): cache per-class reflection plans during hydration

### DIFF
--- a/packages/auth/tests/OAuthTest.php
+++ b/packages/auth/tests/OAuthTest.php
@@ -26,6 +26,7 @@ use Tempest\Auth\OAuth\OAuthClientInitializer;
 use Tempest\Auth\OAuth\OAuthUser;
 use Tempest\Container\Container;
 use Tempest\Container\GenericContainer;
+use Tempest\Mapper\MapperCache;
 use Tempest\Mapper\MapperConfig;
 use Tempest\Mapper\Mappers\ArrayToObjectMapper;
 use Tempest\Mapper\ObjectFactory;
@@ -37,7 +38,7 @@ final class OAuthTest extends TestCase
     }
 
     private ObjectFactory $factory {
-        get => $this->factory ??= new ObjectFactory(new MapperConfig([ArrayToObjectMapper::class]), $this->container);
+        get => $this->factory ??= new ObjectFactory(new MapperConfig([ArrayToObjectMapper::class]), $this->container, new MapperCache());
     }
 
     #[Before]

--- a/packages/database/src/Builder/ModelInspector.php
+++ b/packages/database/src/Builder/ModelInspector.php
@@ -741,7 +741,7 @@ final class ModelInspector
 
     public function getPrimaryKeyProperty(): ?PropertyReflector
     {
-        return $this->memoize('primary_key_property', fn () => $this->resolvePrimaryKeyProperty());
+        return $this->memoize('primary_key_property', $this->resolvePrimaryKeyProperty(...));
     }
 
     private function resolvePrimaryKeyProperty(): ?PropertyReflector

--- a/packages/database/src/Builder/ModelInspector.php
+++ b/packages/database/src/Builder/ModelInspector.php
@@ -741,6 +741,11 @@ final class ModelInspector
 
     public function getPrimaryKeyProperty(): ?PropertyReflector
     {
+        return $this->memoize('primary_key_property', fn () => $this->resolvePrimaryKeyProperty());
+    }
+
+    private function resolvePrimaryKeyProperty(): ?PropertyReflector
+    {
         if (! $this->isObjectModel()) {
             return null;
         }

--- a/packages/mapper/src/MapperCache.php
+++ b/packages/mapper/src/MapperCache.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Mapper;
+
+use Tempest\Container\Resettable;
+use Tempest\Container\Singleton;
+
+/**
+ * Caches the mapper instances that were resolved for a given mapping context.
+ *
+ * Scoped to a container rather than a static. Mappers therefore cannot leak between containers, and
+ * resetting keeps workers from holding on to mappers built from dependencies that were unregistered.
+ */
+#[Singleton]
+final class MapperCache implements Resettable
+{
+    /** @var array<string, \Tempest\Mapper\Mapper[]> */
+    private array $mappers = [];
+
+    /**
+     * @param callable(): \Tempest\Mapper\Mapper[] $resolve
+     * @return \Tempest\Mapper\Mapper[]
+     */
+    public function resolve(Context $context, callable $resolve): array
+    {
+        return $this->mappers[$context->name] ??= $resolve();
+    }
+
+    public function reset(): void
+    {
+        $this->mappers = [];
+    }
+}

--- a/packages/mapper/src/MapperCache.php
+++ b/packages/mapper/src/MapperCache.php
@@ -6,6 +6,7 @@ namespace Tempest\Mapper;
 
 use Tempest\Container\Resettable;
 use Tempest\Container\Singleton;
+use WeakMap;
 
 /**
  * Caches the mapper instances that were resolved for a given mapping context.
@@ -19,17 +20,32 @@ final class MapperCache implements Resettable
     /** @var array<string, \Tempest\Mapper\Mapper[]> */
     private array $mappers = [];
 
+    /** @var WeakMap<Context, \Tempest\Mapper\Mapper[]> */
+    private WeakMap $contextualMappers;
+
+    public function __construct()
+    {
+        $this->contextualMappers = new WeakMap();
+    }
+
     /**
      * @param callable(): \Tempest\Mapper\Mapper[] $resolve
      * @return \Tempest\Mapper\Mapper[]
      */
     public function resolve(Context $context, callable $resolve): array
     {
+        // A `MappingContext` holds only a name, allowing its mappers to be shared by name.
+        // Other contexts may carry payload data, so they are keyed by instance.
+        if (! $context instanceof MappingContext) {
+            return $this->contextualMappers[$context] ??= $resolve();
+        }
+
         return $this->mappers[$context->name] ??= $resolve();
     }
 
     public function reset(): void
     {
         $this->mappers = [];
+        $this->contextualMappers = new WeakMap();
     }
 }

--- a/packages/mapper/src/Mappers/ArrayToObjectMapper.php
+++ b/packages/mapper/src/Mappers/ArrayToObjectMapper.php
@@ -135,45 +135,67 @@ final class ArrayToObjectMapper implements Mapper
 
     private function setParentRelations(object $parent, ClassReflector $parentClass): void
     {
-        foreach ($parentClass->getPublicProperties() as $property) {
+        static $plans = [];
+
+        $plan = $plans[$parentClass->getName()] ??= array_filter(array_map(
+            function (PropertyReflector $property): ?array {
+                if ($property->isVirtual()) {
+                    return null;
+                }
+
+                $type = $property->getIterableType() ?? $property->getType();
+
+                if (! $type->isClass()) {
+                    return null;
+                }
+
+                return [$property, $type->asClass()];
+            },
+            $parentClass->getPublicProperties(),
+        ));
+
+        foreach ($plan as [$property, $childClass]) {
             if (! $property->isInitialized($parent)) {
-                continue;
-            }
-
-            if ($property->isVirtual()) {
-                continue;
-            }
-
-            $type = $property->getIterableType() ?? $property->getType();
-
-            if (! $type->isClass()) {
                 continue;
             }
 
             $child = $property->getValue($parent);
 
-            if ($child === null) {
+            if ($child === null || $child === []) {
                 continue;
             }
 
-            $this->setChildParentRelation($parent, $child, $type->asClass());
+            $this->setChildParentRelation($parent, $child, $childClass);
         }
     }
 
     private function setChildParentRelation(object $parent, mixed $child, ClassReflector $childClass): void
     {
-        foreach ($childClass->getPublicProperties() as $childProperty) {
-            if ($childProperty->isVirtual()) {
-                continue;
-            }
+        static $plans = [];
 
-            if ($childProperty->getType()->equals($parent::class)) {
-                $valueToSet = $parent;
-            } elseif ($childProperty->getIterableType()?->equals($parent::class)) {
-                $valueToSet = [$parent];
-            } else {
-                continue;
-            }
+        $key = $childClass->getName() . '|' . $parent::class;
+
+        $plan = $plans[$key] ??= array_filter(array_map(
+            function (PropertyReflector $childProperty) use ($parent): ?array {
+                if ($childProperty->isVirtual()) {
+                    return null;
+                }
+
+                if ($childProperty->getType()->equals($parent::class)) {
+                    return [$childProperty, false];
+                }
+
+                if ($childProperty->getIterableType()?->equals($parent::class)) {
+                    return [$childProperty, true];
+                }
+
+                return null;
+            },
+            $childClass->getPublicProperties(),
+        ));
+
+        foreach ($plan as [$childProperty, $wrapInArray]) {
+            $valueToSet = $wrapInArray ? [$parent] : $parent;
 
             if (is_array($child)) {
                 foreach ($child as $childItem) {

--- a/packages/mapper/src/Mappers/ArrayToObjectMapper.php
+++ b/packages/mapper/src/Mappers/ArrayToObjectMapper.php
@@ -137,7 +137,9 @@ final class ArrayToObjectMapper implements Mapper
     {
         static $plans = [];
 
-        $plan = $plans[$parentClass->getName()] ??= array_filter(array_map(
+        $key = $parentClass->getName();
+
+        $plans[$key] ??= array_filter(array_map(
             function (PropertyReflector $property): ?array {
                 if ($property->isVirtual()) {
                     return null;
@@ -154,7 +156,7 @@ final class ArrayToObjectMapper implements Mapper
             $parentClass->getPublicProperties(),
         ));
 
-        foreach ($plan as [$property, $childClass]) {
+        foreach ($plans[$key] as [$property, $childClass]) {
             if (! $property->isInitialized($parent)) {
                 continue;
             }
@@ -175,7 +177,7 @@ final class ArrayToObjectMapper implements Mapper
 
         $key = $childClass->getName() . '|' . $parent::class;
 
-        $plan = $plans[$key] ??= array_filter(array_map(
+        $plans[$key] ??= array_filter(array_map(
             function (PropertyReflector $childProperty) use ($parent): ?array {
                 if ($childProperty->isVirtual()) {
                     return null;
@@ -194,7 +196,7 @@ final class ArrayToObjectMapper implements Mapper
             $childClass->getPublicProperties(),
         ));
 
-        foreach ($plan as [$childProperty, $wrapInArray]) {
+        foreach ($plans[$key] as [$childProperty, $wrapInArray]) {
             $valueToSet = $wrapInArray ? [$parent] : $parent;
 
             if (is_array($child)) {

--- a/packages/mapper/src/ObjectFactory.php
+++ b/packages/mapper/src/ObjectFactory.php
@@ -33,14 +33,15 @@ final class ObjectFactory
     private Context|UnitEnum|string|null $context = null;
 
     /** @var \Tempest\Mapper\Mapper[] */
-    private array $mappers;
+    private array $mappers {
+        get => $this->resolveMappers();
+    }
 
     public function __construct(
         private readonly MapperConfig $config,
         private readonly Container $container,
-    ) {
-        $this->mappers = $this->resolveMappers();
-    }
+        private readonly MapperCache $cache,
+    ) {}
 
     /**
      * Sets the target class for mapping operations.
@@ -112,13 +113,9 @@ final class ObjectFactory
      */
     public function in(Context|UnitEnum|string|null $context): self
     {
-        $clone = clone($this, [
+        return clone($this, [
             'context' => $context,
         ]);
-
-        $clone->mappers = $clone->resolveMappers();
-
-        return $clone;
     }
 
     /**
@@ -369,20 +366,23 @@ final class ObjectFactory
     }
 
     /**
-     * We cache mapper instances within the factory so that we prevent mappers being resolved on every mapping call.
-     * Whenever a mapping context changes, we'll have to re-resolve the mapper classes with the new context.
+     * Mapper instances are cached per context in {@see \Tempest\Mapper\MapperCache}, so that they are not resolved
+     * from the container on every mapping call. Whenever a mapping context changes, we'll have to re-resolve the
+     * mapper classes with the new context.
      */
     private function resolveMappers(): array
     {
-        /** @var Mapper[] $mappers */
-        $mappers = [];
-
         $context = MappingContext::from($this->context);
 
-        foreach ($this->config->mappers as $mapperClass) {
-            $mappers[] = $this->container->get($mapperClass, context: $context);
-        }
+        return $this->cache->resolve($context, function () use ($context): array {
+            /** @var Mapper[] $mappers */
+            $mappers = [];
 
-        return $mappers;
+            foreach ($this->config->mappers as $mapperClass) {
+                $mappers[] = $this->container->get($mapperClass, context: $context);
+            }
+
+            return $mappers;
+        });
     }
 }

--- a/packages/reflection/src/ClassReflector.php
+++ b/packages/reflection/src/ClassReflector.php
@@ -7,6 +7,7 @@ namespace Tempest\Reflection;
 use Closure;
 use ReflectionClass as PHPReflectionClass;
 use ReflectionMethod as PHPReflectionMethod;
+use ReflectionObject as PHPReflectionObject;
 use ReflectionProperty as PHPReflectionProperty;
 
 /**
@@ -65,10 +66,22 @@ final class ClassReflector implements Reflector
     /** @return PropertyReflector[] */
     public function getPublicProperties(): array
     {
+        // A ReflectionObject may expose runtime-added properties, so its property set is
+        // not determined by the class name the cache is keyed on.
+        if ($this->reflectionClass instanceof PHPReflectionObject) {
+            return $this->resolvePublicProperties();
+        }
+
         static $cache = [];
 
-        return $cache[$this->reflectionClass->getName()] ??= array_map(
-            fn (PHPReflectionProperty $property) => new PropertyReflector($property),
+        return $cache[$this->reflectionClass->getName()] ??= $this->resolvePublicProperties();
+    }
+
+    /** @return PropertyReflector[] */
+    private function resolvePublicProperties(): array
+    {
+        return array_map(
+            static fn (PHPReflectionProperty $property) => new PropertyReflector($property),
             $this->reflectionClass->getProperties(PHPReflectionProperty::IS_PUBLIC),
         );
     }

--- a/packages/reflection/src/ClassReflector.php
+++ b/packages/reflection/src/ClassReflector.php
@@ -65,7 +65,9 @@ final class ClassReflector implements Reflector
     /** @return PropertyReflector[] */
     public function getPublicProperties(): array
     {
-        return array_map(
+        static $cache = [];
+
+        return $cache[$this->reflectionClass->getName()] ??= array_map(
             fn (PHPReflectionProperty $property) => new PropertyReflector($property),
             $this->reflectionClass->getProperties(PHPReflectionProperty::IS_PUBLIC),
         );

--- a/packages/reflection/tests/ClassReflectorTest.php
+++ b/packages/reflection/tests/ClassReflectorTest.php
@@ -7,7 +7,9 @@ namespace Tempest\Reflection\Tests;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use ReflectionObject;
 use Tempest\Reflection\ClassReflector;
+use Tempest\Reflection\PropertyReflector;
 use Tempest\Reflection\Tests\Fixtures\ChildWithRecursiveAttribute;
 use Tempest\Reflection\Tests\Fixtures\ClassWithInterfaceWithRecursiveAttribute;
 use Tempest\Reflection\Tests\Fixtures\RecursiveAttribute;
@@ -19,6 +21,22 @@ use Tempest\Reflection\Tests\Fixtures\TestClassB;
  */
 final class ClassReflectorTest extends TestCase
 {
+    #[Test]
+    public function public_properties_are_specific_to_the_reflected_object(): void
+    {
+        $first = new ClassReflector(new ReflectionObject((object) ['first' => 1]));
+        $second = new ClassReflector(new ReflectionObject((object) ['second' => 2]));
+
+        $this->assertSame(['first'], array_map(
+            fn (PropertyReflector $property) => $property->getName(),
+            $first->getPublicProperties(),
+        ));
+        $this->assertSame(['second'], array_map(
+            fn (PropertyReflector $property) => $property->getName(),
+            $second->getPublicProperties(),
+        ));
+    }
+
     #[Test]
     public function getting_underlying_reflection_class(): void
     {

--- a/tests/Benchmark/Mapper/Fixtures/BenchmarkBook.php
+++ b/tests/Benchmark/Mapper/Fixtures/BenchmarkBook.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Benchmark\Mapper\Fixtures;
+
+use DateTimeImmutable;
+
+final class BenchmarkBook
+{
+    public int $id;
+
+    public string $title;
+
+    public string $description;
+
+    public bool $published;
+
+    public float $price;
+
+    public DateTimeImmutable $created_at;
+}

--- a/tests/Benchmark/Mapper/ObjectHydrationBench.php
+++ b/tests/Benchmark/Mapper/ObjectHydrationBench.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Benchmark\Mapper;
+
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\ParamProviders;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+use Tempest\Container\GenericContainer;
+use Tempest\Mapper\CasterFactory;
+use Tempest\Mapper\Casters\BooleanCaster;
+use Tempest\Mapper\Casters\FloatCaster;
+use Tempest\Mapper\Casters\IntegerCaster;
+use Tempest\Mapper\Casters\NativeDateTimeCaster;
+use Tempest\Mapper\MapperCache;
+use Tempest\Mapper\MapperConfig;
+use Tempest\Mapper\Mappers\ArrayToObjectMapper;
+use Tempest\Mapper\Mappers\ObjectToArrayMapper;
+use Tempest\Mapper\ObjectFactory;
+use Tests\Tempest\Benchmark\Mapper\Fixtures\BenchmarkBook;
+
+final class ObjectHydrationBench
+{
+    private GenericContainer $container;
+
+    private MapperConfig $config;
+
+    private ObjectFactory $factory;
+
+    /** @var array<int, array<string, mixed>> */
+    private array $rows;
+
+    public function setUp(): void
+    {
+        $this->container = new GenericContainer();
+
+        // Casters are normally registered through discovery. The benchmark registers the ones the
+        // fixture needs so that it hydrates the same way an application would.
+        $casters = new CasterFactory($this->container);
+
+        foreach ([BooleanCaster::class, IntegerCaster::class, FloatCaster::class, NativeDateTimeCaster::class] as $caster) {
+            $casters->addCaster($caster);
+        }
+
+        $this->container->singleton(CasterFactory::class, $casters);
+        $this->config = new MapperConfig([ArrayToObjectMapper::class, ObjectToArrayMapper::class]);
+        $this->factory = new ObjectFactory($this->config, $this->container, new MapperCache());
+
+        $this->rows = array_map(
+            static fn (int $i) => [
+                'id' => $i,
+                'title' => "Book {$i}",
+                'description' => "Description {$i}",
+                'published' => ($i % 2) === 0,
+                'price' => $i / 3,
+                'created_at' => '2025-01-01 00:00:00',
+            ],
+            range(1, 5000),
+        );
+    }
+
+    #[BeforeMethods('setUp')]
+    #[Iterations(5)]
+    #[Revs(1000)]
+    #[Warmup(10)]
+    public function benchHydrateObject(): void
+    {
+        $this->factory->withData($this->rows[0])->to(BenchmarkBook::class);
+    }
+
+    #[BeforeMethods('setUp')]
+    #[ParamProviders('provideCollectionSizes')]
+    #[Iterations(5)]
+    #[Revs(20)]
+    #[Warmup(2)]
+    public function benchHydrateCollection(array $params): void
+    {
+        $this->factory
+            ->withData(array_slice($this->rows, 0, $params['size']))
+            ->collection()
+            ->to(BenchmarkBook::class);
+    }
+
+    public function provideCollectionSizes(): iterable
+    {
+        yield '10 rows' => ['size' => 10];
+        yield '100 rows' => ['size' => 100];
+        yield '1000 rows' => ['size' => 1000];
+        yield '5000 rows' => ['size' => 5000];
+    }
+
+    /**
+     * Resolves the mappers from the container on every operation, as happened before they were
+     * cached. Compare against {@see self::benchHydrateObject()}, which reuses a warm cache.
+     */
+    #[BeforeMethods('setUp')]
+    #[Iterations(5)]
+    #[Revs(1000)]
+    #[Warmup(10)]
+    public function benchMapWithColdMapperCache(): void
+    {
+        new ObjectFactory($this->config, $this->container, new MapperCache())
+            ->withData($this->rows[0])
+            ->to(BenchmarkBook::class);
+    }
+}

--- a/tests/Integration/Mapper/ContextualFactoryCacheTest.php
+++ b/tests/Integration/Mapper/ContextualFactoryCacheTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\DatabaseContext;
+use Tempest\Mapper\CasterFactory;
+use Tempest\Mapper\SerializerFactory;
+use Tempest\Reflection\ClassReflector;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithContextDialect;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithDialectSensitiveProperty;
+
+/**
+ * @internal
+ */
+final class ContextualFactoryCacheTest extends FrameworkIntegrationTestCase
+{
+    #[Test]
+    public function serializers_are_not_shared_between_context_payloads(): void
+    {
+        $property = new ClassReflector(ObjectWithDialectSensitiveProperty::class)->getProperty('published');
+        $factory = $this->container->get(SerializerFactory::class);
+
+        $mysql = $factory
+            ->in(new DatabaseContext(DatabaseDialect::MYSQL))
+            ->forProperty($property);
+
+        $postgresql = $factory
+            ->in(new DatabaseContext(DatabaseDialect::POSTGRESQL))
+            ->forProperty($property);
+
+        $this->assertSame('1', $mysql->serialize(true));
+        $this->assertSame('true', $postgresql->serialize(true));
+    }
+
+    #[Test]
+    public function casters_are_not_shared_between_context_payloads(): void
+    {
+        $property = new ClassReflector(ObjectWithContextDialect::class)->getProperty('dialect');
+        $factory = $this->container->get(CasterFactory::class);
+
+        $mysql = $factory
+            ->in(new DatabaseContext(DatabaseDialect::MYSQL))
+            ->forProperty($property);
+
+        $postgresql = $factory
+            ->in(new DatabaseContext(DatabaseDialect::POSTGRESQL))
+            ->forProperty($property);
+
+        $this->assertSame('MYSQL', $mysql->cast('input'));
+        $this->assertSame('POSTGRESQL', $postgresql->cast('input'));
+    }
+}

--- a/tests/Integration/Mapper/Fixtures/ContextDialectCaster.php
+++ b/tests/Integration/Mapper/Fixtures/ContextDialectCaster.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+use Tempest\Database\DatabaseContext;
+use Tempest\Discovery\SkipDiscovery;
+use Tempest\Mapper\Caster;
+
+#[SkipDiscovery]
+final readonly class ContextDialectCaster implements Caster
+{
+    public function __construct(
+        private DatabaseContext $context,
+    ) {}
+
+    public function cast(mixed $input): string
+    {
+        return $this->context->dialect->name;
+    }
+}

--- a/tests/Integration/Mapper/Fixtures/MapperPrefix.php
+++ b/tests/Integration/Mapper/Fixtures/MapperPrefix.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+use Tempest\Discovery\SkipDiscovery;
+
+#[SkipDiscovery]
+final readonly class MapperPrefix
+{
+    public function __construct(
+        public string $value,
+    ) {}
+}

--- a/tests/Integration/Mapper/Fixtures/ObjectWithContextDialect.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithContextDialect.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+use Tempest\Mapper\CastWith;
+
+final readonly class ObjectWithContextDialect
+{
+    public function __construct(
+        #[CastWith(ContextDialectCaster::class)]
+        public string $dialect,
+    ) {}
+}

--- a/tests/Integration/Mapper/Fixtures/ObjectWithDialectSensitiveProperty.php
+++ b/tests/Integration/Mapper/Fixtures/ObjectWithDialectSensitiveProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+final class ObjectWithDialectSensitiveProperty
+{
+    public bool $published;
+}

--- a/tests/Integration/Mapper/Fixtures/PrefixedString.php
+++ b/tests/Integration/Mapper/Fixtures/PrefixedString.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+use Tempest\Discovery\SkipDiscovery;
+
+#[SkipDiscovery]
+final class PrefixedString
+{
+    public function __construct(
+        public string $value,
+    ) {}
+}

--- a/tests/Integration/Mapper/Fixtures/PrefixedStringMapper.php
+++ b/tests/Integration/Mapper/Fixtures/PrefixedStringMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper\Fixtures;
+
+use Tempest\Discovery\SkipDiscovery;
+use Tempest\Mapper\Mapper;
+
+#[SkipDiscovery]
+final readonly class PrefixedStringMapper implements Mapper
+{
+    public function __construct(
+        private MapperPrefix $prefix,
+    ) {}
+
+    public function canMap(mixed $from, mixed $to): bool
+    {
+        return $to === PrefixedString::class;
+    }
+
+    public function map(mixed $from, mixed $to): PrefixedString
+    {
+        return new PrefixedString($this->prefix->value . $from);
+    }
+}

--- a/tests/Integration/Mapper/MapperCacheTest.php
+++ b/tests/Integration/Mapper/MapperCacheTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Tempest\Integration\Mapper;
 
 use PHPUnit\Framework\Attributes\Test;
-use ReflectionProperty;
 use Tempest\Container\GenericContainer;
 use Tempest\Mapper\MapperCache;
 use Tempest\Mapper\MapperConfig;
@@ -13,6 +12,9 @@ use Tempest\Mapper\Mappers\ArrayToObjectMapper;
 use Tempest\Mapper\MappingContext;
 use Tempest\Mapper\ObjectFactory;
 use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+use Tests\Tempest\Integration\Mapper\Fixtures\MapperPrefix;
+use Tests\Tempest\Integration\Mapper\Fixtures\PrefixedString;
+use Tests\Tempest\Integration\Mapper\Fixtures\PrefixedStringMapper;
 
 /**
  * @internal
@@ -73,19 +75,18 @@ final class MapperCacheTest extends FrameworkIntegrationTestCase
     #[Test]
     public function mappers_are_not_shared_between_containers(): void
     {
-        $config = new MapperConfig([ArrayToObjectMapper::class]);
+        $container = function (string $prefix): GenericContainer {
+            $container = new GenericContainer();
+            $container->singleton(MapperPrefix::class, new MapperPrefix($prefix));
+            $container->singleton(MapperConfig::class, new MapperConfig([PrefixedStringMapper::class]));
 
-        $factory = fn (GenericContainer $container) => new ObjectFactory($config, $container, new MapperCache());
-
-        $mappersOf = function (ObjectFactory $factory): array {
-            $reflection = new ReflectionProperty(ObjectFactory::class, 'mappers');
-
-            return $reflection->getValue($factory);
+            return $container;
         };
 
-        $a = $mappersOf($factory(new GenericContainer()));
-        $b = $mappersOf($factory(new GenericContainer()));
+        $a = $container('a:')->get(ObjectFactory::class);
+        $b = $container('b:')->get(ObjectFactory::class);
 
-        $this->assertNotSame($a[0], $b[0]);
+        $this->assertSame('a:value', $a->withData('value')->to(PrefixedString::class)->value);
+        $this->assertSame('b:value', $b->withData('value')->to(PrefixedString::class)->value);
     }
 }

--- a/tests/Integration/Mapper/MapperCacheTest.php
+++ b/tests/Integration/Mapper/MapperCacheTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Mapper;
+
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+use Tempest\Container\GenericContainer;
+use Tempest\Mapper\MapperCache;
+use Tempest\Mapper\MapperConfig;
+use Tempest\Mapper\Mappers\ArrayToObjectMapper;
+use Tempest\Mapper\MappingContext;
+use Tempest\Mapper\ObjectFactory;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+/**
+ * @internal
+ */
+final class MapperCacheTest extends FrameworkIntegrationTestCase
+{
+    #[Test]
+    public function resolves_mappers_once_per_context(): void
+    {
+        $cache = new MapperCache();
+        $resolved = 0;
+
+        $resolve = function () use (&$resolved): array {
+            $resolved++;
+
+            return [$this->container->get(ArrayToObjectMapper::class, context: MappingContext::default())];
+        };
+
+        $first = $cache->resolve(new MappingContext('default'), $resolve);
+        $second = $cache->resolve(new MappingContext('default'), $resolve);
+
+        $this->assertSame(1, $resolved);
+        $this->assertSame($first, $second);
+
+        $cache->resolve(new MappingContext('other'), $resolve);
+
+        $this->assertSame(2, $resolved);
+    }
+
+    #[Test]
+    public function is_reset_between_worker_requests(): void
+    {
+        $cache = $this->container->get(MapperCache::class);
+        $resolved = 0;
+
+        $resolve = function () use (&$resolved): array {
+            $resolved++;
+
+            return [$this->container->get(ArrayToObjectMapper::class, context: MappingContext::default())];
+        };
+
+        $cache->resolve(new MappingContext('default'), $resolve);
+        $cache->resolve(new MappingContext('default'), $resolve);
+
+        $this->assertSame(1, $resolved);
+
+        $this->container->reset();
+
+        // A reset clears the cache without dropping the singleton. The mappers must therefore be
+        // re-resolved through the same instance.
+        $this->assertSame($cache, $this->container->get(MapperCache::class));
+
+        $cache->resolve(new MappingContext('default'), $resolve);
+
+        $this->assertSame(2, $resolved);
+    }
+
+    #[Test]
+    public function mappers_are_not_shared_between_containers(): void
+    {
+        $config = new MapperConfig([ArrayToObjectMapper::class]);
+
+        $factory = fn (GenericContainer $container) => new ObjectFactory($config, $container, new MapperCache());
+
+        $mappersOf = function (ObjectFactory $factory): array {
+            $reflection = new ReflectionProperty(ObjectFactory::class, 'mappers');
+
+            return $reflection->getValue($factory);
+        };
+
+        $a = $mappersOf($factory(new GenericContainer()));
+        $b = $mappersOf($factory(new GenericContainer()));
+
+        $this->assertNotSame($a[0], $b[0]);
+    }
+}

--- a/tests/Integration/Mapper/MapperTest.php
+++ b/tests/Integration/Mapper/MapperTest.php
@@ -6,6 +6,8 @@ namespace Tests\Tempest\Integration\Mapper;
 
 use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\Test;
+use Tempest\Database\Config\DatabaseDialect;
+use Tempest\Database\DatabaseContext;
 use Tempest\DateTime\DateTime;
 use Tempest\DateTime\DateTimeInterface;
 use Tempest\Mapper\Exceptions\MappingValuesWereMissing;
@@ -20,6 +22,7 @@ use Tests\Tempest\Integration\Mapper\Fixtures\ObjectA;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectFactoryA;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectThatShouldUseCasters;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithConfiguredTempestDateTimeFormat;
+use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithContextDialect;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithInterfaceTypedProperties;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMapFromAttribute;
 use Tests\Tempest\Integration\Mapper\Fixtures\ObjectWithMapToAttribute;
@@ -38,6 +41,21 @@ use function Tempest\Mapper\map;
  */
 final class MapperTest extends FrameworkIntegrationTestCase
 {
+    #[Test]
+    public function mapping_uses_the_current_context_payload(): void
+    {
+        $mysql = map(['dialect' => 'input'])
+            ->in(new DatabaseContext(DatabaseDialect::MYSQL))
+            ->to(ObjectWithContextDialect::class);
+
+        $postgresql = map(['dialect' => 'input'])
+            ->in(new DatabaseContext(DatabaseDialect::POSTGRESQL))
+            ->to(ObjectWithContextDialect::class);
+
+        $this->assertSame('MYSQL', $mysql->dialect);
+        $this->assertSame('POSTGRESQL', $postgresql->dialect);
+    }
+
     #[Test]
     public function make_object_from_class_string(): void
     {


### PR DESCRIPTION
Hydrating rows into models now caches reflection metadata, primary key scans, and resolved mappers to avoid redundant per-row work.

## Improvements

* **Per-Class Reflection Plans:** Caches reflection metadata, property types, and parent-child relations by class rather than recalculating them per row.
* **Cached Primary Key:** Memoizes the primary key property lookup on model inspectors to prevent thousands of redundant scans per nested eager-loading query.
* **Singleton Mapper Cache:** Replaces a factory-level cache that never hit (a fresh factory is built per `map()` call) with a container-scoped `#[Singleton]`, so the cache lives and dies with its container - no cross-container leaks. It implements `Resettable`, so workers calling `resetContainer()` between requests re-resolve mappers instead of holding ones built from unregistered dependencies. `ObjectFactory::__construct()` takes a third argument as a result.

## Performance Impact

<table>
  <thead>
    <tr>
      <th>Benchmark</th>
      <th>Before</th>
      <th>After</th>
      <th>Change</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Mapper stage<br><small>2,000-row SQLite select</small></td>
      <td>73.8ms</td>
      <td>35.3ms</td>
      <td>-52.2%</td>
    </tr>
    <tr>
      <td>End-to-end <code>Model::all()</code></td>
      <td>92.0ms</td>
      <td>53.4ms</td>
      <td>-42.0%</td>
    </tr>
    <tr>
      <td>Eager-loading<br><small>50 authors with nested relations</small></td>
      <td>3,344ms</td>
      <td>1,527ms</td>
      <td>-54.3%</td>
    </tr>
    <tr>
      <td><code>map()</code> in a hydration loop<br><small>Per call, steady state</small></td>
      <td>0.342ms</td>
      <td>0.018ms</td>
      <td>-94.8%</td>
    </tr>
  </tbody>
</table>