### PR TITLE
refactor(http): deprecate HeaderSessionIdResolver

### DIFF
--- a/packages/http/src/Session/Resolvers/HeaderSessionIdResolver.php
+++ b/packages/http/src/Session/Resolvers/HeaderSessionIdResolver.php
@@ -12,6 +12,11 @@ use Tempest\Http\Session\SessionIdResolver;
 
 use function Tempest\Support\str;
 
+/**
+ * Resolves the session identifier from a request header.
+ *
+ * @deprecated Will be removed in 4.0. Use {@see CookieSessionIdResolver} instead.
+ */
 final readonly class HeaderSessionIdResolver implements SessionIdResolver
 {
     public function __construct(


### PR DESCRIPTION
Deprecates `HeaderSessionIdResolver`, scheduled for removal in 4.0.

## Why

* **Unused:** Not wired up by any initializer or selectable via configuration.
* **Never a default:** Replaced by `CookieSessionIdResolver` prior to the first tagged release (`v1.0.0-alpha.1`).
* **Undocumented:** Absent from all in-repo and official documentation.
* **Header name never matches:** It looks up an underscore header name (`*_session_id`), but request headers are normalized to hyphens by our own request layer (Laminas `ServerRequestFactory`, after the SAPI collapses both forms to `HTTP_..._..._`), so the lookup can't match a client-supplied identifier. This is the unresolved half of #1892; #1893 fixed the broken import but not the name mismatch.

Given the above, deprecating and later removing it seems cleaner than investing further in fixing it. Happy to adjust if there's an intended use case I've missed.
