### PR TITLE
ci: cap benchmark runtime and split its steps

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,6 +27,7 @@ jobs:
     if: ${{ github.event.pull_request.base.ref == github.event.repository.default_branch }}
     name: Performance Regression Check
     runs-on: ubuntu-latest
+    timeout-minutes: 180
 
     steps:
       - name: Checkout PR branch
@@ -44,23 +45,35 @@ jobs:
       - name: Install dependencies
         uses: ramsey/composer-install@v3
 
-      - name: Benchmark base branch
+      - name: Check out base branch
         run: |
           git checkout ${{ github.event.pull_request.base.sha }}
           cp .env.example .env
           sed -i 's/^INTERNAL_CACHES=.*/INTERNAL_CACHES=false/' .env
           sed -i 's/^DISCOVERY_CACHE=.*/DISCOVERY_CACHE=false/' .env
-          composer update --no-interaction --prefer-dist --quiet
-          vendor/bin/phpbench run --tag=base --store --progress=none
 
-      - name: Benchmark PR branch
+      - name: Install base branch dependencies
+        timeout-minutes: 20
+        run: composer update --no-interaction --prefer-dist --quiet
+
+      - name: Benchmark base branch
+        timeout-minutes: 70
+        run: vendor/bin/phpbench run --tag=base --store --progress=none
+
+      - name: Check out PR branch
         run: |
           git checkout ${{ github.event.pull_request.head.sha }}
           cp .env.example .env
           sed -i 's/^INTERNAL_CACHES=.*/INTERNAL_CACHES=false/' .env
           sed -i 's/^DISCOVERY_CACHE=.*/DISCOVERY_CACHE=false/' .env
-          composer update --no-interaction --prefer-dist --quiet
-          vendor/bin/phpbench run --tag=pr --store --ref=base --report=aggregate --progress=none --output=benchmark-comment | tee benchmark-result.txt || true
+
+      - name: Install PR branch dependencies
+        timeout-minutes: 20
+        run: composer update --no-interaction --prefer-dist --quiet
+
+      - name: Benchmark PR branch
+        timeout-minutes: 70
+        run: vendor/bin/phpbench run --tag=pr --store --ref=base --report=aggregate --progress=none --output=benchmark-comment | tee benchmark-result.txt || true
 
       - name: Prepare artifact
         run: |


### PR DESCRIPTION
A [recent benchmark run hung for ~4? hours](https://github.com/tempestphp/tempest-framework/actions/runs/34121011777/job/101738781072?pr=2285). To isolate whether Composer or phpbench is driving the recurring ~30x performance variance, this PR splits the workflow steps so future slow runs or timeouts immediately reveal where things get stuck. It also adds a 180-minute overall job cap (giving `composer update` 20m and `phpbench run` 70m) while safely accommodating historical slow-but-successful outliers.