### PR TITLE
fix(router): clear the matched route between requests

### DIFF
--- a/packages/router/src/MatchRouteMiddleware.php
+++ b/packages/router/src/MatchRouteMiddleware.php
@@ -21,6 +21,10 @@ final readonly class MatchRouteMiddleware implements HttpMiddleware
 
     public function __invoke(Request $request, HttpMiddlewareCallable $next): Response
     {
+        // In long-running contexts, a previous request may have left a matched route behind.
+        // It must be cleared before matching, since we only rebind it on a successful match.
+        $this->container->unregister(MatchedRoute::class);
+
         $matchedRoute = $this->routeMatcher->match($request);
 
         if (! $matchedRoute instanceof MatchedRoute && $request->method === Method::HEAD && $request instanceof GenericRequest) {

--- a/packages/router/src/RouterReset.php
+++ b/packages/router/src/RouterReset.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tempest\Router;
+
+use Tempest\Container\Container;
+use Tempest\Container\Resettable;
+
+final readonly class RouterReset implements Resettable
+{
+    public function __construct(
+        private Container $container,
+    ) {}
+
+    public function reset(): void
+    {
+        $this->container->unregister(MatchedRoute::class);
+    }
+}

--- a/tests/Integration/Router/MatchRouteMiddlewareTest.php
+++ b/tests/Integration/Router/MatchRouteMiddlewareTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Router;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Router\MatchedRoute;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+final class MatchRouteMiddlewareTest extends FrameworkIntegrationTestCase
+{
+    #[Test]
+    public function unmatched_request_does_not_leave_the_previous_matched_route_bound(): void
+    {
+        $this->http->get('/repeated/a')->assertOk();
+
+        $this->assertTrue($this->container->has(MatchedRoute::class));
+
+        $this->http->get('/does-not-exist')->assertNotFound();
+
+        $this->assertFalse($this->container->has(MatchedRoute::class));
+    }
+}

--- a/tests/Integration/Router/RouterResetTest.php
+++ b/tests/Integration/Router/RouterResetTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Tempest\Integration\Router;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tempest\Router\MatchedRoute;
+use Tests\Tempest\Integration\FrameworkIntegrationTestCase;
+
+final class RouterResetTest extends FrameworkIntegrationTestCase
+{
+    #[Test]
+    public function reset_clears_the_matched_route(): void
+    {
+        $this->http->get('/repeated/a')->assertOk();
+
+        $this->assertTrue($this->container->has(MatchedRoute::class));
+
+        $this->container->reset();
+
+        $this->assertFalse($this->container->has(MatchedRoute::class));
+    }
+}


### PR DESCRIPTION
Implement `RouterReset` to unregister `MatchedRoute` from the container during resets, and clear the binding in `MatchRouteMiddleware` before matching.

## Problem

`MatchRouteMiddleware` binds `MatchedRoute` into the container as a singleton. In long-running workers (FrankenPHP worker mode) or test suites where the container is reused across requests, this state leaks across boundaries: `GenericContainer::reset()` clears resolved singletons and dynamic initializers, but not `singletonDefinitions`, where the binding lives. Anything sharing the container - the next request, a console command, a deferred task - incorrectly inherits the previous request's matched route, causing stale data in URI generation, route model binding, and middleware execution.

## Solution

* Create `RouterReset` implementing `Resettable` to automatically unregister `MatchedRoute::class` during container resets, discovered via `ResettableDiscovery` and following the existing resets from worker mode support (#2172).
* Clear any existing `MatchedRoute` binding inside `MatchRouteMiddleware` before running a new match, ensuring safe reuse even when container resets do not occur, ie in test suite:
```php
$this->http->get('/docs/installation')->assertOk();
$this->http->get('/does-not-exist')->assertNotFound();

is_current_uri([DocsController::class, 'show'], slug: 'installation'); // true, on a 404
```
