### PR TITLE
feat(auth): add id_token to GenericOAuthClient

### DIFF
--- a/packages/auth/src/OAuth/GenericOAuthClient.php
+++ b/packages/auth/src/OAuth/GenericOAuthClient.php
@@ -153,6 +153,7 @@ final class GenericOAuthClient implements OAuthClient
         $token = $this->requestAccessToken(
             code: $request->get('code'),
         );
+        $this->storeIdToken($token);
         $user = $this->fetchUser(token: $token);
 
         $authenticable = $map($user, $token);
@@ -160,5 +161,14 @@ final class GenericOAuthClient implements OAuthClient
         $this->authenticator->authenticate($authenticable);
 
         return $authenticable;
+    }
+
+    private function storeIdToken(AccessToken $token): void
+    {
+        $values = $token->getValues();
+
+        if (isset($values['id_token'])) {
+            $this->session->set('id_token', $values['id_token']);
+        }
     }
 }


### PR DESCRIPTION
Hello,
I want to make use of RP Initiated Logout. For that per OIDC Spec I have to pass on the id_token_hint. I preserve this in the GenericOAuthClient and pass it on as a url parameter later on.

Thanks and kind regards
Zoë